### PR TITLE
feat: streams MINID from Redis 6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ before_install: |
   sudo apt-get install stunnel -y
 
 install: |
-  wget https://github.com/redis/redis/archive/6.0.6.tar.gz;
-  tar -xzvf 6.0.6.tar.gz;
-  pushd redis-6.0.6 && BUILD_TLS=yes make && export PATH=$PWD/src:$PATH && popd;
+  wget https://github.com/redis/redis/archive/6.2.0.tar.gz;
+  tar -xzvf 6.2.0.tar.gz;
+  pushd redis-6.2.0 && BUILD_TLS=yes make && export PATH=$PWD/src:$PATH && popd;
 
 matrix:
   include:


### PR DESCRIPTION
Adds support for capping stream length via MINID (an alternative
to MAXLEN) when using XADD or XTRIM.

Question: Do we need additional MINID test cases?

Resolves mitsuhiko/redis-rs#458

- - -

This PR follows the proposal in #458, which might not be everyone's preference.