### PR TITLE
Add RedisValueInto (like FromRedisValue, but move instead of copy).

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,6 +381,7 @@ pub use crate::types::{
 
     // conversion traits
     FromRedisValue,
+    RedisValueInto,
 
     // utility types
     InfoDict,
@@ -445,3 +446,4 @@ mod connection;
 mod parser;
 mod script;
 mod types;
+mod types_into;

--- a/src/types.rs
+++ b/src/types.rs
@@ -173,7 +173,7 @@ impl Value {
         }
     }
 
-    /// Returns an `&[Value]` if `self` is compatible with a sequence type
+    /// Returns an `Vec<Value>` if `self` is compatible with a sequence type
     pub fn as_into_sequence(self) -> Option<Vec<Value>> {
         match self {
             Value::Bulk(items) => Some(items),

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,6 +8,9 @@ use std::hash::{BuildHasher, Hash};
 use std::io;
 use std::str::{from_utf8, Utf8Error};
 use std::string::FromUtf8Error;
+use crate::types_into::MapIntoIter;
+
+pub use crate::types_into::RedisValueInto;
 
 macro_rules! invalid_type_error {
     ($v:expr, $det:expr) => {{
@@ -166,6 +169,23 @@ impl Value {
     pub fn as_map_iter(&self) -> Option<MapIter<'_>> {
         match self {
             Value::Bulk(items) => Some(MapIter(items.iter())),
+            _ => None,
+        }
+    }
+
+    /// Returns an `&[Value]` if `self` is compatible with a sequence type
+    pub fn as_into_sequence(self) -> Option<Vec<Value>> {
+        match self {
+            Value::Bulk(items) => Some(items),
+            Value::Nil => Some(vec![]),
+            _ => None,
+        }
+    }
+
+    /// Returns an iterator of `(Value, Value)` if `self` is compatible with a map type
+    pub fn as_map_into_iter(self) -> Option<MapIntoIter> {
+        match self {
+            Value::Bulk(items) => Some(MapIntoIter(items.into_iter())),
             _ => None,
         }
     }

--- a/src/types_into.rs
+++ b/src/types_into.rs
@@ -1,0 +1,258 @@
+use {
+    crate::{ErrorKind, InfoDict, RedisError, RedisResult, Value},
+    std::{
+        collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+        hash::{BuildHasher, Hash},
+        vec::IntoIter,
+    },
+};
+
+pub struct MapIntoIter(pub(crate) IntoIter<Value>);
+
+impl Iterator for MapIntoIter {
+    type Item = (Value, Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some((self.0.next()?, self.0.next()?))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (low, high) = self.0.size_hint();
+        (low / 2, high.map(|h| h / 2))
+    }
+}
+
+macro_rules! invalid_type_error {
+    ($det:expr) => {{
+        fail!(invalid_type_error_inner!($det))
+    }};
+}
+
+macro_rules! invalid_type_error_inner {
+    ($det:expr) => {
+        RedisError::from((
+            ErrorKind::TypeError,
+            "Response was of incompatible type",
+            format!("{:?}", $det),
+        ))
+    };
+}
+
+/// This trait is used to convert a redis value into a more appropriate
+/// type like FromRedisValue but move instead of copy.
+pub trait RedisValueInto: Sized {
+    /// Given a redis `Value` this attempts to convert it into the given
+    /// destination type by move. If that fails because it's not compatible an
+    /// appropriate error is generated.
+    fn redis_value_into(v: Value) -> RedisResult<Self>;
+
+    #[doc(hidden)]
+    fn from_byte_vec(_vec: Vec<u8>) -> Option<Vec<Self>> {
+        None
+    }
+}
+
+macro_rules! redis_value_into_for_num_internal {
+    ($t:ty, $v:expr) => {{
+        let v = $v;
+        match v {
+            Value::Int(val) => Ok(val as $t),
+            Value::Status(s) => match s.parse::<$t>() {
+                Ok(rv) => Ok(rv),
+                Err(_) => invalid_type_error!("Could not convert from string."),
+            },
+            Value::Data(bytes) => match String::from_utf8(bytes)?.parse::<$t>() {
+                Ok(rv) => Ok(rv),
+                Err(_) => invalid_type_error!("Could not convert from string."),
+            },
+            _ => invalid_type_error!("Response type not convertible to numeric."),
+        }
+    }};
+}
+
+macro_rules! redis_value_into_for_num {
+    ($t:ty) => {
+        impl RedisValueInto for $t {
+            fn redis_value_into(v: Value) -> RedisResult<$t> {
+                redis_value_into_for_num_internal!($t, v)
+            }
+        }
+    };
+}
+
+impl RedisValueInto for u8 {
+    fn redis_value_into(v: Value) -> RedisResult<u8> {
+        redis_value_into_for_num_internal!(u8, v)
+    }
+
+    fn from_byte_vec(vec: Vec<u8>) -> Option<Vec<u8>> {
+        Some(vec)
+    }
+}
+
+redis_value_into_for_num!(i8);
+redis_value_into_for_num!(i16);
+redis_value_into_for_num!(u16);
+redis_value_into_for_num!(i32);
+redis_value_into_for_num!(u32);
+redis_value_into_for_num!(i64);
+redis_value_into_for_num!(u64);
+redis_value_into_for_num!(i128);
+redis_value_into_for_num!(u128);
+redis_value_into_for_num!(f32);
+redis_value_into_for_num!(f64);
+redis_value_into_for_num!(isize);
+redis_value_into_for_num!(usize);
+
+impl RedisValueInto for bool {
+    fn redis_value_into(v: Value) -> RedisResult<bool> {
+        match v {
+            Value::Nil => Ok(false),
+            Value::Int(val) => Ok(val != 0),
+            Value::Status(s) => {
+                if &s[..] == "1" {
+                    Ok(true)
+                } else if &s[..] == "0" {
+                    Ok(false)
+                } else {
+                    invalid_type_error!("Response status not valid boolean");
+                }
+            }
+            Value::Data(bytes) => {
+                if bytes == b"1" {
+                    Ok(true)
+                } else if bytes == b"0" {
+                    Ok(false)
+                } else {
+                    invalid_type_error!("Response type not bool compatible.");
+                }
+            }
+            Value::Okay => Ok(true),
+            _ => invalid_type_error!("Response type not bool compatible."),
+        }
+    }
+}
+
+impl RedisValueInto for String {
+    fn redis_value_into(v: Value) -> RedisResult<String> {
+        match v {
+            Value::Data(bytes) => Ok(String::from_utf8(bytes)?),
+            Value::Okay => Ok("OK".to_string()),
+            Value::Status(val) => Ok(val),
+            _ => invalid_type_error!("Response type not string compatible."),
+        }
+    }
+}
+
+impl<T: RedisValueInto> RedisValueInto for Vec<T> {
+    fn redis_value_into(v: Value) -> RedisResult<Vec<T>> {
+        match v {
+            // this hack allows us to specialize Vec<u8> to work with
+            // binary data whereas all others will fail with an error.
+            Value::Data(bytes) => match RedisValueInto::from_byte_vec(bytes) {
+                Some(x) => Ok(x),
+                None => invalid_type_error!("Response type not vector compatible."),
+            },
+            Value::Bulk(items) => Ok(items
+                .into_iter()
+                .filter_map(|item| RedisValueInto::redis_value_into(item).ok())
+                .collect()),
+            Value::Nil => Ok(vec![]),
+            _ => invalid_type_error!("Response type not vector compatible."),
+        }
+    }
+}
+
+impl<K: RedisValueInto + Eq + Hash, V: RedisValueInto, S: BuildHasher + Default> RedisValueInto
+    for HashMap<K, V, S>
+{
+    fn redis_value_into(v: Value) -> RedisResult<HashMap<K, V, S>> {
+        v.as_map_into_iter()
+            .ok_or_else(|| invalid_type_error_inner!("Response type not hashmap compatible"))?
+            .map(|(k, v)| Ok((redis_value_into(k)?, redis_value_into(v)?)))
+            .collect()
+    }
+}
+
+impl<K: RedisValueInto + Eq + Hash, V: RedisValueInto> RedisValueInto for BTreeMap<K, V>
+where
+    K: Ord,
+{
+    fn redis_value_into(v: Value) -> RedisResult<BTreeMap<K, V>> {
+        v.as_map_into_iter()
+            .ok_or_else(|| invalid_type_error_inner!("Response type not btreemap compatible"))?
+            .map(|(k, v)| Ok((redis_value_into(k)?, redis_value_into(v)?)))
+            .collect()
+    }
+}
+
+impl<T: RedisValueInto + Eq + Hash, S: BuildHasher + Default> RedisValueInto for HashSet<T, S> {
+    fn redis_value_into(v: Value) -> RedisResult<HashSet<T, S>> {
+        let items = v
+            .as_into_sequence()
+            .ok_or_else(|| invalid_type_error_inner!("Response type not hashset compatible"))?;
+        items
+            .into_iter()
+            .map(|item| redis_value_into(item))
+            .collect()
+    }
+}
+
+impl<T: RedisValueInto + Eq + Hash> RedisValueInto for BTreeSet<T>
+where
+    T: Ord,
+{
+    fn redis_value_into(v: Value) -> RedisResult<BTreeSet<T>> {
+        let items = v
+            .as_into_sequence()
+            .ok_or_else(|| invalid_type_error_inner!("Response type not btreeset compatible"))?;
+        items
+            .into_iter()
+            .map(|item| redis_value_into(item))
+            .collect()
+    }
+}
+
+impl RedisValueInto for Value {
+    fn redis_value_into(v: Value) -> RedisResult<Value> {
+        Ok(v.clone())
+    }
+}
+
+impl RedisValueInto for () {
+    fn redis_value_into(_v: Value) -> RedisResult<()> {
+        Ok(())
+    }
+}
+
+impl RedisValueInto for InfoDict {
+    fn redis_value_into(v: Value) -> RedisResult<InfoDict> {
+        let s: String = redis_value_into(v)?;
+        Ok(InfoDict::new(&s))
+    }
+}
+
+impl<T: RedisValueInto> RedisValueInto for Option<T> {
+    fn redis_value_into(v: Value) -> RedisResult<Option<T>> {
+        if let Value::Nil = v {
+            return Ok(None);
+        }
+        Ok(Some(redis_value_into(v)?))
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl RedisValueInto for bytes::Bytes {
+    fn redis_value_into(v: Value) -> RedisResult<Self> {
+        match v {
+            Value::Data(bytes_vec) => Ok(bytes::Bytes::from(bytes_vec)),
+            _ => invalid_type_error!("Not binary data"),
+        }
+    }
+}
+
+/// A shortcut function to invoke `RedisValueInto::redis_value_into`
+/// to make the API slightly nicer.
+pub fn redis_value_into<T: RedisValueInto>(v: Value) -> RedisResult<T> {
+    RedisValueInto::redis_value_into(v)
+}

--- a/tests/test_types_into.rs
+++ b/tests/test_types_into.rs
@@ -1,0 +1,195 @@
+#[test]
+fn test_info_dict() {
+    use redis::{InfoDict, RedisValueInto, Value};
+
+    let d: InfoDict = RedisValueInto::redis_value_into(Value::Status(
+        "# this is a comment\nkey1:foo\nkey2:42\n".into(),
+    ))
+    .unwrap();
+
+    assert_eq!(d.get("key1"), Some("foo".to_string()));
+    assert_eq!(d.get("key2"), Some(42i64));
+    assert_eq!(d.get::<String>("key3"), None);
+}
+
+#[test]
+fn test_i32() {
+    use redis::{ErrorKind, RedisValueInto, Value};
+
+    let i = RedisValueInto::redis_value_into(Value::Status("42".into()));
+    assert_eq!(i, Ok(42i32));
+
+    let i = RedisValueInto::redis_value_into(Value::Int(42));
+    assert_eq!(i, Ok(42i32));
+
+    let i = RedisValueInto::redis_value_into(Value::Data("42".into()));
+    assert_eq!(i, Ok(42i32));
+
+    let bad_i: Result<i32, _> = RedisValueInto::redis_value_into(Value::Status("42x".into()));
+    assert_eq!(bad_i.unwrap_err().kind(), ErrorKind::TypeError);
+}
+
+#[test]
+fn test_u32() {
+    use redis::{ErrorKind, RedisValueInto, Value};
+
+    let i = RedisValueInto::redis_value_into(Value::Status("42".into()));
+    assert_eq!(i, Ok(42u32));
+
+    let bad_i: Result<u32, _> = RedisValueInto::redis_value_into(Value::Status("-1".into()));
+    assert_eq!(bad_i.unwrap_err().kind(), ErrorKind::TypeError);
+}
+
+#[test]
+fn test_vec() {
+    use redis::{RedisValueInto, Value};
+
+    let v = RedisValueInto::redis_value_into(Value::Bulk(vec![
+        Value::Data("1".into()),
+        Value::Data("2".into()),
+        Value::Data("3".into()),
+    ]));
+
+    assert_eq!(v, Ok(vec![1i32, 2, 3]));
+}
+
+#[test]
+fn test_hashmap() {
+    use fnv::FnvHasher;
+    use redis::{RedisValueInto, Value};
+    use std::collections::HashMap;
+    use std::hash::BuildHasherDefault;
+
+    type Hm = HashMap<String, i32>;
+
+    let v: Result<Hm, _> = RedisValueInto::redis_value_into(Value::Bulk(vec![
+        Value::Data("a".into()),
+        Value::Data("1".into()),
+        Value::Data("b".into()),
+        Value::Data("2".into()),
+        Value::Data("c".into()),
+        Value::Data("3".into()),
+    ]));
+    let mut e: Hm = HashMap::new();
+    e.insert("a".into(), 1);
+    e.insert("b".into(), 2);
+    e.insert("c".into(), 3);
+    assert_eq!(v, Ok(e));
+
+    type Hasher = BuildHasherDefault<FnvHasher>;
+    type HmHasher = HashMap<String, i32, Hasher>;
+    let v: Result<HmHasher, _> = RedisValueInto::redis_value_into(Value::Bulk(vec![
+        Value::Data("a".into()),
+        Value::Data("1".into()),
+        Value::Data("b".into()),
+        Value::Data("2".into()),
+        Value::Data("c".into()),
+        Value::Data("3".into()),
+    ]));
+
+    let fnv = Hasher::default();
+    let mut e: HmHasher = HashMap::with_hasher(fnv);
+    e.insert("a".into(), 1);
+    e.insert("b".into(), 2);
+    e.insert("c".into(), 3);
+    assert_eq!(v, Ok(e));
+}
+
+#[test]
+fn test_bool() {
+    use redis::{ErrorKind, RedisValueInto, Value};
+
+    let v = RedisValueInto::redis_value_into(Value::Data("1".into()));
+    assert_eq!(v, Ok(true));
+
+    let v = RedisValueInto::redis_value_into(Value::Data("0".into()));
+    assert_eq!(v, Ok(false));
+
+    let v: Result<bool, _> = RedisValueInto::redis_value_into(Value::Data("garbage".into()));
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+    let v = RedisValueInto::redis_value_into(Value::Status("1".into()));
+    assert_eq!(v, Ok(true));
+
+    let v = RedisValueInto::redis_value_into(Value::Status("0".into()));
+    assert_eq!(v, Ok(false));
+
+    let v: Result<bool, _> = RedisValueInto::redis_value_into(Value::Status("garbage".into()));
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+    let v = RedisValueInto::redis_value_into(Value::Okay);
+    assert_eq!(v, Ok(true));
+
+    let v = RedisValueInto::redis_value_into(Value::Nil);
+    assert_eq!(v, Ok(false));
+
+    let v = RedisValueInto::redis_value_into(Value::Int(0));
+    assert_eq!(v, Ok(false));
+
+    let v = RedisValueInto::redis_value_into(Value::Int(42));
+    assert_eq!(v, Ok(true));
+}
+
+#[cfg(feature = "bytes")]
+#[test]
+fn test_bytes() {
+    use bytes::Bytes;
+    use redis::{ErrorKind, RedisResult, RedisValueInto, Value};
+
+    let content: &[u8] = b"\x01\x02\x03\x04";
+    let content_vec: Vec<u8> = Vec::from(content);
+    let content_bytes = Bytes::from_static(content);
+
+    let v: RedisResult<Bytes> = RedisValueInto::redis_value_into(Value::Data(content_vec));
+    assert_eq!(v, Ok(content_bytes));
+
+    let v: RedisResult<Bytes> = RedisValueInto::redis_value_into(Value::Status("garbage".into()));
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+    let v: RedisResult<Bytes> = RedisValueInto::redis_value_into(Value::Okay);
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+    let v: RedisResult<Bytes> = RedisValueInto::redis_value_into(Value::Nil);
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+    let v: RedisResult<Bytes> = RedisValueInto::redis_value_into(Value::Int(0));
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+    let v: RedisResult<Bytes> = RedisValueInto::redis_value_into(Value::Int(42));
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+}
+
+#[test]
+fn test_types_to_redis_args() {
+    use redis::ToRedisArgs;
+    use std::collections::BTreeMap;
+    use std::collections::BTreeSet;
+    use std::collections::HashSet;
+
+    assert!(!5i32.to_redis_args().is_empty());
+    assert!(!"abc".to_redis_args().is_empty());
+    assert!(!"abc".to_redis_args().is_empty());
+    assert!(!String::from("x").to_redis_args().is_empty());
+
+    assert!(![5, 4]
+        .iter()
+        .cloned()
+        .collect::<HashSet<_>>()
+        .to_redis_args()
+        .is_empty());
+
+    assert!(![5, 4]
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .to_redis_args()
+        .is_empty());
+
+    // this can be used on something HMSET
+    assert!(![("a", 5), ("b", 6), ("C", 7)]
+        .iter()
+        .cloned()
+        .collect::<BTreeMap<_, _>>()
+        .to_redis_args()
+        .is_empty());
+}


### PR DESCRIPTION
Greetings!

Why does `FromRedisValue` copy data instead of moving it? In my code, I must use something like this:
```rust
fn from_redis_value(v: Value) -> RedisResult<String> {
    match v {
        Value::Data(bytes) => Ok(std::string::String::from_utf8(bytes)?),
        Value::Okay => Ok("OK".to_string()),
        Value::Status(val) => Ok(val),
        _ => Err(RedisError::from((
            ErrorKind::TypeError,
            "Response was of incompatible type",
            format!(
                "Response type not string compatible. (response was {:?})",
                v
            ),
        ))),
    }
}
```

P.S. Pattern matching is not available for `Vec`, so I don't figure out how to do that functionality.