### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -289,8 +289,8 @@ impl ClusterConnection {
         let len = connections.len();
         let mut samples = connections.values_mut().choose_multiple(&mut rng, len);
 
-        for mut conn in samples.iter_mut() {
-            if let Ok(mut slots_data) = get_slots(&mut conn, self.tls) {
+        for conn in samples.iter_mut() {
+            if let Ok(mut slots_data) = get_slots(conn, self.tls) {
                 slots_data.sort_by_key(|s| s.start());
                 let last_slot = slots_data.iter().try_fold(0, |prev_end, slot_data| {
                     if prev_end != slot_data.start() {

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -432,10 +432,10 @@ impl StreamId {
         let mut stream_id = StreamId::default();
         if let Value::Bulk(ref values) = *v {
             if let Some(v) = values.get(0) {
-                stream_id.id = from_redis_value(&v)?;
+                stream_id.id = from_redis_value(v)?;
             }
             if let Some(v) = values.get(1) {
-                stream_id.map = from_redis_value(&v)?;
+                stream_id.map = from_redis_value(v)?;
             }
         }
 
@@ -446,7 +446,7 @@ impl StreamId {
     /// type.
     pub fn get<T: FromRedisValue>(&self, key: &str) -> Option<T> {
         match self.map.get(key) {
-            Some(ref x) => from_redis_value(*x).ok(),
+            Some(x) => from_redis_value(x).ok(),
             None => None,
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -364,7 +364,7 @@ impl RedisError {
             ErrorKind::MasterDown => Some("MASTERDOWN"),
             ErrorKind::ReadOnly => Some("READONLY"),
             _ => match self.repr {
-                ErrorRepr::ExtensionError(ref code, _) => Some(&code),
+                ErrorRepr::ExtensionError(ref code, _) => Some(code),
                 _ => None,
             },
         }
@@ -479,7 +479,7 @@ impl RedisError {
     #[deprecated(note = "use code() instead")]
     pub fn extension_error_code(&self) -> Option<&str> {
         match self.repr {
-            ErrorRepr::ExtensionError(ref code, _) => Some(&code),
+            ErrorRepr::ExtensionError(ref code, _) => Some(code),
             _ => None,
         }
     }
@@ -574,7 +574,7 @@ impl InfoDict {
     /// Typical types are `String`, `bool` and integer types.
     pub fn get<T: FromRedisValue>(&self, key: &str) -> Option<T> {
         match self.find(&key) {
-            Some(ref x) => from_redis_value(*x).ok(),
+            Some(x) => from_redis_value(x).ok(),
             None => None,
         }
     }
@@ -607,7 +607,7 @@ pub trait RedisWrite {
 
     /// Accepts a serialized redis command.
     fn write_arg_fmt(&mut self, arg: impl fmt::Display) {
-        self.write_arg(&arg.to_string().as_bytes())
+        self.write_arg(arg.to_string().as_bytes())
     }
 }
 

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -362,7 +362,7 @@ fn test_script_returning_complex_type() {
             .map_ok(|(i, s, b): (i32, String, bool)| {
                 assert_eq!(i, 1);
                 assert_eq!(s, "hello");
-                assert_eq!(b, true);
+                assert!(b);
             })
             .await
     })

--- a/tests/test_async_async_std.rs
+++ b/tests/test_async_async_std.rs
@@ -298,7 +298,7 @@ fn test_script_returning_complex_type() {
             .map_ok(|(i, s, b): (i32, String, bool)| {
                 assert_eq!(i, 1);
                 assert_eq!(s, "hello");
-                assert_eq!(b, true);
+                assert!(b);
             })
             .await
     })

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -440,7 +440,7 @@ fn test_pipeline_reuse_query_clear() {
         .unwrap();
     pl.clear();
 
-    assert_eq!(k1, false);
+    assert!(!k1);
     assert_eq!(k2, 45);
 }
 

--- a/tests/test_streams.rs
+++ b/tests/test_streams.rs
@@ -457,7 +457,7 @@ fn test_xclaim() {
             "g1",
             "c5",
             4,
-            &claim_justids,
+            claim_justids,
             StreamClaimOptions::default().with_force().with_justid(),
         )
         .unwrap();


### PR DESCRIPTION
I'm pretty sure the black_box's I removed had no effect due to the inner function returning `()`.
I'm happy to instead put them back and manually ignore the clippy lint if removing them is problematic.