### PR TITLE
Make async_trait dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ crc16 = { version = "0.4", optional = true }
 rand = { version = "0.8", optional = true }
 # Only needed for async_std support
 async-std = { version = "1.5.0", optional = true}
-async-trait = "0.1.24"
+async-trait = { version = "0.1.24", optional = true }
 
 # Only needed for TLS
 native-tls = { version = "0.2", optional = true }
@@ -61,7 +61,7 @@ async-native-tls = { version = "0.3", optional = true }
 [features]
 default = ["acl", "streams", "geospatial", "script"]
 acl = []
-aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/alloc", "futures-util/sink", "tokio/io-util", "tokio-util", "tokio-util/codec", "tokio/sync", "combine/tokio"]
+aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/alloc", "futures-util/sink", "tokio/io-util", "tokio-util", "tokio-util/codec", "tokio/sync", "combine/tokio", "async-trait"]
 geospatial = []
 cluster = ["crc16", "rand"]
 script = ["sha1"]


### PR DESCRIPTION
I hope this is correct. I had issues when building with the following command line:

```
RUSTFLAGS="$RUSTFLAGS -D unused-crate-dependencies" cargo build
```