### PR TITLE
Impl `ToRedisArgs` for integers of size 128

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -718,6 +718,12 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
@@ -1192,7 +1198,7 @@ dependencies = [
  "fnv",
  "futures 0.3.17",
  "futures-util",
- "itoa",
+ "itoa 1.0.1",
  "native-tls",
  "partial-io",
  "percent-encoding",
@@ -1361,7 +1367,7 @@ version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
 dependencies = [
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 # much of a point to optimize these, but these could in theory be removed for
 # an indirection through std::Formatter.
 dtoa = "0.4"
-itoa = "0.4.3"
+itoa = "1.0.1"
 
 # This is a dependency that already exists in url
 percent-encoding = "2.1"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -204,7 +204,9 @@ where
     I: IntoIterator<Item = Arg<&'a [u8]>> + Clone + ExactSizeIterator,
 {
     cmd.write_all(b"*")?;
-    ::itoa::write(&mut *cmd, args.len())?;
+    let mut buffer = ::itoa::Buffer::new();
+    let args_len = buffer.format(args.len());
+    cmd.write_all(args_len.as_bytes())?;
     cmd.write_all(b"\r\n")?;
 
     let mut cursor_bytes = itoa::Buffer::new();
@@ -215,7 +217,8 @@ where
         };
 
         cmd.write_all(b"$")?;
-        ::itoa::write(&mut *cmd, bytes.len())?;
+        let bytes_len = buffer.format(bytes.len());
+        cmd.write_all(bytes_len.as_bytes())?;
         cmd.write_all(b"\r\n")?;
 
         cmd.write_all(bytes)?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -754,9 +754,9 @@ impl ToRedisArgs for u8 {
     where
         W: ?Sized + RedisWrite,
     {
-        let mut buf = [0u8; 3];
-        let n = ::itoa::write(&mut buf[..], *self).unwrap();
-        out.write_arg(&buf[..n])
+      let mut buf = ::itoa::Buffer::new();
+      let n = buf.format(*self);
+        out.write_arg(n.as_bytes())
     }
 
     fn make_arg_vec<W>(items: &[u8], out: &mut W)
@@ -778,6 +778,8 @@ itoa_based_to_redis_impl!(i32, NumericBehavior::NumberIsInteger);
 itoa_based_to_redis_impl!(u32, NumericBehavior::NumberIsInteger);
 itoa_based_to_redis_impl!(i64, NumericBehavior::NumberIsInteger);
 itoa_based_to_redis_impl!(u64, NumericBehavior::NumberIsInteger);
+itoa_based_to_redis_impl!(i128, NumericBehavior::NumberIsInteger);
+itoa_based_to_redis_impl!(u128, NumericBehavior::NumberIsInteger);
 itoa_based_to_redis_impl!(isize, NumericBehavior::NumberIsInteger);
 itoa_based_to_redis_impl!(usize, NumericBehavior::NumberIsInteger);
 
@@ -789,6 +791,8 @@ non_zero_itoa_based_to_redis_impl!(core::num::NonZeroU32, NumericBehavior::Numbe
 non_zero_itoa_based_to_redis_impl!(core::num::NonZeroI32, NumericBehavior::NumberIsInteger);
 non_zero_itoa_based_to_redis_impl!(core::num::NonZeroU64, NumericBehavior::NumberIsInteger);
 non_zero_itoa_based_to_redis_impl!(core::num::NonZeroI64, NumericBehavior::NumberIsInteger);
+non_zero_itoa_based_to_redis_impl!(core::num::NonZeroU128, NumericBehavior::NumberIsInteger);
+non_zero_itoa_based_to_redis_impl!(core::num::NonZeroI128, NumericBehavior::NumberIsInteger);
 non_zero_itoa_based_to_redis_impl!(core::num::NonZeroUsize, NumericBehavior::NumberIsInteger);
 non_zero_itoa_based_to_redis_impl!(core::num::NonZeroIsize, NumericBehavior::NumberIsInteger);
 


### PR DESCRIPTION
Implementing `ToRedisArgs` for `i128`, `u128`, `NonZeroI128` and `NonZeroU128` required changing the version of `itoa` from `0.4.3` to `1.0.*`, as the former doesn't implement its `Integer` trait for these types.

Aditionally, the interface of the `itoa` crate has changed between these two versions, making some of its uses in other parts of the code non functiona. This PR also fixes them.