### PR TITLE
Feat: GETEX and GETDEL Added

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -397,6 +397,16 @@ implement_commands! {
         cmd("PTTL").arg(key)
     }
 
+    /// Get the value of a key and set expiration
+    fn get_ex<K: ToRedisArgs>(key: K, seconds: usize) {
+        cmd("GETEX").arg(key).arg("EX").arg(seconds)
+    }
+
+    /// Get the value of a key and delete it
+    fn get_del<K: ToRedisArgs>(key: K) {
+        cmd("GETDEL").arg(key)
+    }
+
     /// Rename a key.
     fn rename<K: ToRedisArgs>(key: K, new_key: K) {
         cmd("RENAME").arg(key).arg(new_key)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,6 +372,8 @@ pub use crate::pipeline::Pipeline;
 #[cfg_attr(docsrs, doc(cfg(feature = "script")))]
 pub use crate::script::{Script, ScriptInvocation};
 
+// preserve grouping and order
+#[rustfmt::skip]
 pub use crate::types::{
     // utility functions
     from_redis_value,
@@ -385,6 +387,7 @@ pub use crate::types::{
     // utility types
     InfoDict,
     NumericBehavior,
+    Expiry,
 
     // error and result types
     RedisError,

--- a/src/types.rs
+++ b/src/types.rs
@@ -25,6 +25,20 @@ macro_rules! invalid_type_error_inner {
     };
 }
 
+/// Helper enum that is used to define expiry time
+pub enum Expiry {
+    /// EX seconds -- Set the specified expire time, in seconds.
+    EX(usize),
+    /// PX milliseconds -- Set the specified expire time, in milliseconds.
+    PX(usize),
+    /// EXAT timestamp-seconds -- Set the specified Unix time at which the key will expire, in seconds.
+    EXAT(usize),
+    /// PXAT timestamp-milliseconds -- Set the specified Unix time at which the key will expire, in milliseconds.
+    PXAT(usize),
+    /// PERSIST -- Remove the time to live associated with the key.
+    PERSIST,
+}
+
 /// Helper enum that is used in some situations to describe
 /// the behavior of arguments in a numeric context.
 #[derive(PartialEq, Eq, Clone, Debug, Copy)]


### PR DESCRIPTION
This PR adds the following commands:
1. [GETEX](https://redis.io/commands/getex) (Available since 6.2.0)
2. [GETDEL](https://redis.io/commands/getdel) (Available since 6.2.0)

Closes #485 