### PR TITLE
Update Command expiration values to be an appropriate type

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -93,12 +93,12 @@ implement_commands! {
     }
 
     /// Set the value and expiration of a key.
-    fn set_ex<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V, seconds: usize) {
+    fn set_ex<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V, seconds: u64) {
         cmd("SETEX").arg(key).arg(seconds).arg(value)
     }
 
     /// Set the value and expiration in milliseconds of a key.
-    fn pset_ex<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V, milliseconds: usize) {
+    fn pset_ex<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V, milliseconds: u64) {
         cmd("PSETEX").arg(key).arg(milliseconds).arg(value)
     }
 
@@ -138,22 +138,22 @@ implement_commands! {
     }
 
     /// Set a key's time to live in seconds.
-    fn expire<K: ToRedisArgs>(key: K, seconds: usize) {
+    fn expire<K: ToRedisArgs>(key: K, seconds: i64) {
         cmd("EXPIRE").arg(key).arg(seconds)
     }
 
     /// Set the expiration for a key as a UNIX timestamp.
-    fn expire_at<K: ToRedisArgs>(key: K, ts: usize) {
+    fn expire_at<K: ToRedisArgs>(key: K, ts: i64) {
         cmd("EXPIREAT").arg(key).arg(ts)
     }
 
     /// Set a key's time to live in milliseconds.
-    fn pexpire<K: ToRedisArgs>(key: K, ms: usize) {
+    fn pexpire<K: ToRedisArgs>(key: K, ms: i64) {
         cmd("PEXPIRE").arg(key).arg(ms)
     }
 
     /// Set the expiration for a key as a UNIX timestamp in milliseconds.
-    fn pexpire_at<K: ToRedisArgs>(key: K, ts: usize) {
+    fn pexpire_at<K: ToRedisArgs>(key: K, ts: i64) {
         cmd("PEXPIREAT").arg(key).arg(ts)
     }
 


### PR DESCRIPTION
This change updates expiration values provided to some commands in the `Command` trait to be of type `i64` or `u64` where appropriate, replacing the previously used `usize` type.

More specifically, the commands that are updated are

- SETEX, PSETEX
  - Expiration value changed from `usize` to `u64`
- EXPIRE, PEXPIRE, EXPIREAT, PEXPIREAT
  - Expiration value changed from `usize` to `i64`

For the `*SETEX` commands, there is no mention of supporting negative values. And indeed, providing a negative value through redis-cli returns an error message.

For the `*EXPIRE*` commands, I couldn't find the paragraph in the docs referenced in #575, nor any other mention that the commands accept a negative expiration argument. However, in testing with redis-cli it seems a negative expiration value is valid and in checking the code I found it to confirm these observations. See [here][code1] and [here][code2].

Note that this is a breaking change.

Closes #575 

[code1]: https://github.com/redis/redis/blob/e3ef73dc2a557232c60c732705e8e6ff2050eba9/src/expire.c#L570-L571
[code2]: https://github.com/redis/redis/blob/e3ef73dc2a557232c60c732705e8e6ff2050eba9/src/expire.c#L483-L491