### PR TITLE
[Feat]: Implement support for rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,6 +1178,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util 0.7.0",
  "url",
  "webpki-roots",
@@ -1557,6 +1558,17 @@ checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4151fda0cf2798550ad0b34bcfc9b9dcc2a9d2471c895c68f3a8818e54f2389e"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,6 +1171,7 @@ dependencies = [
  "quickcheck",
  "r2d2",
  "rand 0.8.5",
+ "rustls",
  "ryu",
  "sha1_smol",
  "socket2 0.3.19",
@@ -1179,6 +1180,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-util 0.7.0",
  "url",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1223,12 +1225,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -1270,6 +1299,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -1376,6 +1415,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "syn"
@@ -1570,6 +1615,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,6 +1751,25 @@ checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,8 @@ async-trait = "0.1.24"
 native-tls = { version = "0.2", optional = true }
 tokio-native-tls = { version = "0.3", optional = true }
 async-native-tls = { version = "0.4", optional = true }
+rustls = { version = "0.20.4", features = ["dangerous_configuration"], optional = true }
+webpki-roots = { version = "0.22.3", optional = true }
 
 [features]
 default = ["acl", "streams", "geospatial", "script"]
@@ -66,6 +68,7 @@ geospatial = []
 cluster = ["crc16", "rand"]
 script = ["sha1_smol"]
 tls = ["native-tls"]
+rustls = ["dep:rustls", "webpki-roots"]
 async-std-comp = ["aio", "async-std"]
 async-std-tls-comp = ["async-std-comp", "async-native-tls", "tls"]
 tokio-comp = ["aio", "tokio", "tokio/net"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,15 @@ rand = { version = "0.8", optional = true }
 async-std = { version = "1.5.0", optional = true}
 async-trait = "0.1.24"
 
-# Only needed for TLS
+# Only needed for native tls
 native-tls = { version = "0.2", optional = true }
 tokio-native-tls = { version = "0.3", optional = true }
 async-native-tls = { version = "0.4", optional = true }
+
+# Only needed for rustls
 rustls = { version = "0.20.4", features = ["dangerous_configuration"], optional = true }
 webpki-roots = { version = "0.22.3", optional = true }
+tokio-rustls = { version = "0.23.3", optional = true }
 
 [features]
 default = ["acl", "streams", "geospatial", "script"]
@@ -73,6 +76,7 @@ async-std-comp = ["aio", "async-std"]
 async-std-tls-comp = ["async-std-comp", "async-native-tls", "tls"]
 tokio-comp = ["aio", "tokio", "tokio/net"]
 tokio-native-tls-comp = ["tls", "tokio-native-tls"]
+tokio-rustls-comp = ["rustls", "tokio-rustls"]
 connection-manager = ["arc-swap", "futures", "aio"]
 streams = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ tokio-native-tls = { version = "0.3", optional = true }
 async-native-tls = { version = "0.4", optional = true }
 
 # Only needed for rustls
-rustls = { version = "0.20.4", features = ["dangerous_configuration"], optional = true }
+rustls = { version = "0.20.4", optional = true }
 webpki-roots = { version = "0.22.3", optional = true }
 tokio-rustls = { version = "0.23.3", optional = true }
 
@@ -72,6 +72,7 @@ cluster = ["crc16", "rand"]
 script = ["sha1_smol"]
 tls = ["native-tls"]
 rustls = ["dep:rustls", "webpki-roots"]
+rustls-insecure = ["rustls", "rustls/dangerous_configuration"]
 async-std-comp = ["aio", "async-std"]
 async-std-tls-comp = ["async-std-comp", "async-native-tls", "tls"]
 tokio-comp = ["aio", "tokio", "tokio/net"]

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -57,7 +57,7 @@ pub(crate) trait RedisRuntime: AsyncStream + Send + Sync + Sized + 'static {
     async fn connect_tcp(socket_addr: SocketAddr) -> RedisResult<Self>;
 
     // Performs a TCP TLS connection
-    #[cfg(feature = "tls")]
+    #[cfg(any(feature = "tls", feature = "rustls"))]
     async fn connect_tcp_tls(
         hostname: &str,
         socket_addr: SocketAddr,
@@ -460,7 +460,7 @@ pub(crate) async fn connect_simple<T: RedisRuntime>(
             <T>::connect_tcp(socket_addr).await?
         }
 
-        #[cfg(feature = "tls")]
+        #[cfg(any(feature = "tls", feature = "rustls"))]
         ConnectionAddr::TcpTls {
             ref host,
             port,
@@ -470,7 +470,7 @@ pub(crate) async fn connect_simple<T: RedisRuntime>(
             <T>::connect_tcp_tls(host, socket_addr, insecure).await?
         }
 
-        #[cfg(not(feature = "tls"))]
+        #[cfg(not(any(feature = "tls", feature = "rustls")))]
         ConnectionAddr::TcpTls { .. } => {
             fail!((
                 ErrorKind::InvalidClientConfig,

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -141,34 +141,31 @@ where
 
     /// Subscribes to a new channel.
     pub async fn subscribe<T: ToRedisArgs>(&mut self, channel: T) -> RedisResult<()> {
-        Ok(cmd("SUBSCRIBE")
-            .arg(channel)
-            .query_async(&mut self.0)
-            .await?)
+        cmd("SUBSCRIBE").arg(channel).query_async(&mut self.0).await
     }
 
     /// Subscribes to a new channel with a pattern.
     pub async fn psubscribe<T: ToRedisArgs>(&mut self, pchannel: T) -> RedisResult<()> {
-        Ok(cmd("PSUBSCRIBE")
+        cmd("PSUBSCRIBE")
             .arg(pchannel)
             .query_async(&mut self.0)
-            .await?)
+            .await
     }
 
     /// Unsubscribes from a channel.
     pub async fn unsubscribe<T: ToRedisArgs>(&mut self, channel: T) -> RedisResult<()> {
-        Ok(cmd("UNSUBSCRIBE")
+        cmd("UNSUBSCRIBE")
             .arg(channel)
             .query_async(&mut self.0)
-            .await?)
+            .await
     }
 
     /// Unsubscribes from a channel with a pattern.
     pub async fn punsubscribe<T: ToRedisArgs>(&mut self, pchannel: T) -> RedisResult<()> {
-        Ok(cmd("PUNSUBSCRIBE")
+        cmd("PUNSUBSCRIBE")
             .arg(pchannel)
             .query_async(&mut self.0)
-            .await?)
+            .await
     }
 
     /// Returns [`Stream`] of [`Msg`]s from this [`PubSub`]s subscriptions.
@@ -212,7 +209,7 @@ where
 
     /// Deliver the MONITOR command to this [`Monitor`]ing wrapper.
     pub async fn monitor(&mut self) -> RedisResult<()> {
-        Ok(cmd("MONITOR").query_async(&mut self.0).await?)
+        cmd("MONITOR").query_async(&mut self.0).await
     }
 
     /// Returns [`Stream`] of [`FromRedisValue`] values from this [`Monitor`]ing connection

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -141,31 +141,34 @@ where
 
     /// Subscribes to a new channel.
     pub async fn subscribe<T: ToRedisArgs>(&mut self, channel: T) -> RedisResult<()> {
-        cmd("SUBSCRIBE").arg(channel).query_async(&mut self.0).await
+        Ok(cmd("SUBSCRIBE")
+            .arg(channel)
+            .query_async(&mut self.0)
+            .await?)
     }
 
     /// Subscribes to a new channel with a pattern.
     pub async fn psubscribe<T: ToRedisArgs>(&mut self, pchannel: T) -> RedisResult<()> {
-        cmd("PSUBSCRIBE")
+        Ok(cmd("PSUBSCRIBE")
             .arg(pchannel)
             .query_async(&mut self.0)
-            .await
+            .await?)
     }
 
     /// Unsubscribes from a channel.
     pub async fn unsubscribe<T: ToRedisArgs>(&mut self, channel: T) -> RedisResult<()> {
-        cmd("UNSUBSCRIBE")
+        Ok(cmd("UNSUBSCRIBE")
             .arg(channel)
             .query_async(&mut self.0)
-            .await
+            .await?)
     }
 
     /// Unsubscribes from a channel with a pattern.
     pub async fn punsubscribe<T: ToRedisArgs>(&mut self, pchannel: T) -> RedisResult<()> {
-        cmd("PUNSUBSCRIBE")
+        Ok(cmd("PUNSUBSCRIBE")
             .arg(pchannel)
             .query_async(&mut self.0)
-            .await
+            .await?)
     }
 
     /// Returns [`Stream`] of [`Msg`]s from this [`PubSub`]s subscriptions.
@@ -209,7 +212,7 @@ where
 
     /// Deliver the MONITOR command to this [`Monitor`]ing wrapper.
     pub async fn monitor(&mut self) -> RedisResult<()> {
-        cmd("MONITOR").query_async(&mut self.0).await
+        Ok(cmd("MONITOR").query_async(&mut self.0).await?)
     }
 
     /// Returns [`Stream`] of [`FromRedisValue`] values from this [`Monitor`]ing connection

--- a/src/aio/tokio.rs
+++ b/src/aio/tokio.rs
@@ -19,15 +19,11 @@ use tokio::{
 use super::TlsConnector;
 
 #[cfg(feature = "rustls")]
-use crate::connection::NoCertificateVerification;
-#[cfg(feature = "rustls")]
-use rustls::{cipher_suite, kx_group, OwnedTrustAnchor, RootCertStore};
+use crate::connection::create_rustls_config;
 #[cfg(feature = "rustls")]
 use std::{convert::TryInto, sync::Arc};
 #[cfg(feature = "rustls")]
 use tokio_rustls::{client::TlsStream, TlsConnector};
-#[cfg(feature = "rustls")]
-use webpki_roots::TLS_SERVER_ROOTS;
 
 #[cfg(feature = "tokio-native-tls-comp")]
 use tokio_native_tls::TlsStream;
@@ -137,30 +133,7 @@ impl RedisRuntime for Tokio {
         socket_addr: SocketAddr,
         insecure: bool,
     ) -> RedisResult<Self> {
-        let mut root_store = RootCertStore::empty();
-        root_store.add_server_trust_anchors(TLS_SERVER_ROOTS.0.iter().map(|ta| {
-            OwnedTrustAnchor::from_subject_spki_name_constraints(
-                ta.subject,
-                ta.spki,
-                ta.name_constraints,
-            )
-        }));
-
-        let mut config = rustls::ClientConfig::builder()
-            .with_cipher_suites(&[cipher_suite::TLS13_CHACHA20_POLY1305_SHA256])
-            .with_kx_groups(&[&kx_group::X25519])
-            .with_protocol_versions(&[&rustls::version::TLS13])
-            .unwrap()
-            .with_root_certificates(root_store)
-            .with_no_client_auth();
-
-        if insecure {
-            config.enable_sni = false;
-            config
-                .dangerous()
-                .set_certificate_verifier(Arc::new(NoCertificateVerification))
-        }
-
+        let config = create_rustls_config(insecure)?;
         let tls_connector = TlsConnector::from(Arc::new(config));
 
         Ok(tls_connector

--- a/src/aio/tokio.rs
+++ b/src/aio/tokio.rs
@@ -18,6 +18,17 @@ use tokio::{
 #[cfg(feature = "tls")]
 use super::TlsConnector;
 
+#[cfg(feature = "rustls")]
+use crate::connection::NoCertificateVerification;
+#[cfg(feature = "rustls")]
+use rustls::{cipher_suite, kx_group, OwnedTrustAnchor, RootCertStore};
+#[cfg(feature = "rustls")]
+use std::{convert::TryInto, sync::Arc};
+#[cfg(feature = "rustls")]
+use tokio_rustls::{client::TlsStream, TlsConnector};
+#[cfg(feature = "rustls")]
+use webpki_roots::TLS_SERVER_ROOTS;
+
 #[cfg(feature = "tokio-native-tls-comp")]
 use tokio_native_tls::TlsStream;
 
@@ -28,7 +39,7 @@ pub(crate) enum Tokio {
     /// Represents a Tokio TCP connection.
     Tcp(TcpStreamTokio),
     /// Represents a Tokio TLS encrypted TCP connection
-    #[cfg(feature = "tokio-native-tls-comp")]
+    #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
     TcpTls(TlsStream<TcpStreamTokio>),
     /// Represents a Tokio Unix connection.
     #[cfg(unix)]
@@ -43,7 +54,7 @@ impl AsyncWrite for Tokio {
     ) -> Poll<io::Result<usize>> {
         match &mut *self {
             Tokio::Tcp(r) => Pin::new(r).poll_write(cx, buf),
-            #[cfg(feature = "tokio-native-tls-comp")]
+            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
             Tokio::TcpTls(r) => Pin::new(r).poll_write(cx, buf),
             #[cfg(unix)]
             Tokio::Unix(r) => Pin::new(r).poll_write(cx, buf),
@@ -53,7 +64,7 @@ impl AsyncWrite for Tokio {
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<io::Result<()>> {
         match &mut *self {
             Tokio::Tcp(r) => Pin::new(r).poll_flush(cx),
-            #[cfg(feature = "tokio-native-tls-comp")]
+            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
             Tokio::TcpTls(r) => Pin::new(r).poll_flush(cx),
             #[cfg(unix)]
             Tokio::Unix(r) => Pin::new(r).poll_flush(cx),
@@ -63,7 +74,7 @@ impl AsyncWrite for Tokio {
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<io::Result<()>> {
         match &mut *self {
             Tokio::Tcp(r) => Pin::new(r).poll_shutdown(cx),
-            #[cfg(feature = "tokio-native-tls-comp")]
+            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
             Tokio::TcpTls(r) => Pin::new(r).poll_shutdown(cx),
             #[cfg(unix)]
             Tokio::Unix(r) => Pin::new(r).poll_shutdown(cx),
@@ -79,7 +90,7 @@ impl AsyncRead for Tokio {
     ) -> Poll<io::Result<()>> {
         match &mut *self {
             Tokio::Tcp(r) => Pin::new(r).poll_read(cx, buf),
-            #[cfg(feature = "tokio-native-tls-comp")]
+            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
             Tokio::TcpTls(r) => Pin::new(r).poll_read(cx, buf),
             #[cfg(unix)]
             Tokio::Unix(r) => Pin::new(r).poll_read(cx, buf),
@@ -95,7 +106,7 @@ impl RedisRuntime for Tokio {
             .map(Tokio::Tcp)?)
     }
 
-    #[cfg(feature = "tls")]
+    #[cfg(all(feature = "tls", not(feature = "rustls")))]
     async fn connect_tcp_tls(
         hostname: &str,
         socket_addr: SocketAddr,
@@ -117,6 +128,58 @@ impl RedisRuntime for Tokio {
             .map(Tokio::TcpTls)?)
     }
 
+    #[cfg(all(feature = "rustls", not(feature = "tls")))]
+    async fn connect_tcp_tls(
+        hostname: &str,
+        socket_addr: SocketAddr,
+        insecure: bool,
+    ) -> RedisResult<Self> {
+        let mut root_store = RootCertStore::empty();
+        root_store.add_server_trust_anchors(TLS_SERVER_ROOTS.0.iter().map(|ta| {
+            OwnedTrustAnchor::from_subject_spki_name_constraints(
+                ta.subject,
+                ta.spki,
+                ta.name_constraints,
+            )
+        }));
+
+        let mut config = rustls::ClientConfig::builder()
+            .with_cipher_suites(&[cipher_suite::TLS13_CHACHA20_POLY1305_SHA256])
+            .with_kx_groups(&[&kx_group::X25519])
+            .with_protocol_versions(&[&rustls::version::TLS13])
+            .unwrap()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
+
+        if insecure {
+            config.enable_sni = false;
+            config
+                .dangerous()
+                .set_certificate_verifier(Arc::new(NoCertificateVerification))
+        }
+
+        let tls_connector = TlsConnector::from(Arc::new(config));
+
+        Ok(tls_connector
+            .connect(
+                hostname.try_into()?,
+                TcpStreamTokio::connect(&socket_addr).await?,
+            )
+            .await
+            .map(Tokio::TcpTls)?)
+    }
+    #[cfg(all(feature = "rustls", feature = "tls"))]
+    async fn connect_tcp_tls(
+        _hostname: &str,
+        _socket_addr: SocketAddr,
+        _insecure: bool,
+    ) -> RedisResult<Self> {
+        fail!((
+            ErrorKind::InvalidClientConfig,
+            "Cannot have both `tls` and `rustls` features active at the same time"
+        ));
+    }
+
     #[cfg(unix)]
     async fn connect_unix(path: &Path) -> RedisResult<Self> {
         Ok(UnixStreamTokio::connect(path).await.map(Tokio::Unix)?)
@@ -135,7 +198,7 @@ impl RedisRuntime for Tokio {
     fn boxed(self) -> Pin<Box<dyn AsyncStream + Send + Sync>> {
         match self {
             Tokio::Tcp(x) => Box::pin(x),
-            #[cfg(feature = "tokio-native-tls-comp")]
+            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
             Tokio::TcpTls(x) => Box::pin(x),
             #[cfg(unix)]
             Tokio::Unix(x) => Box::pin(x),

--- a/src/aio/tokio.rs
+++ b/src/aio/tokio.rs
@@ -127,7 +127,7 @@ impl RedisRuntime for Tokio {
             .map(Tokio::TcpTls)?)
     }
 
-    #[cfg(all(feature = "rustls", not(feature = "tls")))]
+    #[cfg(feature = "rustls")]
     async fn connect_tcp_tls(
         hostname: &str,
         socket_addr: SocketAddr,
@@ -143,17 +143,6 @@ impl RedisRuntime for Tokio {
             )
             .await
             .map(Tokio::TcpTls)?)
-    }
-    #[cfg(all(feature = "rustls", feature = "tls"))]
-    async fn connect_tcp_tls(
-        _hostname: &str,
-        _socket_addr: SocketAddr,
-        _insecure: bool,
-    ) -> RedisResult<Self> {
-        fail!((
-            ErrorKind::InvalidClientConfig,
-            "Cannot have both `tls` and `rustls` features active at the same time"
-        ));
     }
 
     #[cfg(unix)]

--- a/src/aio/tokio.rs
+++ b/src/aio/tokio.rs
@@ -35,6 +35,9 @@ use tokio_native_tls::TlsStream;
 #[cfg(unix)]
 use super::Path;
 
+// The rustls implementation of TlsStream is a larger enum, but it will only exist if the "rustls"
+// feature is enabled, and in that case, it should be the variant that is used.
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum Tokio {
     /// Represents a Tokio TCP connection.
     Tcp(TcpStreamTokio),

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -461,7 +461,7 @@ impl ActualConnection {
                     open: true,
                 })
             }
-            #[cfg(all(feature = "rustls", not(feature = "tls")))]
+            #[cfg(feature = "rustls")]
             ConnectionAddr::TcpTls {
                 ref host,
                 port,
@@ -505,13 +505,6 @@ impl ActualConnection {
                 };
 
                 ActualConnection::TcpRustls(TcpRustlsConnection { reader, open: true })
-            }
-            #[cfg(all(feature = "tls", feature = "rustls"))]
-            ConnectionAddr::TcpTls { .. } => {
-                fail!((
-                    ErrorKind::InvalidClientConfig,
-                    "Cannot have both `tls` and `rustls` features active at the same time"
-                ));
             }
             #[cfg(not(any(feature = "tls", feature = "rustls")))]
             ConnectionAddr::TcpTls { .. } => {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -19,7 +19,7 @@ use std::os::unix::net::UnixStream;
 use native_tls::{TlsConnector, TlsStream};
 
 #[cfg(feature = "rustls")]
-use rustls::{cipher_suite, kx_group, OwnedTrustAnchor, RootCertStore, StreamOwned};
+use rustls::{OwnedTrustAnchor, RootCertStore, StreamOwned};
 #[cfg(feature = "rustls")]
 use std::{convert::TryInto, sync::Arc};
 #[cfg(feature = "rustls")]
@@ -659,10 +659,9 @@ pub(crate) fn create_rustls_config(insecure: bool) -> RedisResult<rustls::Client
     }));
 
     let mut config = rustls::ClientConfig::builder()
-        .with_cipher_suites(&[cipher_suite::TLS13_CHACHA20_POLY1305_SHA256])
-        .with_kx_groups(&[&kx_group::X25519])
-        .with_protocol_versions(&[&rustls::version::TLS13])
-        .unwrap()
+        .with_safe_default_cipher_suites()
+        .with_safe_default_kx_groups()
+        .with_protocol_versions(rustls::ALL_VERSIONS)?
         .with_root_certificates(root_store)
         .with_no_client_auth();
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -319,7 +319,7 @@ enum ActualConnection {
 }
 
 #[cfg(feature = "rustls")]
-struct NoCertificateVerification;
+pub(crate) struct NoCertificateVerification;
 
 #[cfg(feature = "rustls")]
 impl rustls::client::ServerCertVerifier for NoCertificateVerification {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -319,7 +319,7 @@ enum ActualConnection {
 }
 
 #[cfg(feature = "rustls")]
-pub(crate) struct NoCertificateVerification;
+struct NoCertificateVerification;
 
 #[cfg(feature = "rustls")]
 impl rustls::client::ServerCertVerifier for NoCertificateVerification {
@@ -468,30 +468,7 @@ impl ActualConnection {
                 insecure,
             } => {
                 let host: &str = &*host;
-                let mut root_store = RootCertStore::empty();
-                root_store.add_server_trust_anchors(TLS_SERVER_ROOTS.0.iter().map(|ta| {
-                    OwnedTrustAnchor::from_subject_spki_name_constraints(
-                        ta.subject,
-                        ta.spki,
-                        ta.name_constraints,
-                    )
-                }));
-
-                let mut config = rustls::ClientConfig::builder()
-                    .with_cipher_suites(&[cipher_suite::TLS13_CHACHA20_POLY1305_SHA256])
-                    .with_kx_groups(&[&kx_group::X25519])
-                    .with_protocol_versions(&[&rustls::version::TLS13])
-                    .unwrap()
-                    .with_root_certificates(root_store)
-                    .with_no_client_auth();
-
-                if insecure {
-                    config.enable_sni = false;
-                    config
-                        .dangerous()
-                        .set_certificate_verifier(Arc::new(NoCertificateVerification))
-                }
-
+                let config = create_rustls_config(insecure)?;
                 let conn = rustls::ClientConnection::new(Arc::new(config), host.try_into()?)?;
                 let reader = match timeout {
                     None => {
@@ -668,6 +645,34 @@ impl ActualConnection {
             ActualConnection::Unix(UnixConnection { open, .. }) => open,
         }
     }
+}
+
+#[cfg(feature = "rustls")]
+pub(crate) fn create_rustls_config(insecure: bool) -> RedisResult<rustls::ClientConfig> {
+    let mut root_store = RootCertStore::empty();
+    root_store.add_server_trust_anchors(TLS_SERVER_ROOTS.0.iter().map(|ta| {
+        OwnedTrustAnchor::from_subject_spki_name_constraints(
+            ta.subject,
+            ta.spki,
+            ta.name_constraints,
+        )
+    }));
+
+    let mut config = rustls::ClientConfig::builder()
+        .with_cipher_suites(&[cipher_suite::TLS13_CHACHA20_POLY1305_SHA256])
+        .with_kx_groups(&[&kx_group::X25519])
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .unwrap()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+
+    if insecure {
+        config.enable_sni = false;
+        config
+            .dangerous()
+            .set_certificate_verifier(Arc::new(NoCertificateVerification))
+    }
+    Ok(config)
 }
 
 fn connect_auth(con: &mut Connection, connection_info: &RedisConnectionInfo) -> RedisResult<()> {

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -432,10 +432,10 @@ impl StreamId {
         let mut stream_id = StreamId::default();
         if let Value::Bulk(ref values) = *v {
             if let Some(v) = values.get(0) {
-                stream_id.id = from_redis_value(&v)?;
+                stream_id.id = from_redis_value(v)?;
             }
             if let Some(v) = values.get(1) {
-                stream_id.map = from_redis_value(&v)?;
+                stream_id.map = from_redis_value(v)?;
             }
         }
 
@@ -446,7 +446,7 @@ impl StreamId {
     /// type.
     pub fn get<T: FromRedisValue>(&self, key: &str) -> Option<T> {
         match self.map.get(key) {
-            Some(ref x) => from_redis_value(*x).ok(),
+            Some(x) => from_redis_value(x).ok(),
             None => None,
         }
     }

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -432,10 +432,10 @@ impl StreamId {
         let mut stream_id = StreamId::default();
         if let Value::Bulk(ref values) = *v {
             if let Some(v) = values.get(0) {
-                stream_id.id = from_redis_value(v)?;
+                stream_id.id = from_redis_value(&v)?;
             }
             if let Some(v) = values.get(1) {
-                stream_id.map = from_redis_value(v)?;
+                stream_id.map = from_redis_value(&v)?;
             }
         }
 
@@ -446,7 +446,7 @@ impl StreamId {
     /// type.
     pub fn get<T: FromRedisValue>(&self, key: &str) -> Option<T> {
         match self.map.get(key) {
-            Some(x) => from_redis_value(x).ok(),
+            Some(ref x) => from_redis_value(*x).ok(),
             None => None,
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -364,7 +364,7 @@ impl RedisError {
             ErrorKind::MasterDown => Some("MASTERDOWN"),
             ErrorKind::ReadOnly => Some("READONLY"),
             _ => match self.repr {
-                ErrorRepr::ExtensionError(ref code, _) => Some(&code),
+                ErrorRepr::ExtensionError(ref code, _) => Some(code),
                 _ => None,
             },
         }
@@ -479,7 +479,7 @@ impl RedisError {
     #[deprecated(note = "use code() instead")]
     pub fn extension_error_code(&self) -> Option<&str> {
         match self.repr {
-            ErrorRepr::ExtensionError(ref code, _) => Some(&code),
+            ErrorRepr::ExtensionError(ref code, _) => Some(code),
             _ => None,
         }
     }
@@ -574,7 +574,7 @@ impl InfoDict {
     /// Typical types are `String`, `bool` and integer types.
     pub fn get<T: FromRedisValue>(&self, key: &str) -> Option<T> {
         match self.find(&key) {
-            Some(ref x) => from_redis_value(*x).ok(),
+            Some(x) => from_redis_value(x).ok(),
             None => None,
         }
     }
@@ -607,7 +607,7 @@ pub trait RedisWrite {
 
     /// Accepts a serialized redis command.
     fn write_arg_fmt(&mut self, arg: impl fmt::Display) {
-        self.write_arg(&arg.to_string().as_bytes())
+        self.write_arg(arg.to_string().as_bytes())
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -260,6 +260,32 @@ impl From<native_tls::Error> for RedisError {
     }
 }
 
+#[cfg(feature = "rustls")]
+impl From<rustls::Error> for RedisError {
+    fn from(err: rustls::Error) -> RedisError {
+        RedisError {
+            repr: ErrorRepr::WithDescriptionAndDetail(
+                ErrorKind::IoError,
+                "TLS error",
+                err.to_string(),
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "rustls")]
+impl From<rustls::client::InvalidDnsNameError> for RedisError {
+    fn from(err: rustls::client::InvalidDnsNameError) -> RedisError {
+        RedisError {
+            repr: ErrorRepr::WithDescriptionAndDetail(
+                ErrorKind::IoError,
+                "TLS Error",
+                err.to_string(),
+            ),
+        }
+    }
+}
+
 impl From<FromUtf8Error> for RedisError {
     fn from(_: FromUtf8Error) -> RedisError {
         RedisError {

--- a/src/types.rs
+++ b/src/types.rs
@@ -390,7 +390,7 @@ impl RedisError {
             ErrorKind::MasterDown => Some("MASTERDOWN"),
             ErrorKind::ReadOnly => Some("READONLY"),
             _ => match self.repr {
-                ErrorRepr::ExtensionError(ref code, _) => Some(code),
+                ErrorRepr::ExtensionError(ref code, _) => Some(&code),
                 _ => None,
             },
         }
@@ -505,7 +505,7 @@ impl RedisError {
     #[deprecated(note = "use code() instead")]
     pub fn extension_error_code(&self) -> Option<&str> {
         match self.repr {
-            ErrorRepr::ExtensionError(ref code, _) => Some(code),
+            ErrorRepr::ExtensionError(ref code, _) => Some(&code),
             _ => None,
         }
     }
@@ -600,7 +600,7 @@ impl InfoDict {
     /// Typical types are `String`, `bool` and integer types.
     pub fn get<T: FromRedisValue>(&self, key: &str) -> Option<T> {
         match self.find(&key) {
-            Some(x) => from_redis_value(x).ok(),
+            Some(ref x) => from_redis_value(*x).ok(),
             None => None,
         }
     }
@@ -633,7 +633,7 @@ pub trait RedisWrite {
 
     /// Accepts a serialized redis command.
     fn write_arg_fmt(&mut self, arg: impl fmt::Display) {
-        self.write_arg(arg.to_string().as_bytes())
+        self.write_arg(&arg.to_string().as_bytes())
     }
 }
 


### PR DESCRIPTION
This PR will add support for tls connections using rustls under the "rustls" feature flag. It also adds support for tokio rustls under the "tokio-rustls-comp" flag.

Any feedback is greatly appreciated!
Resolves #574.