### PR TITLE
Add Script::load function

### DIFF
--- a/src/script.rs
+++ b/src/script.rs
@@ -183,4 +183,34 @@ impl<'a> ScriptInvocation<'a> {
             }
         }
     }
+
+    /// Loads the script and returns the SHA1 of it.
+    #[inline]
+    pub fn load(&self, con: &mut dyn ConnectionLike) -> RedisResult<String> {
+        let hash: String = cmd("SCRIPT")
+            .arg("LOAD")
+            .arg(self.script.code.as_bytes())
+            .query(con)?;
+
+        debug_assert_eq!(hash, self.script.hash);
+
+        Ok(hash)
+    }
+
+    /// Asynchronously loads the script and returns the SHA1 of it.
+    #[inline]
+    #[cfg(feature = "aio")]
+    pub async fn load_async<C>(&self, con: &mut C) -> RedisResult<String>
+    where
+        C: crate::aio::ConnectionLike,
+    {
+        let hash: String = cmd("SCRIPT")
+            .arg("LOAD")
+            .arg(self.script.code.as_bytes())
+            .query_async(con).await?;
+
+        debug_assert_eq!(hash, self.script.hash);
+
+        Ok(hash)
+    }
 }

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -354,19 +354,14 @@ fn test_script() {
 #[cfg(feature = "script")]
 fn test_script_load() {
     let ctx = TestContext::new();
-    let mut con = ctx.connection();
-
     let script = redis::Script::new("return 'Hello World'");
 
     block_on_all(async move {
-        let mut con = ctx.multiplexed_async_connection().await?;
+        let mut con = ctx.multiplexed_async_connection().await.unwrap();
 
-        let hash = script.prepare_invoke().load_async(&mut con);
-        assert_eq!(hash, Ok(script.get_hash().to_string()));
-
-        Ok(())
-    })
-    .unwrap();
+        let hash = script.prepare_invoke().load_async(&mut con).await.unwrap();
+        assert_eq!(hash, script.get_hash().to_string());
+    });
 }
 
 #[test]

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -352,6 +352,25 @@ fn test_script() {
 
 #[test]
 #[cfg(feature = "script")]
+fn test_script_load() {
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+
+    let script = redis::Script::new("return 'Hello World'");
+
+    block_on_all(async move {
+        let mut con = ctx.multiplexed_async_connection().await?;
+
+        let hash = script.prepare_invoke().load_async(&mut con);
+        assert_eq!(hash, Ok(script.get_hash().to_string()));
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+#[cfg(feature = "script")]
 fn test_script_returning_complex_type() {
     let ctx = TestContext::new();
     block_on_all(async {

--- a/tests/test_async_async_std.rs
+++ b/tests/test_async_async_std.rs
@@ -288,6 +288,25 @@ fn test_script() {
 
 #[test]
 #[cfg(feature = "script")]
+fn test_script_load() {
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+
+    let script = redis::Script::new("return 'Hello World'");
+
+    block_on_all(async move {
+        let mut con = ctx.multiplexed_async_connection_async_std().await?;
+
+        let hash = script.prepare_invoke().load_async(&mut con);
+        assert_eq!(hash, Ok(script.get_hash().to_string()));
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+#[cfg(feature = "script")]
 fn test_script_returning_complex_type() {
     let ctx = TestContext::new();
     block_on_all_using_async_std(async {

--- a/tests/test_async_async_std.rs
+++ b/tests/test_async_async_std.rs
@@ -295,14 +295,11 @@ fn test_script_load() {
     let script = redis::Script::new("return 'Hello World'");
 
     block_on_all(async move {
-        let mut con = ctx.multiplexed_async_connection_async_std().await?;
+        let mut con = ctx.multiplexed_async_connection_async_std().await.unwrap();
 
-        let hash = script.prepare_invoke().load_async(&mut con);
-        assert_eq!(hash, Ok(script.get_hash().to_string()));
-
-        Ok(())
-    })
-    .unwrap();
+        let hash = script.prepare_invoke().load_async(&mut con).await.unwrap();
+        assert_eq!(hash, script.get_hash().to_string());
+    });
 }
 
 #[test]

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -678,6 +678,19 @@ fn test_script() {
 }
 
 #[test]
+#[cfg(feature = "script")]
+fn test_script_load() {
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+
+    let script = redis::Script::new("return 'Hello World'");
+
+    let hash = script.prepare_invoke().load(&mut con);
+
+    assert_eq!(hash, Ok(script.get_hash().to_string()));
+}
+
+#[test]
 fn test_tuple_args() {
     let ctx = TestContext::new();
     let mut con = ctx.connection();


### PR DESCRIPTION
Hi there

This PR exposes a load function to not do it manually.
It also changes a repeat logic in sync version of `Script::invoke` to limit the repeat cycle to 2 attempts (The same way as is done in async version).

Take care.