### PR TITLE
Return errors from parsing inner items

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1014,10 +1014,10 @@ pub trait FromRedisValue: Sized {
     /// from another vector of values.  This primarily exists internally
     /// to customize the behavior for vectors of tuples.
     fn from_redis_values(items: &[Value]) -> RedisResult<Vec<Self>> {
-        Ok(items
+        items
             .iter()
-            .filter_map(|item| FromRedisValue::from_redis_value(item).ok())
-            .collect())
+            .map(FromRedisValue::from_redis_value)
+            .collect()
     }
 
     /// This only exists internally as a workaround for the lack of

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -235,12 +235,12 @@ fn test_filtered_scanning() {
         }
     }
 
-    let iter = con.hscan_match("foo", "key_0_*").unwrap();
+    let iter = con
+        .hscan_match::<&str, &str, (String, usize)>("foo", "key_0_*")
+        .unwrap();
 
-    for x in iter {
-        // type inference limitations
-        let x: usize = x;
-        unseen.remove(&x);
+    for (_field, value) in iter {
+        unseen.remove(&value);
     }
 
     assert_eq!(unseen.len(), 0);


### PR DESCRIPTION
Thanks to @doyshinda for pointing this out in #585.

Fixes #587.