### PR TITLE
Fix return type of iter in test_filtered_scanning

### DIFF
--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -235,12 +235,12 @@ fn test_filtered_scanning() {
         }
     }
 
-    let iter = con.hscan_match("foo", "key_0_*").unwrap();
+    let iter = con
+        .hscan_match::<&str, &str, (String, usize)>("foo", "key_0_*")
+        .unwrap();
 
-    for x in iter {
-        // type inference limitations
-        let x: usize = x;
-        unseen.remove(&x);
+    for (_field, value) in iter {
+        unseen.remove(&value);
     }
 
     assert_eq!(unseen.len(), 0);


### PR DESCRIPTION
https://github.com/redis-rs/redis-rs/pull/608 changes the `iter` behavior makes these wrong assumed types now causing tests to fail.

The correct return type for HSCAN is (String, usize) as the field name is returned along the value of that field.