### PR TITLE
use 2021 edition of Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/mitsuhiko/redis-rs"
 repository = "https://github.com/mitsuhiko/redis-rs"
 documentation = "https://docs.rs/redis"
 license = "BSD-3-Clause"
-edition = "2018"
+edition = "2021"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Use the 2021 edition of Rust.