### PR TITLE
remove unused import of `Deref` since already covered by `DerefMut`

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::io::{self, Write};
 use std::net::{self, TcpStream, ToSocketAddrs};
-use std::ops::{Deref, DerefMut};
+use std::ops::DerefMut;
 use std::path::PathBuf;
 use std::str::{from_utf8, FromStr};
 use std::time::Duration;


### PR DESCRIPTION
Remove the unnecessary import of `std::ops::Deref` which was triggering a clippy lint because access to the `.deref` method is already covered by the import of `std::ops::DerefMut`.