### PR TITLE
[WIP] update redis::aio::ConnectionLike to accept Bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,9 @@ sha1_smol = { version = "1.0", optional = true }
 
 combine = { version = "4.6", default-features = false, features = ["std"] }
 
+bytes = { version = "1" }
+
 # Only needed for AIO
-bytes = { version = "1", optional = true }
 futures-util = { version = "0.3.15", default-features = false, optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 tokio-util = { version = "0.7", optional = true }
@@ -60,7 +61,7 @@ async-native-tls = { version = "0.4", optional = true }
 [features]
 default = ["acl", "streams", "geospatial", "script"]
 acl = []
-aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/alloc", "futures-util/sink", "tokio/io-util", "tokio-util", "tokio-util/codec", "tokio/sync", "combine/tokio", "async-trait"]
+aio = ["pin-project-lite", "futures-util", "futures-util/alloc", "futures-util/sink", "tokio/io-util", "tokio-util", "tokio-util/codec", "tokio/sync", "combine/tokio", "async-trait"]
 geospatial = []
 cluster = ["crc16", "rand"]
 script = ["sha1_smol"]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -155,7 +155,7 @@ where
 mod aio_support {
     use super::*;
 
-    use bytes::{Buf, BytesMut};
+    use bytes::{Buf, Bytes, BytesMut};
     use tokio::io::AsyncRead;
     use tokio_util::codec::{Decoder, Encoder};
 
@@ -201,6 +201,14 @@ mod aio_support {
     impl Encoder<Vec<u8>> for ValueCodec {
         type Error = RedisError;
         fn encode(&mut self, item: Vec<u8>, dst: &mut BytesMut) -> Result<(), Self::Error> {
+            dst.extend_from_slice(item.as_ref());
+            Ok(())
+        }
+    }
+
+    impl Encoder<Bytes> for ValueCodec {
+        type Error = RedisError;
+        fn encode(&mut self, item: Bytes, dst: &mut BytesMut) -> Result<(), Self::Error> {
             dst.extend_from_slice(item.as_ref());
             Ok(())
         }


### PR DESCRIPTION
This PR teaches the `redis::aio::ConnectionLike` trait to accept prepacked Redis commands. The synchronous trait `redis::connection::ConnectionLike` already accepts prepacked commands because its `req_packed_command` and `req_packed_commands` methods take a `&[u8]` slice.

The asynchronous trait, however, despite having methods with the same names, takes references `&Cmd` or &Pipeline` respectively, which are not prepacked. The prevents using the async support in this crate for use cases like the ones described in https://github.com/redis-rs/redis-rs/issues/615.

Breaking changes:
- Change the `&Cmd` argment to `req_packed_command` and `&Pipeline` argument to `req_packed_commands` to both take a `Bytes` with a prepacked command.
- Add `req_command` and `req_pipeline` methods to `redis::aio::ConnectionLike` to allow existing users to continue to be able to pass in a `&Cmd` or `&Pipeline`.