### PR TITLE
Split stream async pubsub, and impl Stream for PubSub

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -83,7 +83,7 @@ log = { version = "0.4", optional = true }
 [features]
 default = ["acl", "streams", "geospatial", "script", "keep-alive"]
 acl = []
-aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/alloc", "futures-util/sink", "tokio/io-util", "tokio-util", "tokio-util/codec", "tokio/sync", "combine/tokio", "async-trait"]
+aio = ["bytes", "pin-project-lite", "futures", "futures-util", "futures-util/alloc", "futures-util/sink", "tokio/io-util", "tokio-util", "tokio-util/codec", "tokio/sync", "combine/tokio", "async-trait"]
 geospatial = []
 json = ["serde", "serde/derive", "serde_json"]
 cluster = ["crc16", "rand"]

--- a/redis/examples/async-pub-sub.rs
+++ b/redis/examples/async-pub-sub.rs
@@ -1,4 +1,4 @@
-use futures_util::StreamExt as _;
+use futures_util::StreamExt;
 use redis::AsyncCommands;
 
 #[tokio::main]
@@ -8,12 +8,20 @@ async fn main() -> redis::RedisResult<()> {
     let mut pubsub_conn = client.get_async_connection().await?.into_pubsub();
 
     pubsub_conn.subscribe("wavephone").await?;
-    let mut pubsub_stream = pubsub_conn.on_message();
-
     publish_conn.publish("wavephone", "banana").await?;
 
-    let pubsub_msg: String = pubsub_stream.next().await.unwrap().get_payload()?;
+    let pubsub_msg: String = pubsub_conn.next().await.unwrap().get_payload()?;
     assert_eq!(&pubsub_msg, "banana");
+
+    let (mut sink, mut stream) = pubsub_conn.split();
+
+    let pubsub_msg = tokio::spawn(async move { stream.next().await });
+
+    sink.subscribe("wavephone2").await?;
+    publish_conn.publish("wavephone2", "apple").await?;
+
+    let pubsub_payload: String = pubsub_msg.await.unwrap().unwrap().get_payload::<String>()?;
+    assert_eq!(&pubsub_payload, "apple");
 
     Ok(())
 }

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -129,6 +129,10 @@ pub enum ErrorKind {
     EmptySentinelList,
     /// Attempted to kill a script/function while they werent' executing
     NotBusy,
+    /// Response was dropped
+    ResponseDropped,
+    /// Failed to forward response to split pubsub
+    ResponseForwardError,
 
     #[cfg(feature = "json")]
     /// Error Serializing a struct to JSON form
@@ -502,6 +506,8 @@ impl RedisError {
             ErrorKind::NoValidReplicasFoundBySentinel => "no valid replicas found by sentinel",
             ErrorKind::EmptySentinelList => "empty sentinel list",
             ErrorKind::NotBusy => "not busy",
+            ErrorKind::ResponseDropped => "response dropped",
+            ErrorKind::ResponseForwardError => "response forward error",
             #[cfg(feature = "json")]
             ErrorKind::Serialize => "serializing",
         }
@@ -653,6 +659,8 @@ impl RedisError {
             ErrorKind::ClientError => false,
             ErrorKind::EmptySentinelList => false,
             ErrorKind::NotBusy => false,
+            ErrorKind::ResponseDropped => false,
+            ErrorKind::ResponseForwardError => false,
             #[cfg(feature = "json")]
             ErrorKind::Serialize => false,
         }

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -503,6 +503,8 @@ mod pub_sub {
     use std::collections::HashMap;
     use std::time::Duration;
 
+    use tokio::spawn;
+
     use super::*;
 
     #[test]
@@ -513,12 +515,67 @@ mod pub_sub {
         block_on_all(async move {
             let mut pubsub_conn = ctx.async_connection().await?.into_pubsub();
             pubsub_conn.subscribe("phonewave").await?;
-            let mut pubsub_stream = pubsub_conn.on_message();
+
             let mut publish_conn = ctx.async_connection().await?;
             publish_conn.publish("phonewave", "banana").await?;
 
-            let msg_payload: String = pubsub_stream.next().await.unwrap().get_payload()?;
+            let msg_payload: String = pubsub_conn.next().await.unwrap().get_payload()?;
+
             assert_eq!("banana".to_string(), msg_payload);
+
+            Ok::<_, RedisError>(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn split_pub_sub_subscription() {
+        use redis::RedisError;
+
+        let ctx = TestContext::new();
+        block_on_all(async move {
+            let (mut sink, mut stream) = ctx.async_connection().await?.into_pubsub().split();
+
+            let msg = spawn(async move { stream.next().await });
+
+            sink.subscribe("phonewave").await?;
+
+            let mut pubsub_conn = ctx.async_connection().await?;
+
+            pubsub_conn.publish("phonewave", "banana").await?;
+
+            assert_eq!(
+                "banana".to_string(),
+                msg.await.unwrap().unwrap().get_payload::<String>()?
+            );
+
+            Ok::<_, RedisError>(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn split_pub_sub_subscription_with_drop() {
+        use redis::RedisError;
+
+        let ctx = TestContext::new();
+        block_on_all(async move {
+            let (mut sink, mut stream) = ctx.async_connection().await?.into_pubsub().split();
+
+            let msg = spawn(async move { stream.next().await });
+
+            sink.subscribe("phonewave").await?;
+
+            drop(sink);
+
+            let mut pubsub_conn = ctx.async_connection().await?;
+
+            pubsub_conn.publish("phonewave", "banana").await?;
+
+            assert_eq!(
+                "banana".to_string(),
+                msg.await.unwrap().unwrap().get_payload::<String>()?
+            );
 
             Ok::<_, RedisError>(())
         })
@@ -536,6 +593,35 @@ mod pub_sub {
             let mut pubsub_conn = ctx.async_connection().await?.into_pubsub();
             pubsub_conn.subscribe(SUBSCRIPTION_KEY).await?;
             pubsub_conn.unsubscribe(SUBSCRIPTION_KEY).await?;
+
+            let mut conn = ctx.async_connection().await?;
+            let subscriptions_counts: HashMap<String, u32> = redis::cmd("PUBSUB")
+                .arg("NUMSUB")
+                .arg(SUBSCRIPTION_KEY)
+                .query_async(&mut conn)
+                .await?;
+            let subscription_count = *subscriptions_counts.get(SUBSCRIPTION_KEY).unwrap();
+            assert_eq!(subscription_count, 0);
+
+            Ok::<_, RedisError>(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn split_pub_sub_unsubscription() {
+        use redis::RedisError;
+
+        const SUBSCRIPTION_KEY: &str = "phonewave-pub-sub-unsubscription";
+
+        let ctx = TestContext::new();
+        block_on_all(async move {
+            let (mut sink, mut stream) = ctx.async_connection().await?.into_pubsub().split();
+
+            spawn(async move { while stream.next().await.is_some() {} });
+
+            sink.subscribe(SUBSCRIPTION_KEY).await?;
+            sink.unsubscribe(SUBSCRIPTION_KEY).await?;
 
             let mut conn = ctx.async_connection().await?;
             let subscriptions_counts: HashMap<String, u32> = redis::cmd("PUBSUB")
@@ -587,24 +673,34 @@ mod pub_sub {
     }
 
     #[test]
-    fn pub_sub_conn_reuse() {
+    fn split_automatic_unsubscription() {
         use redis::RedisError;
+
+        const SUBSCRIPTION_KEY: &str = "phonewave-automatic-unsubscription";
 
         let ctx = TestContext::new();
         block_on_all(async move {
-            let mut pubsub_conn = ctx.async_connection().await?.into_pubsub();
-            pubsub_conn.subscribe("phonewave").await?;
-            pubsub_conn.psubscribe("*").await?;
+            let mut pubsub = ctx.async_connection().await?.into_pubsub();
+            pubsub.subscribe(SUBSCRIPTION_KEY).await?;
+            drop(pubsub);
 
-            let mut conn = pubsub_conn.into_connection().await;
-            redis::cmd("SET")
-                .arg("foo")
-                .arg("bar")
-                .query_async(&mut conn)
-                .await?;
+            let mut conn = ctx.async_connection().await?;
+            let mut subscription_count = 1;
+            // Allow for the unsubscription to occur within 5 seconds
+            for _ in 0..100 {
+                let subscriptions_counts: HashMap<String, u32> = redis::cmd("PUBSUB")
+                    .arg("NUMSUB")
+                    .arg(SUBSCRIPTION_KEY)
+                    .query_async(&mut conn)
+                    .await?;
+                subscription_count = *subscriptions_counts.get(SUBSCRIPTION_KEY).unwrap();
+                if subscription_count == 0 {
+                    break;
+                }
 
-            let res: String = redis::cmd("GET").arg("foo").query_async(&mut conn).await?;
-            assert_eq!(&res, "bar");
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            assert_eq!(subscription_count, 0);
 
             Ok::<_, RedisError>(())
         })


### PR DESCRIPTION
## Bugfix/Feature
 - Issue: https://github.com/mitsuhiko/redis-rs/issues/310
 - Previous fix: https://github.com/redis-rs/redis-rs/pull/486
 - Fix
   - Use Stream implementations and buffer responses for combined PubSub
 - Feature
   - Users can send commands (mainly subscribe) while reading pubsub messages
   - Allow for splitting to a Sink & Stream

## Example of Issue
```
< pubsub message comes in
> subscribe request
< subscribe function reads pubsub message instead of subscribe response
[subscribe response is left hanging]
```
