### PR TITLE
Cluster: Create read_from_replicas option

### DIFF
--- a/benches/bench_cluster.rs
+++ b/benches/bench_cluster.rs
@@ -87,7 +87,7 @@ fn bench_cluster_setup(c: &mut Criterion) {
 #[allow(dead_code)]
 fn bench_cluster_read_from_replicas_setup(c: &mut Criterion) {
     let cluster = TestClusterContext::new_with_cluster_client_builder(6, 1, |builder| {
-        builder.read_from_replicas(true)
+        builder.read_from_replicas()
     });
     cluster.wait_for_cluster_up();
 

--- a/benches/bench_cluster.rs
+++ b/benches/bench_cluster.rs
@@ -15,7 +15,10 @@ fn bench_set_get_and_del(c: &mut Criterion, con: &mut redis::cluster::ClusterCon
     let mut group = c.benchmark_group("cluster_basic");
 
     group.bench_function("set", |b| {
-        b.iter(|| black_box(redis::cmd("SET").arg(key).arg(42).execute(con)))
+        b.iter(|| {
+            redis::cmd("SET").arg(key).arg(42).execute(con);
+            black_box(())
+        })
     });
 
     group.bench_function("get", |b| {
@@ -26,7 +29,12 @@ fn bench_set_get_and_del(c: &mut Criterion, con: &mut redis::cluster::ClusterCon
         redis::cmd("SET").arg(key).arg(42).execute(con);
         redis::cmd("DEL").arg(key).execute(con);
     };
-    group.bench_function("set_and_del", |b| b.iter(|| black_box(set_and_del())));
+    group.bench_function("set_and_del", |b| {
+        b.iter(|| {
+            set_and_del();
+            black_box(())
+        })
+    });
 
     group.finish();
 }
@@ -46,14 +54,22 @@ fn bench_pipeline(c: &mut Criterion, con: &mut redis::cluster::ClusterConnection
             pipe.set(q, "bar").ignore();
         }
     };
-    group.bench_function("build_pipeline", |b| b.iter(|| black_box(build_pipeline())));
+    group.bench_function("build_pipeline", |b| {
+        b.iter(|| {
+            build_pipeline();
+            black_box(())
+        })
+    });
 
     let mut pipe = cluster_pipe();
     for q in &queries {
         pipe.set(q, "bar").ignore();
     }
     group.bench_function("query_pipeline", |b| {
-        b.iter(|| black_box(pipe.query::<()>(con).unwrap()))
+        b.iter(|| {
+            pipe.query::<()>(con).unwrap();
+            black_box(())
+        })
     });
 
     group.finish();
@@ -68,5 +84,21 @@ fn bench_cluster_setup(c: &mut Criterion) {
     bench_pipeline(c, &mut con);
 }
 
-criterion_group!(cluster_bench, bench_cluster_setup);
+#[allow(dead_code)]
+fn bench_cluster_read_from_replicas_setup(c: &mut Criterion) {
+    let cluster = TestClusterContext::new_with_cluster_client_builder(6, 1, |builder| {
+        builder.read_from_replicas(true)
+    });
+    cluster.wait_for_cluster_up();
+
+    let mut con = cluster.connection();
+    bench_set_get_and_del(c, &mut con);
+    bench_pipeline(c, &mut con);
+}
+
+criterion_group!(
+    cluster_bench,
+    bench_cluster_setup,
+    // bench_cluster_read_from_replicas_setup
+);
 criterion_main!(cluster_bench);

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -156,7 +156,7 @@ impl ClusterConnection {
     /// method.
     pub fn set_write_timeout(&self, dur: Option<Duration>) -> RedisResult<()> {
         // Check if duration is valid before updating local value.
-        if dur.is_some() && dur.unwrap() == Duration::default() {
+        if dur.is_some() && dur.unwrap().is_zero() {
             return Err(RedisError::from((
                 ErrorKind::InvalidClientConfig,
                 "Duration should be None or non-zero.",
@@ -179,7 +179,7 @@ impl ClusterConnection {
     /// method.
     pub fn set_read_timeout(&self, dur: Option<Duration>) -> RedisResult<()> {
         // Check if duration is valid before updating local value.
-        if dur.is_some() && dur.unwrap() == Duration::default() {
+        if dur.is_some() && dur.unwrap().is_zero() {
             return Err(RedisError::from((
                 ErrorKind::InvalidClientConfig,
                 "Duration should be None or non-zero.",

--- a/src/cluster_client.rs
+++ b/src/cluster_client.rs
@@ -54,15 +54,16 @@ impl ClusterClientBuilder {
     ///
     /// If True, then read queries will go to the replica nodes & write queries will go to the
     /// primary nodes. If there are no replica nodes, then all queries will go to the primary nodes.
-    pub fn read_from_replicas(mut self, read_from_replicas: bool) -> ClusterClientBuilder {
-        self.read_from_replicas = read_from_replicas;
+    pub fn read_from_replicas(mut self) -> ClusterClientBuilder {
+        self.read_from_replicas = true;
         self
     }
 
-    /// Use `read_from_replicas`.
-    #[deprecated(since = "0.22.0")]
-    pub fn readonly(self, read_from_replicas: bool) -> ClusterClientBuilder {
-        self.read_from_replicas(read_from_replicas)
+    /// Use `read_from_replicas()`.
+    #[deprecated(since = "0.22.0", note = "Use read_from_replicas()")]
+    pub fn readonly(mut self, read_from_replicas: bool) -> ClusterClientBuilder {
+        self.read_from_replicas = read_from_replicas;
+        self
     }
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -28,23 +28,25 @@ pub(crate) fn is_readonly_cmd(cmd: &[u8]) -> bool {
         // @connection
         b"CLIENT" | b"ECHO" |
         // @geo
-        b"GEODIST" | b"GEOHASH" | b"GEOPOS" | b"GEORADIUS_RO" | b"GEORADIUSBYMEMBER_RO" |
+        b"GEODIST" | b"GEOHASH" | b"GEOPOS" | b"GEORADIUSBYMEMBER_RO" | b"GEORADIUS_RO" | b"GEOSEARCH" |
         // @hash
-        b"HEXISTS" | b"HGET" | b"HGETALL" | b"HKEYS" | b"HLEN" | b"HMGET" | b"HSCAN" | b"HSTRLEN" | b"HVALS" |
+        b"HEXISTS" | b"HGET" | b"HGETALL" | b"HKEYS" | b"HLEN" | b"HMGET" | b"HRANDFIELD" | b"HSCAN" | b"HSTRLEN" | b"HVALS" |
         // @hyperloglog
         b"PFCOUNT" |
         // @keyspace
-        b"DBSIZE" | b"DUMP" | b"EXISTS" | b"KEYS" | b"OBJECT" | b"PTTL" | b"RANDOMKEY" | b"SCAN" | b"TOUCH" | b"TTL" | b"TYPE" |
+        b"DBSIZE" | b"DUMP" | b"EXISTS" | b"EXPIRETIME" | b"KEYS" | b"OBJECT" | b"PEXPIRETIME" | b"PTTL" | b"RANDOMKEY" | b"SCAN" | b"TOUCH" | b"TTL" | b"TYPE" |
         // @list
-        b"LINDEX" | b"LLEN" | b"LPOS" | b"LRANGE" |
+        b"LINDEX" | b"LLEN" | b"LPOS" | b"LRANGE" | b"SORT_RO" |
+        // @scripting
+        b"EVALSHA_RO" | b"EVAL_RO" | b"FCALL_RO" |
         // @set
-        b"SCARD" | b"SDIFF" | b"SINTER" | b"SISMEMBER" | b"SMEMBERS" | b"SRANDMEMBER" | b"SSCAN" | b"SUNION" |
+        b"SCARD" | b"SDIFF" | b"SINTER" | b"SINTERCARD" | b"SISMEMBER" | b"SMEMBERS" | b"SMISMEMBER" | b"SRANDMEMBER" | b"SSCAN" | b"SUNION" |
         // @sortedset
-        b"ZCARD" | b"ZCOUNT" | b"ZLEXCOUNT" | b"ZRANGE" | b"ZRANGEBYLEX" | b"ZRANGEBYSCORE" | b"ZRANK" | b"ZREVRANGE" | b"ZREVRANGEBYLEX" | b"ZREVRANGEBYSCORE" | b"ZREVRANK" | b"ZSCAN" | b"ZSCORE" |
+        b"ZCARD" | b"ZCOUNT" | b"ZDIFF" | b"ZINTER" | b"ZINTERCARD" | b"ZLEXCOUNT" | b"ZMSCORE" | b"ZRANDMEMBER" | b"ZRANGE" | b"ZRANGEBYLEX" | b"ZRANGEBYSCORE" | b"ZRANK" | b"ZREVRANGE" | b"ZREVRANGEBYLEX" | b"ZREVRANGEBYSCORE" | b"ZREVRANK" | b"ZSCAN" | b"ZSCORE" | b"ZUNION" |
         // @stream
         b"XINFO" | b"XLEN" | b"XPENDING" | b"XRANGE" | b"XREAD" | b"XREVRANGE" |
         // @string
-        b"GET" | b"GETRANGE" | b"MGET" | b"STRALGO" | b"STRLEN" | b"SUBSTR"
+        b"GET" | b"GETRANGE" | b"LCS" | b"MGET" | b"STRALGO" | b"STRLEN" | b"SUBSTR"
     )
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -17,6 +17,37 @@ use crate::streams;
 #[cfg(feature = "acl")]
 use crate::acl;
 
+#[cfg(feature = "cluster")]
+pub(crate) fn is_readonly_cmd(cmd: &[u8]) -> bool {
+    matches!(
+        cmd,
+        // @admin
+        b"LASTSAVE" | b"PRIVILEGE" | b"PRIVILIDGE" | b"SETCLIENTADDR" |
+        // @bitmap
+        b"BITCOUNT" | b"BITFIELD_RO" | b"BITPOS" | b"GETBIT" |
+        // @connection
+        b"CLIENT" | b"ECHO" |
+        // @geo
+        b"GEODIST" | b"GEOHASH" | b"GEOPOS" | b"GEORADIUS_RO" | b"GEORADIUSBYMEMBER_RO" |
+        // @hash
+        b"HEXISTS" | b"HGET" | b"HGETALL" | b"HKEYS" | b"HLEN" | b"HMGET" | b"HSCAN" | b"HSTRLEN" | b"HVALS" |
+        // @hyperloglog
+        b"PFCOUNT" |
+        // @keyspace
+        b"DBSIZE" | b"DUMP" | b"EXISTS" | b"KEYS" | b"OBJECT" | b"PTTL" | b"RANDOMKEY" | b"SCAN" | b"TOUCH" | b"TTL" | b"TYPE" |
+        // @list
+        b"LINDEX" | b"LLEN" | b"LPOS" | b"LRANGE" |
+        // @set
+        b"SCARD" | b"SDIFF" | b"SINTER" | b"SISMEMBER" | b"SMEMBERS" | b"SRANDMEMBER" | b"SSCAN" | b"SUNION" |
+        // @sortedset
+        b"ZCARD" | b"ZCOUNT" | b"ZLEXCOUNT" | b"ZRANGE" | b"ZRANGEBYLEX" | b"ZRANGEBYSCORE" | b"ZRANK" | b"ZREVRANGE" | b"ZREVRANGEBYLEX" | b"ZREVRANGEBYSCORE" | b"ZREVRANK" | b"ZSCAN" | b"ZSCORE" |
+        // @stream
+        b"XINFO" | b"XLEN" | b"XPENDING" | b"XRANGE" | b"XREAD" | b"XREVRANGE" |
+        // @string
+        b"GET" | b"GETRANGE" | b"MGET" | b"STRALGO" | b"STRLEN" | b"SUBSTR"
+    )
+}
+
 macro_rules! implement_commands {
     (
         $lifetime: lifetime
@@ -831,13 +862,13 @@ implement_commands! {
         cmd("ZPOPMIN").arg(key).arg(count)
     }
 
-    /// Removes and returns up to count members with the highest scores, 
+    /// Removes and returns up to count members with the highest scores,
     /// from the first non-empty sorted set in the provided list of key names.
     fn zmpop_max<K: ToRedisArgs>(keys: &'a [K], count: isize) {
         cmd("ZMPOP").arg(keys.len()).arg(keys).arg("MAX").arg("COUNT").arg(count)
     }
 
-    /// Removes and returns up to count members with the lowest scores, 
+    /// Removes and returns up to count members with the lowest scores,
     /// from the first non-empty sorted set in the provided list of key names.
     fn zmpop_min<K: ToRedisArgs>(keys: &'a [K], count: isize) {
         cmd("ZMPOP").arg(keys.len()).arg(keys).arg("MIN").arg("COUNT").arg(count)

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -22,7 +22,7 @@ pub(crate) fn is_readonly_cmd(cmd: &[u8]) -> bool {
     matches!(
         cmd,
         // @admin
-        b"LASTSAVE" | b"PRIVILEGE" | b"PRIVILIDGE" | b"SETCLIENTADDR" |
+        b"LASTSAVE" |
         // @bitmap
         b"BITCOUNT" | b"BITFIELD_RO" | b"BITPOS" | b"GETBIT" |
         // @connection

--- a/tests/test_cluster.rs
+++ b/tests/test_cluster.rs
@@ -58,7 +58,7 @@ fn test_cluster_with_bad_password() {
 #[test]
 fn test_cluster_read_from_replicas() {
     let cluster = TestClusterContext::new_with_cluster_client_builder(6, 1, |builder| {
-        builder.read_from_replicas(true)
+        builder.read_from_replicas()
     });
     let mut con = cluster.connection();
 

--- a/tests/test_cluster.rs
+++ b/tests/test_cluster.rs
@@ -56,19 +56,20 @@ fn test_cluster_with_bad_password() {
 }
 
 #[test]
-fn test_cluster_readonly() {
-    let cluster =
-        TestClusterContext::new_with_cluster_client_builder(6, 1, |builder| builder.readonly(true));
+fn test_cluster_read_from_replicas() {
+    let cluster = TestClusterContext::new_with_cluster_client_builder(6, 1, |builder| {
+        builder.read_from_replicas(true)
+    });
     let mut con = cluster.connection();
 
-    // con is a READONLY replica, so we'll get the MOVED response and will be redirected
-    // to the master
+    // Write commands would go to the primary nodes
     redis::cmd("SET")
         .arg("{x}key1")
         .arg(b"foo")
         .execute(&mut con);
     redis::cmd("SET").arg(&["{x}key2", "bar"]).execute(&mut con);
 
+    // Read commands would go to the replica nodes
     assert_eq!(
         redis::cmd("MGET")
             .arg(&["{x}key1", "{x}key2"])


### PR DESCRIPTION
Currently, all cluster commands in readonly mode first go to the replica & then in case of errors, they're redirected to the primary.
Instead of the unnecessary replica call & then creating a connection, we can check if a command is readonly or not & then set it to the appropriate node.
This results in a benchmark improvement of ~80% for write commands in readonly mode.
IMO, the option should be renamed from `readonly` to `read_from_replicas`, but that would create a breaking change.