### PR TITLE
add support for weights in zunionstore and zinterstore

### DIFF
--- a/redis/src/commands.rs
+++ b/redis/src/commands.rs
@@ -849,6 +849,30 @@ implement_commands! {
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MAX")
     }
 
+    /// [`Commands::zinterstore`], but with the ability to specify a
+    /// multiplication factor for each sorted set by pairing one with each key
+    /// in a tuple.
+    fn zinterstore_weights<K: ToRedisArgs, W: ToRedisArgs>(dstkey: K, keys: &'a [(K, W)]) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map( | (key, weight) | { (key, weight) } ).unzip();
+        cmd("ZINTERSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("WEIGHTS").arg(weights)
+    }
+
+    /// [`Commands::zinterstore_min`], but with the ability to specify a
+    /// multiplication factor for each sorted set by pairing one with each key
+    /// in a tuple.
+    fn zinterstore_min_weights<K: ToRedisArgs, W: ToRedisArgs>(dstkey: K, keys: &'a [(K, W)]) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map( | (key, weight) | { (key, weight) } ).unzip();
+        cmd("ZINTERSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MIN").arg("WEIGHTS").arg(weights)
+    }
+
+    /// [`Commands::zinterstore_max`], but with the ability to specify a
+    /// multiplication factor for each sorted set by pairing one with each key
+    /// in a tuple.
+    fn zinterstore_max_weights<K: ToRedisArgs, W: ToRedisArgs>(dstkey: K, keys: &'a [(K, W)]) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map( | (key, weight) | { (key, weight) } ).unzip();
+        cmd("ZINTERSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MAX").arg("WEIGHTS").arg(weights)
+    }
+
     /// Count the number of members in a sorted set between a given lexicographical range.
     fn zlexcount<K: ToRedisArgs, L: ToRedisArgs>(key: K, min: L, max: L) {
         cmd("ZLEXCOUNT").arg(key).arg(min).arg(max)
@@ -1034,6 +1058,30 @@ implement_commands! {
     /// a new key using MAX as aggregation function.
     fn zunionstore_max<K: ToRedisArgs>(dstkey: K, keys: &'a [K]) {
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MAX")
+    }
+
+    /// [`Commands::zunionstore`], but with the ability to specify a
+    /// multiplication factor for each sorted set by pairing one with each key
+    /// in a tuple.
+    fn zunionstore_weights<K: ToRedisArgs, W: ToRedisArgs>(dstkey: K, keys: &'a [(K, W)]) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map( | (key, weight) | { (key, weight) } ).unzip();
+        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("WEIGHTS").arg(weights)
+    }
+
+    /// [`Commands::zunionstore_min`], but with the ability to specify a
+    /// multiplication factor for each sorted set by pairing one with each key
+    /// in a tuple.
+    fn zunionstore_min_weights<K: ToRedisArgs, W: ToRedisArgs>(dstkey: K, keys: &'a [(K, W)]) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map( | (key, weight) | { (key, weight) } ).unzip();
+        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MIN").arg("WEIGHTS").arg(weights)
+    }
+
+    /// [`Commands::zunionstore_max`], but with the ability to specify a
+    /// multiplication factor for each sorted set by pairing one with each key
+    /// in a tuple.
+    fn zunionstore_max_weights<K: ToRedisArgs, W: ToRedisArgs>(dstkey: K, keys: &'a [(K, W)]) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map( | (key, weight) | { (key, weight) } ).unzip();
+        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MAX").arg("WEIGHTS").arg(weights)
     }
 
     // hyperloglog commands

--- a/redis/src/commands.rs
+++ b/redis/src/commands.rs
@@ -853,7 +853,7 @@ implement_commands! {
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
     fn zinterstore_weights<K: ToRedisArgs, W: ToRedisArgs>(dstkey: K, keys: &'a [(K, W)]) {
-        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map( | (key, weight) | { (key, weight) } ).unzip();
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight)| (key, weight)).unzip();
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("WEIGHTS").arg(weights)
     }
 
@@ -861,7 +861,7 @@ implement_commands! {
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
     fn zinterstore_min_weights<K: ToRedisArgs, W: ToRedisArgs>(dstkey: K, keys: &'a [(K, W)]) {
-        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map( | (key, weight) | { (key, weight) } ).unzip();
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight)| (key, weight)).unzip();
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MIN").arg("WEIGHTS").arg(weights)
     }
 
@@ -869,7 +869,7 @@ implement_commands! {
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
     fn zinterstore_max_weights<K: ToRedisArgs, W: ToRedisArgs>(dstkey: K, keys: &'a [(K, W)]) {
-        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map( | (key, weight) | { (key, weight) } ).unzip();
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight)| (key, weight)).unzip();
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MAX").arg("WEIGHTS").arg(weights)
     }
 
@@ -1064,7 +1064,7 @@ implement_commands! {
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
     fn zunionstore_weights<K: ToRedisArgs, W: ToRedisArgs>(dstkey: K, keys: &'a [(K, W)]) {
-        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map( | (key, weight) | { (key, weight) } ).unzip();
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight)| (key, weight)).unzip();
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("WEIGHTS").arg(weights)
     }
 
@@ -1072,7 +1072,7 @@ implement_commands! {
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
     fn zunionstore_min_weights<K: ToRedisArgs, W: ToRedisArgs>(dstkey: K, keys: &'a [(K, W)]) {
-        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map( | (key, weight) | { (key, weight) } ).unzip();
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight)| (key, weight)).unzip();
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MIN").arg("WEIGHTS").arg(weights)
     }
 
@@ -1080,7 +1080,7 @@ implement_commands! {
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
     fn zunionstore_max_weights<K: ToRedisArgs, W: ToRedisArgs>(dstkey: K, keys: &'a [(K, W)]) {
-        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map( | (key, weight) | { (key, weight) } ).unzip();
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight)| (key, weight)).unzip();
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MAX").arg("WEIGHTS").arg(weights)
     }
 

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -922,6 +922,119 @@ fn test_redis_server_down() {
 }
 
 #[test]
+fn test_zinterstore_weights() {
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+
+    let _: () = con
+        .zadd_multiple("zset1", &[(1, "one"), (2, "two"), (4, "four")])
+        .unwrap();
+    let _: () = con
+        .zadd_multiple("zset2", &[(1, "one"), (2, "two"), (3, "three")])
+        .unwrap();
+
+    // zinterstore_weights
+    assert_eq!(
+        con.zinterstore_weights("out", &[("zset1", 2), ("zset2", 3)]),
+        Ok(2)
+    );
+
+    assert_eq!(
+        con.zrange_withscores("out", 0, -1),
+        Ok(vec![
+            ("one".to_string(), "5".to_string()),
+            ("two".to_string(), "10".to_string())
+        ])
+    );
+
+    // zinterstore_min_weights
+    assert_eq!(
+        con.zinterstore_min_weights("out", &[("zset1", 2), ("zset2", 3)]),
+        Ok(2)
+    );
+
+    assert_eq!(
+        con.zrange_withscores("out", 0, -1),
+        Ok(vec![
+            ("one".to_string(), "2".to_string()),
+            ("two".to_string(), "4".to_string()),
+        ])
+    );
+
+    // zinterstore_max_weights
+    assert_eq!(
+        con.zinterstore_max_weights("out", &[("zset1", 2), ("zset2", 3)]),
+        Ok(2)
+    );
+
+    assert_eq!(
+        con.zrange_withscores("out", 0, -1),
+        Ok(vec![
+            ("one".to_string(), "3".to_string()),
+            ("two".to_string(), "6".to_string()),
+        ])
+    );
+}
+
+#[test]
+fn test_zunionstore_weights() {
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+
+    let _: () = con
+        .zadd_multiple("zset1", &[(1, "one"), (2, "two")])
+        .unwrap();
+    let _: () = con
+        .zadd_multiple("zset2", &[(1, "one"), (2, "two"), (3, "three")])
+        .unwrap();
+
+    // zunionstore_weights
+    assert_eq!(
+        con.zunionstore_weights("out", &[("zset1", 2), ("zset2", 3)]),
+        Ok(3)
+    );
+
+    assert_eq!(
+        con.zrange_withscores("out", 0, -1),
+        Ok(vec![
+            ("one".to_string(), "5".to_string()),
+            ("three".to_string(), "9".to_string()),
+            ("two".to_string(), "10".to_string())
+        ])
+    );
+
+    // zunionstore_min_weights
+    assert_eq!(
+        con.zunionstore_min_weights("out", &[("zset1", 2), ("zset2", 3)]),
+        Ok(3)
+    );
+
+    assert_eq!(
+        con.zrange_withscores("out", 0, -1),
+        Ok(vec![
+            ("one".to_string(), "2".to_string()),
+            ("two".to_string(), "4".to_string()),
+            ("three".to_string(), "9".to_string())
+        ])
+    );
+
+    // zunionstore_max_weights
+    assert_eq!(
+        con.zunionstore_max_weights("out", &[("zset1", 2), ("zset2", 3)]),
+        Ok(3)
+    );
+
+    assert_eq!(
+        con.zrange_withscores("out", 0, -1),
+        Ok(vec![
+            ("one".to_string(), "3".to_string()),
+            ("two".to_string(), "6".to_string()),
+            ("three".to_string(), "9".to_string())
+        ])
+    );
+}
+
+#[test]
 fn test_zrembylex() {
     let ctx = TestContext::new();
     let mut con = ctx.connection();


### PR DESCRIPTION
Resolves https://github.com/redis-rs/redis-rs/issues/634

Let me know if there's a preferred way to adding WEIGHTS functionality (or anything else that needs to be added or changed!). I contemplated modifying the existing `zinterstore` and `zunionstore` functions, but realized that I would have to make a change to `ToRedisArgs` if I wanted to add this functionality while maintaining the  same parameters.