### PR TITLE
`make docs` and `make lint` warning fixes

### DIFF
--- a/src/aio.rs
+++ b/src/aio.rs
@@ -141,34 +141,31 @@ where
 
     /// Subscribes to a new channel.
     pub async fn subscribe<T: ToRedisArgs>(&mut self, channel: T) -> RedisResult<()> {
-        Ok(cmd("SUBSCRIBE")
-            .arg(channel)
-            .query_async(&mut self.0)
-            .await?)
+        cmd("SUBSCRIBE").arg(channel).query_async(&mut self.0).await
     }
 
     /// Subscribes to a new channel with a pattern.
     pub async fn psubscribe<T: ToRedisArgs>(&mut self, pchannel: T) -> RedisResult<()> {
-        Ok(cmd("PSUBSCRIBE")
+        cmd("PSUBSCRIBE")
             .arg(pchannel)
             .query_async(&mut self.0)
-            .await?)
+            .await
     }
 
     /// Unsubscribes from a channel.
     pub async fn unsubscribe<T: ToRedisArgs>(&mut self, channel: T) -> RedisResult<()> {
-        Ok(cmd("UNSUBSCRIBE")
+        cmd("UNSUBSCRIBE")
             .arg(channel)
             .query_async(&mut self.0)
-            .await?)
+            .await
     }
 
     /// Unsubscribes from a channel with a pattern.
     pub async fn punsubscribe<T: ToRedisArgs>(&mut self, pchannel: T) -> RedisResult<()> {
-        Ok(cmd("PUNSUBSCRIBE")
+        cmd("PUNSUBSCRIBE")
             .arg(pchannel)
             .query_async(&mut self.0)
-            .await?)
+            .await
     }
 
     /// Returns [`Stream`] of [`Msg`]s from this [`PubSub`]s subscriptions.
@@ -212,7 +209,7 @@ where
 
     /// Deliver the MONITOR command to this [`Monitor`]ing wrapper.
     pub async fn monitor(&mut self) -> RedisResult<()> {
-        Ok(cmd("MONITOR").query_async(&mut self.0).await?)
+        cmd("MONITOR").query_async(&mut self.0).await
     }
 
     /// Returns [`Stream`] of [`FromRedisValue`] values from this [`Monitor`]ing connection

--- a/src/client.rs
+++ b/src/client.rs
@@ -209,7 +209,7 @@ impl Client {
     #[cfg(feature = "connection-manager")]
     #[cfg_attr(docsrs, doc(cfg(feature = "connection-manager")))]
     pub async fn get_tokio_connection_manager(&self) -> RedisResult<crate::aio::ConnectionManager> {
-        Ok(crate::aio::ConnectionManager::new(self.clone()).await?)
+        crate::aio::ConnectionManager::new(self.clone()).await
     }
 
     async fn get_multiplexed_async_connection_inner<T>(

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -304,8 +304,8 @@ impl ClusterConnection {
         let len = connections.len();
         let mut samples = connections.values_mut().choose_multiple(&mut rng, len);
 
-        for mut conn in samples.iter_mut() {
-            if let Ok(mut slots_data) = get_slots(&mut conn, self.tls) {
+        for conn in samples.iter_mut() {
+            if let Ok(mut slots_data) = get_slots(conn, self.tls) {
                 slots_data.sort_by_key(|s| s.start());
                 let last_slot = slots_data.iter().try_fold(0, |prev_end, slot_data| {
                     if prev_end != slot_data.start() {
@@ -592,7 +592,7 @@ impl ClusterConnection {
     // Receive from each node, keeping track of which commands need to be retried.
     fn recv_all_commands(
         &self,
-        results: &mut Vec<Value>,
+        results: &mut [Value],
         node_cmds: &[NodeCmd],
     ) -> RedisResult<Vec<usize>> {
         let mut to_retry = Vec::new();

--- a/src/cluster_pipeline.rs
+++ b/src/cluster_pipeline.rs
@@ -48,7 +48,7 @@ pub struct ClusterPipeline {
     ignored_commands: HashSet<usize>,
 }
 
-/// A cluster pipeline is almost identical to a normal [Pipeline](Pipeline), with two exceptions:
+/// A cluster pipeline is almost identical to a normal [Pipeline](crate::pipeline::Pipeline), with two exceptions:
 /// * It does not support transactions
 /// * The following commands can not be used in a cluster pipeline:
 /// ```text

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,7 +355,7 @@ assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
 
 #![deny(non_camel_case_types)]
 #![warn(missing_docs)]
-#![cfg_attr(docsrs, warn(broken_intra_doc_links))]
+#![cfg_attr(docsrs, warn(rustdoc::broken_intra_doc_links))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 // public api

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -376,7 +376,7 @@ fn test_script_returning_complex_type() {
             .map_ok(|(i, s, b): (i32, String, bool)| {
                 assert_eq!(i, 1);
                 assert_eq!(s, "hello");
-                assert_eq!(b, true);
+                assert!(b);
             })
             .await
     })

--- a/tests/test_async_async_std.rs
+++ b/tests/test_async_async_std.rs
@@ -290,8 +290,6 @@ fn test_script() {
 #[cfg(feature = "script")]
 fn test_script_load() {
     let ctx = TestContext::new();
-    let mut con = ctx.connection();
-
     let script = redis::Script::new("return 'Hello World'");
 
     block_on_all(async move {
@@ -314,7 +312,7 @@ fn test_script_returning_complex_type() {
             .map_ok(|(i, s, b): (i32, String, bool)| {
                 assert_eq!(i, 1);
                 assert_eq!(s, "hello");
-                assert_eq!(b, true);
+                assert!(b);
             })
             .await
     })


### PR DESCRIPTION
While working on https://github.com/redis-rs/redis-rs/pull/641, I ran into warnings executing `make docs` and `make lint` that weren't related to my PR; thought I would make another PR so that others wouldn't run into this when running these commands.

It seems like CI passes in spite of these warnings. I'm not an expert at GitHub workflows and didn't see anything wrong with how things are set up. Maybe something's wrong on my side? Currently running `rustc 1.61.0 (fe5b13d68 2022-05-18)`.