### PR TITLE
fix: &Vec is_single_arg check

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -898,6 +898,10 @@ impl<T: ToRedisArgs> ToRedisArgs for &T {
     {
         (*self).write_redis_args(out)
     }
+
+    fn is_single_arg(&self) -> bool {
+        (*self).is_single_arg()
+    }
 }
 
 /// @note: Redis cannot store empty sets so the application has to

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -792,6 +792,8 @@ fn test_auto_m_versions() {
 
     assert_eq!(con.set_multiple(&[("key1", 1), ("key2", 2)]), Ok(()));
     assert_eq!(con.get(&["key1", "key2"]), Ok((1, 2)));
+    assert_eq!(con.get(vec!["key1", "key2"]), Ok((1, 2)));
+    assert_eq!(con.get(&vec!["key1", "key2"]), Ok((1, 2)));
 }
 
 #[test]


### PR DESCRIPTION
Without this, `con.get(&vec!["key1", "key2"]` will cause `Err(An error was signalled by the server: wrong number of arguments for 'get' command)`.

(Not sure if I put tests in the right place.