### PR TITLE
[3/5] cluster: refactor/optimize for Async Cluster

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -12,7 +12,7 @@
 //! use redis::cluster::ClusterClient;
 //!
 //! let nodes = vec!["redis://127.0.0.1:6379/", "redis://127.0.0.1:6378/", "redis://127.0.0.1:6377/"];
-//! let client = ClusterClient::open(nodes).unwrap();
+//! let client = ClusterClient::new(nodes).unwrap();
 //! let mut connection = client.get_connection().unwrap();
 //!
 //! let _: () = connection.set("test", "test_data").unwrap();
@@ -27,7 +27,7 @@
 //! use redis::cluster::{cluster_pipe, ClusterClient};
 //!
 //! let nodes = vec!["redis://127.0.0.1:6379/", "redis://127.0.0.1:6378/", "redis://127.0.0.1:6377/"];
-//! let client = ClusterClient::open(nodes).unwrap();
+//! let client = ClusterClient::new(nodes).unwrap();
 //! let mut connection = client.get_connection().unwrap();
 //!
 //! let key = "test";

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -124,6 +124,11 @@ impl ClusterConnection {
         Ok(())
     }
 
+    /// Set the retries parameter for this connection.
+    pub fn set_retries(&mut self, value: u8) {
+        self.cluster_params.retries = value;
+    }
+
     /// Set the auto reconnect parameter for this connection.
     pub fn set_auto_reconnect(&mut self, value: bool) {
         self.cluster_params.auto_reconnect = value;
@@ -365,7 +370,7 @@ impl ClusterConnection {
             None => fail!(UNROUTABLE_ERROR),
         };
 
-        let mut retries = 16;
+        let mut retries = self.cluster_params.retries;
         let mut excludes = HashSet::new();
         let mut redirected = None::<String>;
         let mut is_asking = false;
@@ -416,7 +421,7 @@ impl ClusterConnection {
                             continue;
                         } else if kind == ErrorKind::TryAgain || kind == ErrorKind::ClusterDown {
                             // Sleep and retry.
-                            let sleep_time = 2u64.pow(16 - retries.max(9)) * 10;
+                            let sleep_time = 2u64.pow(16 - u32::from(retries.max(9))) * 10;
                             thread::sleep(Duration::from_millis(sleep_time));
                             excludes.clear();
                             continue;

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -49,18 +49,18 @@ use rand::{
     thread_rng, Rng,
 };
 
-use super::{
-    cmd, parse_redis_value,
-    types::{HashMap, HashSet},
-    Cmd, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, ErrorKind, IntoConnectionInfo,
-    RedisError, RedisResult, Value,
-};
 use crate::cluster_client::ClusterParams;
+use crate::cluster_pipeline::UNROUTABLE_ERROR;
+use crate::cluster_routing::{Routable, RoutingInfo, Slot, SLOT_SIZE};
+use crate::cmd::{cmd, Cmd};
+use crate::connection::{
+    Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, IntoConnectionInfo,
+};
+use crate::parser::parse_redis_value;
+use crate::types::{ErrorKind, HashMap, HashSet, RedisError, RedisResult, Value};
 
 pub use crate::cluster_client::{ClusterClient, ClusterClientBuilder};
-use crate::cluster_pipeline::UNROUTABLE_ERROR;
 pub use crate::cluster_pipeline::{cluster_pipe, ClusterPipeline};
-use crate::cluster_routing::{Routable, RoutingInfo, Slot, SLOT_SIZE};
 
 type SlotMap = BTreeMap<u16, [String; 2]>;
 

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::cluster::ClusterConnection;
 use crate::connection::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo};
 use crate::types::{ErrorKind, RedisError, RedisResult};
@@ -9,6 +11,9 @@ pub(crate) struct ClusterParams {
     pub(crate) username: Option<String>,
     pub(crate) read_from_replicas: bool,
     pub(crate) tls_insecure: Option<bool>,
+    pub(crate) write_timeout: Option<Duration>,
+    pub(crate) read_timeout: Option<Duration>,
+    pub(crate) auto_reconnect: bool,
 }
 
 /// Used to configure and build a [ClusterClient](ClusterClient).

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -137,6 +137,40 @@ impl ClusterClientBuilder {
         self
     }
 
+    /// Sets the default write timeout for all new connections (default is None).
+    ///
+    /// If the value is `None`, then `send_packed_command` call may block indefinitely.
+    /// Passing Some(Duration::ZERO) to this method will result in an error.
+    pub fn write_timeout(mut self, dur: Option<Duration>) -> RedisResult<ClusterClientBuilder> {
+        // Check if duration is valid before updating local value.
+        if dur.is_some() && dur.unwrap().is_zero() {
+            return Err(RedisError::from((
+                ErrorKind::InvalidClientConfig,
+                "Duration should be None or non-zero.",
+            )));
+        }
+
+        self.cluster_params.write_timeout = dur;
+        Ok(self)
+    }
+
+    /// Sets the default read timeout for all new connections (default is None).
+    ///
+    /// If the value is `None`, then `recv_response` call may block indefinitely.
+    /// Passing Some(Duration::ZERO) to this method will result in an error.
+    pub fn read_timeout(mut self, dur: Option<Duration>) -> RedisResult<ClusterClientBuilder> {
+        // Check if duration is valid before updating local value.
+        if dur.is_some() && dur.unwrap().is_zero() {
+            return Err(RedisError::from((
+                ErrorKind::InvalidClientConfig,
+                "Duration should be None or non-zero.",
+            )));
+        }
+
+        self.cluster_params.read_timeout = dur;
+        Ok(self)
+    }
+
     /// Use `build()`.
     #[deprecated(since = "0.22.0", note = "Use build()")]
     pub fn open(self) -> RedisResult<ClusterClient> {

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -171,6 +171,14 @@ impl ClusterClientBuilder {
         Ok(self)
     }
 
+    /// Sets the default auto reconnect parameter for all new connections (default is true).
+    ///
+    /// `ClusterConnection` will attempt to reconnect in case of [IoError](ErrorKind::IoError).
+    pub fn auto_reconnect(mut self, value: bool) -> ClusterClientBuilder {
+        self.cluster_params.auto_reconnect = value;
+        self
+    }
+
     /// Use `build()`.
     #[deprecated(since = "0.22.0", note = "Use build()")]
     pub fn open(self) -> RedisResult<ClusterClient> {

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -13,8 +13,13 @@ pub struct ClusterClientBuilder {
 }
 
 impl ClusterClientBuilder {
-    /// Generate the base configuration for new Client.
-    pub fn new<T: IntoConnectionInfo>(initial_nodes: Vec<T>) -> ClusterClientBuilder {
+    /// Creates a new `ClusterClientBuilder` with the the provided initial_nodes.
+    ///
+    /// This is the same as `ClusterClient::builder(initial_nodes)`.
+    pub fn new<T>(initial_nodes: Vec<T>) -> ClusterClientBuilder
+    where
+        T: IntoConnectionInfo,
+    {
         ClusterClientBuilder {
             initial_nodes: initial_nodes
                 .into_iter()
@@ -26,16 +31,59 @@ impl ClusterClientBuilder {
         }
     }
 
-    /// Builds a [ClusterClient](ClusterClient). Despite the name, this does not actually open
-    /// a connection to Redis Cluster, but will perform some basic checks of the initial
-    /// nodes' URLs and passwords.
+    /// Creates a new `ClusterClient` with the parameters.
+    ///
+    /// This does not create connections to the Redis Cluster, but only performs some basic checks
+    /// on the initial nodes' URLs and passwords/usernames.
     ///
     /// # Errors
     ///
-    /// Upon failure to parse initial nodes or if the initial nodes have different passwords,
-    /// an error is returned.
-    pub fn open(self) -> RedisResult<ClusterClient> {
-        ClusterClient::build(self)
+    /// Upon failure to parse initial nodes or if the initial nodes have different passwords or
+    /// usernames, an error is returned.
+    pub fn build(self) -> RedisResult<ClusterClient> {
+        let initial_nodes = self.initial_nodes?;
+
+        let mut nodes = Vec::with_capacity(initial_nodes.len());
+        let mut connection_info_password = None::<String>;
+        let mut connection_info_username = None::<String>;
+
+        for (index, info) in initial_nodes.into_iter().enumerate() {
+            if let ConnectionAddr::Unix(_) = info.addr {
+                return Err(RedisError::from((ErrorKind::InvalidClientConfig,
+                                         "This library cannot use unix socket because Redis's cluster command returns only cluster's IP and port.")));
+            }
+
+            if self.password.is_none() {
+                if index == 0 {
+                    connection_info_password = info.redis.password.clone();
+                } else if connection_info_password != info.redis.password {
+                    return Err(RedisError::from((
+                        ErrorKind::InvalidClientConfig,
+                        "Cannot use different password among initial nodes.",
+                    )));
+                }
+            }
+
+            if self.username.is_none() {
+                if index == 0 {
+                    connection_info_username = info.redis.username.clone();
+                } else if connection_info_username != info.redis.username {
+                    return Err(RedisError::from((
+                        ErrorKind::InvalidClientConfig,
+                        "Cannot use different username among initial nodes.",
+                    )));
+                }
+            }
+
+            nodes.push(info);
+        }
+
+        Ok(ClusterClient {
+            initial_nodes: nodes,
+            read_from_replicas: self.read_from_replicas,
+            username: self.username.or(connection_info_username),
+            password: self.password.or(connection_info_password),
+        })
     }
 
     /// Set password for new ClusterClient.
@@ -59,6 +107,12 @@ impl ClusterClientBuilder {
         self
     }
 
+    /// Use `build()`.
+    #[deprecated(since = "0.22.0", note = "Use build()")]
+    pub fn open(self) -> RedisResult<ClusterClient> {
+        self.build()
+    }
+
     /// Use `read_from_replicas()`.
     #[deprecated(since = "0.22.0", note = "Use read_from_replicas()")]
     pub fn readonly(mut self, read_from_replicas: bool) -> ClusterClientBuilder {
@@ -76,16 +130,28 @@ pub struct ClusterClient {
 }
 
 impl ClusterClient {
-    /// Create a [ClusterClient](ClusterClient) with the default configuration. Despite the name,
-    /// this does not actually open a connection to Redis Cluster, but only performs some basic
-    /// checks of the initial nodes' URLs and passwords.
+    /// Creates a `ClusterClient` with the default parameters.
+    ///
+    /// This does not create connections to the Redis Cluster, but only performs some basic checks
+    /// on the initial nodes' URLs and passwords/usernames.
     ///
     /// # Errors
     ///
-    /// Upon failure to parse initial nodes or if the initial nodes have different passwords,
-    /// an error is returned.
-    pub fn open<T: IntoConnectionInfo>(initial_nodes: Vec<T>) -> RedisResult<ClusterClient> {
-        ClusterClientBuilder::new(initial_nodes).open()
+    /// Upon failure to parse initial nodes or if the initial nodes have different passwords or
+    /// usernames, an error is returned.
+    pub fn new<T>(initial_nodes: Vec<T>) -> RedisResult<ClusterClient>
+    where
+        T: IntoConnectionInfo,
+    {
+        ClusterClientBuilder::new(initial_nodes).build()
+    }
+
+    /// Creates a [ClusterClientBuilder](ClusterClientBuilder) with the the provided initial_nodes.
+    pub fn builder<T>(initial_nodes: Vec<T>) -> ClusterClientBuilder
+    where
+        T: IntoConnectionInfo,
+    {
+        ClusterClientBuilder::new(initial_nodes)
     }
 
     /// Opens connections to Redis Cluster nodes and returns a
@@ -103,55 +169,19 @@ impl ClusterClient {
         )
     }
 
-    fn build(builder: ClusterClientBuilder) -> RedisResult<ClusterClient> {
-        let initial_nodes = builder.initial_nodes?;
-        let mut nodes = Vec::with_capacity(initial_nodes.len());
-        let mut connection_info_password = None::<String>;
-        let mut connection_info_username = None::<String>;
-
-        for (index, info) in initial_nodes.into_iter().enumerate() {
-            if let ConnectionAddr::Unix(_) = info.addr {
-                return Err(RedisError::from((ErrorKind::InvalidClientConfig,
-                                             "This library cannot use unix socket because Redis's cluster command returns only cluster's IP and port.")));
-            }
-
-            if builder.password.is_none() {
-                if index == 0 {
-                    connection_info_password = info.redis.password.clone();
-                } else if connection_info_password != info.redis.password {
-                    return Err(RedisError::from((
-                        ErrorKind::InvalidClientConfig,
-                        "Cannot use different password among initial nodes.",
-                    )));
-                }
-            }
-
-            if builder.username.is_none() {
-                if index == 0 {
-                    connection_info_username = info.redis.username.clone();
-                } else if connection_info_username != info.redis.username {
-                    return Err(RedisError::from((
-                        ErrorKind::InvalidClientConfig,
-                        "Cannot use different username among initial nodes.",
-                    )));
-                }
-            }
-
-            nodes.push(info);
-        }
-
-        Ok(ClusterClient {
-            initial_nodes: nodes,
-            read_from_replicas: builder.read_from_replicas,
-            username: builder.username.or(connection_info_username),
-            password: builder.password.or(connection_info_password),
-        })
+    /// Use `new()`.
+    #[deprecated(since = "0.22.0", note = "Use new()")]
+    pub fn open<T>(initial_nodes: Vec<T>) -> RedisResult<ClusterClient>
+    where
+        T: IntoConnectionInfo,
+    {
+        ClusterClient::new(initial_nodes)
     }
 }
 
 impl Clone for ClusterClient {
     fn clone(&self) -> ClusterClient {
-        ClusterClient::open(self.initial_nodes.clone()).unwrap()
+        ClusterClient::new(self.initial_nodes.clone()).unwrap()
     }
 }
 
@@ -198,26 +228,26 @@ mod tests {
 
     #[test]
     fn give_no_password() {
-        let client = ClusterClient::open(get_connection_data()).unwrap();
+        let client = ClusterClient::new(get_connection_data()).unwrap();
         assert_eq!(client.password, None);
     }
 
     #[test]
     fn give_password_by_initial_nodes() {
-        let client = ClusterClient::open(get_connection_data_with_password()).unwrap();
+        let client = ClusterClient::new(get_connection_data_with_password()).unwrap();
         assert_eq!(client.password, Some("password".to_string()));
     }
 
     #[test]
     fn give_username_and_password_by_initial_nodes() {
-        let client = ClusterClient::open(get_connection_data_with_username_and_password()).unwrap();
+        let client = ClusterClient::new(get_connection_data_with_username_and_password()).unwrap();
         assert_eq!(client.password, Some("password".to_string()));
         assert_eq!(client.username, Some("user1".to_string()));
     }
 
     #[test]
     fn give_different_password_by_initial_nodes() {
-        let result = ClusterClient::open(vec![
+        let result = ClusterClient::new(vec![
             "redis://:password1@127.0.0.1:6379",
             "redis://:password2@127.0.0.1:6378",
             "redis://:password3@127.0.0.1:6377",
@@ -227,7 +257,7 @@ mod tests {
 
     #[test]
     fn give_different_username_by_initial_nodes() {
-        let result = ClusterClient::open(vec![
+        let result = ClusterClient::new(vec![
             "redis://user1:password@127.0.0.1:6379",
             "redis://user2:password@127.0.0.1:6378",
             "redis://user1:password@127.0.0.1:6377",
@@ -240,7 +270,7 @@ mod tests {
         let client = ClusterClientBuilder::new(get_connection_data_with_password())
             .password("pass".to_string())
             .username("user1".to_string())
-            .open()
+            .build()
             .unwrap();
         assert_eq!(client.password, Some("pass".to_string()));
         assert_eq!(client.username, Some("user1".to_string()));

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -1,15 +1,19 @@
 use crate::cluster::ClusterConnection;
+use crate::connection::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo};
+use crate::types::{ErrorKind, RedisError, RedisResult};
 
-use super::{
-    ConnectionAddr, ConnectionInfo, ErrorKind, IntoConnectionInfo, RedisError, RedisResult,
-};
+/// Redis cluster specific parameters.
+#[derive(Default, Clone)]
+pub(crate) struct ClusterParams {
+    pub(crate) password: Option<String>,
+    pub(crate) username: Option<String>,
+    pub(crate) read_from_replicas: bool,
+}
 
 /// Used to configure and build a [ClusterClient](ClusterClient).
 pub struct ClusterClientBuilder {
     initial_nodes: RedisResult<Vec<ConnectionInfo>>,
-    read_from_replicas: bool,
-    username: Option<String>,
-    password: Option<String>,
+    cluster_params: ClusterParams,
 }
 
 impl ClusterClientBuilder {
@@ -25,9 +29,7 @@ impl ClusterClientBuilder {
                 .into_iter()
                 .map(|x| x.into_connection_info())
                 .collect(),
-            read_from_replicas: false,
-            username: None,
-            password: None,
+            cluster_params: ClusterParams::default(),
         }
     }
 
@@ -41,69 +43,72 @@ impl ClusterClientBuilder {
     /// Upon failure to parse initial nodes or if the initial nodes have different passwords or
     /// usernames, an error is returned.
     pub fn build(self) -> RedisResult<ClusterClient> {
-        let initial_nodes = self.initial_nodes?;
+        let mut initial_nodes = self.initial_nodes?;
 
-        let mut nodes = Vec::with_capacity(initial_nodes.len());
-        let mut connection_info_password = None::<String>;
-        let mut connection_info_username = None::<String>;
+        let mut cluster_params = self.cluster_params;
+        let password = if cluster_params.password.is_none() {
+            cluster_params.password = initial_nodes[0].redis.password.clone();
+            &cluster_params.password
+        } else {
+            &None
+        };
+        let username = if cluster_params.username.is_none() {
+            cluster_params.username = initial_nodes[0].redis.username.clone();
+            &cluster_params.username
+        } else {
+            &None
+        };
 
-        for (index, info) in initial_nodes.into_iter().enumerate() {
-            if let ConnectionAddr::Unix(_) = info.addr {
-                return Err(RedisError::from((ErrorKind::InvalidClientConfig,
-                                         "This library cannot use unix socket because Redis's cluster command returns only cluster's IP and port.")));
-            }
+        initial_nodes = initial_nodes
+            .into_iter()
+            .map(|node| {
+                if let ConnectionAddr::Unix(_) = node.addr {
+                    return Err(RedisError::from((ErrorKind::InvalidClientConfig,
+                                                 "This library cannot use unix socket because Redis's cluster command returns only cluster's IP and port.")));
+                }
 
-            if self.password.is_none() {
-                if index == 0 {
-                    connection_info_password = info.redis.password.clone();
-                } else if connection_info_password != info.redis.password {
+                if password.is_some() && node.redis.password != *password {
                     return Err(RedisError::from((
                         ErrorKind::InvalidClientConfig,
                         "Cannot use different password among initial nodes.",
                     )));
                 }
-            }
 
-            if self.username.is_none() {
-                if index == 0 {
-                    connection_info_username = info.redis.username.clone();
-                } else if connection_info_username != info.redis.username {
+                if username.is_some() && node.redis.username != *username {
                     return Err(RedisError::from((
                         ErrorKind::InvalidClientConfig,
                         "Cannot use different username among initial nodes.",
                     )));
                 }
-            }
 
-            nodes.push(info);
-        }
+                Ok(node)
+            })
+            .collect::<Result<_, _>>()?;
 
         Ok(ClusterClient {
-            initial_nodes: nodes,
-            read_from_replicas: self.read_from_replicas,
-            username: self.username.or(connection_info_username),
-            password: self.password.or(connection_info_password),
+            initial_nodes,
+            cluster_params,
         })
     }
 
-    /// Set password for new ClusterClient.
+    /// Sets password for new ClusterClient.
     pub fn password(mut self, password: String) -> ClusterClientBuilder {
-        self.password = Some(password);
+        self.cluster_params.password = Some(password);
         self
     }
 
-    /// Set username for new ClusterClient.
+    /// Sets username for new ClusterClient.
     pub fn username(mut self, username: String) -> ClusterClientBuilder {
-        self.username = Some(username);
+        self.cluster_params.username = Some(username);
         self
     }
 
-    /// Enable read from replicas for new ClusterClient (default is false).
+    /// Enables read from replicas for new ClusterClient (default is false).
     ///
     /// If True, then read queries will go to the replica nodes & write queries will go to the
     /// primary nodes. If there are no replica nodes, then all queries will go to the primary nodes.
     pub fn read_from_replicas(mut self) -> ClusterClientBuilder {
-        self.read_from_replicas = true;
+        self.cluster_params.read_from_replicas = true;
         self
     }
 
@@ -116,17 +121,16 @@ impl ClusterClientBuilder {
     /// Use `read_from_replicas()`.
     #[deprecated(since = "0.22.0", note = "Use read_from_replicas()")]
     pub fn readonly(mut self, read_from_replicas: bool) -> ClusterClientBuilder {
-        self.read_from_replicas = read_from_replicas;
+        self.cluster_params.read_from_replicas = read_from_replicas;
         self
     }
 }
 
 /// This is a Redis cluster client.
+#[derive(Clone)]
 pub struct ClusterClient {
     initial_nodes: Vec<ConnectionInfo>,
-    read_from_replicas: bool,
-    username: Option<String>,
-    password: Option<String>,
+    cluster_params: ClusterParams,
 }
 
 impl ClusterClient {
@@ -154,19 +158,14 @@ impl ClusterClient {
         ClusterClientBuilder::new(initial_nodes)
     }
 
-    /// Opens connections to Redis Cluster nodes and returns a
+    /// Creates new connections to Redis Cluster nodes and return a
     /// [ClusterConnection](ClusterConnection).
     ///
     /// # Errors
     ///
-    /// An error is returned if there is a failure to open connections or to create slots.
+    /// An error is returned if there is a failure while creating connections or slots.
     pub fn get_connection(&self) -> RedisResult<ClusterConnection> {
-        ClusterConnection::new(
-            self.initial_nodes.clone(),
-            self.read_from_replicas,
-            self.username.clone(),
-            self.password.clone(),
-        )
+        ClusterConnection::new(&self.cluster_params, &self.initial_nodes)
     }
 
     /// Use `new()`.
@@ -179,16 +178,9 @@ impl ClusterClient {
     }
 }
 
-impl Clone for ClusterClient {
-    fn clone(&self) -> ClusterClient {
-        ClusterClient::new(self.initial_nodes.clone()).unwrap()
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{ClusterClient, ClusterClientBuilder};
-    use super::{ConnectionInfo, IntoConnectionInfo};
+    use super::{ClusterClient, ClusterClientBuilder, ConnectionInfo, IntoConnectionInfo};
 
     fn get_connection_data() -> Vec<ConnectionInfo> {
         vec![
@@ -229,20 +221,20 @@ mod tests {
     #[test]
     fn give_no_password() {
         let client = ClusterClient::new(get_connection_data()).unwrap();
-        assert_eq!(client.password, None);
+        assert_eq!(client.cluster_params.password, None);
     }
 
     #[test]
     fn give_password_by_initial_nodes() {
         let client = ClusterClient::new(get_connection_data_with_password()).unwrap();
-        assert_eq!(client.password, Some("password".to_string()));
+        assert_eq!(client.cluster_params.password, Some("password".to_string()));
     }
 
     #[test]
     fn give_username_and_password_by_initial_nodes() {
         let client = ClusterClient::new(get_connection_data_with_username_and_password()).unwrap();
-        assert_eq!(client.password, Some("password".to_string()));
-        assert_eq!(client.username, Some("user1".to_string()));
+        assert_eq!(client.cluster_params.password, Some("password".to_string()));
+        assert_eq!(client.cluster_params.username, Some("user1".to_string()));
     }
 
     #[test]
@@ -272,7 +264,7 @@ mod tests {
             .username("user1".to_string())
             .build()
             .unwrap();
-        assert_eq!(client.password, Some("pass".to_string()));
-        assert_eq!(client.username, Some("user1".to_string()));
+        assert_eq!(client.cluster_params.password, Some("pass".to_string()));
+        assert_eq!(client.cluster_params.username, Some("user1".to_string()));
     }
 }

--- a/redis/src/cluster_pipeline.rs
+++ b/redis/src/cluster_pipeline.rs
@@ -1,13 +1,7 @@
 use crate::cluster::ClusterConnection;
+use crate::cluster_routing::UNROUTABLE_ERROR;
 use crate::cmd::{cmd, Cmd};
-use crate::types::{
-    from_redis_value, ErrorKind, FromRedisValue, HashSet, RedisResult, ToRedisArgs, Value,
-};
-
-pub(crate) const UNROUTABLE_ERROR: (ErrorKind, &str) = (
-    ErrorKind::ClientError,
-    "This command cannot be safely routed in cluster mode",
-);
+use crate::types::{from_redis_value, FromRedisValue, HashSet, RedisResult, ToRedisArgs, Value};
 
 fn is_illegal_cmd(cmd: &str) -> bool {
     matches!(

--- a/redis/src/cluster_pipeline.rs
+++ b/redis/src/cluster_pipeline.rs
@@ -92,7 +92,7 @@ impl ClusterPipeline {
     ///
     /// ```rust,no_run
     /// # let nodes = vec!["redis://127.0.0.1:6379/"];
-    /// # let client = redis::cluster::ClusterClient::open(nodes).unwrap();
+    /// # let client = redis::cluster::ClusterClient::new(nodes).unwrap();
     /// # let mut con = client.get_connection().unwrap();
     /// let mut pipe = redis::cluster::cluster_pipe();
     /// let (k1, k2) : (i32, i32) = pipe
@@ -137,7 +137,7 @@ impl ClusterPipeline {
     ///
     /// ```rust,no_run
     /// # let nodes = vec!["redis://127.0.0.1:6379/"];
-    /// # let client = redis::cluster::ClusterClient::open(nodes).unwrap();
+    /// # let client = redis::cluster::ClusterClient::new(nodes).unwrap();
     /// # let mut con = client.get_connection().unwrap();
     /// let mut pipe = redis::cluster::cluster_pipe();
     /// let _ : () = pipe.cmd("SET").arg("key_1").arg(42).ignore().query(&mut con).unwrap();

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -4,6 +4,7 @@ use rand::{thread_rng, Rng};
 
 use crate::cmd::{Arg, Cmd};
 use crate::commands::is_readonly_cmd;
+use crate::connection::ConnectionAddr;
 use crate::types::{ErrorKind, RedisError, RedisResult, Value};
 
 pub(crate) const SLOT_SIZE: u16 = 16384;
@@ -141,39 +142,11 @@ impl Routable for Value {
     }
 }
 
-#[derive(Debug)]
 pub(crate) struct Slot {
-    start: u16,
-    end: u16,
-    master: String,
-    replicas: Vec<String>,
-}
-
-impl Slot {
-    pub fn new(s: u16, e: u16, m: String, r: Vec<String>) -> Self {
-        Self {
-            start: s,
-            end: e,
-            master: m,
-            replicas: r,
-        }
-    }
-
-    pub fn start(&self) -> u16 {
-        self.start
-    }
-
-    pub fn end(&self) -> u16 {
-        self.end
-    }
-
-    pub fn master(&self) -> &str {
-        &self.master
-    }
-
-    pub fn replicas(&self) -> &Vec<String> {
-        &self.replicas
-    }
+    pub(crate) start: u16,
+    pub(crate) end: u16,
+    pub(crate) master: ConnectionAddr,
+    pub(crate) replicas: Vec<ConnectionAddr>,
 }
 
 fn get_hashtag(key: &[u8]) -> Option<&[u8]> {

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -226,7 +226,7 @@ impl TestClusterContext {
                 .collect(),
         );
         builder = initializer(builder);
-        let client = builder.open().unwrap();
+        let client = builder.build().unwrap();
         TestClusterContext { cluster, client }
     }
 


### PR DESCRIPTION
Continuing from the previous PR, this PR refactors & optimizes ClusterConnection impl for Async Cluster.

Main changes:
- Removed random connection logic
  - Since we only operate in 100% slot coverage scenarios, there is no point in maintaining random connection logic, which is supposed to help us find missing nodes in the cluster topology
  - This also allows us to remove RefCell around connections & slots
- Removed RefCell from connections/slot in the struct
  - RefCells aren't needed anymore & removing them gives a minor performance bump
- Consolidated logic for query routing into the Routable trait
  - This improves code reuse within the impl as well as later in Async impl
- Consolidated logic for create_initial_connections & refresh_slots
  - This improves code reuse within the impl as well as later in Async impl
  - Also renamed addr -> node where it is used as a string
- Directly exposed Slot fields instead of bare methods
  - There is no benefit of accessing the fields via functions
- Merge send_all_commands & recv_all_commands
  - There is no point in having 2 different methods