### PR TITLE
[1/5] cluster: implement proper builder pattern & minor refactor

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -12,7 +12,7 @@
 //! use redis::cluster::ClusterClient;
 //!
 //! let nodes = vec!["redis://127.0.0.1:6379/", "redis://127.0.0.1:6378/", "redis://127.0.0.1:6377/"];
-//! let client = ClusterClient::open(nodes).unwrap();
+//! let client = ClusterClient::new(nodes).unwrap();
 //! let mut connection = client.get_connection().unwrap();
 //!
 //! let _: () = connection.set("test", "test_data").unwrap();
@@ -27,7 +27,7 @@
 //! use redis::cluster::{cluster_pipe, ClusterClient};
 //!
 //! let nodes = vec!["redis://127.0.0.1:6379/", "redis://127.0.0.1:6378/", "redis://127.0.0.1:6377/"];
-//! let client = ClusterClient::open(nodes).unwrap();
+//! let client = ClusterClient::new(nodes).unwrap();
 //! let mut connection = client.get_connection().unwrap();
 //!
 //! let key = "test";

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -55,6 +55,7 @@ use super::{
     Cmd, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, ErrorKind, IntoConnectionInfo,
     RedisError, RedisResult, Value,
 };
+use crate::cluster_client::ClusterParams;
 
 pub use crate::cluster_client::{ClusterClient, ClusterClientBuilder};
 use crate::cluster_pipeline::UNROUTABLE_ERROR;
@@ -95,25 +96,23 @@ impl TlsMode {
 
 impl ClusterConnection {
     pub(crate) fn new(
+        cluster_params: ClusterParams,
         initial_nodes: Vec<ConnectionInfo>,
-        read_from_replicas: bool,
-        username: Option<String>,
-        password: Option<String>,
     ) -> RedisResult<ClusterConnection> {
         let connections = Self::create_initial_connections(
             &initial_nodes,
-            read_from_replicas,
-            username.clone(),
-            password.clone(),
+            cluster_params.read_from_replicas,
+            cluster_params.username.clone(),
+            cluster_params.password.clone(),
         )?;
 
         let connection = ClusterConnection {
             connections: RefCell::new(connections),
             slots: RefCell::new(SlotMap::new()),
             auto_reconnect: RefCell::new(true),
-            read_from_replicas,
-            username,
-            password,
+            read_from_replicas: cluster_params.read_from_replicas,
+            username: cluster_params.username,
+            password: cluster_params.password,
             read_timeout: RefCell::new(None),
             write_timeout: RefCell::new(None),
             #[cfg(feature = "tls")]
@@ -135,7 +134,7 @@ impl ClusterConnection {
             },
             #[cfg(not(feature = "tls"))]
             tls: None,
-            initial_nodes,
+            initial_nodes: initial_nodes.to_vec(),
         };
         connection.refresh_slots()?;
 

--- a/redis/src/cluster_pipeline.rs
+++ b/redis/src/cluster_pipeline.rs
@@ -92,7 +92,7 @@ impl ClusterPipeline {
     ///
     /// ```rust,no_run
     /// # let nodes = vec!["redis://127.0.0.1:6379/"];
-    /// # let client = redis::cluster::ClusterClient::open(nodes).unwrap();
+    /// # let client = redis::cluster::ClusterClient::new(nodes).unwrap();
     /// # let mut con = client.get_connection().unwrap();
     /// let mut pipe = redis::cluster::cluster_pipe();
     /// let (k1, k2) : (i32, i32) = pipe
@@ -137,7 +137,7 @@ impl ClusterPipeline {
     ///
     /// ```rust,no_run
     /// # let nodes = vec!["redis://127.0.0.1:6379/"];
-    /// # let client = redis::cluster::ClusterClient::open(nodes).unwrap();
+    /// # let client = redis::cluster::ClusterClient::new(nodes).unwrap();
     /// # let mut con = client.get_connection().unwrap();
     /// let mut pipe = redis::cluster::cluster_pipe();
     /// let _ : () = pipe.cmd("SET").arg("key_1").arg(42).ignore().query(&mut con).unwrap();

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -232,7 +232,7 @@ impl TestClusterContext {
                 .collect(),
         );
         builder = initializer(builder);
-        let client = builder.open().unwrap();
+        let client = builder.build().unwrap();
         TestClusterContext { cluster, client }
     }
 


### PR DESCRIPTION
Most of the crates in the Rust ecosystem use `builder()` & `build()` for client & builder as well as `new()` for both of them. Currently, the redis crate uses the unintuitive `open()` methods for the same.
With this PR, I've changed the cluster client to follow the proper builder pattern and redirect the old methods to the new ones.

Also refactored the cluster client in 2 main ways:
- Moved the `build()` method from the client to the builder & made it public
- Create a crate-level struct `ClusterParams` to hold all the params inside a single struct instead of multiple fields in the main struct
  - This struct will be used in the later PRs to pass cluster params to & inside the ClusterConnection impl

In addition, improved the documentation as I saw fit.