### PR TITLE
[2/5] cluster: refactor param passing & add params to the builder

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -97,6 +97,8 @@ impl ClusterConnection {
     }
 
     /// Set the write timeout for this connection.
+    ///
+    /// See [ClusterClientBuilder](ClusterClientBuilder::write_timeout).
     pub fn set_write_timeout(&mut self, dur: Option<Duration>) -> RedisResult<()> {
         // Check if duration is valid before updating local value.
         ClusterParams::validate_duration(&dur)?;
@@ -109,6 +111,8 @@ impl ClusterConnection {
     }
 
     /// Set the read timeout for this connection.
+    ///
+    /// See [ClusterClientBuilder](ClusterClientBuilder::read_timeout).
     pub fn set_read_timeout(&mut self, dur: Option<Duration>) -> RedisResult<()> {
         // Check if duration is valid before updating local value.
         ClusterParams::validate_duration(&dur)?;

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -135,6 +135,11 @@ impl ClusterConnection {
         Ok(())
     }
 
+    /// Set the read from replicas parameter for this connection.
+    pub fn set_read_from_replicas(&mut self, value: bool) {
+        self.cluster_params.read_from_replicas = value;
+    }
+
     /// Set the retries parameter for this connection.
     pub fn set_retries(&mut self, value: u8) {
         self.cluster_params.retries = value;

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -135,6 +135,11 @@ impl ClusterConnection {
         Ok(())
     }
 
+    /// Set the retries parameter for this connection.
+    pub fn set_retries(&mut self, value: u8) {
+        self.cluster_params.retries = value;
+    }
+
     /// Set the auto reconnect parameter for this connection.
     pub fn set_auto_reconnect(&mut self, value: bool) {
         self.cluster_params.auto_reconnect = value;
@@ -403,7 +408,7 @@ impl ClusterConnection {
             None => fail!(UNROUTABLE_ERROR),
         };
 
-        let mut retries = 16;
+        let mut retries = self.cluster_params.retries;
         let mut excludes = HashSet::new();
         let mut redirected = None::<String>;
         let mut is_asking = false;
@@ -454,7 +459,7 @@ impl ClusterConnection {
                             continue;
                         } else if kind == ErrorKind::TryAgain || kind == ErrorKind::ClusterDown {
                             // Sleep and retry.
-                            let sleep_time = 2u64.pow(16 - retries.max(9)) * 10;
+                            let sleep_time = 2u64.pow(16 - u32::from(retries.max(9))) * 10;
                             thread::sleep(Duration::from_millis(sleep_time));
                             excludes.clear();
                             continue;

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -41,7 +41,6 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::iter::Iterator;
-use std::str::FromStr;
 use std::thread;
 use std::time::Duration;
 
@@ -54,9 +53,7 @@ use crate::cluster_client::ClusterParams;
 use crate::cluster_pipeline::UNROUTABLE_ERROR;
 use crate::cluster_routing::{Routable, RoutingInfo, Slot, SLOT_SIZE};
 use crate::cmd::{cmd, Cmd};
-use crate::connection::{
-    connect, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, RedisConnectionInfo,
-};
+use crate::connection::{connect, Connection, ConnectionInfo, ConnectionLike};
 use crate::parser::parse_redis_value;
 use crate::types::{ErrorKind, HashMap, HashSet, RedisError, RedisResult, Value};
 
@@ -75,17 +72,13 @@ pub enum TlsMode {
 }
 
 /// This is a connection of Redis cluster.
+#[derive(Default)]
 pub struct ClusterConnection {
+    cluster_params: ClusterParams,
     initial_nodes: Vec<ConnectionInfo>,
+
     connections: RefCell<HashMap<String, Connection>>,
     slots: RefCell<SlotMap>,
-    auto_reconnect: RefCell<bool>,
-    read_from_replicas: bool,
-    username: Option<String>,
-    password: Option<String>,
-    read_timeout: RefCell<Option<Duration>>,
-    write_timeout: RefCell<Option<Duration>>,
-    tls_mode: Option<TlsMode>,
 }
 
 impl ClusterConnection {
@@ -94,73 +87,42 @@ impl ClusterConnection {
         initial_nodes: Vec<ConnectionInfo>,
     ) -> RedisResult<ClusterConnection> {
         let connection = ClusterConnection {
-            connections: RefCell::new(HashMap::new()),
-            slots: RefCell::new(SlotMap::new()),
-            auto_reconnect: RefCell::new(true),
-            read_from_replicas: cluster_params.read_from_replicas,
-            username: cluster_params.username,
-            password: cluster_params.password,
-            read_timeout: RefCell::new(None),
-            write_timeout: RefCell::new(None),
-            tls_mode: cluster_params.tls_mode,
-            initial_nodes: initial_nodes.to_vec(),
+            cluster_params,
+            initial_nodes,
+            ..Default::default()
         };
         connection.create_initial_connections()?;
 
         Ok(connection)
     }
 
-    /// Sets the write timeout for the connection.
-    ///
-    /// If the provided value is `None`, then `send_packed_command` call will
-    /// block indefinitely. It is an error to pass the zero `Duration` to this
-    /// method.
-    pub fn set_write_timeout(&self, dur: Option<Duration>) -> RedisResult<()> {
+    /// Set the write timeout for this connection.
+    pub fn set_write_timeout(&mut self, dur: Option<Duration>) -> RedisResult<()> {
         // Check if duration is valid before updating local value.
-        if dur.is_some() && dur.unwrap().is_zero() {
-            return Err(RedisError::from((
-                ErrorKind::InvalidClientConfig,
-                "Duration should be None or non-zero.",
-            )));
-        }
+        ClusterParams::validate_duration(&dur)?;
 
-        let mut t = self.write_timeout.borrow_mut();
-        *t = dur;
-        let connections = self.connections.borrow();
-        for conn in connections.values() {
+        self.cluster_params.write_timeout = dur;
+        for conn in self.connections.borrow().values() {
             conn.set_write_timeout(dur)?;
         }
         Ok(())
     }
 
-    /// Sets the read timeout for the connection.
-    ///
-    /// If the provided value is `None`, then `recv_response` call will
-    /// block indefinitely. It is an error to pass the zero `Duration` to this
-    /// method.
-    pub fn set_read_timeout(&self, dur: Option<Duration>) -> RedisResult<()> {
+    /// Set the read timeout for this connection.
+    pub fn set_read_timeout(&mut self, dur: Option<Duration>) -> RedisResult<()> {
         // Check if duration is valid before updating local value.
-        if dur.is_some() && dur.unwrap().is_zero() {
-            return Err(RedisError::from((
-                ErrorKind::InvalidClientConfig,
-                "Duration should be None or non-zero.",
-            )));
-        }
+        ClusterParams::validate_duration(&dur)?;
 
-        let mut t = self.read_timeout.borrow_mut();
-        *t = dur;
-        let connections = self.connections.borrow();
-        for conn in connections.values() {
+        self.cluster_params.read_timeout = dur;
+        for conn in self.connections.borrow().values() {
             conn.set_read_timeout(dur)?;
         }
         Ok(())
     }
 
-    /// Set an auto reconnect attribute.
-    /// Default value is true;
-    pub fn set_auto_reconnect(&self, value: bool) {
-        let mut auto_reconnect = self.auto_reconnect.borrow_mut();
-        *auto_reconnect = value;
+    /// Set the auto reconnect parameter for this connection.
+    pub fn set_auto_reconnect(&mut self, value: bool) {
+        self.cluster_params.auto_reconnect = value;
     }
 
     pub(crate) fn execute_pipeline(&mut self, pipe: &ClusterPipeline) -> RedisResult<Vec<Value>> {
@@ -204,15 +166,16 @@ impl ClusterConnection {
     fn refresh_slots(&self) -> RedisResult<()> {
         let mut slots = self.slots.borrow_mut();
         *slots = self.create_new_slots(|slot_data| {
-            let replica = if !self.read_from_replicas || slot_data.replicas().is_empty() {
-                slot_data.master().to_string()
-            } else {
-                slot_data
-                    .replicas()
-                    .choose(&mut thread_rng())
-                    .unwrap()
-                    .to_string()
-            };
+            let replica =
+                if !self.cluster_params.read_from_replicas || slot_data.replicas().is_empty() {
+                    slot_data.master().to_string()
+                } else {
+                    slot_data
+                        .replicas()
+                        .choose(&mut thread_rng())
+                        .unwrap()
+                        .to_string()
+                };
 
             [slot_data.master().to_string(), replica]
         })?;
@@ -234,8 +197,9 @@ impl ClusterConnection {
 
                 if let Ok(mut conn) = self.connect(addr) {
                     if conn.check_connection() {
-                        conn.set_read_timeout(*self.read_timeout.borrow()).unwrap();
-                        conn.set_write_timeout(*self.write_timeout.borrow())
+                        conn.set_read_timeout(self.cluster_params.read_timeout)
+                            .unwrap();
+                        conn.set_write_timeout(self.cluster_params.write_timeout)
                             .unwrap();
                         return Some((addr.to_string(), conn));
                     }
@@ -259,7 +223,7 @@ impl ClusterConnection {
         let mut samples = connections.values_mut().choose_multiple(&mut rng, len);
 
         for conn in samples.iter_mut() {
-            if let Ok(mut slots_data) = get_slots(conn, self.tls_mode) {
+            if let Ok(mut slots_data) = get_slots(conn, &self.cluster_params) {
                 slots_data.sort_by_key(|s| s.start());
                 let last_slot = slots_data.iter().try_fold(0, |prev_end, slot_data| {
                     if prev_end != slot_data.start() {
@@ -306,16 +270,10 @@ impl ClusterConnection {
     }
 
     fn connect(&self, node: &str) -> RedisResult<Connection> {
-        let params = ClusterParams {
-            password: self.password.clone(),
-            username: self.username.clone(),
-            tls_mode: self.tls_mode,
-            ..Default::default()
-        };
-        let info = get_connection_info(node, &params);
+        let info = self.cluster_params.get_connection_info(node);
 
         let mut conn = connect(&info, None)?;
-        if self.read_from_replicas {
+        if self.cluster_params.read_from_replicas {
             // If READONLY is sent to primary nodes, it will have no effect
             cmd("READONLY").query(&mut conn)?;
         }
@@ -486,7 +444,7 @@ impl ClusterConnection {
                             excludes.clear();
                             continue;
                         }
-                    } else if *self.auto_reconnect.borrow() && err.is_io_error() {
+                    } else if self.cluster_params.auto_reconnect && err.is_io_error() {
                         self.create_initial_connections()?;
                         excludes.clear();
                         continue;
@@ -687,7 +645,10 @@ fn get_random_connection<'a>(
 }
 
 // Get slot data from connection.
-fn get_slots(connection: &mut Connection, tls_mode: Option<TlsMode>) -> RedisResult<Vec<Slot>> {
+fn get_slots(
+    connection: &mut Connection,
+    cluster_params: &ClusterParams,
+) -> RedisResult<Vec<Slot>> {
     let mut cmd = Cmd::new();
     cmd.arg("CLUSTER").arg("SLOTS");
     let value = connection.req_command(&cmd)?;
@@ -737,7 +698,11 @@ fn get_slots(connection: &mut Connection, tls_mode: Option<TlsMode>) -> RedisRes
                         } else {
                             return None;
                         };
-                        Some(get_connection_addr(ip.into_owned(), port, tls_mode).to_string())
+                        Some(
+                            cluster_params
+                                .get_connection_addr(ip.into_owned(), port)
+                                .to_string(),
+                        )
                     } else {
                         None
                     }
@@ -754,35 +719,4 @@ fn get_slots(connection: &mut Connection, tls_mode: Option<TlsMode>) -> RedisRes
     }
 
     Ok(result)
-}
-
-fn get_connection_info(node: &str, cluster_params: &ClusterParams) -> ConnectionInfo {
-    let mut split = node.split(':');
-    let host = split.next().unwrap().to_string();
-    let port = u16::from_str(split.next().unwrap()).unwrap();
-
-    ConnectionInfo {
-        addr: get_connection_addr(host, port, cluster_params.tls_mode),
-        redis: RedisConnectionInfo {
-            password: cluster_params.password.clone(),
-            username: cluster_params.username.clone(),
-            ..Default::default()
-        },
-    }
-}
-
-fn get_connection_addr(host: String, port: u16, tls_mode: Option<TlsMode>) -> ConnectionAddr {
-    match tls_mode {
-        Some(TlsMode::Secure) => ConnectionAddr::TcpTls {
-            host,
-            port,
-            insecure: false,
-        },
-        Some(TlsMode::Insecure) => ConnectionAddr::TcpTls {
-            host,
-            port,
-            insecure: true,
-        },
-        _ => ConnectionAddr::Tcp(host, port),
-    }
 }

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -49,18 +49,18 @@ use rand::{
     thread_rng, Rng,
 };
 
-use super::{
-    cmd, parse_redis_value,
-    types::{HashMap, HashSet},
-    Cmd, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, ErrorKind, IntoConnectionInfo,
-    RedisError, RedisResult, Value,
-};
 use crate::cluster_client::ClusterParams;
+use crate::cluster_pipeline::UNROUTABLE_ERROR;
+use crate::cluster_routing::{Routable, RoutingInfo, Slot, SLOT_SIZE};
+use crate::cmd::{cmd, Cmd};
+use crate::connection::{
+    Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, IntoConnectionInfo,
+};
+use crate::parser::parse_redis_value;
+use crate::types::{ErrorKind, HashMap, HashSet, RedisError, RedisResult, Value};
 
 pub use crate::cluster_client::{ClusterClient, ClusterClientBuilder};
-use crate::cluster_pipeline::UNROUTABLE_ERROR;
 pub use crate::cluster_pipeline::{cluster_pipe, ClusterPipeline};
-use crate::cluster_routing::{Routable, RoutingInfo, Slot, SLOT_SIZE};
 
 type SlotMap = BTreeMap<u16, [String; 2]>;
 

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -64,6 +64,12 @@ use crate::cluster_routing::{Routable, RoutingInfo, Slot, SLOT_SIZE};
 
 type SlotMap = BTreeMap<u16, [String; 2]>;
 
+#[derive(Clone, Copy)]
+enum TlsMode {
+    Secure,
+    Insecure,
+}
+
 /// This is a connection of Redis cluster.
 pub struct ClusterConnection {
     initial_nodes: Vec<ConnectionInfo>,
@@ -76,12 +82,6 @@ pub struct ClusterConnection {
     read_timeout: RefCell<Option<Duration>>,
     write_timeout: RefCell<Option<Duration>>,
     tls: Option<TlsMode>,
-}
-
-#[derive(Clone, Copy)]
-enum TlsMode {
-    Secure,
-    Insecure,
 }
 
 impl TlsMode {
@@ -141,13 +141,6 @@ impl ClusterConnection {
         Ok(connection)
     }
 
-    /// Set an auto reconnect attribute.
-    /// Default value is true;
-    pub fn set_auto_reconnect(&self, value: bool) {
-        let mut auto_reconnect = self.auto_reconnect.borrow_mut();
-        *auto_reconnect = value;
-    }
-
     /// Sets the write timeout for the connection.
     ///
     /// If the provided value is `None`, then `send_packed_command` call will
@@ -194,15 +187,11 @@ impl ClusterConnection {
         Ok(())
     }
 
-    /// Check that all connections it has are available (`PING` internally).
-    pub fn check_connection(&mut self) -> bool {
-        let mut connections = self.connections.borrow_mut();
-        for conn in connections.values_mut() {
-            if !conn.check_connection() {
-                return false;
-            }
-        }
-        true
+    /// Set an auto reconnect attribute.
+    /// Default value is true;
+    pub fn set_auto_reconnect(&self, value: bool) {
+        let mut auto_reconnect = self.auto_reconnect.borrow_mut();
+        *auto_reconnect = value;
     }
 
     pub(crate) fn execute_pipeline(&mut self, pipe: &ClusterPipeline) -> RedisResult<Vec<Value>> {
@@ -238,7 +227,7 @@ impl ClusterConnection {
                 _ => panic!("No reach."),
             };
 
-            if let Ok(mut conn) = connect(
+            if let Ok(mut conn) = Self::connect(
                 info.clone(),
                 read_from_replicas,
                 username.clone(),
@@ -292,7 +281,7 @@ impl ClusterConnection {
                     }
                 }
 
-                if let Ok(mut conn) = connect(
+                if let Ok(mut conn) = Self::connect(
                     addr.as_ref(),
                     self.read_from_replicas,
                     self.username.clone(),
@@ -370,6 +359,28 @@ impl ClusterConnection {
         }
     }
 
+    fn connect<T: IntoConnectionInfo>(
+        info: T,
+        read_from_replicas: bool,
+        username: Option<String>,
+        password: Option<String>,
+    ) -> RedisResult<Connection>
+    where
+        T: std::fmt::Debug,
+    {
+        let mut connection_info = info.into_connection_info()?;
+        connection_info.redis.username = username;
+        connection_info.redis.password = password;
+        let client = super::Client::open(connection_info)?;
+
+        let mut conn = client.get_connection()?;
+        if read_from_replicas {
+            // If READONLY is sent to primary nodes, it will have no effect
+            cmd("READONLY").query(&mut conn)?;
+        }
+        Ok(conn)
+    }
+
     fn get_connection<'a>(
         &self,
         connections: &'a mut HashMap<String, Connection>,
@@ -399,7 +410,7 @@ impl ClusterConnection {
         } else {
             // Create new connection.
             // TODO: error handling
-            let conn = connect(
+            let conn = Self::connect(
                 addr,
                 self.read_from_replicas,
                 self.username.clone(),
@@ -407,6 +418,47 @@ impl ClusterConnection {
             )?;
             Ok(connections.entry(addr.to_string()).or_insert(conn))
         }
+    }
+
+    fn get_addr_for_cmd(&self, cmd: &Cmd) -> RedisResult<String> {
+        let slots = self.slots.borrow();
+
+        let addr_for_slot = |slot: u16, idx: usize| -> RedisResult<String> {
+            let (_, addr) = slots
+                .range(&slot..)
+                .next()
+                .ok_or((ErrorKind::ClusterDown, "Missing slot coverage"))?;
+            Ok(addr[idx].clone())
+        };
+
+        match RoutingInfo::for_routable(cmd) {
+            Some(RoutingInfo::Random) => {
+                let mut rng = thread_rng();
+                Ok(addr_for_slot(rng.gen_range(0..SLOT_SIZE) as u16, 0)?)
+            }
+            Some(RoutingInfo::MasterSlot(slot)) => Ok(addr_for_slot(slot, 0)?),
+            Some(RoutingInfo::ReplicaSlot(slot)) => Ok(addr_for_slot(slot, 1)?),
+            _ => fail!(UNROUTABLE_ERROR),
+        }
+    }
+
+    fn map_cmds_to_nodes(&self, cmds: &[Cmd]) -> RedisResult<Vec<NodeCmd>> {
+        let mut cmd_map: HashMap<String, NodeCmd> = HashMap::new();
+
+        for (idx, cmd) in cmds.iter().enumerate() {
+            let addr = self.get_addr_for_cmd(cmd)?;
+            let nc = cmd_map
+                .entry(addr.clone())
+                .or_insert_with(|| NodeCmd::new(addr));
+            nc.indexes.push(idx);
+            cmd.write_packed_command(&mut nc.pipe);
+        }
+
+        let mut result = Vec::new();
+        for (_, v) in cmd_map.drain() {
+            result.push(v);
+        }
+        Ok(result)
     }
 
     fn execute_on_all_nodes<T, F>(&self, mut func: F) -> RedisResult<T>
@@ -570,47 +622,6 @@ impl ClusterConnection {
         Ok(node_cmds)
     }
 
-    fn get_addr_for_cmd(&self, cmd: &Cmd) -> RedisResult<String> {
-        let slots = self.slots.borrow();
-
-        let addr_for_slot = |slot: u16, idx: usize| -> RedisResult<String> {
-            let (_, addr) = slots
-                .range(&slot..)
-                .next()
-                .ok_or((ErrorKind::ClusterDown, "Missing slot coverage"))?;
-            Ok(addr[idx].clone())
-        };
-
-        match RoutingInfo::for_routable(cmd) {
-            Some(RoutingInfo::Random) => {
-                let mut rng = thread_rng();
-                Ok(addr_for_slot(rng.gen_range(0..SLOT_SIZE) as u16, 0)?)
-            }
-            Some(RoutingInfo::MasterSlot(slot)) => Ok(addr_for_slot(slot, 0)?),
-            Some(RoutingInfo::ReplicaSlot(slot)) => Ok(addr_for_slot(slot, 1)?),
-            _ => fail!(UNROUTABLE_ERROR),
-        }
-    }
-
-    fn map_cmds_to_nodes(&self, cmds: &[Cmd]) -> RedisResult<Vec<NodeCmd>> {
-        let mut cmd_map: HashMap<String, NodeCmd> = HashMap::new();
-
-        for (idx, cmd) in cmds.iter().enumerate() {
-            let addr = self.get_addr_for_cmd(cmd)?;
-            let nc = cmd_map
-                .entry(addr.clone())
-                .or_insert_with(|| NodeCmd::new(addr));
-            nc.indexes.push(idx);
-            cmd.write_packed_command(&mut nc.pipe);
-        }
-
-        let mut result = Vec::new();
-        for (_, v) in cmd_map.drain() {
-            result.push(v);
-        }
-        Ok(result)
-    }
-
     // Receive from each node, keeping track of which commands need to be retried.
     fn recv_all_commands(
         &self,
@@ -636,49 +647,6 @@ impl ClusterConnection {
         match first_err {
             Some(err) => Err(err),
             None => Ok(to_retry),
-        }
-    }
-}
-
-trait MergeResults {
-    fn merge_results(_values: HashMap<&str, Self>) -> Self
-    where
-        Self: Sized;
-}
-
-impl MergeResults for Value {
-    fn merge_results(values: HashMap<&str, Value>) -> Value {
-        let mut items = vec![];
-        for (addr, value) in values.into_iter() {
-            items.push(Value::Bulk(vec![
-                Value::Data(addr.as_bytes().to_vec()),
-                value,
-            ]));
-        }
-        Value::Bulk(items)
-    }
-}
-
-impl MergeResults for Vec<Value> {
-    fn merge_results(_values: HashMap<&str, Vec<Value>>) -> Vec<Value> {
-        unreachable!("attempted to merge a pipeline. This should not happen");
-    }
-}
-
-#[derive(Debug)]
-struct NodeCmd {
-    // The original command indexes
-    indexes: Vec<usize>,
-    pipe: Vec<u8>,
-    addr: String,
-}
-
-impl NodeCmd {
-    fn new(a: String) -> NodeCmd {
-        NodeCmd {
-            indexes: vec![],
-            pipe: vec![],
-            addr: a,
         }
     }
 }
@@ -734,26 +702,47 @@ impl ConnectionLike for ClusterConnection {
     }
 }
 
-fn connect<T: IntoConnectionInfo>(
-    info: T,
-    read_from_replicas: bool,
-    username: Option<String>,
-    password: Option<String>,
-) -> RedisResult<Connection>
-where
-    T: std::fmt::Debug,
-{
-    let mut connection_info = info.into_connection_info()?;
-    connection_info.redis.username = username;
-    connection_info.redis.password = password;
-    let client = super::Client::open(connection_info)?;
+trait MergeResults {
+    fn merge_results(_values: HashMap<&str, Self>) -> Self
+    where
+        Self: Sized;
+}
 
-    let mut con = client.get_connection()?;
-    if read_from_replicas {
-        // If READONLY is sent to primary nodes, it will have no effect
-        cmd("READONLY").query(&mut con)?;
+impl MergeResults for Value {
+    fn merge_results(values: HashMap<&str, Value>) -> Value {
+        let mut items = vec![];
+        for (addr, value) in values.into_iter() {
+            items.push(Value::Bulk(vec![
+                Value::Data(addr.as_bytes().to_vec()),
+                value,
+            ]));
+        }
+        Value::Bulk(items)
     }
-    Ok(con)
+}
+
+impl MergeResults for Vec<Value> {
+    fn merge_results(_values: HashMap<&str, Vec<Value>>) -> Vec<Value> {
+        unreachable!("attempted to merge a pipeline. This should not happen");
+    }
+}
+
+#[derive(Debug)]
+struct NodeCmd {
+    // The original command indexes
+    indexes: Vec<usize>,
+    pipe: Vec<u8>,
+    addr: String,
+}
+
+impl NodeCmd {
+    fn new(a: String) -> NodeCmd {
+        NodeCmd {
+            indexes: vec![],
+            pipe: vec![],
+            addr: a,
+        }
+    }
 }
 
 fn get_random_connection<'a>(

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -65,8 +65,11 @@ pub use crate::cluster_pipeline::{cluster_pipe, ClusterPipeline};
 type SlotMap = BTreeMap<u16, [String; 2]>;
 
 #[derive(Clone, Copy)]
-enum TlsMode {
+/// See [ConnectionAddr](ConnectionAddr::TcpTls::insecure).
+pub enum TlsMode {
+    /// Tls Secure mode
     Secure,
+    /// Tls Insecure mode
     Insecure,
 }
 
@@ -81,17 +84,7 @@ pub struct ClusterConnection {
     password: Option<String>,
     read_timeout: RefCell<Option<Duration>>,
     write_timeout: RefCell<Option<Duration>>,
-    tls: Option<TlsMode>,
-}
-
-impl TlsMode {
-    fn from_insecure_flag(insecure: bool) -> TlsMode {
-        if insecure {
-            TlsMode::Insecure
-        } else {
-            TlsMode::Secure
-        }
-    }
+    tls_mode: Option<TlsMode>,
 }
 
 impl ClusterConnection {
@@ -115,25 +108,7 @@ impl ClusterConnection {
             password: cluster_params.password,
             read_timeout: RefCell::new(None),
             write_timeout: RefCell::new(None),
-            #[cfg(feature = "tls")]
-            tls: {
-                if initial_nodes.is_empty() {
-                    None
-                } else {
-                    // TODO: Maybe should run through whole list and make sure they're all matching?
-                    match &initial_nodes.get(0).unwrap().addr {
-                        ConnectionAddr::Tcp(_, _) => None,
-                        ConnectionAddr::TcpTls {
-                            host: _,
-                            port: _,
-                            insecure,
-                        } => Some(TlsMode::from_insecure_flag(*insecure)),
-                        _ => None,
-                    }
-                }
-            },
-            #[cfg(not(feature = "tls"))]
-            tls: None,
+            tls_mode: cluster_params.tls_mode,
             initial_nodes: initial_nodes.to_vec(),
         };
         connection.refresh_slots()?;
@@ -214,18 +189,7 @@ impl ClusterConnection {
         let mut connections = HashMap::with_capacity(initial_nodes.len());
 
         for info in initial_nodes.iter() {
-            let addr = match info.addr {
-                ConnectionAddr::Tcp(ref host, port) => format!("redis://{}:{}", host, port),
-                ConnectionAddr::TcpTls {
-                    ref host,
-                    port,
-                    insecure,
-                } => {
-                    let tls_mode = TlsMode::from_insecure_flag(insecure);
-                    build_connection_string(host, Some(port), Some(tls_mode))
-                }
-                _ => panic!("No reach."),
-            };
+            let addr = info.addr.to_string();
 
             if let Ok(mut conn) = Self::connect(
                 info.clone(),
@@ -313,7 +277,7 @@ impl ClusterConnection {
         let mut samples = connections.values_mut().choose_multiple(&mut rng, len);
 
         for conn in samples.iter_mut() {
-            if let Ok(mut slots_data) = get_slots(conn, self.tls) {
+            if let Ok(mut slots_data) = get_slots(conn, self.tls_mode) {
                 slots_data.sort_by_key(|s| s.start());
                 let last_slot = slots_data.iter().try_fold(0, |prev_end, slot_data| {
                     if prev_end != slot_data.start() {
@@ -532,9 +496,7 @@ impl ClusterConnection {
                         let kind = err.kind();
 
                         if kind == ErrorKind::Ask {
-                            redirected = err
-                                .redirect_node()
-                                .map(|(node, _slot)| build_connection_string(node, None, self.tls));
+                            redirected = err.redirect_node().map(|(node, _slot)| node.to_string());
                             is_asking = true;
                         } else if kind == ErrorKind::Moved {
                             // Refresh slots.
@@ -542,9 +504,7 @@ impl ClusterConnection {
                             excludes.clear();
 
                             // Request again.
-                            redirected = err
-                                .redirect_node()
-                                .map(|(node, _slot)| build_connection_string(node, None, self.tls));
+                            redirected = err.redirect_node().map(|(node, _slot)| node.to_string());
                             is_asking = false;
                             continue;
                         } else if kind == ErrorKind::TryAgain || kind == ErrorKind::ClusterDown {
@@ -815,7 +775,7 @@ fn get_slots(connection: &mut Connection, tls_mode: Option<TlsMode>) -> RedisRes
                         } else {
                             return None;
                         };
-                        Some(build_connection_string(&ip, Some(port), tls_mode))
+                        Some(get_connection_addr((ip.into_owned(), port), tls_mode).to_string())
                     } else {
                         None
                     }
@@ -834,16 +794,19 @@ fn get_slots(connection: &mut Connection, tls_mode: Option<TlsMode>) -> RedisRes
     Ok(result)
 }
 
-fn build_connection_string(host: &str, port: Option<u16>, tls_mode: Option<TlsMode>) -> String {
-    let host_port = match port {
-        Some(port) => format!("{}:{}", host, port),
-        None => host.to_string(),
-    };
+fn get_connection_addr(node: (String, u16), tls_mode: Option<TlsMode>) -> ConnectionAddr {
+    let (host, port) = node;
     match tls_mode {
-        None => format!("redis://{}", host_port),
-        Some(TlsMode::Insecure) => {
-            format!("rediss://{}/#insecure", host_port)
-        }
-        Some(TlsMode::Secure) => format!("rediss://{}", host_port),
+        Some(TlsMode::Secure) => ConnectionAddr::TcpTls {
+            host,
+            port,
+            insecure: false,
+        },
+        Some(TlsMode::Insecure) => ConnectionAddr::TcpTls {
+            host,
+            port,
+            insecure: true,
+        },
+        _ => ConnectionAddr::Tcp(host, port),
     }
 }

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -222,11 +222,12 @@ impl ClusterClientBuilder {
         self
     }
 
-    /// Sets the default auto reconnect parameter for all new connections (default is true).
+    /// Disables auto reconnect for all new connections (default is enabled).
     ///
-    /// `ClusterConnection` will attempt to reconnect in case of [IoError](ErrorKind::IoError).
-    pub fn auto_reconnect(mut self, value: bool) -> ClusterClientBuilder {
-        self.cluster_params.auto_reconnect = value;
+    /// If enabled, `ClusterConnection` will attempt to reconnect in case of
+    /// [IoError](ErrorKind::IoError).
+    pub fn disable_auto_reconnect(mut self) -> ClusterClientBuilder {
+        self.cluster_params.auto_reconnect = false;
         self
     }
 

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -222,6 +222,14 @@ impl ClusterClientBuilder {
         self
     }
 
+    /// Sets the default auto reconnect parameter for all new connections (default is true).
+    ///
+    /// `ClusterConnection` will attempt to reconnect in case of [IoError](ErrorKind::IoError).
+    pub fn auto_reconnect(mut self, value: bool) -> ClusterClientBuilder {
+        self.cluster_params.auto_reconnect = value;
+        self
+    }
+
     /// Use `build()`.
     #[deprecated(since = "0.22.0", note = "Use build()")]
     pub fn open(self) -> RedisResult<ClusterClient> {

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -1,4 +1,4 @@
-use crate::cluster::ClusterConnection;
+use crate::cluster::{ClusterConnection, TlsMode};
 use crate::connection::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo};
 use crate::types::{ErrorKind, RedisError, RedisResult};
 
@@ -8,6 +8,7 @@ pub(crate) struct ClusterParams {
     pub(crate) password: Option<String>,
     pub(crate) username: Option<String>,
     pub(crate) read_from_replicas: bool,
+    pub(crate) tls_mode: Option<TlsMode>,
 }
 
 /// Used to configure and build a [`ClusterClient`].
@@ -65,6 +66,19 @@ impl ClusterClientBuilder {
         } else {
             &None
         };
+        if cluster_params.tls_mode.is_none() {
+            cluster_params.tls_mode = match first_node.addr {
+                ConnectionAddr::TcpTls {
+                    host: _,
+                    port: _,
+                    insecure,
+                } => Some(match insecure {
+                    false => TlsMode::Secure,
+                    true => TlsMode::Insecure,
+                }),
+                _ => None,
+            };
+        }
 
         let mut nodes = Vec::with_capacity(initial_nodes.len());
         for node in initial_nodes {
@@ -105,6 +119,15 @@ impl ClusterClientBuilder {
     /// Sets username for the new ClusterClient.
     pub fn username(mut self, username: String) -> ClusterClientBuilder {
         self.cluster_params.username = Some(username);
+        self
+    }
+
+    /// Sets TLS mode for the new ClusterClient (default is false).
+    ///
+    /// See [ConnectionAddr](ConnectionAddr::TcpTls::insecure).
+    #[cfg(feature = "tls")]
+    pub fn tls_mode(mut self, tls_mode: TlsMode) -> ClusterClientBuilder {
+        self.cluster_params.tls_mode = Some(tls_mode);
         self
     }
 

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -12,6 +12,7 @@ pub(crate) struct ClusterParams {
     pub(crate) username: Option<String>,
     pub(crate) read_from_replicas: bool,
     pub(crate) tls_mode: Option<TlsMode>,
+    pub(crate) connect_timeout: Option<Duration>,
     pub(crate) write_timeout: Option<Duration>,
     pub(crate) read_timeout: Option<Duration>,
     pub(crate) auto_reconnect: bool,
@@ -181,6 +182,21 @@ impl ClusterClientBuilder {
     pub fn tls_mode(mut self, tls_mode: TlsMode) -> ClusterClientBuilder {
         self.cluster_params.tls_mode = Some(tls_mode);
         self
+    }
+
+    /// Sets the default timeout for all new connections (default is None).
+    ///
+    /// If the value is `None`, then `get_connection` call may block indefinitely.
+    ///
+    /// # Errors
+    ///
+    /// Passing Some(Duration::ZERO)
+    pub fn connect_timeout(mut self, dur: Option<Duration>) -> RedisResult<ClusterClientBuilder> {
+        // Check if duration is valid before updating local value.
+        ClusterParams::validate_duration(&dur)?;
+
+        self.cluster_params.connect_timeout = dur;
+        Ok(self)
     }
 
     /// Sets the default write timeout for all new connections (default is None).

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -15,6 +15,7 @@ pub(crate) struct ClusterParams {
     pub(crate) connect_timeout: Option<Duration>,
     pub(crate) write_timeout: Option<Duration>,
     pub(crate) read_timeout: Option<Duration>,
+    pub(crate) retries: u8,
     pub(crate) auto_reconnect: bool,
 }
 
@@ -78,6 +79,7 @@ impl ClusterClientBuilder {
                 .map(|x| x.into_connection_info())
                 .collect(),
             cluster_params: ClusterParams {
+                retries: 16,
                 auto_reconnect: true,
                 ..Default::default()
             },
@@ -235,6 +237,20 @@ impl ClusterClientBuilder {
     /// primary nodes. If there are no replica nodes, then all queries will go to the primary nodes.
     pub fn read_from_replicas(mut self) -> ClusterClientBuilder {
         self.cluster_params.read_from_replicas = true;
+        self
+    }
+
+    /// Sets the default retries parameter for all new connections (default is 16).
+    ///
+    /// Commands are retried in case of the following errors:
+    ///
+    /// * [Ask](ErrorKind::Ask)
+    /// * [Moved](ErrorKind::Moved)
+    /// * [TryAgain](ErrorKind::TryAgain)
+    /// * [ClusterDown](ErrorKind::ClusterDown)
+    /// * [IoError](ErrorKind::IoError)
+    pub fn retries(mut self, value: u8) -> ClusterClientBuilder {
+        self.cluster_params.retries = value;
         self
     }
 

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -183,6 +183,36 @@ impl ClusterClientBuilder {
         self
     }
 
+    /// Sets the default write timeout for all new connections (default is None).
+    ///
+    /// If the value is `None`, then `send_packed_command` call may block indefinitely.
+    ///
+    /// # Errors
+    ///
+    /// Passing Some(Duration::ZERO)
+    pub fn write_timeout(mut self, dur: Option<Duration>) -> RedisResult<ClusterClientBuilder> {
+        // Check if duration is valid before updating local value.
+        ClusterParams::validate_duration(&dur)?;
+
+        self.cluster_params.write_timeout = dur;
+        Ok(self)
+    }
+
+    /// Sets the default read timeout for all new connections (default is None).
+    ///
+    /// If the value is `None`, then `recv_response` call may block indefinitely.
+    ///
+    /// # Errors
+    ///
+    /// Passing Some(Duration::ZERO)
+    pub fn read_timeout(mut self, dur: Option<Duration>) -> RedisResult<ClusterClientBuilder> {
+        // Check if duration is valid before updating local value.
+        ClusterParams::validate_duration(&dur)?;
+
+        self.cluster_params.read_timeout = dur;
+        Ok(self)
+    }
+
     /// Enables reading from replicas for all new connections (default is disabled).
     ///
     /// If enabled, then read queries will go to the replica nodes & write queries will go to the

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -1,5 +1,8 @@
+use std::str::FromStr;
+use std::time::Duration;
+
 use crate::cluster::{ClusterConnection, TlsMode};
-use crate::connection::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo};
+use crate::connection::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo, RedisConnectionInfo};
 use crate::types::{ErrorKind, RedisError, RedisResult};
 
 /// Redis cluster specific parameters.
@@ -9,6 +12,52 @@ pub(crate) struct ClusterParams {
     pub(crate) username: Option<String>,
     pub(crate) read_from_replicas: bool,
     pub(crate) tls_mode: Option<TlsMode>,
+    pub(crate) write_timeout: Option<Duration>,
+    pub(crate) read_timeout: Option<Duration>,
+    pub(crate) auto_reconnect: bool,
+}
+
+impl ClusterParams {
+    pub(crate) fn validate_duration(dur: &Option<Duration>) -> RedisResult<()> {
+        if dur.is_some() && dur.unwrap().is_zero() {
+            return Err(RedisError::from((
+                ErrorKind::InvalidClientConfig,
+                "Duration should be None or non-zero.",
+            )));
+        };
+        Ok(())
+    }
+
+    pub(crate) fn get_connection_info(&self, node: &str) -> ConnectionInfo {
+        let mut split = node.split(':');
+        let host = split.next().unwrap().to_string();
+        let port = u16::from_str(split.next().unwrap()).unwrap();
+
+        ConnectionInfo {
+            addr: self.get_connection_addr(host, port),
+            redis: RedisConnectionInfo {
+                password: self.password.clone(),
+                username: self.username.clone(),
+                ..Default::default()
+            },
+        }
+    }
+
+    pub(crate) fn get_connection_addr(&self, host: String, port: u16) -> ConnectionAddr {
+        match self.tls_mode {
+            Some(TlsMode::Secure) => ConnectionAddr::TcpTls {
+                host,
+                port,
+                insecure: false,
+            },
+            Some(TlsMode::Insecure) => ConnectionAddr::TcpTls {
+                host,
+                port,
+                insecure: true,
+            },
+            _ => ConnectionAddr::Tcp(host, port),
+        }
+    }
 }
 
 /// Used to configure and build a [`ClusterClient`].
@@ -27,7 +76,10 @@ impl ClusterClientBuilder {
                 .into_iter()
                 .map(|x| x.into_connection_info())
                 .collect(),
-            cluster_params: ClusterParams::default(),
+            cluster_params: ClusterParams {
+                auto_reconnect: true,
+                ..Default::default()
+            },
         }
     }
 

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -17,7 +17,7 @@ pub struct ClusterClientBuilder {
 }
 
 impl ClusterClientBuilder {
-    /// Creates a new `ClusterClientBuilder` with the the provided initial_nodes.
+    /// Creates a new `ClusterClientBuilder` with the provided initial_nodes.
     ///
     /// This is the same as `ClusterClient::builder(initial_nodes)`.
     pub fn new<T: IntoConnectionInfo>(initial_nodes: Vec<T>) -> ClusterClientBuilder {
@@ -30,7 +30,7 @@ impl ClusterClientBuilder {
         }
     }
 
-    /// Creates a new [`ClusterClient`] with the parameters.
+    /// Creates a new [`ClusterClient`] from the parameters.
     ///
     /// This does not create connections to the Redis Cluster, but only performs some basic checks
     /// on the initial nodes' URLs and passwords/usernames.
@@ -96,21 +96,21 @@ impl ClusterClientBuilder {
         })
     }
 
-    /// Sets password for new ClusterClient.
+    /// Sets password for the new ClusterClient.
     pub fn password(mut self, password: String) -> ClusterClientBuilder {
         self.cluster_params.password = Some(password);
         self
     }
 
-    /// Sets username for new ClusterClient.
+    /// Sets username for the new ClusterClient.
     pub fn username(mut self, username: String) -> ClusterClientBuilder {
         self.cluster_params.username = Some(username);
         self
     }
 
-    /// Enables read from replicas for new ClusterClient (default is false).
+    /// Enables reading from replicas for all new connections (default is disabled).
     ///
-    /// If True, then read queries will go to the replica nodes & write queries will go to the
+    /// If enabled, then read queries will go to the replica nodes & write queries will go to the
     /// primary nodes. If there are no replica nodes, then all queries will go to the primary nodes.
     pub fn read_from_replicas(mut self) -> ClusterClientBuilder {
         self.cluster_params.read_from_replicas = true;
@@ -149,7 +149,7 @@ impl ClusterClient {
     /// Upon failure to parse initial nodes or if the initial nodes have different passwords or
     /// usernames, an error is returned.
     pub fn new<T: IntoConnectionInfo>(initial_nodes: Vec<T>) -> RedisResult<ClusterClient> {
-        ClusterClientBuilder::new(initial_nodes).build()
+        Self::builder(initial_nodes).build()
     }
 
     /// Creates a [`ClusterClientBuilder`] with the the provided initial_nodes.
@@ -170,7 +170,7 @@ impl ClusterClient {
     /// Use `new()`.
     #[deprecated(since = "0.22.0", note = "Use new()")]
     pub fn open<T: IntoConnectionInfo>(initial_nodes: Vec<T>) -> RedisResult<ClusterClient> {
-        ClusterClient::new(initial_nodes)
+        Self::new(initial_nodes)
     }
 }
 


### PR DESCRIPTION
Currently, all the params in the `ClusterConnection` have individual fields in the struct, which makes it challenging to add new parameters to the client & also forces us to pass 3-4 params over & over (user/password/tls_insecure etc.). Also, there is no way to provide default values for the parameters that can be set on the connection level.

With this PR, I've refactored the cluster connection to store & pass all the parameters using the `ClusterParams` struct added in the [previous PR](#669) & also added functions to the builder to set default values for each.

In addition, I've made the following changes:
- Simplified logic around TlsMode
  - Currently, we check if the connection is a Tls connection or not as well as the value of the insecure param each time we get a connection. The value of the insecure param is also added to the node string, which is used as a key to get connections.
  - Instead, it is safe to assume that the connection type (Tls or not) & insecure flag is the same for all the nodes in the cluster. Thus, we can just parse the insecure flag once within the `build()` function in the cluster client builder & only use it when we need to create the connection
  - This also simplifies creating the node string from the ConnectionAddr
- Converted most functions in the impl to methods, i.e. used self instead of passing all the required params
- Added configuration for connect_timeout & retries
- Moved the slots response parsing logic to the get_slots function
  - This is the only change not related to the cluster client, but it will make the next PR easier to review

Depends on #669.