### PR TITLE
bump MSRV to 1.59.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.57.0
+          - 1.59.0
 
     steps:
     - name: Cache redis
@@ -66,14 +66,14 @@ jobs:
       # This will avoid this issue in what is admittedly a bit of a janky but still fully functional way
       #
       #   1. Copy the untouched file (into Cargo.toml.actual)
-      #   2. Exclude ./__ci/redis-json from the workspace 
+      #   2. Exclude ./__ci/redis-json from the workspace
       #      (preventing it from being compiled as a workspace module)
       #   3. Build RedisJSON
       #   4. Move the built RedisJSON Module (librejson.so) to /tmp
       #   5. Restore Cargo.toml to its untouched state
       #   6. Remove the RedisJSON Source code so it doesn't interfere with tests
       #
-      # This shouldn't cause issues in the future so long as no profiles or patches 
+      # This shouldn't cause issues in the future so long as no profiles or patches
       # are applied to the workspace Cargo.toml file
     - name: Compile RedisJSON
       run: |

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/redis-rs/redis-rs"
 documentation = "https://docs.rs/redis"
 license = "BSD-3-Clause"
 edition = "2018"
-rust-version = "1.57"
+rust-version = "1.59"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Bumping as the latest version of async-global-executor has bumped its MSRV