### PR TITLE
Make Direction a public enum to use with Commands like `blmove` (#646)

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2166,7 +2166,9 @@ impl ToRedisArgs for LposOptions {
 
 /// Enum for the LEFT | RIGHT args used by some commands
 pub enum Direction {
+    /// Targets the first element (head) of the list
     Left,
+    /// Targets the last element (tail) of the list
     Right,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,7 +360,7 @@ assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
 // public api
 pub use crate::client::Client;
 pub use crate::cmd::{cmd, pack_command, pipe, Arg, Cmd, Iter};
-pub use crate::commands::{Commands, ControlFlow, LposOptions, PubSubCommands};
+pub use crate::commands::{Commands, ControlFlow, Direction, LposOptions, PubSubCommands};
 pub use crate::connection::{
     parse_redis_url, transaction, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike,
     IntoConnectionInfo, Msg, PubSub, RedisConnectionInfo,


### PR DESCRIPTION
Cherry-picked from the main branch