### PR TITLE
Add Rule::Other to cover newly defined flags. #682

### DIFF
--- a/redis/src/acl.rs
+++ b/redis/src/acl.rs
@@ -101,7 +101,7 @@ impl ToRedisArgs for Rule {
 
             Reset => out.write_arg(b"reset"),
 
-            Other(rule) => out.write_arg_fmt(format_args!("{}", rule)),
+            Other(rule) => out.write_arg(rule.as_bytes()),
         };
     }
 }
@@ -169,7 +169,7 @@ impl FromRedisValue for AclInfo {
                             b"allkeys" => Ok(Rule::AllKeys),
                             b"allcommands" => Ok(Rule::AllCommands),
                             b"nopass" => Ok(Rule::NoPass),
-                            other => Ok(Rule::Other(String::from_utf8_lossy(other).to_string())),
+                            other => Ok(Rule::Other(String::from_utf8_lossy(other).into_owned())),
                         },
                         _ => Err(not_convertible_error!(
                             flag,

--- a/redis/src/acl.rs
+++ b/redis/src/acl.rs
@@ -64,8 +64,9 @@ pub enum Rule {
     /// The user returns to the same state it has immediately after its creation.
     Reset,
 
-    /// Raw text of ACL rule that not enumerated above.
-    /// Ref: https://redis.io/docs/manual/security/acl
+    /// Raw text of [`ACL rule`][1]  that not enumerated above.
+    /// 
+    /// [1]: https://redis.io/docs/manual/security/acl
     Other(String),
 }
 

--- a/redis/src/acl.rs
+++ b/redis/src/acl.rs
@@ -65,7 +65,7 @@ pub enum Rule {
     Reset,
 
     /// Raw text of [`ACL rule`][1]  that not enumerated above.
-    /// 
+    ///
     /// [1]: https://redis.io/docs/manual/security/acl
     Other(String),
 }

--- a/redis/src/acl.rs
+++ b/redis/src/acl.rs
@@ -282,7 +282,10 @@ mod tests {
     fn test_from_redis_value() {
         let redis_value = Value::Bulk(vec![
             Value::Data("flags".into()),
-            Value::Bulk(vec![Value::Data("on".into()), Value::Data("allchannels".into())]),
+            Value::Bulk(vec![
+                Value::Data("on".into()),
+                Value::Data("allchannels".into()),
+            ]),
             Value::Data("passwords".into()),
             Value::Bulk(vec![]),
             Value::Data("commands".into()),

--- a/redis/src/acl.rs
+++ b/redis/src/acl.rs
@@ -63,6 +63,10 @@ pub enum Rule {
     /// Performs the following actions: `resetpass`, `resetkeys`, `off`, `-@all`.
     /// The user returns to the same state it has immediately after its creation.
     Reset,
+
+    /// Raw text of ACL rule that not enumerated above.
+    /// Ref: https://redis.io/docs/manual/security/acl
+    Other(String),
 }
 
 impl ToRedisArgs for Rule {
@@ -95,6 +99,8 @@ impl ToRedisArgs for Rule {
             ResetKeys => out.write_arg(b"resetkeys"),
 
             Reset => out.write_arg(b"reset"),
+
+            Other(rule) => out.write_arg_fmt(format_args!("{}", rule)),
         };
     }
 }
@@ -162,7 +168,7 @@ impl FromRedisValue for AclInfo {
                             b"allkeys" => Ok(Rule::AllKeys),
                             b"allcommands" => Ok(Rule::AllCommands),
                             b"nopass" => Ok(Rule::NoPass),
-                            _ => Err(not_convertible_error!(flag, "Expect a valid ACL flag")),
+                            other => Ok(Rule::Other(String::from_utf8_lossy(other).to_string())),
                         },
                         _ => Err(not_convertible_error!(
                             flag,
@@ -269,13 +275,14 @@ mod tests {
         assert_args!(AllKeys, b"allkeys");
         assert_args!(ResetKeys, b"resetkeys");
         assert_args!(Reset, b"reset");
+        assert_args!(Other("resetchannels".to_owned()), b"resetchannels");
     }
 
     #[test]
     fn test_from_redis_value() {
         let redis_value = Value::Bulk(vec![
             Value::Data("flags".into()),
-            Value::Bulk(vec![Value::Data("on".into())]),
+            Value::Bulk(vec![Value::Data("on".into()), Value::Data("allchannels".into())]),
             Value::Data("passwords".into()),
             Value::Bulk(vec![]),
             Value::Data("commands".into()),
@@ -288,7 +295,7 @@ mod tests {
         assert_eq!(
             acl_info,
             AclInfo {
-                flags: vec![Rule::On],
+                flags: vec![Rule::On, Rule::Other("allchannels".into())],
                 passwords: vec![],
                 commands: vec![
                     Rule::RemoveCategory("all".to_owned()),


### PR DESCRIPTION
Fix bug of unhandled newly defined flags when call `acl_getuser`.