### PR TITLE
cluster: simplify TlsMode logic, add param to builder, & refactor create_initial_connections/connect

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -54,7 +54,7 @@ use crate::cluster_pipeline::UNROUTABLE_ERROR;
 use crate::cluster_routing::{Routable, RoutingInfo, Slot, SLOT_SIZE};
 use crate::cmd::{cmd, Cmd};
 use crate::connection::{
-    Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, IntoConnectionInfo,
+    connect, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, IntoConnectionInfo,
 };
 use crate::parser::parse_redis_value;
 use crate::types::{ErrorKind, HashMap, HashSet, RedisError, RedisResult, Value};
@@ -215,12 +215,7 @@ impl ClusterConnection {
                 _ => panic!("No reach."),
             };
 
-            if let Ok(mut conn) = Self::connect(
-                info.clone(),
-                self.read_from_replicas,
-                self.username.clone(),
-                self.password.clone(),
-            ) {
+            if let Ok(mut conn) = self.connect(info.clone()) {
                 if conn.check_connection() {
                     connections.insert(addr, conn);
                     break;
@@ -272,12 +267,7 @@ impl ClusterConnection {
                     }
                 }
 
-                if let Ok(mut conn) = Self::connect(
-                    addr.as_ref(),
-                    self.read_from_replicas,
-                    self.username.clone(),
-                    self.password.clone(),
-                ) {
+                if let Ok(mut conn) = self.connect(addr) {
                     if conn.check_connection() {
                         conn.set_read_timeout(*self.read_timeout.borrow()).unwrap();
                         conn.set_write_timeout(*self.write_timeout.borrow())
@@ -350,22 +340,13 @@ impl ClusterConnection {
         }
     }
 
-    fn connect<T: IntoConnectionInfo>(
-        info: T,
-        read_from_replicas: bool,
-        username: Option<String>,
-        password: Option<String>,
-    ) -> RedisResult<Connection>
-    where
-        T: std::fmt::Debug,
-    {
+    fn connect<T: IntoConnectionInfo>(&self, info: T) -> RedisResult<Connection> {
         let mut connection_info = info.into_connection_info()?;
-        connection_info.redis.username = username;
-        connection_info.redis.password = password;
-        let client = super::Client::open(connection_info)?;
+        connection_info.redis.username = self.username.clone();
+        connection_info.redis.password = self.password.clone();
 
-        let mut conn = client.get_connection()?;
-        if read_from_replicas {
+        let mut conn = connect(&connection_info, None)?;
+        if self.read_from_replicas {
             // If READONLY is sent to primary nodes, it will have no effect
             cmd("READONLY").query(&mut conn)?;
         }
@@ -401,12 +382,7 @@ impl ClusterConnection {
         } else {
             // Create new connection.
             // TODO: error handling
-            let conn = Self::connect(
-                addr,
-                self.read_from_replicas,
-                self.username.clone(),
-                self.password.clone(),
-            )?;
+            let conn = self.connect(addr)?;
             Ok(connections.entry(addr.to_string()).or_insert(conn))
         }
     }

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -49,18 +49,18 @@ use rand::{
     thread_rng, Rng,
 };
 
-use super::{
-    cmd, parse_redis_value,
-    types::{HashMap, HashSet},
-    Cmd, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, ErrorKind, IntoConnectionInfo,
-    RedisError, RedisResult, Value,
-};
 use crate::cluster_client::ClusterParams;
+use crate::cluster_pipeline::UNROUTABLE_ERROR;
+use crate::cluster_routing::{Routable, RoutingInfo, Slot, SLOT_SIZE};
+use crate::cmd::{cmd, Cmd};
+use crate::connection::{
+    Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, IntoConnectionInfo,
+};
+use crate::parser::parse_redis_value;
+use crate::types::{ErrorKind, HashMap, HashSet, RedisError, RedisResult, Value};
 
 pub use crate::cluster_client::{ClusterClient, ClusterClientBuilder};
-use crate::cluster_pipeline::UNROUTABLE_ERROR;
 pub use crate::cluster_pipeline::{cluster_pipe, ClusterPipeline};
-use crate::cluster_routing::{Routable, RoutingInfo, Slot, SLOT_SIZE};
 
 type SlotMap = BTreeMap<u16, [String; 2]>;
 

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -17,7 +17,7 @@ pub struct ClusterClientBuilder {
 }
 
 impl ClusterClientBuilder {
-    /// Creates a new `ClusterClientBuilder` with the the provided initial_nodes.
+    /// Creates a new `ClusterClientBuilder` with the provided initial_nodes.
     ///
     /// This is the same as `ClusterClient::builder(initial_nodes)`.
     pub fn new<T: IntoConnectionInfo>(initial_nodes: Vec<T>) -> ClusterClientBuilder {
@@ -30,7 +30,7 @@ impl ClusterClientBuilder {
         }
     }
 
-    /// Creates a new [`ClusterClient`] with the parameters.
+    /// Creates a new [`ClusterClient`] from the parameters.
     ///
     /// This does not create connections to the Redis Cluster, but only performs some basic checks
     /// on the initial nodes' URLs and passwords/usernames.
@@ -96,21 +96,21 @@ impl ClusterClientBuilder {
         })
     }
 
-    /// Sets password for new ClusterClient.
+    /// Sets password for the new ClusterClient.
     pub fn password(mut self, password: String) -> ClusterClientBuilder {
         self.cluster_params.password = Some(password);
         self
     }
 
-    /// Sets username for new ClusterClient.
+    /// Sets username for the new ClusterClient.
     pub fn username(mut self, username: String) -> ClusterClientBuilder {
         self.cluster_params.username = Some(username);
         self
     }
 
-    /// Enables read from replicas for new ClusterClient (default is false).
+    /// Enables reading from replicas for all new connections (default is disabled).
     ///
-    /// If True, then read queries will go to the replica nodes & write queries will go to the
+    /// If enabled, then read queries will go to the replica nodes & write queries will go to the
     /// primary nodes. If there are no replica nodes, then all queries will go to the primary nodes.
     pub fn read_from_replicas(mut self) -> ClusterClientBuilder {
         self.cluster_params.read_from_replicas = true;
@@ -149,7 +149,7 @@ impl ClusterClient {
     /// Upon failure to parse initial nodes or if the initial nodes have different passwords or
     /// usernames, an error is returned.
     pub fn new<T: IntoConnectionInfo>(initial_nodes: Vec<T>) -> RedisResult<ClusterClient> {
-        ClusterClientBuilder::new(initial_nodes).build()
+        Self::builder(initial_nodes).build()
     }
 
     /// Creates a [`ClusterClientBuilder`] with the the provided initial_nodes.
@@ -170,7 +170,7 @@ impl ClusterClient {
     /// Use `new()`.
     #[deprecated(since = "0.22.0", note = "Use new()")]
     pub fn open<T: IntoConnectionInfo>(initial_nodes: Vec<T>) -> RedisResult<ClusterClient> {
-        ClusterClient::new(initial_nodes)
+        Self::new(initial_nodes)
     }
 }
 

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -84,6 +84,7 @@ impl ConnectionAddr {
 
 impl fmt::Display for ConnectionAddr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Cluster::get_connection_info depends on the return value from this function
         match *self {
             ConnectionAddr::Tcp(ref host, port) => write!(f, "{}:{}", host, port),
             ConnectionAddr::TcpTls { ref host, port, .. } => write!(f, "{}:{}", host, port),


### PR DESCRIPTION
- Minor doc changes in cluster_client
- Moved related imports/structs/functions in cluster.rs together to improve code readability
- Convert create_initial_connections to a method to reduce code duplication
- Convert connect to a method to reduce passing arguments over & over
- Create a connection inside the connect method directly instead of creating a client first
- Simplified logic around TlsMode
  - Currently, we check if the connection is a Tls connection or not as well as the value of the insecure param each time we get a connection. The value of the insecure param is also added to the node string, which is used as a key to get connections.
  - Instead, it is safe to assume that the connection type (Tls or not) & insecure flag is the same for all the nodes in the cluster. Thus, we can just parse the TlsMode once within the build() function in the cluster client builder & only use it when we need to create the connection
  - This also simplifies creating the node string from the ConnectionAddr
