### PR TITLE
add test case for atomic pipeline

### DIFF
--- a/redis-test/src/lib.rs
+++ b/redis-test/src/lib.rs
@@ -397,4 +397,27 @@ mod tests {
             .expect("success");
         assert_eq!(results, vec!["hello", "world"]);
     }
+
+    #[test]
+    fn pipeline_atomic_test() {
+        let mut conn = MockRedisConnection::new(vec![MockCmd::with_values(
+            pipe().atomic().cmd("GET").arg("foo").cmd("GET").arg("bar"),
+            Ok(vec![Value::Bulk(
+                vec!["hello", "world"]
+                    .into_iter()
+                    .map(|x| Value::Data(x.as_bytes().into()))
+                    .collect(),
+            )]),
+        )]);
+
+        let results: Vec<String> = pipe()
+            .atomic()
+            .cmd("GET")
+            .arg("foo")
+            .cmd("GET")
+            .arg("bar")
+            .query(&mut conn)
+            .expect("success");
+        assert_eq!(results, vec!["hello", "world"]);
+    }
 }


### PR DESCRIPTION
`redis-test`  is a convenient tool to write UT, but the correct way to write mock responses for some cases is not obvious.

This PR contains a test case about `pipeline` with `atomic`.

This test case may help people find that they should use `Value::Bulk` as a mock response to test the pipeline with atomic instead of a plain `vec`.