### PR TITLE
fix: solve lint issues

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -451,7 +451,7 @@ impl ClusterConnection {
             let (addr, rv) = {
                 let mut connections = self.connections.borrow_mut();
                 let (addr, conn) = if let Some(addr) = redirected.take() {
-                    let conn = self.get_connection_by_addr(&mut *connections, &addr)?;
+                    let conn = self.get_connection_by_addr(&mut connections, &addr)?;
                     if is_asking {
                         // if we are in asking mode we want to feed a single
                         // ASKING command into the connection before what we
@@ -461,9 +461,9 @@ impl ClusterConnection {
                     }
                     (addr.to_string(), conn)
                 } else if !excludes.is_empty() || route.is_none() {
-                    get_random_connection(&mut *connections, Some(&excludes))
+                    get_random_connection(&mut connections, Some(&excludes))
                 } else {
-                    self.get_connection(&mut *connections, route.unwrap())?
+                    self.get_connection(&mut connections, route.unwrap())?
                 };
                 (addr, func(conn))
             };

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -224,7 +224,7 @@ implement_commands! {
 
     /// Sets or clears the bit at offset in the string value stored at key.
     fn setbit<K: ToRedisArgs>(key: K, offset: usize, value: bool) {
-        cmd("SETBIT").arg(key).arg(offset).arg(if value {1} else {0})
+        cmd("SETBIT").arg(key).arg(offset).arg(i32::from(value))
     }
 
     /// Returns the bit value at offset in the string value stored at key.

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -897,11 +897,11 @@ impl<'a, T: ToRedisArgs> ToRedisArgs for &'a [T] {
     where
         W: ?Sized + RedisWrite,
     {
-        ToRedisArgs::make_arg_vec(*self, out)
+        ToRedisArgs::make_arg_vec(self, out)
     }
 
     fn is_single_arg(&self) -> bool {
-        ToRedisArgs::is_single_vec_arg(*self)
+        ToRedisArgs::is_single_vec_arg(self)
     }
 }
 

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -122,7 +122,7 @@ impl RedisCluster {
                             cmd.arg("--tls-replication").arg("yes");
                         }
                     }
-                    cmd.current_dir(&tempdir.path());
+                    cmd.current_dir(tempdir.path());
                     folders.push(tempdir);
                     addrs.push(format!("127.0.0.1:{}", port));
                     dbg!(&cmd);

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -191,7 +191,7 @@ impl RedisServer {
                     .arg("--port")
                     .arg("0")
                     .arg("--unixsocket")
-                    .arg(&path);
+                    .arg(path);
                 RedisServer {
                     process: spawner(&mut redis_cmd),
                     tempdir: Some(tempdir),
@@ -209,7 +209,7 @@ impl RedisServer {
         let _ = self.process.kill();
         let _ = self.process.wait();
         if let redis::ConnectionAddr::Unix(ref path) = *self.get_client_addr() {
-            fs::remove_file(&path).ok();
+            fs::remove_file(path).ok();
         }
     }
 }


### PR DESCRIPTION
On rust 1.65.0, main branch of redis-rs can not pass lint workflow.
Solved issues is
- explicit-auto-deref
- bool-to-int-with-if
- needless-borrow