### PR TITLE
[2/5] [2] cluster, cluster_client: minor refactorings (change order of code, use Self)

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -194,17 +194,6 @@ impl ClusterConnection {
         Ok(())
     }
 
-    /// Check that all connections it has are available (`PING` internally).
-    pub fn check_connection(&mut self) -> bool {
-        let mut connections = self.connections.borrow_mut();
-        for conn in connections.values_mut() {
-            if !conn.check_connection() {
-                return false;
-            }
-        }
-        true
-    }
-
     pub(crate) fn execute_pipeline(&mut self, pipe: &ClusterPipeline) -> RedisResult<Vec<Value>> {
         self.send_recv_and_retry_cmds(pipe.commands())
     }

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -49,18 +49,18 @@ use rand::{
     thread_rng, Rng,
 };
 
-use super::{
-    cmd, parse_redis_value,
-    types::{HashMap, HashSet},
-    Cmd, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, ErrorKind, IntoConnectionInfo,
-    RedisError, RedisResult, Value,
-};
 use crate::cluster_client::ClusterParams;
+use crate::cluster_pipeline::UNROUTABLE_ERROR;
+use crate::cluster_routing::{Routable, RoutingInfo, Slot, SLOT_SIZE};
+use crate::cmd::{cmd, Cmd};
+use crate::connection::{
+    Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, IntoConnectionInfo,
+};
+use crate::parser::parse_redis_value;
+use crate::types::{ErrorKind, HashMap, HashSet, RedisError, RedisResult, Value};
 
 pub use crate::cluster_client::{ClusterClient, ClusterClientBuilder};
-use crate::cluster_pipeline::UNROUTABLE_ERROR;
 pub use crate::cluster_pipeline::{cluster_pipe, ClusterPipeline};
-use crate::cluster_routing::{Routable, RoutingInfo, Slot, SLOT_SIZE};
 
 type SlotMap = BTreeMap<u16, [String; 2]>;
 

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -149,7 +149,7 @@ impl ClusterClient {
     /// Upon failure to parse initial nodes or if the initial nodes have different passwords or
     /// usernames, an error is returned.
     pub fn new<T: IntoConnectionInfo>(initial_nodes: Vec<T>) -> RedisResult<ClusterClient> {
-        ClusterClientBuilder::new(initial_nodes).build()
+        Self::builder(initial_nodes).build()
     }
 
     /// Creates a [`ClusterClientBuilder`] with the the provided initial_nodes.
@@ -170,7 +170,7 @@ impl ClusterClient {
     /// Use `new()`.
     #[deprecated(since = "0.22.0", note = "Use new()")]
     pub fn open<T: IntoConnectionInfo>(initial_nodes: Vec<T>) -> RedisResult<ClusterClient> {
-        ClusterClient::new(initial_nodes)
+        Self::new(initial_nodes)
     }
 }
 


### PR DESCRIPTION
## Changes

- cluster: change orders of declarations
- cluster_client: add `Self::`

## Effect

- no public api is changed
- cluster: implementation is not changed only order of declarations is changed
- cluster_client: add `Self::` it should do not change behavior

## Note

- this PR is from https://github.com/redis-rs/redis-rs/pull/690
- this PR is depends on https://github.com/redis-rs/redis-rs/pull/705
- you can check actual file changes on https://github.com/0xWOF/redis-rs/pull/14