### PR TITLE
Add `Script::invoke_async` method

### DIFF
--- a/redis/src/script.rs
+++ b/redis/src/script.rs
@@ -86,6 +86,23 @@ impl Script {
         }
         .invoke(con)
     }
+
+    /// Asynchronously invokes the script without arguments.
+    #[inline]
+    #[cfg(feature = "aio")]
+    pub async fn invoke_async<C, T>(&self, con: &mut C) -> RedisResult<T>
+    where
+        C: crate::aio::ConnectionLike,
+        T: FromRedisValue,
+    {
+        ScriptInvocation {
+            script: self,
+            args: vec![],
+            keys: vec![],
+        }
+        .invoke_async(con)
+        .await
+    }
 }
 
 /// Represents a prepared script call.

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -323,6 +323,7 @@ fn test_script() {
     // into Redis and when they need to be loaded in
     let script1 = redis::Script::new("return redis.call('SET', KEYS[1], ARGV[1])");
     let script2 = redis::Script::new("return redis.call('GET', KEYS[1])");
+    let script3 = redis::Script::new("return redis.call('KEYS', '*')");
 
     let ctx = TestContext::new();
 
@@ -335,6 +336,8 @@ fn test_script() {
             .await?;
         let val: String = script2.key("key1").invoke_async(&mut con).await?;
         assert_eq!(val, "foo");
+        let keys: Vec<String> = script3.invoke_async(&mut con).await?;
+        assert_eq!(keys, ["key1"]);
         script1
             .key("key1")
             .arg("bar")
@@ -342,6 +345,8 @@ fn test_script() {
             .await?;
         let val: String = script2.key("key1").invoke_async(&mut con).await?;
         assert_eq!(val, "bar");
+        let keys: Vec<String> = script3.invoke_async(&mut con).await?;
+        assert_eq!(keys, ["key1"]);
         Ok::<_, RedisError>(())
     })
     .unwrap();

--- a/redis/tests/test_async_async_std.rs
+++ b/redis/tests/test_async_async_std.rs
@@ -261,6 +261,7 @@ fn test_script() {
     // into Redis and when they need to be loaded in
     let script1 = redis::Script::new("return redis.call('SET', KEYS[1], ARGV[1])");
     let script2 = redis::Script::new("return redis.call('GET', KEYS[1])");
+    let script3 = redis::Script::new("return redis.call('KEYS', '*')");
 
     let ctx = TestContext::new();
 
@@ -273,6 +274,8 @@ fn test_script() {
             .await?;
         let val: String = script2.key("key1").invoke_async(&mut con).await?;
         assert_eq!(val, "foo");
+        let keys: Vec<String> = script3.invoke_async(&mut con).await?;
+        assert_eq!(keys, ["key1"]);
         script1
             .key("key1")
             .arg("bar")
@@ -280,6 +283,8 @@ fn test_script() {
             .await?;
         let val: String = script2.key("key1").invoke_async(&mut con).await?;
         assert_eq!(val, "bar");
+        let keys: Vec<String> = script3.invoke_async(&mut con).await?;
+        assert_eq!(keys, ["key1"]);
         Ok::<_, RedisError>(())
     })
     .unwrap();


### PR DESCRIPTION
This PR adds the `Script::invoke_async` method and corresponding tests.

The aim is to have an asynchronous equivalent to the synchronous `Script::invoke` method.