### PR TITLE
Fix/nil hash value

### DIFF
--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1228,10 +1228,16 @@ impl<K: FromRedisValue + Eq + Hash, V: FromRedisValue, S: BuildHasher + Default>
     for std::collections::HashMap<K, V, S>
 {
     fn from_redis_value(v: &Value) -> RedisResult<std::collections::HashMap<K, V, S>> {
-        v.as_map_iter()
-            .ok_or_else(|| invalid_type_error_inner!(v, "Response type not hashmap compatible"))?
-            .map(|(k, v)| Ok((from_redis_value(k)?, from_redis_value(v)?)))
-            .collect()
+        match *v {
+            Value::Nil => Ok(Default::default()),
+            _ => v
+                .as_map_iter()
+                .ok_or_else(|| {
+                    invalid_type_error_inner!(v, "Response type not hashmap compatible")
+                })?
+                .map(|(k, v)| Ok((from_redis_value(k)?, from_redis_value(v)?)))
+                .collect(),
+        }
     }
 }
 

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1246,10 +1246,16 @@ impl<K: FromRedisValue + Eq + Hash, V: FromRedisValue, S: BuildHasher + Default>
     for ahash::AHashMap<K, V, S>
 {
     fn from_redis_value(v: &Value) -> RedisResult<ahash::AHashMap<K, V, S>> {
-        v.as_map_iter()
-            .ok_or_else(|| invalid_type_error_inner!(v, "Response type not hashmap compatible"))?
-            .map(|(k, v)| Ok((from_redis_value(k)?, from_redis_value(v)?)))
-            .collect()
+        match *v {
+            Value::Nil => Ok(ahash::AHashMap::with_hasher(Default::default())),
+            _ => v
+                .as_map_iter()
+                .ok_or_else(|| {
+                    invalid_type_error_inner!(v, "Response type not hashmap compatible")
+                })?
+                .map(|(k, v)| Ok((from_redis_value(k)?, from_redis_value(v)?)))
+                .collect(),
+        }
     }
 }
 


### PR DESCRIPTION
Hello!

xread_options seems to not handle correctly case when a pending message is deleted.

In my understanding, if a pending message is deleted, its id should still be returned https://redis.io/commands/xreadgroup/#what-happens-when-a-pending-message-is-deleted

This is useful for acknowledging them and cleaning the PEL if some messages could not be processed.

<details>

<summary> Expected vs actual result </summary>

The expected result from the test case is:

```
&result_deleted_entry = StreamReadReply {
    keys: [
        StreamKey {
            key: "k1",
            ids: [
                StreamId {
                    id: "1666711514590-0",
                    map: {},
                },
            ],
        },
    ],
}
```

On redis-rs 0.20.2:
```
&result_deleted_entry = StreamReadReply {
    keys: [
        StreamKey {
            key: "k1",
            ids: [],
        },
    ],
}
```

On main an Err is thrown: 
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Response was of incompatible type: "Response type not hashmap compatible" (response was nil)', redis/tests/test_streams.rs:393:10
```

</details>

This is fixed by converting a nil value from redis when casting as an hash into a empty hash.

I am open to better solutions/suggestions!

