### PR TITLE
[2/5] [7] cluster: make ClusterConnection use same tls_mode on every connections using ClusterParams

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -463,9 +463,9 @@ impl ClusterConnection {
                         let kind = err.kind();
 
                         if kind == ErrorKind::Ask {
-                            redirected = err
-                                .redirect_node()
-                                .map(|(node, _slot)| build_connection_string(node, None, self.tls_mode));
+                            redirected = err.redirect_node().map(|(node, _slot)| {
+                                build_connection_string(node, None, self.tls_mode)
+                            });
                             is_asking = true;
                         } else if kind == ErrorKind::Moved {
                             // Refresh slots.
@@ -473,9 +473,9 @@ impl ClusterConnection {
                             excludes.clear();
 
                             // Request again.
-                            redirected = err
-                                .redirect_node()
-                                .map(|(node, _slot)| build_connection_string(node, None, self.tls_mode));
+                            redirected = err.redirect_node().map(|(node, _slot)| {
+                                build_connection_string(node, None, self.tls_mode)
+                            });
                             is_asking = false;
                             continue;
                         } else if kind == ErrorKind::TryAgain || kind == ErrorKind::ClusterDown {

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -692,9 +692,13 @@ impl NodeCmd {
     }
 }
 
+/// TlsMode indicates use or do not use verification of certification.
+/// Check [ConnectionAddr](ConnectionAddr::TcpTls::insecure) for more.
 #[derive(Clone, Copy)]
-enum TlsMode {
+pub enum TlsMode {
+    /// Secure verify certification.
     Secure,
+    /// Insecure do not verify certification.
     Insecure,
 }
 

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -191,20 +191,9 @@ impl ClusterConnection {
         let mut connections = HashMap::with_capacity(self.initial_nodes.len());
 
         for info in self.initial_nodes.iter() {
-            let addr = match info.addr {
-                ConnectionAddr::Tcp(ref host, port) => format!("redis://{host}:{port}"),
-                ConnectionAddr::TcpTls {
-                    ref host,
-                    port,
-                    insecure,
-                } => {
-                    let tls_mode = TlsMode::from_insecure_flag(insecure);
-                    build_connection_string(host, Some(port), Some(tls_mode))
-                }
-                _ => panic!("No reach."),
-            };
+            let addr = info.addr.to_string();
 
-            if let Ok(mut conn) = self.connect(info.clone()) {
+            if let Ok(mut conn) = self.connect(&addr) {
                 if conn.check_connection() {
                     connections.insert(addr, conn);
                     break;
@@ -256,7 +245,7 @@ impl ClusterConnection {
                     }
                 }
 
-                if let Ok(mut conn) = self.connect(addr.as_ref()) {
+                if let Ok(mut conn) = self.connect(addr) {
                     if conn.check_connection() {
                         conn.set_read_timeout(*self.read_timeout.borrow()).unwrap();
                         conn.set_write_timeout(*self.write_timeout.borrow())

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -73,7 +73,7 @@ pub struct ClusterConnection {
     password: Option<String>,
     read_timeout: RefCell<Option<Duration>>,
     write_timeout: RefCell<Option<Duration>>,
-    tls: Option<TlsMode>,
+    tls_mode: Option<TlsMode>,
 }
 
 impl ClusterConnection {
@@ -91,7 +91,7 @@ impl ClusterConnection {
             read_timeout: RefCell::new(None),
             write_timeout: RefCell::new(None),
             #[cfg(feature = "tls")]
-            tls: {
+            tls_mode: {
                 if initial_nodes.is_empty() {
                     None
                 } else {
@@ -108,7 +108,7 @@ impl ClusterConnection {
                 }
             },
             #[cfg(not(feature = "tls"))]
-            tls: None,
+            tls_mode: None,
             initial_nodes: initial_nodes.to_vec(),
         };
         connection.create_initial_connections()?;
@@ -282,7 +282,7 @@ impl ClusterConnection {
         let mut samples = connections.values_mut().choose_multiple(&mut rng, len);
 
         for conn in samples.iter_mut() {
-            if let Ok(mut slots_data) = get_slots(conn, self.tls) {
+            if let Ok(mut slots_data) = get_slots(conn, self.tls_mode) {
                 slots_data.sort_by_key(|s| s.start());
                 let last_slot = slots_data.iter().try_fold(0, |prev_end, slot_data| {
                     if prev_end != slot_data.start() {
@@ -489,7 +489,7 @@ impl ClusterConnection {
                         if kind == ErrorKind::Ask {
                             redirected = err
                                 .redirect_node()
-                                .map(|(node, _slot)| build_connection_string(node, None, self.tls));
+                                .map(|(node, _slot)| build_connection_string(node, None, self.tls_mode));
                             is_asking = true;
                         } else if kind == ErrorKind::Moved {
                             // Refresh slots.
@@ -499,7 +499,7 @@ impl ClusterConnection {
                             // Request again.
                             redirected = err
                                 .redirect_node()
-                                .map(|(node, _slot)| build_connection_string(node, None, self.tls));
+                                .map(|(node, _slot)| build_connection_string(node, None, self.tls_mode));
                             is_asking = false;
                             continue;
                         } else if kind == ErrorKind::TryAgain || kind == ErrorKind::ClusterDown {

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -329,12 +329,16 @@ impl ClusterConnection {
         }
     }
 
-    fn connect<T: IntoConnectionInfo>(&self, info: T) -> RedisResult<Connection> {
-        let mut connection_info = info.into_connection_info()?;
-        connection_info.redis.username = self.username.clone();
-        connection_info.redis.password = self.password.clone();
+    fn connect(&self, node: &str) -> RedisResult<Connection> {
+        let params = ClusterParams {
+            password: self.password.clone(),
+            username: self.username.clone(),
+            tls_mode: self.tls_mode,
+            ..Default::default()
+        };
+        let info = get_connection_info(node, params)?;
 
-        let mut conn = connect(&connection_info, None)?;
+        let mut conn = connect(&info, None)?;
         if self.read_from_replicas {
             // If READONLY is sent to primary nodes, it will have no effect
             cmd("READONLY").query(&mut conn)?;

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -91,25 +91,7 @@ impl ClusterConnection {
             password: cluster_params.password,
             read_timeout: RefCell::new(None),
             write_timeout: RefCell::new(None),
-            #[cfg(feature = "tls")]
-            tls_mode: {
-                if initial_nodes.is_empty() {
-                    None
-                } else {
-                    // TODO: Maybe should run through whole list and make sure they're all matching?
-                    match &initial_nodes.get(0).unwrap().addr {
-                        ConnectionAddr::Tcp(_, _) => None,
-                        ConnectionAddr::TcpTls {
-                            host: _,
-                            port: _,
-                            insecure,
-                        } => Some(TlsMode::from_insecure_flag(*insecure)),
-                        _ => None,
-                    }
-                }
-            },
-            #[cfg(not(feature = "tls"))]
-            tls_mode: None,
+            tls_mode: cluster_params.tls_mode,
             initial_nodes: initial_nodes.to_vec(),
         };
         connection.create_initial_connections()?;
@@ -694,16 +676,6 @@ pub enum TlsMode {
     Secure,
     /// Insecure do not verify certification.
     Insecure,
-}
-
-impl TlsMode {
-    fn from_insecure_flag(insecure: bool) -> TlsMode {
-        if insecure {
-            TlsMode::Insecure
-        } else {
-            TlsMode::Secure
-        }
-    }
 }
 
 fn get_random_connection<'a>(

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -8,10 +8,10 @@ pub(crate) struct ClusterParams {
     pub(crate) password: Option<String>,
     pub(crate) username: Option<String>,
     pub(crate) read_from_replicas: bool,
-    /// tls_mode indicates tls behavior of connections.
+    /// tls indicates tls behavior of connections.
     /// When Some(TlsMode), connections use tls and verify certification depends on TlsMode.
     /// When None, connections do not use tls.
-    pub(crate) tls_mode: Option<TlsMode>,
+    pub(crate) tls: Option<TlsMode>,
 }
 
 /// Used to configure and build a [`ClusterClient`].
@@ -69,8 +69,8 @@ impl ClusterClientBuilder {
         } else {
             &None
         };
-        if cluster_params.tls_mode.is_none() {
-            cluster_params.tls_mode = match first_node.addr {
+        if cluster_params.tls.is_none() {
+            cluster_params.tls = match first_node.addr {
                 ConnectionAddr::TcpTls {
                     host: _,
                     port: _,
@@ -129,8 +129,8 @@ impl ClusterClientBuilder {
     ///
     /// It is extracted from the first node of initial_nodes if not set.
     #[cfg(feature = "tls")]
-    pub fn tls_mode(mut self, tls_mode: TlsMode) -> ClusterClientBuilder {
-        self.cluster_params.tls_mode = Some(tls_mode);
+    pub fn tls(mut self, tls: TlsMode) -> ClusterClientBuilder {
+        self.cluster_params.tls = Some(tls);
         self
     }
 

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -1,4 +1,4 @@
-use crate::cluster::ClusterConnection;
+use crate::cluster::{ClusterConnection, TlsMode};
 use crate::connection::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo};
 use crate::types::{ErrorKind, RedisError, RedisResult};
 
@@ -8,6 +8,10 @@ pub(crate) struct ClusterParams {
     pub(crate) password: Option<String>,
     pub(crate) username: Option<String>,
     pub(crate) read_from_replicas: bool,
+    /// tls_mode indicates tls behavior of connections.
+    /// When Some(TlsMode), connections use tls and verify certification depends on TlsMode.
+    /// When None, connections do not use tls.
+    pub(crate) tls_mode: Option<TlsMode>,
 }
 
 /// Used to configure and build a [`ClusterClient`].
@@ -65,6 +69,19 @@ impl ClusterClientBuilder {
         } else {
             &None
         };
+        if cluster_params.tls_mode.is_none() {
+            cluster_params.tls_mode = match first_node.addr {
+                ConnectionAddr::TcpTls {
+                    host: _,
+                    port: _,
+                    insecure,
+                } => Some(match insecure {
+                    false => TlsMode::Secure,
+                    true => TlsMode::Insecure,
+                }),
+                _ => None,
+            };
+        }
 
         let mut nodes = Vec::with_capacity(initial_nodes.len());
         for node in initial_nodes {
@@ -105,6 +122,15 @@ impl ClusterClientBuilder {
     /// Sets username for the new ClusterClient.
     pub fn username(mut self, username: String) -> ClusterClientBuilder {
         self.cluster_params.username = Some(username);
+        self
+    }
+
+    /// Sets TLS mode for the new ClusterClient.
+    ///
+    /// It is extracted from the first node of initial_nodes if not set.
+    #[cfg(feature = "tls")]
+    pub fn tls_mode(mut self, tls_mode: TlsMode) -> ClusterClientBuilder {
+        self.cluster_params.tls_mode = Some(tls_mode);
         self
     }
 

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -84,6 +84,7 @@ impl ConnectionAddr {
 
 impl fmt::Display for ConnectionAddr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Cluster::get_connection_info depends on the return value from this function
         match *self {
             ConnectionAddr::Tcp(ref host, port) => write!(f, "{host}:{port}"),
             ConnectionAddr::TcpTls { ref host, port, .. } => write!(f, "{host}:{port}"),


### PR DESCRIPTION
## Changes

- cluster
    - rename tls to tls_mode
    - make ClusterConnection use same tls_mode on every connections
    - determine tls_mode from ClusterParams
- cluster_client
    - add tls_mode to ClusterParams
    - add tls_mode to builder
- connection
    - add comment

## Effect

- cluster:
    - ClusterConnection do not use other tls_mode for each connections any more.
- cluster_client
    - ** public api is changed **
    - user can determine tls_mode of ClusterConnection from builder
    - when user do not specify tls_mode, tls_mode is determined from first item of initial_nodes
- connection
    - no public api and binary is changed

## Note

- this PR is from https://github.com/redis-rs/redis-rs/pull/690