### PR TITLE
Add hashmap to redis args

### DIFF
--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1025,7 +1025,6 @@ impl<T: ToRedisArgs + Hash + Eq + Ord, V: ToRedisArgs> ToRedisArgs
         W: ?Sized + RedisWrite,
     {
         for (key, value) in self.iter() {
-            // otherwise things like HMSET will simply NOT work
             assert!(key.is_single_arg() && value.is_single_arg());
 
             key.write_redis_args(out);

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1017,24 +1017,22 @@ impl<T: ToRedisArgs + Hash + Eq + Ord, V: ToRedisArgs> ToRedisArgs for BTreeMap<
     }
 }
 
-impl<T: ToRedisArgs + Hash + Eq + Ord, V: ToRedisArgs> ToRedisArgs
-    for HashMap<T, V>
-{
-    fn write_redis_args<W>(&self, out: &mut W)
-    where
-        W: ?Sized + RedisWrite,
-    {
-        for (key, value) in self.iter() {
-            assert!(key.is_single_arg() && value.is_single_arg());
+impl<T: ToRedisArgs + Hash + Eq + Ord, V: ToRedisArgs> ToRedisArgs for std::collections::HashMap<T, V> {
+  fn write_redis_args<W>(&self, out: &mut W)
+  where
+      W: ?Sized + RedisWrite,
+  {
+      for (key, value) in self {
+          assert!(key.is_single_arg() && value.is_single_arg());
 
-            key.write_redis_args(out);
-            value.write_redis_args(out);
-        }
-    }
+          key.write_redis_args(out);
+          value.write_redis_args(out);
+      }
+  }
 
-    fn is_single_arg(&self) -> bool {
-        self.len() <= 1
-    }
+  fn is_single_arg(&self) -> bool {
+      self.len() <= 1
+  }
 }
 
 macro_rules! to_redis_args_for_tuple {

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1017,22 +1017,24 @@ impl<T: ToRedisArgs + Hash + Eq + Ord, V: ToRedisArgs> ToRedisArgs for BTreeMap<
     }
 }
 
-impl<T: ToRedisArgs + Hash + Eq + Ord, V: ToRedisArgs> ToRedisArgs for std::collections::HashMap<T, V> {
-  fn write_redis_args<W>(&self, out: &mut W)
-  where
-      W: ?Sized + RedisWrite,
-  {
-      for (key, value) in self {
-          assert!(key.is_single_arg() && value.is_single_arg());
+impl<T: ToRedisArgs + Hash + Eq + Ord, V: ToRedisArgs> ToRedisArgs
+    for std::collections::HashMap<T, V>
+{
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        for (key, value) in self {
+            assert!(key.is_single_arg() && value.is_single_arg());
 
-          key.write_redis_args(out);
-          value.write_redis_args(out);
-      }
-  }
+            key.write_redis_args(out);
+            value.write_redis_args(out);
+        }
+    }
 
-  fn is_single_arg(&self) -> bool {
-      self.len() <= 1
-  }
+    fn is_single_arg(&self) -> bool {
+        self.len() <= 1
+    }
 }
 
 macro_rules! to_redis_args_for_tuple {

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -261,7 +261,7 @@ fn test_types_to_redis_args() {
         .is_empty());
 
     // this can also be used on something HMSET
-    assert!(![("a", 5), ("b", 6), ("C", 7)]
+    assert!(![("d", 8), ("e", 9), ("f", 10)]
         .iter()
         .cloned()
         .collect::<HashMap<_, _>>()

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -230,6 +230,7 @@ fn test_types_to_redis_args() {
     use redis::ToRedisArgs;
     use std::collections::BTreeMap;
     use std::collections::BTreeSet;
+    use std::collections::HashMap;
     use std::collections::HashSet;
 
     assert!(!5i32.to_redis_args().is_empty());
@@ -256,6 +257,14 @@ fn test_types_to_redis_args() {
         .iter()
         .cloned()
         .collect::<BTreeMap<_, _>>()
+        .to_redis_args()
+        .is_empty());
+
+    // this can also be used on something HMSET
+    assert!(![("a", 5), ("b", 6), ("C", 7)]
+        .iter()
+        .cloned()
+        .collect::<HashMap<_, _>>()
         .to_redis_args()
         .is_empty());
 }


### PR DESCRIPTION
This is adding the std::collections::HashMap as a ToRedisArgs so that now would be possible to run HSET commands using a simple HashMap (as it already supports for BTreeMap)

Fixes #444.