### PR TITLE
Enable discovery of aborted Connections

### DIFF
--- a/redis/src/aio.rs
+++ b/redis/src/aio.rs
@@ -576,9 +576,11 @@ where
             }
 
             if self.send_state != ConnectionSendState::Quiescent {
-                return Err(RedisError::from((ErrorKind::IoError, "Your connection was leaked. You might read previous commands' output.")))
+                return Err(RedisError::from((
+                    ErrorKind::IoError,
+                    "Your connection was leaked. You might read previous commands' output.",
+                )));
             }
-
 
             self.buf.clear();
             self.send_state = ConnectionSendState::Sending;
@@ -609,7 +611,10 @@ where
             }
 
             if self.send_state != ConnectionSendState::Quiescent {
-                return Err(RedisError::from((ErrorKind::IoError, "Your connection was leaked. You might read previous commands' output.")))
+                return Err(RedisError::from((
+                    ErrorKind::IoError,
+                    "Your connection was leaked. You might read previous commands' output.",
+                )));
             }
 
             self.buf.clear();

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -471,7 +471,7 @@ impl Cmd {
     pub fn execute(&self, con: &mut dyn ConnectionLike) {
         match self.query::<()>(con) {
             Ok(_) => (),
-            Err(e) => panic!("Error during execute: {e:?}")
+            Err(e) => panic!("Error during execute: {e:?}"),
         }
     }
 

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -469,7 +469,10 @@ impl Cmd {
     /// ```
     #[inline]
     pub fn execute(&self, con: &mut dyn ConnectionLike) {
-        self.query::<()>(con).unwrap();
+        match self.query::<()>(con) {
+            Ok(_) => (),
+            Err(e) => panic!("Error during execute: {e:?}")
+        }
     }
 
     /// Returns an iterator over the arguments in this command (including the command name itself)

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -655,7 +655,7 @@ fn dirty_connections_block_illegal_reuse() {
         match conn.get::<&str, String>("pong").await {
             Ok(bad) => {
                 panic!("This connection is busy. It cannot return, but it returned: {bad}")
-            },
+            }
             Err(e) => {
                 assert_eq!(ErrorKind::IoError, e.kind())
             }


### PR DESCRIPTION
This will allow connection managers like bb8 to drop async Connections
when the Future that owned them was dropped.
See: https://github.com/djc/bb8/blob/main/redis/src/lib.rs#L78-L80

Futures drop synchronously, so there's no practical way to block them
until their response from Redis has been fully hydrated. Instead,
this change _only_ seeks to make such a situation knowable to a
ConnectionManager so it can make a choice as to what to do with the
connection.

The impact of reusing a connection in this state has no upper bound;
it violates privacy of unrelated values. This change addresses this
by adding an IO error in the Connection under ConnectionLike such
that if the connection is in some partial & unknown state it will
refuse to execute the requested commands.

By using IoError as the ErrorKind, it is believed that other pools
will be able to make a good choice about what to do when they find
a Connection in this state, no matter how it got there.

Relates to: https://github.com/redis-rs/redis-rs/issues/325
