### PR TITLE
Restore inherent `ClusterConnection::check_connection` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The crate is called `redis` and you can depend on it via cargo:
 
 ```ini
 [dependencies]
-redis = "0.22.2"
+redis = "0.22.3"
 ```
 
 Documentation on the library can be found at
@@ -54,10 +54,10 @@ To enable asynchronous clients a feature for the underlying feature need to be a
 
 ```
 # if you use tokio
-redis = { version = "0.22.2", features = ["tokio-comp"] }
+redis = { version = "0.22.3", features = ["tokio-comp"] }
 
 # if you use async-std
-redis = { version = "0.22.2", features = ["async-std-comp"] }
+redis = { version = "0.22.3", features = ["async-std-comp"] }
 ```
 
 ## TLS Support
@@ -65,13 +65,13 @@ redis = { version = "0.22.2", features = ["async-std-comp"] }
 To enable TLS support, you need to use the relevant feature entry in your Cargo.toml.
 
 ```
-redis = { version = "0.22.2", features = ["tls"] }
+redis = { version = "0.22.3", features = ["tls"] }
 
 # if you use tokio
-redis = { version = "0.22.2", features = ["tokio-native-tls-comp"] }
+redis = { version = "0.22.3", features = ["tokio-native-tls-comp"] }
 
 # if you use async-std
-redis = { version = "0.22.2", features = ["async-std-tls-comp"] }
+redis = { version = "0.22.3", features = ["async-std-tls-comp"] }
 ```
 
 then you should be able to connect to a redis instance using the `rediss://` URL scheme:
@@ -84,7 +84,7 @@ let client = redis::Client::open("rediss://127.0.0.1/")?;
 
 Cluster mode can be used by specifying "cluster" as a features entry in your Cargo.toml.
 
-`redis = { version = "0.22.2", features = [ "cluster"] }`
+`redis = { version = "0.22.3", features = [ "cluster"] }`
 
 Then you can simply use the `ClusterClient` which accepts a list of available nodes.
 
@@ -107,7 +107,7 @@ fn fetch_an_integer() -> String {
 
 Support for the RedisJSON Module can be enabled by specifying "json" as a feature in your Cargo.toml.
 
-`redis = { version = "0.22.2", features = ["json"] }`
+`redis = { version = "0.22.3", features = ["json"] }`
 
 Then you can simply import the `JsonCommands` trait which will add the `json` commands to all Redis Connections (not to be confused with just `Commands` which only adds the default commands)
 

--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="0.22.3"></a>
+### 0.22.3 (2023-01-23)
+
+#### Changes
+*   Restore inherent `ClusterConnection::check_connection()` method ([#758](https://github.com/redis-rs/redis-rs/pull/758) @robjtede)
+
+
 <a name="0.22.2"></a>
 ### 0.22.2 (2023-01-07)
 

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis"
-version = "0.22.2"
+version = "0.22.3"
 keywords = ["redis", "database"]
 description = "Redis driver for Rust."
 homepage = "https://github.com/redis-rs/redis-rs"

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -169,6 +169,12 @@ impl ClusterConnection {
         Ok(())
     }
 
+    /// Check that all connections it has are available (`PING` internally).
+    #[doc(hidden)]
+    pub fn check_connection(&mut self) -> bool {
+        <Self as ConnectionLike>::check_connection(self)
+    }
+
     pub(crate) fn execute_pipeline(&mut self, pipe: &ClusterPipeline) -> RedisResult<Vec<Value>> {
         self.send_recv_and_retry_cmds(pipe.commands())
     }


### PR DESCRIPTION
Reverts breaking change made in 85e92c8ce8c24fc9dd057f39e48304a263e902d3.

Cannot be deprecated since it shares it's name with the trait method and the inherent method will always be preferred.

`doc(hidden)` as a somewhat opinionated addition