### PR TITLE
Allow disabling `default` user in tests

### DIFF
--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -157,7 +157,7 @@ impl RedisCluster {
 
     fn wait_for_replicas(&self, replicas: u16) {
         'server: for server in &self.servers {
-            let conn_info = server.get_conn_info();
+            let conn_info = server.connection_info();
             eprintln!(
                 "waiting until {:?} knows required number of replicas",
                 conn_info.addr
@@ -222,7 +222,7 @@ impl TestClusterContext {
         let mut builder = redis::cluster::ClusterClientBuilder::new(
             cluster
                 .iter_servers()
-                .map(RedisServer::get_conn_info)
+                .map(RedisServer::connection_info)
                 .collect(),
         );
         builder = initializer(builder);
@@ -253,7 +253,7 @@ impl TestClusterContext {
 
     pub fn disable_default_user(&self) {
         for server in &self.cluster.servers {
-            let client = redis::Client::open(server.get_conn_info()).unwrap();
+            let client = redis::Client::open(server.connection_info()).unwrap();
             let mut con = client.get_connection().unwrap();
             let _: () = redis::cmd("ACL")
                 .arg("SETUSER")

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -201,13 +201,13 @@ impl RedisServer {
         }
     }
 
-    pub fn get_client_addr(&self) -> &redis::ConnectionAddr {
+    pub fn client_addr(&self) -> &redis::ConnectionAddr {
         &self.addr
     }
 
-    pub fn get_conn_info(&self) -> redis::ConnectionInfo {
+    pub fn connection_info(&self) -> redis::ConnectionInfo {
         redis::ConnectionInfo {
-            addr: self.get_client_addr().clone(),
+            addr: self.client_addr().clone(),
             redis: Default::default(),
         }
     }
@@ -215,7 +215,7 @@ impl RedisServer {
     pub fn stop(&mut self) {
         let _ = self.process.kill();
         let _ = self.process.wait();
-        if let redis::ConnectionAddr::Unix(ref path) = *self.get_client_addr() {
+        if let redis::ConnectionAddr::Unix(ref path) = *self.client_addr() {
             fs::remove_file(path).ok();
         }
     }
@@ -241,7 +241,7 @@ impl TestContext {
         let server = RedisServer::with_modules(modules);
 
         let client = redis::Client::open(redis::ConnectionInfo {
-            addr: server.get_client_addr().clone(),
+            addr: server.client_addr().clone(),
             redis: Default::default(),
         })
         .unwrap();

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -205,6 +205,13 @@ impl RedisServer {
         &self.addr
     }
 
+    pub fn get_conn_info(&self) -> redis::ConnectionInfo {
+        redis::ConnectionInfo {
+            addr: self.get_client_addr().clone(),
+            redis: Default::default(),
+        }
+    }
+
     pub fn stop(&mut self) {
         let _ = self.process.kill();
         let _ = self.process.wait();

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -442,7 +442,7 @@ async fn io_error_on_kill_issue_320() {
 async fn invalid_password_issue_343() {
     let ctx = TestContext::new();
     let coninfo = redis::ConnectionInfo {
-        addr: ctx.server.get_client_addr().clone(),
+        addr: ctx.server.client_addr().clone(),
         redis: redis::RedisConnectionInfo {
             db: 0,
             username: None,

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -29,6 +29,8 @@ fn test_cluster_with_username_and_password() {
             .username(RedisCluster::username().to_string())
             .password(RedisCluster::password().to_string())
     });
+    cluster.disable_default_user();
+
     let mut con = cluster.connection();
 
     redis::cmd("SET")


### PR DESCRIPTION
The goal is to strengthen tests of authentication
by ensuring that auth is actually required during
the test run, else the test could inadvertently pass 
if credentials aren't actually passed for some reason.

Also factor out some repeated test code into common method.