### PR TITLE
Improve documentation, add references to redis-macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ fn set_json_bool<P: ToRedisArgs>(key: P, path: P, b: bool) -> RedisResult<bool> 
 ```
 
 To parse the results, you'll need to use `serde_json` (or some other json lib) to deserialize
-the results from the bytes. It will always be a Vec, if no results were found at the path it'll
-be an empty Vec. If you want to handle deserialization and Vec unwrapping automatically,
+the results from the bytes. It will always be a `Vec`, if no results were found at the path it'll
+be an empty `Vec`. If you want to handle deserialization and `Vec` unwrapping automatically,
 you can use the `Json` wrapper from the
 [redis-macros](https://github.com/daniel7grant/redis-macros/#json-wrapper-with-redisjson) crate.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ fn fetch_an_integer() -> redis::RedisResult<isize> {
 }
 ```
 
+Variables are converted to and from the Redis format for a wide variety of types
+(`String`, num types, tuples, `Vec<u8>`). If you want to use it with your own types,
+you can implement the `FromRedisValue` and `ToRedisArgs` traits, or derive it with the
+[redis-macros](https://github.com/daniel7grant/redis-macros/#json-wrapper-with-redisjson) crate. 
+
 ## Async support
 
 To enable asynchronous clients a feature for the underlying feature need to be activated.
@@ -125,12 +130,15 @@ fn set_json_bool<P: ToRedisArgs>(key: P, path: P, b: bool) -> RedisResult<bool> 
 
     // runs `JSON.SET {key} {path} {b}`
     connection.json_set(key, path, b)?
-    
-    // you'll need to use serde_json (or some other json lib) to deserialize the results from the bytes
-    // It will always be a Vec, if no results were found at the path it'll be an empty Vec
 }
 
 ```
+
+To parse the results, you'll need to use `serde_json` (or some other json lib) to deserialize
+the results from the bytes. It will always be a Vec, if no results were found at the path it'll
+be an empty Vec. If you want to handle deserialization and Vec unwrapping automatically,
+you can use the `Json` wrapper from the
+[redis-macros](https://github.com/daniel7grant/redis-macros/#json-wrapper-with-redisjson) crate.
 
 ## Development
 

--- a/redis/src/commands/json.rs
+++ b/redis/src/commands/json.rs
@@ -30,10 +30,12 @@ macro_rules! implement_json_commands {
         /// For instance this code:
         ///
         /// ```rust,no_run
+        /// use redis::JsonCommands;
+        /// use serde_json::json;
         /// # fn do_something() -> redis::RedisResult<()> {
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
         /// let mut con = client.get_connection()?;
-        /// redis::cmd("JSON.SET").arg("my_key").arg("$").arg(&json!({"item": 42i32})).execute(&mut con);
+        /// redis::cmd("JSON.SET").arg("my_key").arg("$").arg(&json!({"item": 42i32}).to_string()).execute(&mut con);
         /// assert_eq!(redis::cmd("JSON.GET").arg("my_key").arg("$").query(&mut con), Ok(String::from(r#"[{"item":42}]"#)));
         /// # Ok(()) }
         /// ```
@@ -44,10 +46,9 @@ macro_rules! implement_json_commands {
         /// use redis::JsonCommands;
         /// use serde_json::json;
         /// # fn do_something() -> redis::RedisResult<()> {
-        /// use redis::Commands;
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
         /// let mut con = client.get_connection()?;
-        /// con.json_set("my_key", "$", &json!({"item": 42i32}))?;
+        /// con.json_set("my_key", "$", &json!({"item": 42i32}).to_string())?;
         /// assert_eq!(con.json_get("my_key", "$"), Ok(String::from(r#"[{"item":42}]"#)));
         /// assert_eq!(con.json_get("my_key", "$.item"), Ok(String::from(r#"[42]"#)));
         /// # Ok(()) }
@@ -87,10 +88,11 @@ macro_rules! implement_json_commands {
         ///
         /// ```rust,no_run
         /// use redis::JsonAsyncCommands;
+        /// use serde_json::json;
         /// # async fn do_something() -> redis::RedisResult<()> {
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
         /// let mut con = client.get_async_connection().await?;
-        /// redis::cmd("JSON.SET").arg("my_key").arg("$").arg(&json!({"item": 42i32})).query_async(&mut con).await?;
+        /// redis::cmd("JSON.SET").arg("my_key").arg("$").arg(&json!({"item": 42i32}).to_string()).query_async(&mut con).await?;
         /// assert_eq!(redis::cmd("GET").arg("my_key").arg("$").query_async(&mut con).await, Ok(String::from(r#"[{"item":42}]"#)));
         /// # Ok(()) }
         /// ```
@@ -104,7 +106,7 @@ macro_rules! implement_json_commands {
         /// use redis::Commands;
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
         /// let mut con = client.get_async_connection().await?;
-        /// con.json_set("my_key", "$", &json!({"item": 42i32})).await?;
+        /// con.json_set("my_key", "$", &json!({"item": 42i32}).to_string()).await?;
         /// assert_eq!(con.json_get("my_key", "$").await, Ok(String::from(r#"[{"item":42}]"#)));
         /// assert_eq!(con.json_get("my_key", "$.item").await, Ok(String::from(r#"[42]"#)));
         /// # Ok(()) }

--- a/redis/src/commands/json.rs
+++ b/redis/src/commands/json.rs
@@ -42,7 +42,7 @@ macro_rules! implement_json_commands {
         ///
         /// ```rust,no_run
         /// use redis::JsonCommands;
-		/// use serde_json::json;
+        /// use serde_json::json;
         /// # fn do_something() -> redis::RedisResult<()> {
         /// use redis::Commands;
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
@@ -64,7 +64,7 @@ macro_rules! implement_json_commands {
         /// ```rust,no_run
         /// use redis_macros::Json;
         /// # use redis::JsonCommands;
-		/// # use serde_json::json;
+        /// # use serde_json::json;
         /// # fn do_something() -> redis::RedisResult<()> {
         /// # use redis::Commands;
         /// # let client = redis::Client::open("redis://127.0.0.1/")?;
@@ -115,7 +115,7 @@ macro_rules! implement_json_commands {
         ///
         /// ```rust,no_run
         /// use redis::JsonAsyncCommands;
-		/// use serde_json::json;
+        /// use serde_json::json;
         /// # async fn do_something() -> redis::RedisResult<()> {
         /// use redis::Commands;
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
@@ -137,7 +137,7 @@ macro_rules! implement_json_commands {
         /// ```rust,no_run
         /// use redis_macros::Json;
         /// # use redis::JsonAsyncCommands;
-		/// # use serde_json::json;
+        /// # use serde_json::json;
         /// # async fn do_something() -> redis::RedisResult<()> {
         /// # use redis::Commands;
         /// # let client = redis::Client::open("redis://127.0.0.1/")?;

--- a/redis/src/commands/json.rs
+++ b/redis/src/commands/json.rs
@@ -57,22 +57,6 @@ macro_rules! implement_json_commands {
         /// in square brackets (or empty brackets if not found). If you want to deserialize it
         /// with e.g. `serde_json` you have to use `Vec<T>` for your output type instead of `T`.
         /// 
-        /// If you want to avoid manual deserialization altogether, you can use the `Json` wrapper from
-        /// the [redis-macros](https://github.com/daniel7grant/redis-macros/#json-wrapper-with-redisjson) crate.
-        /// This type remove the angle brackets, and deserializes it to your type from string in one step.
-        /// 
-        /// ```rust,no_run
-        /// use redis_macros::Json;
-        /// # use redis::JsonCommands;
-        /// # use serde_json::json;
-        /// # fn do_something() -> redis::RedisResult<()> {
-        /// # use redis::Commands;
-        /// # let client = redis::Client::open("redis://127.0.0.1/")?;
-        /// # let mut con = client.get_connection()?;
-        /// con.json_set("my_key", "$", &json!({"item": 42i32}))?;
-        /// let Json(item): Json<i32> = con.json_get("my_key", "$.item")?;
-        /// assert_eq!(item, 42);
-        /// # Ok(()) }
         /// ```
         pub trait JsonCommands : ConnectionLike + Sized {
             $(
@@ -130,22 +114,6 @@ macro_rules! implement_json_commands {
         /// in square brackets (or empty brackets if not found). If you want to deserialize it
         /// with e.g. `serde_json` you have to use `Vec<T>` for your output type instead of `T`.
         /// 
-        /// If you want to avoid manual deserialization altogether, you can use the `Json` wrapper from
-        /// the [redis-macros](https://github.com/daniel7grant/redis-macros/#json-wrapper-with-redisjson) crate.
-        /// This type remove the angle brackets, and deserializes it to your type from string in one step.
-        /// 
-        /// ```rust,no_run
-        /// use redis_macros::Json;
-        /// # use redis::JsonAsyncCommands;
-        /// # use serde_json::json;
-        /// # async fn do_something() -> redis::RedisResult<()> {
-        /// # use redis::Commands;
-        /// # let client = redis::Client::open("redis://127.0.0.1/")?;
-        /// # let mut con = client.get_async_connection().await?;
-        /// con.json_set("my_key", "$", &json!({"item": 42i32})).await?;
-        /// let Json(item): Json<i32> = con.json_get("my_key", "$.item").await?;
-        /// assert_eq!(item, 42);
-        /// # Ok(()) }
 		#[cfg(feature = "aio")]
         pub trait JsonAsyncCommands : crate::aio::ConnectionLike + Send + Sized {
             $(
@@ -325,8 +293,6 @@ implement_json_commands! {
     /// With RedisJSON commands, you have to note that all results will be wrapped
     /// in square brackets (or empty brackets if not found). If you want to deserialize it
     /// with e.g. `serde_json` you have to use `Vec<T>` for your output type instead of `T`. 
-    /// If you want to avoid manual deserialization altogether, you can use the `Json` wrapper from
-    /// the [redis-macros](https://github.com/daniel7grant/redis-macros/#json-wrapper-with-redisjson) crate.
     fn json_get<K: ToRedisArgs, P: ToRedisArgs>(key: K, path: P) {
         let mut cmd = cmd(if key.is_single_arg() { "JSON.GET" } else { "JSON.MGET" });
 

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -169,7 +169,7 @@
 //! to serialize and deserialize in Redis, you can use the [redis-macros](https://github.com/daniel7grant/redis-macros/)
 //! crate. This will use Serde to save the data in Redis in JSON format.
 //! 
-//! ```rust,no_run
+//! ```rust,ignore
 //! # use redis::Commands;
 //! # use std::collections::{HashMap, HashSet};
 //! #[derive(Serialize, Deserialize, FromRedisValue, ToRedisArgs)]
@@ -192,7 +192,7 @@
 //! be used with `SCAN` like commands in which case iteration will send more
 //! queries until the cursor is exhausted:
 //!
-//! ```rust,no_run
+//! ```rust,ignore
 //! # fn do_something() -> redis::RedisResult<()> {
 //! # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
 //! # let mut con = client.get_connection().unwrap();

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -164,17 +164,17 @@
 //! # Ok(())
 //! # }
 //! ```
-//! 
+//!
 //! If you want to derive `FromRedisValue` and `ToRedisArgs` automatically
 //! to serialize and deserialize in Redis, you can use the [redis-macros](https://github.com/daniel7grant/redis-macros/)
 //! crate. This will use Serde to save the data in Redis in JSON format.
-//! 
+//!
 //! ```rust,ignore
 //! # use redis::Commands;
 //! # use std::collections::{HashMap, HashSet};
 //! #[derive(Serialize, Deserialize, FromRedisValue, ToRedisArgs)]
 //! struct User { name: String }
-//! 
+//!
 //! # fn do_something() -> redis::RedisResult<()> {
 //! # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
 //! # let mut con = client.get_connection().unwrap();

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -164,6 +164,25 @@
 //! # Ok(())
 //! # }
 //! ```
+//! 
+//! If you want to derive `FromRedisValue` and `ToRedisArgs` automatically
+//! to serialize and deserialize in Redis, you can use the [redis-macros](https://github.com/daniel7grant/redis-macros/)
+//! crate. This will use Serde to save the data in Redis in JSON format.
+//! 
+//! ```rust,no_run
+//! # use redis::Commands;
+//! # use std::collections::{HashMap, HashSet};
+//! #[derive(Serialize, Deserialize, FromRedisValue, ToRedisArgs)]
+//! struct User { name: String }
+//! 
+//! # fn do_something() -> redis::RedisResult<()> {
+//! # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+//! # let mut con = client.get_connection().unwrap();
+//! con.set("username", User { name: "user".to_string() })?;
+//! let user: User = con.get("username")?;
+//! # Ok(())
+//! # }
+//! ```
 //!
 //! # Iteration Protocol
 //!

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -165,25 +165,6 @@
 //! # }
 //! ```
 //!
-//! If you want to derive `FromRedisValue` and `ToRedisArgs` automatically
-//! to serialize and deserialize in Redis, you can use the [redis-macros](https://github.com/daniel7grant/redis-macros/)
-//! crate. This will use Serde to save the data in Redis in JSON format.
-//!
-//! ```rust,ignore
-//! # use redis::Commands;
-//! # use std::collections::{HashMap, HashSet};
-//! #[derive(Serialize, Deserialize, FromRedisValue, ToRedisArgs)]
-//! struct User { name: String }
-//!
-//! # fn do_something() -> redis::RedisResult<()> {
-//! # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-//! # let mut con = client.get_connection().unwrap();
-//! con.set("username", User { name: "user".to_string() })?;
-//! let user: User = con.get("username")?;
-//! # Ok(())
-//! # }
-//! ```
-//!
 //! # Iteration Protocol
 //!
 //! In addition to sending a single query, iterators are also supported.  When

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -679,10 +679,6 @@ impl RedisWrite for Vec<Vec<u8>> {
 /// Used to convert a value into one or multiple redis argument
 /// strings.  Most values will produce exactly one item but in
 /// some cases it might make sense to produce more than one.
-/// 
-/// If you want to automatically serialize your own types to JSON strings,
-/// you can derive this trait with the
-/// [redis-macros](https://github.com/daniel7grant/redis-macros/) crate.
 pub trait ToRedisArgs: Sized {
     /// This converts the value into a vector of bytes.  Each item
     /// is a single argument.  Most items generate a vector of a
@@ -1100,11 +1096,6 @@ to_redis_args_for_array! {
 /// back from the redis server, usually you want to map this into something
 /// that works better in rust.  For instance you might want to convert the
 /// return value into a `String` or an integer.
-///
-/// This trait is well supported throughout the library and you can
-/// implement it for your own types if you want. To automatically derive
-/// this trait for your own types, you can use the
-/// [redis-macros](https://github.com/daniel7grant/redis-macros/) crate.
 ///
 /// In addition to what you can see from the docs, this is also implemented
 /// for tuples up to size 12 and for `Vec<u8>`.

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -679,6 +679,10 @@ impl RedisWrite for Vec<Vec<u8>> {
 /// Used to convert a value into one or multiple redis argument
 /// strings.  Most values will produce exactly one item but in
 /// some cases it might make sense to produce more than one.
+/// 
+/// If you want to automatically serialize your own types to JSON strings,
+/// you can derive this trait with the
+/// [redis-macros](https://github.com/daniel7grant/redis-macros/) crate.
 pub trait ToRedisArgs: Sized {
     /// This converts the value into a vector of bytes.  Each item
     /// is a single argument.  Most items generate a vector of a
@@ -1098,7 +1102,9 @@ to_redis_args_for_array! {
 /// return value into a `String` or an integer.
 ///
 /// This trait is well supported throughout the library and you can
-/// implement it for your own types if you want.
+/// implement it for your own types if you want. To automatically derive
+/// this trait for your own types, you can use the
+/// [redis-macros](https://github.com/daniel7grant/redis-macros/) crate.
 ///
 /// In addition to what you can see from the docs, this is also implemented
 /// for tuples up to size 12 and for `Vec<u8>`.

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1097,6 +1097,9 @@ to_redis_args_for_array! {
 /// that works better in rust.  For instance you might want to convert the
 /// return value into a `String` or an integer.
 ///
+/// This trait is well supported throughout the library and you can
+/// implement it for your own types if you want.
+///
 /// In addition to what you can see from the docs, this is also implemented
 /// for tuples up to size 12 and for `Vec<u8>`.
 pub trait FromRedisValue: Sized {


### PR DESCRIPTION
This is made in reference of [#740](https://github.com/redis-rs/redis-rs/issues/740#issuecomment-1409925147).

The crate [redis-macros](https://github.com/daniel7grant/redis-macros/) adds derive macros for `FromRedisValue` and `ToRedisArgs`, as well as a wrapper type `Json` to unwrap RedisJSON command results. I added suggestions for users to use these macros at several places in the documentation where types were mentioned. I fixed the documentation code blocks in `JsonCommands`, and added more information about RedisJSON results, and how to unwrap it with `Json`.

Feel free to edit if you find any inaccuracies.