### PR TITLE
[2/5] [8] cluster: keep all params in ClusterParams struct & use it to pass all cluster related params

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -41,7 +41,6 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::iter::Iterator;
-use std::str::FromStr;
 use std::thread;
 use std::time::Duration;
 
@@ -54,9 +53,7 @@ use crate::cluster_client::ClusterParams;
 use crate::cluster_pipeline::UNROUTABLE_ERROR;
 use crate::cluster_routing::{Routable, RoutingInfo, Slot, SLOT_SIZE};
 use crate::cmd::{cmd, Cmd};
-use crate::connection::{
-    connect, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, RedisConnectionInfo,
-};
+use crate::connection::{connect, Connection, ConnectionInfo, ConnectionLike};
 use crate::parser::parse_redis_value;
 use crate::types::{ErrorKind, HashMap, HashSet, RedisError, RedisResult, Value};
 
@@ -64,17 +61,13 @@ pub use crate::cluster_client::{ClusterClient, ClusterClientBuilder};
 pub use crate::cluster_pipeline::{cluster_pipe, ClusterPipeline};
 
 /// This is a connection of Redis cluster.
+#[derive(Default)]
 pub struct ClusterConnection {
+    cluster_params: ClusterParams,
     initial_nodes: Vec<ConnectionInfo>,
+
     connections: RefCell<HashMap<String, Connection>>,
     slots: RefCell<SlotMap>,
-    auto_reconnect: RefCell<bool>,
-    read_from_replicas: bool,
-    username: Option<String>,
-    password: Option<String>,
-    read_timeout: RefCell<Option<Duration>>,
-    write_timeout: RefCell<Option<Duration>>,
-    tls: Option<TlsMode>,
 }
 
 impl ClusterConnection {
@@ -83,70 +76,45 @@ impl ClusterConnection {
         initial_nodes: Vec<ConnectionInfo>,
     ) -> RedisResult<ClusterConnection> {
         let connection = ClusterConnection {
-            connections: RefCell::new(HashMap::new()),
-            slots: RefCell::new(SlotMap::new()),
-            auto_reconnect: RefCell::new(true),
-            read_from_replicas: cluster_params.read_from_replicas,
-            username: cluster_params.username,
-            password: cluster_params.password,
-            read_timeout: RefCell::new(None),
-            write_timeout: RefCell::new(None),
-            tls: cluster_params.tls,
-            initial_nodes: initial_nodes.to_vec(),
+            cluster_params,
+            initial_nodes,
+            ..Default::default()
         };
         connection.create_initial_connections()?;
 
         Ok(connection)
     }
 
-    /// Set an auto reconnect attribute.
-    /// Default value is true;
-    pub fn set_auto_reconnect(&self, value: bool) {
-        let mut auto_reconnect = self.auto_reconnect.borrow_mut();
-        *auto_reconnect = value;
+    /// Set the auto reconnect parameter for this connection.
+    ///
+    /// See [ClusterClientBuilder](ClusterClientBuilder::auto_reconnect).
+    pub fn set_auto_reconnect(&mut self, value: bool) {
+        self.cluster_params.auto_reconnect = value;
     }
 
-    /// Sets the write timeout for the connection.
+    /// Set the write timeout for this connection.
     ///
-    /// If the provided value is `None`, then `send_packed_command` call will
-    /// block indefinitely. It is an error to pass the zero `Duration` to this
-    /// method.
-    pub fn set_write_timeout(&self, dur: Option<Duration>) -> RedisResult<()> {
+    /// See [ClusterClientBuilder](ClusterClientBuilder::write_timeout).
+    pub fn set_write_timeout(&mut self, dur: Option<Duration>) -> RedisResult<()> {
         // Check if duration is valid before updating local value.
-        if dur.is_some() && dur.unwrap().is_zero() {
-            return Err(RedisError::from((
-                ErrorKind::InvalidClientConfig,
-                "Duration should be None or non-zero.",
-            )));
-        }
+        ClusterParams::validate_duration(&dur)?;
 
-        let mut t = self.write_timeout.borrow_mut();
-        *t = dur;
-        let connections = self.connections.borrow();
-        for conn in connections.values() {
+        self.cluster_params.write_timeout = dur;
+        for conn in self.connections.borrow().values() {
             conn.set_write_timeout(dur)?;
         }
         Ok(())
     }
 
-    /// Sets the read timeout for the connection.
+    /// Set the read timeout for this connection.
     ///
-    /// If the provided value is `None`, then `recv_response` call will
-    /// block indefinitely. It is an error to pass the zero `Duration` to this
-    /// method.
-    pub fn set_read_timeout(&self, dur: Option<Duration>) -> RedisResult<()> {
+    /// See [ClusterClientBuilder](ClusterClientBuilder::read_timeout).
+    pub fn set_read_timeout(&mut self, dur: Option<Duration>) -> RedisResult<()> {
         // Check if duration is valid before updating local value.
-        if dur.is_some() && dur.unwrap().is_zero() {
-            return Err(RedisError::from((
-                ErrorKind::InvalidClientConfig,
-                "Duration should be None or non-zero.",
-            )));
-        }
+        ClusterParams::validate_duration(&dur)?;
 
-        let mut t = self.read_timeout.borrow_mut();
-        *t = dur;
-        let connections = self.connections.borrow();
-        for conn in connections.values() {
+        self.cluster_params.read_timeout = dur;
+        for conn in self.connections.borrow().values() {
             conn.set_read_timeout(dur)?;
         }
         Ok(())
@@ -199,15 +167,16 @@ impl ClusterConnection {
     fn refresh_slots(&self) -> RedisResult<()> {
         let mut slots = self.slots.borrow_mut();
         *slots = self.create_new_slots(|slot_data| {
-            let replica = if !self.read_from_replicas || slot_data.replicas().is_empty() {
-                slot_data.master().to_string()
-            } else {
-                slot_data
-                    .replicas()
-                    .choose(&mut thread_rng())
-                    .unwrap()
-                    .to_string()
-            };
+            let replica =
+                if !self.cluster_params.read_from_replicas || slot_data.replicas().is_empty() {
+                    slot_data.master().to_string()
+                } else {
+                    slot_data
+                        .replicas()
+                        .choose(&mut thread_rng())
+                        .unwrap()
+                        .to_string()
+                };
 
             [slot_data.master().to_string(), replica]
         })?;
@@ -229,8 +198,9 @@ impl ClusterConnection {
 
                 if let Ok(mut conn) = self.connect(addr) {
                     if conn.check_connection() {
-                        conn.set_read_timeout(*self.read_timeout.borrow()).unwrap();
-                        conn.set_write_timeout(*self.write_timeout.borrow())
+                        conn.set_read_timeout(self.cluster_params.read_timeout)
+                            .unwrap();
+                        conn.set_write_timeout(self.cluster_params.write_timeout)
                             .unwrap();
                         return Some((addr.to_string(), conn));
                     }
@@ -254,7 +224,7 @@ impl ClusterConnection {
         let mut samples = connections.values_mut().choose_multiple(&mut rng, len);
 
         for conn in samples.iter_mut() {
-            if let Ok(mut slots_data) = get_slots(conn, self.tls) {
+            if let Ok(mut slots_data) = get_slots(conn, &self.cluster_params) {
                 slots_data.sort_by_key(|s| s.start());
                 let last_slot = slots_data.iter().try_fold(0, |prev_end, slot_data| {
                     if prev_end != slot_data.start() {
@@ -301,16 +271,10 @@ impl ClusterConnection {
     }
 
     fn connect(&self, node: &str) -> RedisResult<Connection> {
-        let params = ClusterParams {
-            password: self.password.clone(),
-            username: self.username.clone(),
-            tls: self.tls,
-            ..Default::default()
-        };
-        let info = get_connection_info(node, params)?;
+        let info = self.cluster_params.get_connection_info(node);
 
         let mut conn = connect(&info, None)?;
-        if self.read_from_replicas {
+        if self.cluster_params.read_from_replicas {
             // If READONLY is sent to primary nodes, it will have no effect
             cmd("READONLY").query(&mut conn)?;
         }
@@ -481,7 +445,7 @@ impl ClusterConnection {
                             excludes.clear();
                             continue;
                         }
-                    } else if *self.auto_reconnect.borrow() && err.is_io_error() {
+                    } else if self.cluster_params.auto_reconnect && err.is_io_error() {
                         self.create_initial_connections()?;
                         excludes.clear();
                         continue;
@@ -694,7 +658,10 @@ fn get_random_connection<'a>(
 }
 
 // Get slot data from connection.
-fn get_slots(connection: &mut Connection, tls: Option<TlsMode>) -> RedisResult<Vec<Slot>> {
+fn get_slots(
+    connection: &mut Connection,
+    cluster_params: &ClusterParams,
+) -> RedisResult<Vec<Slot>> {
     let mut cmd = Cmd::new();
     cmd.arg("CLUSTER").arg("SLOTS");
     let value = connection.req_command(&cmd)?;
@@ -744,7 +711,11 @@ fn get_slots(connection: &mut Connection, tls: Option<TlsMode>) -> RedisResult<V
                         } else {
                             return None;
                         };
-                        Some(get_connection_addr(ip.into_owned(), port, tls).to_string())
+                        Some(
+                            cluster_params
+                                .get_connection_addr(ip.into_owned(), port)
+                                .to_string(),
+                        )
                     } else {
                         None
                     }
@@ -761,43 +732,4 @@ fn get_slots(connection: &mut Connection, tls: Option<TlsMode>) -> RedisResult<V
     }
 
     Ok(result)
-}
-
-// The node string passed to this function will always be in the format host:port as it is either:
-// - Created by calling ConnectionAddr::to_string (unix connections are not supported in cluster mode)
-// - Returned from redis via the ASK/MOVED response
-fn get_connection_info(node: &str, cluster_params: ClusterParams) -> RedisResult<ConnectionInfo> {
-    let mut split = node.split(':');
-    let invalid_error = || (ErrorKind::InvalidClientConfig, "Invalid node string");
-
-    let host = split.next().ok_or_else(invalid_error)?;
-    let port = split
-        .next()
-        .and_then(|string| u16::from_str(string).ok())
-        .ok_or_else(invalid_error)?;
-
-    Ok(ConnectionInfo {
-        addr: get_connection_addr(host.to_string(), port, cluster_params.tls),
-        redis: RedisConnectionInfo {
-            password: cluster_params.password,
-            username: cluster_params.username,
-            ..Default::default()
-        },
-    })
-}
-
-fn get_connection_addr(host: String, port: u16, tls: Option<TlsMode>) -> ConnectionAddr {
-    match tls {
-        Some(TlsMode::Secure) => ConnectionAddr::TcpTls {
-            host,
-            port,
-            insecure: false,
-        },
-        Some(TlsMode::Insecure) => ConnectionAddr::TcpTls {
-            host,
-            port,
-            insecure: true,
-        },
-        _ => ConnectionAddr::Tcp(host, port),
-    }
 }

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -225,6 +225,15 @@ impl ClusterClientBuilder {
         self
     }
 
+    /// Disables auto reconnect for all new connections (default is enabled).
+    ///
+    /// If enabled, `ClusterConnection` will attempt to reconnect in case of
+    /// [IoError](ErrorKind::IoError).
+    pub fn disable_auto_reconnect(mut self) -> ClusterClientBuilder {
+        self.cluster_params.auto_reconnect = false;
+        self
+    }
+
     /// Use `build()`.
     #[deprecated(since = "0.22.0", note = "Use build()")]
     pub fn open(self) -> RedisResult<ClusterClient> {

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -186,6 +186,36 @@ impl ClusterClientBuilder {
         self
     }
 
+    /// Sets the default write timeout for all new connections (default is None).
+    ///
+    /// If the value is `None`, then `send_packed_command` call may block indefinitely.
+    ///
+    /// # Errors
+    ///
+    /// Passing Some(Duration::ZERO)
+    pub fn write_timeout(mut self, dur: Option<Duration>) -> RedisResult<ClusterClientBuilder> {
+        // Check if duration is valid before updating local value.
+        ClusterParams::validate_duration(&dur)?;
+
+        self.cluster_params.write_timeout = dur;
+        Ok(self)
+    }
+
+    /// Sets the default read timeout for all new connections (default is None).
+    ///
+    /// If the value is `None`, then `recv_response` call may block indefinitely.
+    ///
+    /// # Errors
+    ///
+    /// Passing Some(Duration::ZERO)
+    pub fn read_timeout(mut self, dur: Option<Duration>) -> RedisResult<ClusterClientBuilder> {
+        // Check if duration is valid before updating local value.
+        ClusterParams::validate_duration(&dur)?;
+
+        self.cluster_params.read_timeout = dur;
+        Ok(self)
+    }
+
     /// Enables reading from replicas for all new connections (default is disabled).
     ///
     /// If enabled, then read queries will go to the replica nodes & write queries will go to the


### PR DESCRIPTION
This is pull request make user can control every parameters of ClusterConnection with builder pattern

## Changes

- cluster
    - remove every parameters from ClusterConnection
    - instead, handle parameters by CusterParams
    - move validate_duration logic from ClusterConnection to CusterParams
- cluster_client
    - add parameters from ClusterConnection to ClusterClientBuilder

## Effect

- cluster:
    - breaking change: ClusterConnection's struct member is changed
        - It is breaking change but I think it will not break user's code because almost user will create ClusterConnection with new function
- cluster_client
    - public api is added: user can control ClusterConnection's parameters with builder

## Note

- this PR is from https://github.com/redis-rs/redis-rs/pull/670