### PR TITLE
Rename Value enum types in order to match Redis RESP names.

### DIFF
--- a/redis-test/src/lib.rs
+++ b/redis-test/src/lib.rs
@@ -402,7 +402,7 @@ mod tests {
     fn pipeline_atomic_test() {
         let mut conn = MockRedisConnection::new(vec![MockCmd::with_values(
             pipe().atomic().cmd("GET").arg("foo").cmd("GET").arg("bar"),
-            Ok(vec![Value::Bulk(
+            Ok(vec![Value::Array(
                 vec!["hello", "world"]
                     .into_iter()
                     .map(|x| Value::Data(x.as_bytes().into()))

--- a/redis-test/src/lib.rs
+++ b/redis-test/src/lib.rs
@@ -45,26 +45,26 @@ pub trait IntoRedisValue {
 
 impl IntoRedisValue for String {
     fn into_redis_value(self) -> Value {
-        Value::Data(self.as_bytes().to_vec())
+        Value::BulkString(self.as_bytes().to_vec())
     }
 }
 
 impl IntoRedisValue for &str {
     fn into_redis_value(self) -> Value {
-        Value::Data(self.as_bytes().to_vec())
+        Value::BulkString(self.as_bytes().to_vec())
     }
 }
 
 #[cfg(feature = "bytes")]
 impl IntoRedisValue for bytes::Bytes {
     fn into_redis_value(self) -> Value {
-        Value::Data(self.to_vec())
+        Value::BulkString(self.to_vec())
     }
 }
 
 impl IntoRedisValue for Vec<u8> {
     fn into_redis_value(self) -> Value {
-        Value::Data(self)
+        Value::BulkString(self)
     }
 }
 
@@ -311,7 +311,7 @@ mod tests {
         cmd("SET").arg("bar").arg("foo").execute(&mut conn);
         assert_eq!(
             cmd("GET").arg("bar").query(&mut conn),
-            Ok(Value::Data(b"foo".as_ref().into()))
+            Ok(Value::BulkString(b"foo".as_ref().into()))
         );
     }
 
@@ -405,7 +405,7 @@ mod tests {
             Ok(vec![Value::Array(
                 vec!["hello", "world"]
                     .into_iter()
-                    .map(|x| Value::Data(x.as_bytes().into()))
+                    .map(|x| Value::BulkString(x.as_bytes().into()))
                     .collect(),
             )]),
         )]);

--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -54,7 +54,7 @@ Though async Redis Cluster functionality for the time being has been kept as clo
 
 #### Changes
 *   Restore inherent `ClusterConnection::check_connection()` method ([#758](https://github.com/redis-rs/redis-rs/pull/758) @robjtede)
-* Rename Value::Bulk to Value::Array
+* Rename Value::Bulk to Value::Array, Value::Status to Value::SimpleString
 
 
 <a name="0.22.2"></a>

--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -54,7 +54,7 @@ Though async Redis Cluster functionality for the time being has been kept as clo
 
 #### Changes
 *   Restore inherent `ClusterConnection::check_connection()` method ([#758](https://github.com/redis-rs/redis-rs/pull/758) @robjtede)
-* Rename Value::Bulk to Value::Array, Value::Status to Value::SimpleString
+* Rename Value::Bulk to Value::Array, Value::Status to Value::SimpleString, and Value::Data to Value::BulkString, in order to match the Redis RESP naming.
 
 
 <a name="0.22.2"></a>

--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -54,6 +54,7 @@ Though async Redis Cluster functionality for the time being has been kept as clo
 
 #### Changes
 *   Restore inherent `ClusterConnection::check_connection()` method ([#758](https://github.com/redis-rs/redis-rs/pull/758) @robjtede)
+* Rename Value::Bulk to Value::Array
 
 
 <a name="0.22.2"></a>

--- a/redis/benches/bench_basic.rs
+++ b/redis/benches/bench_basic.rs
@@ -261,7 +261,7 @@ fn bench_decode_simple(b: &mut Bencher, input: &[u8]) {
 fn bench_decode(c: &mut Criterion) {
     let value = Value::Array(vec![
         Value::Okay,
-        Value::Status("testing".to_string()),
+        Value::SimpleString("testing".to_string()),
         Value::Array(vec![]),
         Value::Nil,
         Value::Data(vec![b'a'; 10]),

--- a/redis/benches/bench_basic.rs
+++ b/redis/benches/bench_basic.rs
@@ -264,7 +264,7 @@ fn bench_decode(c: &mut Criterion) {
         Value::SimpleString("testing".to_string()),
         Value::Array(vec![]),
         Value::Nil,
-        Value::Data(vec![b'a'; 10]),
+        Value::BulkString(vec![b'a'; 10]),
         Value::Int(7512182390),
     ]);
 

--- a/redis/benches/bench_basic.rs
+++ b/redis/benches/bench_basic.rs
@@ -259,10 +259,10 @@ fn bench_decode_simple(b: &mut Bencher, input: &[u8]) {
     b.iter(|| redis::parse_redis_value(input).unwrap());
 }
 fn bench_decode(c: &mut Criterion) {
-    let value = Value::Bulk(vec![
+    let value = Value::Array(vec![
         Value::Okay,
         Value::Status("testing".to_string()),
-        Value::Bulk(vec![]),
+        Value::Array(vec![]),
         Value::Nil,
         Value::Data(vec![b'a'; 10]),
         Value::Int(7512182390),

--- a/redis/examples/streams.rs
+++ b/redis/examples/streams.rs
@@ -220,7 +220,7 @@ fn read_records(client: &redis::Client) -> RedisResult<()> {
         for StreamId { id, map } in ids {
             println!("\tID {id}");
             for (n, s) in map {
-                if let Value::Data(bytes) = s {
+                if let Value::BulkString(bytes) = s {
                     println!("\t\t{}: {}", n, String::from_utf8(bytes).expect("utf8"))
                 } else {
                     panic!("Weird data")

--- a/redis/src/acl.rs
+++ b/redis/src/acl.rs
@@ -159,7 +159,7 @@ impl FromRedisValue for AclInfo {
                 let flags = flags
                     .as_sequence()
                     .ok_or_else(|| {
-                        not_convertible_error!(flags, "Expect a bulk response of ACL flags")
+                        not_convertible_error!(flags, "Expect an array response of ACL flags")
                     })?
                     .iter()
                     .map(|flag| match flag {
@@ -181,7 +181,7 @@ impl FromRedisValue for AclInfo {
                 let passwords = passwords
                     .as_sequence()
                     .ok_or_else(|| {
-                        not_convertible_error!(flags, "Expect a bulk response of ACL flags")
+                        not_convertible_error!(flags, "Expect an array response of ACL flags")
                     })?
                     .iter()
                     .map(|pass| Ok(Rule::AddHashedPass(String::from_redis_value(pass)?)))
@@ -281,18 +281,18 @@ mod tests {
 
     #[test]
     fn test_from_redis_value() {
-        let redis_value = Value::Bulk(vec![
+        let redis_value = Value::Array(vec![
             Value::Data("flags".into()),
-            Value::Bulk(vec![
+            Value::Array(vec![
                 Value::Data("on".into()),
                 Value::Data("allchannels".into()),
             ]),
             Value::Data("passwords".into()),
-            Value::Bulk(vec![]),
+            Value::Array(vec![]),
             Value::Data("commands".into()),
             Value::Data("-@all +get".into()),
             Value::Data("keys".into()),
-            Value::Bulk(vec![Value::Data("pat:*".into())]),
+            Value::Array(vec![Value::Data("pat:*".into())]),
         ]);
         let acl_info = AclInfo::from_redis_value(&redis_value).expect("Parse successfully");
 

--- a/redis/src/acl.rs
+++ b/redis/src/acl.rs
@@ -163,7 +163,7 @@ impl FromRedisValue for AclInfo {
                     })?
                     .iter()
                     .map(|flag| match flag {
-                        Value::Data(flag) => match flag.as_slice() {
+                        Value::BulkString(flag) => match flag.as_slice() {
                             b"on" => Ok(Rule::On),
                             b"off" => Ok(Rule::Off),
                             b"allkeys" => Ok(Rule::AllKeys),
@@ -188,7 +188,7 @@ impl FromRedisValue for AclInfo {
                     .collect::<RedisResult<_>>()?;
 
                 let commands = match commands {
-                    Value::Data(cmd) => std::str::from_utf8(cmd)?,
+                    Value::BulkString(cmd) => std::str::from_utf8(cmd)?,
                     _ => {
                         return Err(not_convertible_error!(
                             commands,
@@ -282,17 +282,17 @@ mod tests {
     #[test]
     fn test_from_redis_value() {
         let redis_value = Value::Array(vec![
-            Value::Data("flags".into()),
+            Value::BulkString("flags".into()),
             Value::Array(vec![
-                Value::Data("on".into()),
-                Value::Data("allchannels".into()),
+                Value::BulkString("on".into()),
+                Value::BulkString("allchannels".into()),
             ]),
-            Value::Data("passwords".into()),
+            Value::BulkString("passwords".into()),
             Value::Array(vec![]),
-            Value::Data("commands".into()),
-            Value::Data("-@all +get".into()),
-            Value::Data("keys".into()),
-            Value::Array(vec![Value::Data("pat:*".into())]),
+            Value::BulkString("commands".into()),
+            Value::BulkString("-@all +get".into()),
+            Value::BulkString("keys".into()),
+            Value::Array(vec![Value::BulkString("pat:*".into())]),
         ]);
         let acl_info = AclInfo::from_redis_value(&redis_value).expect("Parse successfully");
 

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -672,7 +672,7 @@ impl MergeResults for Value {
         let mut items = vec![];
         for (addr, value) in values.into_iter() {
             items.push(Value::Array(vec![
-                Value::Data(addr.as_bytes().to_vec()),
+                Value::BulkString(addr.as_bytes().to_vec()),
                 value,
             ]));
         }
@@ -761,7 +761,7 @@ pub(crate) fn parse_slots(raw_slot_resp: Value, tls: Option<TlsMode>) -> RedisRe
                             return None;
                         }
 
-                        let ip = if let Value::Data(ref ip) = node[0] {
+                        let ip = if let Value::BulkString(ref ip) = node[0] {
                             String::from_utf8_lossy(ip)
                         } else {
                             return None;

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -671,12 +671,12 @@ impl MergeResults for Value {
     fn merge_results(values: HashMap<&str, Value>) -> Value {
         let mut items = vec![];
         for (addr, value) in values.into_iter() {
-            items.push(Value::Bulk(vec![
+            items.push(Value::Array(vec![
                 Value::Data(addr.as_bytes().to_vec()),
                 value,
             ]));
         }
-        Value::Bulk(items)
+        Value::Array(items)
     }
 }
 
@@ -733,9 +733,9 @@ pub(crate) fn parse_slots(raw_slot_resp: Value, tls: Option<TlsMode>) -> RedisRe
     // Parse response.
     let mut result = Vec::with_capacity(2);
 
-    if let Value::Bulk(items) = raw_slot_resp {
+    if let Value::Array(items) = raw_slot_resp {
         let mut iter = items.into_iter();
-        while let Some(Value::Bulk(item)) = iter.next() {
+        while let Some(Value::Array(item)) = iter.next() {
             if item.len() < 3 {
                 continue;
             }
@@ -756,7 +756,7 @@ pub(crate) fn parse_slots(raw_slot_resp: Value, tls: Option<TlsMode>) -> RedisRe
                 .into_iter()
                 .skip(2)
                 .filter_map(|node| {
-                    if let Value::Bulk(node) = node {
+                    if let Value::Array(node) = node {
                         if node.len() < 2 {
                             return None;
                         }

--- a/redis/src/cluster_pipeline.rs
+++ b/redis/src/cluster_pipeline.rs
@@ -120,7 +120,7 @@ impl ClusterPipeline {
 
         from_redis_value(
             &(if self.commands.is_empty() {
-                Value::Bulk(vec![])
+                Value::Array(vec![])
             } else {
                 self.make_pipeline_results(con.execute_pipeline(self)?)
             }),

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -106,7 +106,7 @@ impl Routable for Value {
     fn arg_idx(&self, idx: usize) -> Option<&[u8]> {
         match self {
             Value::Array(args) => match args.get(idx) {
-                Some(Value::Data(ref data)) => Some(&data[..]),
+                Some(Value::BulkString(ref data)) => Some(&data[..]),
                 _ => None,
             },
             _ => None,
@@ -116,7 +116,7 @@ impl Routable for Value {
     fn position(&self, candidate: &[u8]) -> Option<usize> {
         match self {
             Value::Array(args) => args.iter().position(|a| match a {
-                Value::Data(d) => d.eq_ignore_ascii_case(candidate),
+                Value::BulkString(d) => d.eq_ignore_ascii_case(candidate),
                 _ => false,
             }),
             _ => None,

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -105,7 +105,7 @@ impl Routable for Cmd {
 impl Routable for Value {
     fn arg_idx(&self, idx: usize) -> Option<&[u8]> {
         match self {
-            Value::Bulk(args) => match args.get(idx) {
+            Value::Array(args) => match args.get(idx) {
                 Some(Value::Data(ref data)) => Some(&data[..]),
                 _ => None,
             },
@@ -115,7 +115,7 @@ impl Routable for Value {
 
     fn position(&self, candidate: &[u8]) -> Option<usize> {
         match self {
-            Value::Bulk(args) => args.iter().position(|a| match a {
+            Value::Array(args) => args.iter().position(|a| match a {
                 Value::Data(d) => d.eq_ignore_ascii_case(candidate),
                 _ => false,
             }),

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -1403,7 +1403,7 @@ impl Msg {
     /// not happen) then the return value is `"?"`.
     pub fn get_channel_name(&self) -> &str {
         match self.channel {
-            Value::Data(ref bytes) => from_utf8(bytes).unwrap_or("?"),
+            Value::BulkString(ref bytes) => from_utf8(bytes).unwrap_or("?"),
             _ => "?",
         }
     }
@@ -1418,7 +1418,7 @@ impl Msg {
     /// in the raw bytes in it.
     pub fn get_payload_bytes(&self) -> &[u8] {
         match self.payload {
-            Value::Data(ref bytes) => bytes,
+            Value::BulkString(ref bytes) => bytes,
             _ => b"",
         }
     }

--- a/redis/src/geo.rs
+++ b/redis/src/geo.rs
@@ -267,7 +267,7 @@ impl FromRedisValue for RadiusSearchResult {
         }
 
         // Try to parse the result from multitple values
-        if let Value::Bulk(ref items) = *v {
+        if let Value::Array(ref items) = *v {
             if let Some(result) = RadiusSearchResult::parse_multi_values(items) {
                 return Ok(result);
             }

--- a/redis/src/parser.rs
+++ b/redis/src/parser.rs
@@ -165,14 +165,14 @@ where
                     })
                 };
 
-                let bulk = || {
+                let array = || {
                     int().then_partial(move |&mut length| {
                         if length < 0 {
                             combine::value(Value::Nil).map(Ok).left()
                         } else {
                             let length = length as usize;
                             combine::count_min_max(length, length, value(Some(count + 1)))
-                                .map(|result: ResultExtend<_, _>| result.0.map(Value::Bulk))
+                                .map(|result: ResultExtend<_, _>| result.0.map(Value::Array))
                                 .right()
                         }
                     })
@@ -308,7 +308,7 @@ where
                     b'+' => status().map(Ok),
                     b':' => int().map(|i| Ok(Value::Int(i))),
                     b'$' => data().map(Ok),
-                    b'*' => bulk(),
+                    b'*' => array(),
                     b'%' => map(),
                     b'|' => attribute(),
                     b'~' => set(),

--- a/redis/src/parser.rs
+++ b/redis/src/parser.rs
@@ -151,7 +151,7 @@ where
                             combine::value(Value::Nil).left()
                         } else {
                             take(*size as usize)
-                                .map(|bs: &[u8]| Value::Data(bs.to_vec()))
+                                .map(|bs: &[u8]| Value::BulkString(bs.to_vec()))
                                 .skip(crlf())
                                 .right()
                         }
@@ -239,7 +239,7 @@ where
                                 .map(|result: ResultExtend<Vec<Value>, _>| {
                                     let mut it: IntoIter<Value> = result.0?.into_iter();
                                     let first = it.next().unwrap_or(Value::Nil);
-                                    if let Value::Data(kind) = first {
+                                    if let Value::BulkString(kind) = first {
                                         Ok(Value::Push {
                                             kind: get_push_kind(String::from_utf8(kind)?),
                                             data: it.collect(),

--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -96,7 +96,7 @@ impl Pipeline {
         )?;
         match resp.pop() {
             Some(Value::Nil) => Ok(Value::Nil),
-            Some(Value::Bulk(items)) => Ok(self.make_pipeline_results(items)),
+            Some(Value::Array(items)) => Ok(self.make_pipeline_results(items)),
             _ => fail!((
                 ErrorKind::ResponseError,
                 "Invalid response when parsing multi response"
@@ -131,7 +131,7 @@ impl Pipeline {
         }
         from_redis_value(
             &(if self.commands.is_empty() {
-                Value::Bulk(vec![])
+                Value::Array(vec![])
             } else if self.transaction_mode {
                 self.execute_transaction(con)?
             } else {
@@ -161,7 +161,7 @@ impl Pipeline {
             .await?;
         match resp.pop() {
             Some(Value::Nil) => Ok(Value::Nil),
-            Some(Value::Bulk(items)) => Ok(self.make_pipeline_results(items)),
+            Some(Value::Array(items)) => Ok(self.make_pipeline_results(items)),
             _ => Err((
                 ErrorKind::ResponseError,
                 "Invalid response when parsing multi response",
@@ -178,7 +178,7 @@ impl Pipeline {
         C: crate::aio::ConnectionLike,
     {
         let v = if self.commands.is_empty() {
-            return from_redis_value(&Value::Bulk(vec![]));
+            return from_redis_value(&Value::Array(vec![]));
         } else if self.transaction_mode {
             self.execute_transaction_async(con).await?
         } else {
@@ -311,7 +311,7 @@ macro_rules! implement_pipeline_commands {
                         rv.push(result);
                     }
                 }
-                Value::Bulk(rv)
+                Value::Array(rv)
             }
         }
 

--- a/redis/src/push_manager.rs
+++ b/redis/src/push_manager.rs
@@ -66,7 +66,7 @@ mod tests {
 
         let value = Ok(Value::Push {
             kind: PushKind::Message,
-            data: vec![Value::Data("hello".to_string().into_bytes())],
+            data: vec![Value::BulkString("hello".to_string().into_bytes())],
         });
 
         push_manager.try_send(&value);
@@ -75,7 +75,7 @@ mod tests {
         assert_eq!(push_info.kind, PushKind::Message);
         assert_eq!(
             push_info.data,
-            vec![Value::Data("hello".to_string().into_bytes())]
+            vec![Value::BulkString("hello".to_string().into_bytes())]
         );
     }
     #[test]
@@ -86,7 +86,7 @@ mod tests {
 
         let value = Ok(Value::Push {
             kind: PushKind::Message,
-            data: vec![Value::Data("hello".to_string().into_bytes())],
+            data: vec![Value::BulkString("hello".to_string().into_bytes())],
         });
 
         drop(rx);
@@ -101,19 +101,19 @@ mod tests {
 
         push_manager.try_send(&Ok(Value::Push {
             kind: PushKind::Message,
-            data: vec![Value::Data("hello".to_string().into_bytes())],
+            data: vec![Value::BulkString("hello".to_string().into_bytes())],
         })); // nothing happens!
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         push_manager.replace_sender(tx);
         push_manager.try_send(&Ok(Value::Push {
             kind: PushKind::Message,
-            data: vec![Value::Data("hello2".to_string().into_bytes())],
+            data: vec![Value::BulkString("hello2".to_string().into_bytes())],
         }));
 
         assert_eq!(
             rx.try_recv().unwrap().data,
-            vec![Value::Data("hello2".to_string().into_bytes())]
+            vec![Value::BulkString("hello2".to_string().into_bytes())]
         );
     }
     #[test]

--- a/redis/src/streams.rs
+++ b/redis/src/streams.rs
@@ -566,7 +566,7 @@ impl FromRedisValue for StreamPendingCountReply {
                 for outer in outer_tuple {
                     match outer {
                         Value::Array(inner_tuple) => match &inner_tuple[..] {
-                            [Value::Data(id_bytes), Value::Data(consumer_bytes), Value::Int(last_delivered_ms_u64), Value::Int(times_delivered_u64)] =>
+                            [Value::BulkString(id_bytes), Value::BulkString(consumer_bytes), Value::Int(last_delivered_ms_u64), Value::Int(times_delivered_u64)] =>
                             {
                                 let id = String::from_utf8(id_bytes.to_vec())?;
                                 let consumer = String::from_utf8(consumer_bytes.to_vec())?;

--- a/redis/src/streams.rs
+++ b/redis/src/streams.rs
@@ -428,10 +428,10 @@ pub struct StreamId {
 }
 
 impl StreamId {
-    /// Converts a `Value::Bulk` into a `StreamId`.
-    fn from_bulk_value(v: &Value) -> RedisResult<Self> {
+    /// Converts a `Value::Array` into a `StreamId`.
+    fn from_array_value(v: &Value) -> RedisResult<Self> {
         let mut stream_id = StreamId::default();
-        if let Value::Bulk(ref values) = *v {
+        if let Value::Array(ref values) = *v {
             if let Some(v) = values.get(0) {
                 stream_id.id = from_redis_value(v)?;
             }
@@ -562,10 +562,10 @@ impl FromRedisValue for StreamPendingCountReply {
     fn from_redis_value(v: &Value) -> RedisResult<Self> {
         let mut reply = StreamPendingCountReply::default();
         match v {
-            Value::Bulk(outer_tuple) => {
+            Value::Array(outer_tuple) => {
                 for outer in outer_tuple {
                     match outer {
-                        Value::Bulk(inner_tuple) => match &inner_tuple[..] {
+                        Value::Array(inner_tuple) => match &inner_tuple[..] {
                             [Value::Data(id_bytes), Value::Data(consumer_bytes), Value::Int(last_delivered_ms_u64), Value::Int(times_delivered_u64)] =>
                             {
                                 let id = String::from_utf8(id_bytes.to_vec())?;
@@ -617,10 +617,10 @@ impl FromRedisValue for StreamInfoStreamReply {
             reply.length = from_redis_value(v)?;
         }
         if let Some(v) = &map.get("first-entry") {
-            reply.first_entry = StreamId::from_bulk_value(v)?;
+            reply.first_entry = StreamId::from_array_value(v)?;
         }
         if let Some(v) = &map.get("last-entry") {
-            reply.last_entry = StreamId::from_bulk_value(v)?;
+            reply.last_entry = StreamId::from_array_value(v)?;
         }
         Ok(reply)
     }

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -342,13 +342,13 @@ impl fmt::Debug for Value {
             Value::Nil => write!(fmt, "nil"),
             Value::Int(val) => write!(fmt, "int({val:?})"),
             Value::BulkString(ref val) => match from_utf8(val) {
-                Ok(x) => write!(fmt, "string-data('{x:?}')"),
+                Ok(x) => write!(fmt, "bulk-string('{x:?}')"),
                 Err(_) => write!(fmt, "binary-data({val:?})"),
             },
-            Value::Array(ref values) => write!(fmt, "bulk({values:?})"),
+            Value::Array(ref values) => write!(fmt, "array({values:?})"),
             Value::Push { ref kind, ref data } => write!(fmt, "push({kind:?}, {data:?})"),
             Value::Okay => write!(fmt, "ok"),
-            Value::SimpleString(ref s) => write!(fmt, "status({s:?})"),
+            Value::SimpleString(ref s) => write!(fmt, "simple-string({s:?})"),
             Value::Map(ref values) => write!(fmt, "map({values:?})"),
             Value::Attribute {
                 ref data,

--- a/redis/tests/parser.rs
+++ b/redis/tests/parser.rs
@@ -56,7 +56,7 @@ impl ::quickcheck::Arbitrary for ArbitraryValue {
                     .iter()
                     .map(|x| ArbitraryValue(x.clone()))
                     .collect::<Vec<_>>();
-                ys.insert(0, ArbitraryValue(Value::Status(kind.to_string())));
+                ys.insert(0, ArbitraryValue(Value::SimpleString(kind.to_string())));
                 Box::new(
                     ys.shrink()
                         .map(|xs| xs.into_iter().map(|x| x.0).collect())
@@ -64,8 +64,8 @@ impl ::quickcheck::Arbitrary for ArbitraryValue {
                         .map(ArbitraryValue),
                 )
             }
-            Value::Status(ref status) => {
-                Box::new(status.shrink().map(Value::Status).map(ArbitraryValue))
+            Value::SimpleString(ref status) => {
+                Box::new(status.shrink().map(Value::SimpleString).map(ArbitraryValue))
             }
             Value::Double(i) => Box::new(i.shrink().map(Value::Double).map(ArbitraryValue)),
             Value::Boolean(i) => Box::new(i.shrink().map(Value::Boolean).map(ArbitraryValue)),
@@ -112,18 +112,18 @@ fn arbitrary_value(g: &mut Gen, recursive_size: usize) -> Value {
                     usize::arbitrary(g) % s
                 };
 
-                let mut status = String::with_capacity(size);
+                let mut string = String::with_capacity(size);
                 for _ in 0..size {
                     let c = char::arbitrary(g);
                     if c.is_ascii_alphabetic() {
-                        status.push(c);
+                        string.push(c);
                     }
                 }
 
-                if status == "OK" {
+                if string == "OK" {
                     Value::Okay
                 } else {
-                    Value::Status(status)
+                    Value::SimpleString(string)
                 }
             }
             5 => Value::Okay,

--- a/redis/tests/parser.rs
+++ b/redis/tests/parser.rs
@@ -28,7 +28,7 @@ impl ::quickcheck::Arbitrary for ArbitraryValue {
             Value::Nil | Value::Okay => Box::new(None.into_iter()),
             Value::Int(i) => Box::new(i.shrink().map(Value::Int).map(ArbitraryValue)),
             Value::Data(ref xs) => Box::new(xs.shrink().map(Value::Data).map(ArbitraryValue)),
-            Value::Bulk(ref xs) | Value::Set(ref xs) => {
+            Value::Array(ref xs) | Value::Set(ref xs) => {
                 let ys = xs
                     .iter()
                     .map(|x| ArbitraryValue(x.clone()))
@@ -36,7 +36,7 @@ impl ::quickcheck::Arbitrary for ArbitraryValue {
                 Box::new(
                     ys.shrink()
                         .map(|xs| xs.into_iter().map(|x| x.0).collect())
-                        .map(Value::Bulk)
+                        .map(Value::Array)
                         .map(ArbitraryValue),
                 )
             }
@@ -60,7 +60,7 @@ impl ::quickcheck::Arbitrary for ArbitraryValue {
                 Box::new(
                     ys.shrink()
                         .map(|xs| xs.into_iter().map(|x| x.0).collect())
-                        .map(Value::Bulk)
+                        .map(Value::Array)
                         .map(ArbitraryValue),
                 )
             }
@@ -100,7 +100,7 @@ fn arbitrary_value(g: &mut Gen, recursive_size: usize) -> Value {
                     let s = g.size();
                     usize::arbitrary(g) % s
                 };
-                Value::Bulk(
+                Value::Array(
                     (0..size)
                         .map(|_| arbitrary_value(g, recursive_size / size))
                         .collect(),

--- a/redis/tests/parser.rs
+++ b/redis/tests/parser.rs
@@ -27,7 +27,9 @@ impl ::quickcheck::Arbitrary for ArbitraryValue {
         match self.0 {
             Value::Nil | Value::Okay => Box::new(None.into_iter()),
             Value::Int(i) => Box::new(i.shrink().map(Value::Int).map(ArbitraryValue)),
-            Value::Data(ref xs) => Box::new(xs.shrink().map(Value::Data).map(ArbitraryValue)),
+            Value::BulkString(ref xs) => {
+                Box::new(xs.shrink().map(Value::BulkString).map(ArbitraryValue))
+            }
             Value::Array(ref xs) | Value::Set(ref xs) => {
                 let ys = xs
                     .iter()
@@ -94,7 +96,7 @@ fn arbitrary_value(g: &mut Gen, recursive_size: usize) -> Value {
         match u8::arbitrary(g) % 6 {
             0 => Value::Nil,
             1 => Value::Int(Arbitrary::arbitrary(g)),
-            2 => Value::Data(Arbitrary::arbitrary(g)),
+            2 => Value::BulkString(Arbitrary::arbitrary(g)),
             3 => {
                 let size = {
                     let s = g.size();

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -104,7 +104,7 @@ pub fn contains_slice(xs: &[u8], ys: &[u8]) -> bool {
 
 pub fn respond_startup(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>> {
     if contains_slice(cmd, b"PING") {
-        Err(Ok(Value::Status("OK".into())))
+        Err(Ok(Value::SimpleString("OK".into())))
     } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
         Err(Ok(Value::Array(vec![Value::Array(vec![
             Value::Int(0),
@@ -115,7 +115,7 @@ pub fn respond_startup(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>>
             ]),
         ])])))
     } else if contains_slice(cmd, b"READONLY") {
-        Err(Ok(Value::Status("OK".into())))
+        Err(Ok(Value::SimpleString("OK".into())))
     } else {
         Ok(())
     }
@@ -152,7 +152,7 @@ pub fn respond_startup_two_nodes(name: &str, cmd: &[u8]) -> Result<(), RedisResu
 
 pub fn respond_startup_with_replica(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>> {
     if contains_slice(cmd, b"PING") {
-        Err(Ok(Value::Status("OK".into())))
+        Err(Ok(Value::SimpleString("OK".into())))
     } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
         Err(Ok(Value::Array(vec![
             Value::Array(vec![
@@ -181,7 +181,7 @@ pub fn respond_startup_with_replica(name: &str, cmd: &[u8]) -> Result<(), RedisR
             ]),
         ])))
     } else if contains_slice(cmd, b"READONLY") {
-        Err(Ok(Value::Status("OK".into())))
+        Err(Ok(Value::SimpleString("OK".into())))
     } else {
         Ok(())
     }

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -110,7 +110,7 @@ pub fn respond_startup(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>>
             Value::Int(0),
             Value::Int(16383),
             Value::Array(vec![
-                Value::Data(name.as_bytes().to_vec()),
+                Value::BulkString(name.as_bytes().to_vec()),
                 Value::Int(6379),
             ]),
         ])])))
@@ -123,14 +123,14 @@ pub fn respond_startup(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>>
 
 pub fn respond_startup_two_nodes(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>> {
     if contains_slice(cmd, b"PING") {
-        Err(Ok(Value::Status("OK".into())))
+        Err(Ok(Value::SimpleString("OK".into())))
     } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
         Err(Ok(Value::Array(vec![
             Value::Array(vec![
                 Value::Int(0),
                 Value::Int(8191),
                 Value::Array(vec![
-                    Value::Data(name.as_bytes().to_vec()),
+                    Value::BulkString(name.as_bytes().to_vec()),
                     Value::Int(6379),
                 ]),
             ]),
@@ -138,13 +138,13 @@ pub fn respond_startup_two_nodes(name: &str, cmd: &[u8]) -> Result<(), RedisResu
                 Value::Int(8192),
                 Value::Int(16383),
                 Value::Array(vec![
-                    Value::Data(name.as_bytes().to_vec()),
+                    Value::BulkString(name.as_bytes().to_vec()),
                     Value::Int(6380),
                 ]),
             ]),
         ])))
     } else if contains_slice(cmd, b"READONLY") {
-        Err(Ok(Value::Status("OK".into())))
+        Err(Ok(Value::SimpleString("OK".into())))
     } else {
         Ok(())
     }
@@ -159,11 +159,11 @@ pub fn respond_startup_with_replica(name: &str, cmd: &[u8]) -> Result<(), RedisR
                 Value::Int(0),
                 Value::Int(8191),
                 Value::Array(vec![
-                    Value::Data(name.as_bytes().to_vec()),
+                    Value::BulkString(name.as_bytes().to_vec()),
                     Value::Int(6379),
                 ]),
                 Value::Array(vec![
-                    Value::Data(name.as_bytes().to_vec()),
+                    Value::BulkString(name.as_bytes().to_vec()),
                     Value::Int(6380),
                 ]),
             ]),
@@ -171,11 +171,11 @@ pub fn respond_startup_with_replica(name: &str, cmd: &[u8]) -> Result<(), RedisR
                 Value::Int(8192),
                 Value::Int(16383),
                 Value::Array(vec![
-                    Value::Data(name.as_bytes().to_vec()),
+                    Value::BulkString(name.as_bytes().to_vec()),
                     Value::Int(6381),
                 ]),
                 Value::Array(vec![
-                    Value::Data(name.as_bytes().to_vec()),
+                    Value::BulkString(name.as_bytes().to_vec()),
                     Value::Int(6382),
                 ]),
             ]),

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -106,10 +106,10 @@ pub fn respond_startup(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>>
     if contains_slice(cmd, b"PING") {
         Err(Ok(Value::Status("OK".into())))
     } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
-        Err(Ok(Value::Bulk(vec![Value::Bulk(vec![
+        Err(Ok(Value::Array(vec![Value::Array(vec![
             Value::Int(0),
             Value::Int(16383),
-            Value::Bulk(vec![
+            Value::Array(vec![
                 Value::Data(name.as_bytes().to_vec()),
                 Value::Int(6379),
             ]),
@@ -125,19 +125,19 @@ pub fn respond_startup_two_nodes(name: &str, cmd: &[u8]) -> Result<(), RedisResu
     if contains_slice(cmd, b"PING") {
         Err(Ok(Value::Status("OK".into())))
     } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
-        Err(Ok(Value::Bulk(vec![
-            Value::Bulk(vec![
+        Err(Ok(Value::Array(vec![
+            Value::Array(vec![
                 Value::Int(0),
                 Value::Int(8191),
-                Value::Bulk(vec![
+                Value::Array(vec![
                     Value::Data(name.as_bytes().to_vec()),
                     Value::Int(6379),
                 ]),
             ]),
-            Value::Bulk(vec![
+            Value::Array(vec![
                 Value::Int(8192),
                 Value::Int(16383),
-                Value::Bulk(vec![
+                Value::Array(vec![
                     Value::Data(name.as_bytes().to_vec()),
                     Value::Int(6380),
                 ]),
@@ -154,27 +154,27 @@ pub fn respond_startup_with_replica(name: &str, cmd: &[u8]) -> Result<(), RedisR
     if contains_slice(cmd, b"PING") {
         Err(Ok(Value::Status("OK".into())))
     } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
-        Err(Ok(Value::Bulk(vec![
-            Value::Bulk(vec![
+        Err(Ok(Value::Array(vec![
+            Value::Array(vec![
                 Value::Int(0),
                 Value::Int(8191),
-                Value::Bulk(vec![
+                Value::Array(vec![
                     Value::Data(name.as_bytes().to_vec()),
                     Value::Int(6379),
                 ]),
-                Value::Bulk(vec![
+                Value::Array(vec![
                     Value::Data(name.as_bytes().to_vec()),
                     Value::Int(6380),
                 ]),
             ]),
-            Value::Bulk(vec![
+            Value::Array(vec![
                 Value::Int(8192),
                 Value::Int(16383),
-                Value::Bulk(vec![
+                Value::Array(vec![
                     Value::Data(name.as_bytes().to_vec()),
                     Value::Int(6381),
                 ]),
-                Value::Bulk(vec![
+                Value::Array(vec![
                     Value::Data(name.as_bytes().to_vec()),
                     Value::Int(6382),
                 ]),

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -379,7 +379,7 @@ where
         }
         Value::Array(ref values) => encode_iter(values, writer, "*"),
         Value::Okay => write!(writer, "+OK\r\n"),
-        Value::Status(ref s) => write!(writer, "+{s}\r\n"),
+        Value::SimpleString(ref s) => write!(writer, "+{s}\r\n"),
         Value::Map(ref values) => encode_map(values, writer, "%"),
         Value::Attribute {
             ref data,

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -377,7 +377,7 @@ where
             writer.write_all(val)?;
             writer.write_all(b"\r\n")
         }
-        Value::Bulk(ref values) => encode_iter(values, writer, "*"),
+        Value::Array(ref values) => encode_iter(values, writer, "*"),
         Value::Okay => write!(writer, "+OK\r\n"),
         Value::Status(ref s) => write!(writer, "+{s}\r\n"),
         Value::Map(ref values) => encode_map(values, writer, "%"),

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -372,7 +372,7 @@ where
     match *value {
         Value::Nil => write!(writer, "$-1\r\n"),
         Value::Int(val) => write!(writer, ":{val}\r\n"),
-        Value::Data(ref val) => {
+        Value::BulkString(ref val) => {
             write!(writer, "${}\r\n", val.len())?;
             writer.write_all(val)?;
             writer.write_all(b"\r\n")

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -819,7 +819,9 @@ fn test_push_manager_cm() {
         assert_eq!(
             (
                 PushKind::Invalidate,
-                vec![Value::Array(vec![Value::Data("key_1".as_bytes().to_vec())])]
+                vec![Value::Array(vec![Value::BulkString(
+                    "key_1".as_bytes().to_vec()
+                )])]
             ),
             (kind, data)
         );
@@ -832,7 +834,9 @@ fn test_push_manager_cm() {
         assert_eq!(
             (
                 PushKind::Invalidate,
-                vec![Value::Array(vec![Value::Data("key_1".as_bytes().to_vec())])]
+                vec![Value::Array(vec![Value::BulkString(
+                    "key_1".as_bytes().to_vec()
+                )])]
             ),
             (kind, data)
         );

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -819,7 +819,7 @@ fn test_push_manager_cm() {
         assert_eq!(
             (
                 PushKind::Invalidate,
-                vec![Value::Bulk(vec![Value::Data("key_1".as_bytes().to_vec())])]
+                vec![Value::Array(vec![Value::Data("key_1".as_bytes().to_vec())])]
             ),
             (kind, data)
         );
@@ -832,7 +832,7 @@ fn test_push_manager_cm() {
         assert_eq!(
             (
                 PushKind::Invalidate,
-                vec![Value::Bulk(vec![Value::Data("key_1".as_bytes().to_vec())])]
+                vec![Value::Array(vec![Value::Data("key_1".as_bytes().to_vec())])]
             ),
             (kind, data)
         );

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -1258,7 +1258,7 @@ fn test_push_manager() {
         assert_eq!(
             (
                 PushKind::Invalidate,
-                vec![Value::Bulk(vec![Value::Data("key_1".as_bytes().to_vec())])]
+                vec![Value::Array(vec![Value::Data("key_1".as_bytes().to_vec())])]
             ),
             (kind, data)
         );
@@ -1272,7 +1272,7 @@ fn test_push_manager() {
     assert_eq!(
         (
             PushKind::Invalidate,
-            vec![Value::Bulk(vec![Value::Data("key_1".as_bytes().to_vec())])]
+            vec![Value::Array(vec![Value::Data("key_1".as_bytes().to_vec())])]
         ),
         (kind, data)
     );

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -157,7 +157,7 @@ fn test_info() {
     let info: redis::InfoDict = redis::cmd("INFO").query(&mut con).unwrap();
     assert_eq!(
         info.find(&"role"),
-        Some(&redis::Value::Status("master".to_string()))
+        Some(&redis::Value::SimpleString("master".to_string()))
     );
     assert_eq!(info.get("role"), Some("master".to_string()));
     assert_eq!(info.get("loading"), Some(false));

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -1258,7 +1258,9 @@ fn test_push_manager() {
         assert_eq!(
             (
                 PushKind::Invalidate,
-                vec![Value::Array(vec![Value::Data("key_1".as_bytes().to_vec())])]
+                vec![Value::Array(vec![Value::BulkString(
+                    "key_1".as_bytes().to_vec()
+                )])]
             ),
             (kind, data)
         );
@@ -1272,7 +1274,9 @@ fn test_push_manager() {
     assert_eq!(
         (
             PushKind::Invalidate,
-            vec![Value::Array(vec![Value::Data("key_1".as_bytes().to_vec())])]
+            vec![Value::Array(vec![Value::BulkString(
+                "key_1".as_bytes().to_vec()
+            )])]
         ),
         (kind, data)
     );

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -374,7 +374,7 @@ fn test_cluster_rebuild_with_extra_nodes() {
         started.store(true, atomic::Ordering::SeqCst);
 
         if contains_slice(cmd, b"PING") {
-            return Err(Ok(Value::Status("OK".into())));
+            return Err(Ok(Value::SimpleString("OK".into())));
         }
 
         let i = requests.fetch_add(1, atomic::Ordering::SeqCst);
@@ -455,7 +455,7 @@ fn test_cluster_replica_read() {
         move |cmd: &[u8], port| {
             respond_startup_with_replica(name, cmd)?;
             match port {
-                6379 => Err(Ok(Value::Status("OK".into()))),
+                6379 => Err(Ok(Value::SimpleString("OK".into()))),
                 _ => panic!("Wrong node"),
             }
         },
@@ -465,7 +465,7 @@ fn test_cluster_replica_read() {
         .arg("test")
         .arg("123")
         .query::<Option<Value>>(&mut connection);
-    assert_eq!(value, Ok(Some(Value::Status("OK".to_owned()))));
+    assert_eq!(value, Ok(Some(Value::SimpleString("OK".to_owned()))));
 }
 
 #[test]

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -384,19 +384,19 @@ fn test_cluster_rebuild_with_extra_nodes() {
             // implementation)
             0 => Err(parse_redis_value(b"-MOVED 123\r\n")),
             // Respond with the new masters
-            1 => Err(Ok(Value::Bulk(vec![
-                Value::Bulk(vec![
+            1 => Err(Ok(Value::Array(vec![
+                Value::Array(vec![
                     Value::Int(0),
                     Value::Int(1),
-                    Value::Bulk(vec![
+                    Value::Array(vec![
                         Value::Data(name.as_bytes().to_vec()),
                         Value::Int(6379),
                     ]),
                 ]),
-                Value::Bulk(vec![
+                Value::Array(vec![
                     Value::Int(2),
                     Value::Int(16383),
-                    Value::Bulk(vec![
+                    Value::Array(vec![
                         Value::Data(name.as_bytes().to_vec()),
                         Value::Int(6380),
                     ]),

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -126,12 +126,12 @@ fn test_cluster_resp3() {
         result,
         Value::Map(vec![
             (
-                Value::Data("foo".as_bytes().to_vec()),
-                Value::Data("baz".as_bytes().to_vec())
+                Value::BulkString("foo".as_bytes().to_vec()),
+                Value::BulkString("baz".as_bytes().to_vec())
             ),
             (
-                Value::Data("bar".as_bytes().to_vec()),
-                Value::Data("foobar".as_bytes().to_vec())
+                Value::BulkString("bar".as_bytes().to_vec()),
+                Value::BulkString("foobar".as_bytes().to_vec())
             )
         ])
     );
@@ -312,7 +312,7 @@ fn test_cluster_retries() {
 
             match requests.fetch_add(1, atomic::Ordering::SeqCst) {
                 0..=4 => Err(parse_redis_value(b"-TRYAGAIN mock\r\n")),
-                _ => Err(Ok(Value::Data(b"123".to_vec()))),
+                _ => Err(Ok(Value::BulkString(b"123".to_vec()))),
             }
         },
     );
@@ -389,7 +389,7 @@ fn test_cluster_rebuild_with_extra_nodes() {
                     Value::Int(0),
                     Value::Int(1),
                     Value::Array(vec![
-                        Value::Data(name.as_bytes().to_vec()),
+                        Value::BulkString(name.as_bytes().to_vec()),
                         Value::Int(6379),
                     ]),
                 ]),
@@ -397,7 +397,7 @@ fn test_cluster_rebuild_with_extra_nodes() {
                     Value::Int(2),
                     Value::Int(16383),
                     Value::Array(vec![
-                        Value::Data(name.as_bytes().to_vec()),
+                        Value::BulkString(name.as_bytes().to_vec()),
                         Value::Int(6380),
                     ]),
                 ]),
@@ -405,7 +405,7 @@ fn test_cluster_rebuild_with_extra_nodes() {
             _ => {
                 // Check that the correct node receives the request after rebuilding
                 assert_eq!(port, 6380);
-                Err(Ok(Value::Data(b"123".to_vec())))
+                Err(Ok(Value::BulkString(b"123".to_vec())))
             }
         }
     });
@@ -433,7 +433,7 @@ fn test_cluster_replica_read() {
             respond_startup_with_replica(name, cmd)?;
 
             match port {
-                6380 => Err(Ok(Value::Data(b"123".to_vec()))),
+                6380 => Err(Ok(Value::BulkString(b"123".to_vec()))),
                 _ => panic!("Wrong node"),
             }
         },
@@ -490,7 +490,7 @@ fn test_cluster_io_error() {
                         std::io::ErrorKind::ConnectionReset,
                         "mock-io-error",
                     )))),
-                    _ => Err(Ok(Value::Data(b"123".to_vec()))),
+                    _ => Err(Ok(Value::BulkString(b"123".to_vec()))),
                 },
             }
         },

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -98,12 +98,12 @@ fn test_cluster_resp3() {
             result,
             Value::Map(vec![
                 (
-                    Value::Data("foo".as_bytes().to_vec()),
-                    Value::Data("baz".as_bytes().to_vec())
+                    Value::BulkString("foo".as_bytes().to_vec()),
+                    Value::BulkString("baz".as_bytes().to_vec())
                 ),
                 (
-                    Value::Data("bar".as_bytes().to_vec()),
-                    Value::Data("foobar".as_bytes().to_vec())
+                    Value::BulkString("bar".as_bytes().to_vec()),
+                    Value::BulkString("foobar".as_bytes().to_vec())
                 )
             ])
         );
@@ -352,7 +352,7 @@ fn test_async_cluster_retries() {
 
             match requests.fetch_add(1, atomic::Ordering::SeqCst) {
                 0..=4 => Err(parse_redis_value(b"-TRYAGAIN mock\r\n")),
-                _ => Err(Ok(Value::Data(b"123".to_vec()))),
+                _ => Err(Ok(Value::BulkString(b"123".to_vec()))),
             }
         },
     );
@@ -439,7 +439,7 @@ fn test_async_cluster_rebuild_with_extra_nodes() {
                     Value::Int(0),
                     Value::Int(1),
                     Value::Array(vec![
-                        Value::Data(name.as_bytes().to_vec()),
+                        Value::BulkString(name.as_bytes().to_vec()),
                         Value::Int(6379),
                     ]),
                 ]),
@@ -447,7 +447,7 @@ fn test_async_cluster_rebuild_with_extra_nodes() {
                     Value::Int(2),
                     Value::Int(16383),
                     Value::Array(vec![
-                        Value::Data(name.as_bytes().to_vec()),
+                        Value::BulkString(name.as_bytes().to_vec()),
                         Value::Int(6380),
                     ]),
                 ]),
@@ -455,7 +455,7 @@ fn test_async_cluster_rebuild_with_extra_nodes() {
             _ => {
                 // Check that the correct node receives the request after rebuilding
                 assert_eq!(port, 6380);
-                Err(Ok(Value::Data(b"123".to_vec())))
+                Err(Ok(Value::BulkString(b"123".to_vec())))
             }
         }
     });
@@ -488,7 +488,7 @@ fn test_async_cluster_replica_read() {
             respond_startup_with_replica(name, cmd)?;
 
             match port {
-                6380 => Err(Ok(Value::Data(b"123".to_vec()))),
+                6380 => Err(Ok(Value::BulkString(b"123".to_vec()))),
                 _ => panic!("Wrong node"),
             }
         },
@@ -580,7 +580,7 @@ fn test_async_cluster_io_error() {
                         std::io::ErrorKind::ConnectionReset,
                         "mock-io-error",
                     )))),
-                    _ => Err(Ok(Value::Data(b"123".to_vec()))),
+                    _ => Err(Ok(Value::BulkString(b"123".to_vec()))),
                 },
             }
         },

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -434,19 +434,19 @@ fn test_async_cluster_rebuild_with_extra_nodes() {
             // implementation)
             0 => Err(parse_redis_value(b"-MOVED 123\r\n")),
             // Respond with the new masters
-            1 => Err(Ok(Value::Bulk(vec![
-                Value::Bulk(vec![
+            1 => Err(Ok(Value::Array(vec![
+                Value::Array(vec![
                     Value::Int(0),
                     Value::Int(1),
-                    Value::Bulk(vec![
+                    Value::Array(vec![
                         Value::Data(name.as_bytes().to_vec()),
                         Value::Int(6379),
                     ]),
                 ]),
-                Value::Bulk(vec![
+                Value::Array(vec![
                     Value::Int(2),
                     Value::Int(16383),
-                    Value::Bulk(vec![
+                    Value::Array(vec![
                         Value::Data(name.as_bytes().to_vec()),
                         Value::Int(6380),
                     ]),

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -424,7 +424,7 @@ fn test_async_cluster_rebuild_with_extra_nodes() {
         started.store(true, atomic::Ordering::SeqCst);
 
         if contains_slice(cmd, b"PING") {
-            return Err(Ok(Value::Status("OK".into())));
+            return Err(Ok(Value::SimpleString("OK".into())));
         }
 
         let i = requests.fetch_add(1, atomic::Ordering::SeqCst);
@@ -515,7 +515,7 @@ fn test_async_cluster_replica_read() {
         move |cmd: &[u8], port| {
             respond_startup_with_replica(name, cmd)?;
             match port {
-                6379 => Err(Ok(Value::Status("OK".into()))),
+                6379 => Err(Ok(Value::SimpleString("OK".into()))),
                 _ => panic!("Wrong node"),
             }
         },
@@ -527,7 +527,7 @@ fn test_async_cluster_replica_read() {
             .arg("123")
             .query_async::<_, Option<Value>>(&mut connection),
     );
-    assert_eq!(value, Ok(Some(Value::Status("OK".to_owned()))));
+    assert_eq!(value, Ok(Some(Value::SimpleString("OK".to_owned()))));
 }
 
 #[test]

--- a/redis/tests/test_module_json.rs
+++ b/redis/tests/test_module_json.rs
@@ -66,7 +66,7 @@ fn test_module_json_arr_append() {
 
     let json_append: RedisResult<Value> = con.json_arr_append(TEST_KEY, "$..a", &3i64);
 
-    assert_eq!(json_append, Ok(Bulk(vec![Int(2i64), Int(3i64), Nil])));
+    assert_eq!(json_append, Ok(Array(vec![Int(2i64), Int(3i64), Nil])));
 }
 
 #[test]
@@ -84,7 +84,7 @@ fn test_module_json_arr_index() {
 
     let json_arrindex: RedisResult<Value> = con.json_arr_index(TEST_KEY, "$..a", &2i64);
 
-    assert_eq!(json_arrindex, Ok(Bulk(vec![Int(1i64), Int(-1i64)])));
+    assert_eq!(json_arrindex, Ok(Array(vec![Int(1i64), Int(-1i64)])));
 
     let update_initial: RedisResult<bool> = con.json_set(
         TEST_KEY,
@@ -97,7 +97,7 @@ fn test_module_json_arr_index() {
     let json_arrindex_2: RedisResult<Value> =
         con.json_arr_index_ss(TEST_KEY, "$..a", &2i64, &0, &0);
 
-    assert_eq!(json_arrindex_2, Ok(Bulk(vec![Int(1i64), Nil])));
+    assert_eq!(json_arrindex_2, Ok(Array(vec![Int(1i64), Nil])));
 }
 
 #[test]
@@ -115,7 +115,7 @@ fn test_module_json_arr_insert() {
 
     let json_arrinsert: RedisResult<Value> = con.json_arr_insert(TEST_KEY, "$..a", 0, &1i64);
 
-    assert_eq!(json_arrinsert, Ok(Bulk(vec![Int(2), Int(3)])));
+    assert_eq!(json_arrinsert, Ok(Array(vec![Int(2), Int(3)])));
 
     let update_initial: RedisResult<bool> = con.json_set(
         TEST_KEY,
@@ -127,7 +127,7 @@ fn test_module_json_arr_insert() {
 
     let json_arrinsert_2: RedisResult<Value> = con.json_arr_insert(TEST_KEY, "$..a", 0, &1i64);
 
-    assert_eq!(json_arrinsert_2, Ok(Bulk(vec![Int(5), Nil])));
+    assert_eq!(json_arrinsert_2, Ok(Array(vec![Int(5), Nil])));
 }
 
 #[test]
@@ -145,7 +145,7 @@ fn test_module_json_arr_len() {
 
     let json_arrlen: RedisResult<Value> = con.json_arr_len(TEST_KEY, "$..a");
 
-    assert_eq!(json_arrlen, Ok(Bulk(vec![Int(1), Int(2)])));
+    assert_eq!(json_arrlen, Ok(Array(vec![Int(1), Int(2)])));
 
     let update_initial: RedisResult<bool> = con.json_set(
         TEST_KEY,
@@ -157,7 +157,7 @@ fn test_module_json_arr_len() {
 
     let json_arrlen_2: RedisResult<Value> = con.json_arr_len(TEST_KEY, "$..a");
 
-    assert_eq!(json_arrlen_2, Ok(Bulk(vec![Int(4), Nil])));
+    assert_eq!(json_arrlen_2, Ok(Array(vec![Int(4), Nil])));
 }
 
 #[test]
@@ -177,7 +177,7 @@ fn test_module_json_arr_pop() {
 
     assert_eq!(
         json_arrpop,
-        Ok(Bulk(vec![
+        Ok(Array(vec![
             // convert string 3 to its ascii value as bytes
             Data(Vec::from("3".as_bytes())),
             Data(Vec::from("4".as_bytes()))
@@ -196,7 +196,7 @@ fn test_module_json_arr_pop() {
 
     assert_eq!(
         json_arrpop_2,
-        Ok(Bulk(vec![Data(Vec::from("\"bar\"".as_bytes())), Nil, Nil]))
+        Ok(Array(vec![Data(Vec::from("\"bar\"".as_bytes())), Nil, Nil]))
     );
 }
 
@@ -215,7 +215,7 @@ fn test_module_json_arr_trim() {
 
     let json_arrtrim: RedisResult<Value> = con.json_arr_trim(TEST_KEY, "$..a", 1, 1);
 
-    assert_eq!(json_arrtrim, Ok(Bulk(vec![Int(0), Int(1)])));
+    assert_eq!(json_arrtrim, Ok(Array(vec![Int(0), Int(1)])));
 
     let update_initial: RedisResult<bool> = con.json_set(
         TEST_KEY,
@@ -227,7 +227,7 @@ fn test_module_json_arr_trim() {
 
     let json_arrtrim_2: RedisResult<Value> = con.json_arr_trim(TEST_KEY, "$..a", 1, 1);
 
-    assert_eq!(json_arrtrim_2, Ok(Bulk(vec![Int(1), Nil])));
+    assert_eq!(json_arrtrim_2, Ok(Array(vec![Int(1), Nil])));
 }
 
 #[test]
@@ -325,7 +325,7 @@ fn test_module_json_mget() {
 
     assert_eq!(
         json_mget,
-        Ok(Bulk(vec![
+        Ok(Array(vec![
             Data(Vec::from("[1,3]".as_bytes())),
             Data(Vec::from("[4,6]".as_bytes()))
         ]))
@@ -384,9 +384,9 @@ fn test_module_json_obj_keys() {
 
     assert_eq!(
         json_objkeys,
-        Ok(Bulk(vec![
+        Ok(Array(vec![
             Nil,
-            Bulk(vec![
+            Array(vec![
                 Data(Vec::from("b".as_bytes())),
                 Data(Vec::from("c".as_bytes()))
             ])
@@ -409,7 +409,7 @@ fn test_module_json_obj_len() {
 
     let json_objlen: RedisResult<Value> = con.json_obj_len(TEST_KEY, "$..a");
 
-    assert_eq!(json_objlen, Ok(Bulk(vec![Nil, Int(2)])));
+    assert_eq!(json_objlen, Ok(Array(vec![Nil, Int(2)])));
 }
 
 #[test]
@@ -437,7 +437,7 @@ fn test_module_json_str_append() {
 
     let json_strappend: RedisResult<Value> = con.json_str_append(TEST_KEY, "$..a", "\"baz\"");
 
-    assert_eq!(json_strappend, Ok(Bulk(vec![Int(6), Int(8), Nil])));
+    assert_eq!(json_strappend, Ok(Array(vec![Int(6), Int(8), Nil])));
 
     let json_get_check: RedisResult<String> = con.json_get(TEST_KEY, "$");
 
@@ -462,7 +462,7 @@ fn test_module_json_str_len() {
 
     let json_strlen: RedisResult<Value> = con.json_str_len(TEST_KEY, "$..a");
 
-    assert_eq!(json_strlen, Ok(Bulk(vec![Int(3), Int(5), Nil])));
+    assert_eq!(json_strlen, Ok(Array(vec![Int(3), Int(5), Nil])));
 }
 
 #[test]
@@ -475,10 +475,10 @@ fn test_module_json_toggle() {
     assert_eq!(set_initial, Ok(true));
 
     let json_toggle_a: RedisResult<Value> = con.json_toggle(TEST_KEY, "$.bool");
-    assert_eq!(json_toggle_a, Ok(Bulk(vec![Int(0)])));
+    assert_eq!(json_toggle_a, Ok(Array(vec![Int(0)])));
 
     let json_toggle_b: RedisResult<Value> = con.json_toggle(TEST_KEY, "$.bool");
-    assert_eq!(json_toggle_b, Ok(Bulk(vec![Int(1)])));
+    assert_eq!(json_toggle_b, Ok(Array(vec![Int(1)])));
 }
 
 #[test]
@@ -503,30 +503,32 @@ fn test_module_json_type() {
         // In RESP3 current RedisJSON always gives response in an array.
         assert_eq!(
             json_type_a,
-            Ok(Bulk(vec![Bulk(vec![Data(Vec::from("string".as_bytes()))])]))
+            Ok(Array(vec![Array(vec![Data(Vec::from(
+                "string".as_bytes()
+            ))])]))
         );
 
         assert_eq!(
             json_type_b,
-            Ok(Bulk(vec![Bulk(vec![
+            Ok(Array(vec![Array(vec![
                 Data(Vec::from("integer".as_bytes())),
                 Data(Vec::from("boolean".as_bytes()))
             ])]))
         );
-        assert_eq!(json_type_c, Ok(Bulk(vec![Bulk(vec![])])));
+        assert_eq!(json_type_c, Ok(Array(vec![Array(vec![])])));
     } else {
         assert_eq!(
             json_type_a,
-            Ok(Bulk(vec![Data(Vec::from("string".as_bytes()))]))
+            Ok(Array(vec![Data(Vec::from("string".as_bytes()))]))
         );
 
         assert_eq!(
             json_type_b,
-            Ok(Bulk(vec![
+            Ok(Array(vec![
                 Data(Vec::from("integer".as_bytes())),
                 Data(Vec::from("boolean".as_bytes()))
             ]))
         );
-        assert_eq!(json_type_c, Ok(Bulk(vec![])));
+        assert_eq!(json_type_c, Ok(Array(vec![])));
     }
 }

--- a/redis/tests/test_module_json.rs
+++ b/redis/tests/test_module_json.rs
@@ -179,8 +179,8 @@ fn test_module_json_arr_pop() {
         json_arrpop,
         Ok(Array(vec![
             // convert string 3 to its ascii value as bytes
-            Data(Vec::from("3".as_bytes())),
-            Data(Vec::from("4".as_bytes()))
+            BulkString(Vec::from("3".as_bytes())),
+            BulkString(Vec::from("4".as_bytes()))
         ]))
     );
 
@@ -196,7 +196,11 @@ fn test_module_json_arr_pop() {
 
     assert_eq!(
         json_arrpop_2,
-        Ok(Array(vec![Data(Vec::from("\"bar\"".as_bytes())), Nil, Nil]))
+        Ok(Array(vec![
+            BulkString(Vec::from("\"bar\"".as_bytes())),
+            Nil,
+            Nil
+        ]))
     );
 }
 
@@ -326,8 +330,8 @@ fn test_module_json_mget() {
     assert_eq!(
         json_mget,
         Ok(Array(vec![
-            Data(Vec::from("[1,3]".as_bytes())),
-            Data(Vec::from("[4,6]".as_bytes()))
+            BulkString(Vec::from("[1,3]".as_bytes())),
+            BulkString(Vec::from("[4,6]".as_bytes()))
         ]))
     );
 }
@@ -387,8 +391,8 @@ fn test_module_json_obj_keys() {
         Ok(Array(vec![
             Nil,
             Array(vec![
-                Data(Vec::from("b".as_bytes())),
-                Data(Vec::from("c".as_bytes()))
+                BulkString(Vec::from("b".as_bytes())),
+                BulkString(Vec::from("c".as_bytes()))
             ])
         ]))
     );
@@ -503,7 +507,7 @@ fn test_module_json_type() {
         // In RESP3 current RedisJSON always gives response in an array.
         assert_eq!(
             json_type_a,
-            Ok(Array(vec![Array(vec![Data(Vec::from(
+            Ok(Array(vec![Array(vec![BulkString(Vec::from(
                 "string".as_bytes()
             ))])]))
         );
@@ -511,22 +515,22 @@ fn test_module_json_type() {
         assert_eq!(
             json_type_b,
             Ok(Array(vec![Array(vec![
-                Data(Vec::from("integer".as_bytes())),
-                Data(Vec::from("boolean".as_bytes()))
+                BulkString(Vec::from("integer".as_bytes())),
+                BulkString(Vec::from("boolean".as_bytes()))
             ])]))
         );
         assert_eq!(json_type_c, Ok(Array(vec![Array(vec![])])));
     } else {
         assert_eq!(
             json_type_a,
-            Ok(Array(vec![Data(Vec::from("string".as_bytes()))]))
+            Ok(Array(vec![BulkString(Vec::from("string".as_bytes()))]))
         );
 
         assert_eq!(
             json_type_b,
             Ok(Array(vec![
-                Data(Vec::from("integer".as_bytes())),
-                Data(Vec::from("boolean".as_bytes()))
+                BulkString(Vec::from("integer".as_bytes())),
+                BulkString(Vec::from("boolean".as_bytes()))
             ]))
         );
         assert_eq!(json_type_c, Ok(Array(vec![])));

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -43,7 +43,7 @@ fn test_i32() {
     let i = FromRedisValue::from_redis_value(&Value::Int(42));
     assert_eq!(i, Ok(42i32));
 
-    let i = FromRedisValue::from_redis_value(&Value::Data("42".into()));
+    let i = FromRedisValue::from_redis_value(&Value::BulkString("42".into()));
     assert_eq!(i, Ok(42i32));
 
     let bad_i: Result<i32, _> =
@@ -67,9 +67,9 @@ fn test_vec() {
     use redis::{FromRedisValue, Value};
 
     let v = FromRedisValue::from_redis_value(&Value::Array(vec![
-        Value::Data("1".into()),
-        Value::Data("2".into()),
-        Value::Data("3".into()),
+        Value::BulkString("1".into()),
+        Value::BulkString("2".into()),
+        Value::BulkString("3".into()),
     ]));
 
     assert_eq!(v, Ok(vec![1i32, 2, 3]));
@@ -79,7 +79,7 @@ fn test_vec() {
 fn test_single_bool_vec() {
     use redis::{FromRedisValue, Value};
 
-    let v = FromRedisValue::from_redis_value(&Value::Data("1".into()));
+    let v = FromRedisValue::from_redis_value(&Value::BulkString("1".into()));
 
     assert_eq!(v, Ok(vec![true]));
 }
@@ -88,7 +88,7 @@ fn test_single_bool_vec() {
 fn test_single_i32_vec() {
     use redis::{FromRedisValue, Value};
 
-    let v = FromRedisValue::from_redis_value(&Value::Data("1".into()));
+    let v = FromRedisValue::from_redis_value(&Value::BulkString("1".into()));
 
     assert_eq!(v, Ok(vec![1i32]));
 }
@@ -97,7 +97,7 @@ fn test_single_i32_vec() {
 fn test_single_u32_vec() {
     use redis::{FromRedisValue, Value};
 
-    let v = FromRedisValue::from_redis_value(&Value::Data("42".into()));
+    let v = FromRedisValue::from_redis_value(&Value::BulkString("42".into()));
 
     assert_eq!(v, Ok(vec![42u32]));
 }
@@ -106,7 +106,7 @@ fn test_single_u32_vec() {
 fn test_single_string_vec() {
     use redis::{FromRedisValue, Value};
 
-    let v = FromRedisValue::from_redis_value(&Value::Data("1".into()));
+    let v = FromRedisValue::from_redis_value(&Value::BulkString("1".into()));
 
     assert_eq!(v, Ok(vec!["1".to_string()]));
 }
@@ -116,9 +116,9 @@ fn test_tuple() {
     use redis::{FromRedisValue, Value};
 
     let v = FromRedisValue::from_redis_value(&Value::Array(vec![Value::Array(vec![
-        Value::Data("1".into()),
-        Value::Data("2".into()),
-        Value::Data("3".into()),
+        Value::BulkString("1".into()),
+        Value::BulkString("2".into()),
+        Value::BulkString("3".into()),
     ])]));
 
     assert_eq!(v, Ok(((1i32, 2, 3,),)));
@@ -134,12 +134,12 @@ fn test_hashmap() {
     type Hm = HashMap<String, i32>;
 
     let v: Result<Hm, _> = FromRedisValue::from_redis_value(&Value::Array(vec![
-        Value::Data("a".into()),
-        Value::Data("1".into()),
-        Value::Data("b".into()),
-        Value::Data("2".into()),
-        Value::Data("c".into()),
-        Value::Data("3".into()),
+        Value::BulkString("a".into()),
+        Value::BulkString("1".into()),
+        Value::BulkString("b".into()),
+        Value::BulkString("2".into()),
+        Value::BulkString("c".into()),
+        Value::BulkString("3".into()),
     ]));
     let mut e: Hm = HashMap::new();
     e.insert("a".into(), 1);
@@ -150,12 +150,12 @@ fn test_hashmap() {
     type Hasher = BuildHasherDefault<FnvHasher>;
     type HmHasher = HashMap<String, i32, Hasher>;
     let v: Result<HmHasher, _> = FromRedisValue::from_redis_value(&Value::Array(vec![
-        Value::Data("a".into()),
-        Value::Data("1".into()),
-        Value::Data("b".into()),
-        Value::Data("2".into()),
-        Value::Data("c".into()),
-        Value::Data("3".into()),
+        Value::BulkString("a".into()),
+        Value::BulkString("1".into()),
+        Value::BulkString("b".into()),
+        Value::BulkString("2".into()),
+        Value::BulkString("c".into()),
+        Value::BulkString("3".into()),
     ]));
 
     let fnv = Hasher::default();
@@ -170,13 +170,13 @@ fn test_hashmap() {
 fn test_bool() {
     use redis::{ErrorKind, FromRedisValue, Value};
 
-    let v = FromRedisValue::from_redis_value(&Value::Data("1".into()));
+    let v = FromRedisValue::from_redis_value(&Value::BulkString("1".into()));
     assert_eq!(v, Ok(true));
 
-    let v = FromRedisValue::from_redis_value(&Value::Data("0".into()));
+    let v = FromRedisValue::from_redis_value(&Value::BulkString("0".into()));
     assert_eq!(v, Ok(false));
 
-    let v: Result<bool, _> = FromRedisValue::from_redis_value(&Value::Data("garbage".into()));
+    let v: Result<bool, _> = FromRedisValue::from_redis_value(&Value::BulkString("garbage".into()));
     assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
 
     let v = FromRedisValue::from_redis_value(&Value::SimpleString("1".into()));
@@ -212,7 +212,7 @@ fn test_bytes() {
     let content_vec: Vec<u8> = Vec::from(content);
     let content_bytes = Bytes::from_static(content);
 
-    let v: RedisResult<Bytes> = FromRedisValue::from_redis_value(&Value::Data(content_vec));
+    let v: RedisResult<Bytes> = FromRedisValue::from_redis_value(&Value::BulkString(content_vec));
     assert_eq!(v, Ok(content_bytes));
 
     let v: RedisResult<Bytes> =
@@ -240,7 +240,7 @@ fn test_cstring() {
     let content: &[u8] = b"\x01\x02\x03\x04";
     let content_vec: Vec<u8> = Vec::from(content);
 
-    let v: RedisResult<CString> = FromRedisValue::from_redis_value(&Value::Data(content_vec));
+    let v: RedisResult<CString> = FromRedisValue::from_redis_value(&Value::BulkString(content_vec));
     assert_eq!(v, Ok(CString::new(content).unwrap()));
 
     let v: RedisResult<CString> =

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -23,7 +23,7 @@ fn test_is_single_arg() {
 fn test_info_dict() {
     use redis::{FromRedisValue, InfoDict, Value};
 
-    let d: InfoDict = FromRedisValue::from_redis_value(&Value::Status(
+    let d: InfoDict = FromRedisValue::from_redis_value(&Value::SimpleString(
         "# this is a comment\nkey1:foo\nkey2:42\n".into(),
     ))
     .unwrap();
@@ -37,7 +37,7 @@ fn test_info_dict() {
 fn test_i32() {
     use redis::{ErrorKind, FromRedisValue, Value};
 
-    let i = FromRedisValue::from_redis_value(&Value::Status("42".into()));
+    let i = FromRedisValue::from_redis_value(&Value::SimpleString("42".into()));
     assert_eq!(i, Ok(42i32));
 
     let i = FromRedisValue::from_redis_value(&Value::Int(42));
@@ -46,7 +46,8 @@ fn test_i32() {
     let i = FromRedisValue::from_redis_value(&Value::Data("42".into()));
     assert_eq!(i, Ok(42i32));
 
-    let bad_i: Result<i32, _> = FromRedisValue::from_redis_value(&Value::Status("42x".into()));
+    let bad_i: Result<i32, _> =
+        FromRedisValue::from_redis_value(&Value::SimpleString("42x".into()));
     assert_eq!(bad_i.unwrap_err().kind(), ErrorKind::TypeError);
 }
 
@@ -54,10 +55,10 @@ fn test_i32() {
 fn test_u32() {
     use redis::{ErrorKind, FromRedisValue, Value};
 
-    let i = FromRedisValue::from_redis_value(&Value::Status("42".into()));
+    let i = FromRedisValue::from_redis_value(&Value::SimpleString("42".into()));
     assert_eq!(i, Ok(42u32));
 
-    let bad_i: Result<u32, _> = FromRedisValue::from_redis_value(&Value::Status("-1".into()));
+    let bad_i: Result<u32, _> = FromRedisValue::from_redis_value(&Value::SimpleString("-1".into()));
     assert_eq!(bad_i.unwrap_err().kind(), ErrorKind::TypeError);
 }
 
@@ -178,13 +179,14 @@ fn test_bool() {
     let v: Result<bool, _> = FromRedisValue::from_redis_value(&Value::Data("garbage".into()));
     assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
 
-    let v = FromRedisValue::from_redis_value(&Value::Status("1".into()));
+    let v = FromRedisValue::from_redis_value(&Value::SimpleString("1".into()));
     assert_eq!(v, Ok(true));
 
-    let v = FromRedisValue::from_redis_value(&Value::Status("0".into()));
+    let v = FromRedisValue::from_redis_value(&Value::SimpleString("0".into()));
     assert_eq!(v, Ok(false));
 
-    let v: Result<bool, _> = FromRedisValue::from_redis_value(&Value::Status("garbage".into()));
+    let v: Result<bool, _> =
+        FromRedisValue::from_redis_value(&Value::SimpleString("garbage".into()));
     assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
 
     let v = FromRedisValue::from_redis_value(&Value::Okay);
@@ -213,7 +215,8 @@ fn test_bytes() {
     let v: RedisResult<Bytes> = FromRedisValue::from_redis_value(&Value::Data(content_vec));
     assert_eq!(v, Ok(content_bytes));
 
-    let v: RedisResult<Bytes> = FromRedisValue::from_redis_value(&Value::Status("garbage".into()));
+    let v: RedisResult<Bytes> =
+        FromRedisValue::from_redis_value(&Value::SimpleString("garbage".into()));
     assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
 
     let v: RedisResult<Bytes> = FromRedisValue::from_redis_value(&Value::Okay);
@@ -241,14 +244,14 @@ fn test_cstring() {
     assert_eq!(v, Ok(CString::new(content).unwrap()));
 
     let v: RedisResult<CString> =
-        FromRedisValue::from_redis_value(&Value::Status("garbage".into()));
+        FromRedisValue::from_redis_value(&Value::SimpleString("garbage".into()));
     assert_eq!(v, Ok(CString::new("garbage").unwrap()));
 
     let v: RedisResult<CString> = FromRedisValue::from_redis_value(&Value::Okay);
     assert_eq!(v, Ok(CString::new("OK").unwrap()));
 
     let v: RedisResult<CString> =
-        FromRedisValue::from_redis_value(&Value::Status("gar\0bage".into()));
+        FromRedisValue::from_redis_value(&Value::SimpleString("gar\0bage".into()));
     assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
 
     let v: RedisResult<CString> = FromRedisValue::from_redis_value(&Value::Nil);
@@ -325,7 +328,7 @@ fn test_attributes() {
                 Value::Int(2),
                 Value::Attribute {
                     data: Box::new(Value::Int(3)),
-                    attributes: vec![(Value::Status("ttl".to_string()), Value::Int(3600))]
+                    attributes: vec![(Value::SimpleString("ttl".to_string()), Value::Int(3600))]
                 }
             ])
         )

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -65,7 +65,7 @@ fn test_u32() {
 fn test_vec() {
     use redis::{FromRedisValue, Value};
 
-    let v = FromRedisValue::from_redis_value(&Value::Bulk(vec![
+    let v = FromRedisValue::from_redis_value(&Value::Array(vec![
         Value::Data("1".into()),
         Value::Data("2".into()),
         Value::Data("3".into()),
@@ -114,7 +114,7 @@ fn test_single_string_vec() {
 fn test_tuple() {
     use redis::{FromRedisValue, Value};
 
-    let v = FromRedisValue::from_redis_value(&Value::Bulk(vec![Value::Bulk(vec![
+    let v = FromRedisValue::from_redis_value(&Value::Array(vec![Value::Array(vec![
         Value::Data("1".into()),
         Value::Data("2".into()),
         Value::Data("3".into()),
@@ -132,7 +132,7 @@ fn test_hashmap() {
 
     type Hm = HashMap<String, i32>;
 
-    let v: Result<Hm, _> = FromRedisValue::from_redis_value(&Value::Bulk(vec![
+    let v: Result<Hm, _> = FromRedisValue::from_redis_value(&Value::Array(vec![
         Value::Data("a".into()),
         Value::Data("1".into()),
         Value::Data("b".into()),
@@ -148,7 +148,7 @@ fn test_hashmap() {
 
     type Hasher = BuildHasherDefault<FnvHasher>;
     type HmHasher = HashMap<String, i32, Hasher>;
-    let v: Result<HmHasher, _> = FromRedisValue::from_redis_value(&Value::Bulk(vec![
+    let v: Result<HmHasher, _> = FromRedisValue::from_redis_value(&Value::Array(vec![
         Value::Data("a".into()),
         Value::Data("1".into()),
         Value::Data("b".into()),
@@ -320,7 +320,7 @@ fn test_attributes() {
         let x: Value = FromRedisValue::from_redis_value(&val).unwrap();
         assert_eq!(
             x,
-            Value::Bulk(vec![
+            Value::Array(vec![
                 Value::Int(1),
                 Value::Int(2),
                 Value::Attribute {


### PR DESCRIPTION
See the naming convention here:
https://redis.io/docs/reference/protocol-spec/