### PR TITLE
Bump MSRV to 1.60

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.59.0
+          - 1.60.0
 
     steps:
     - name: Cache redis

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ redis = "0.22.3"
 Documentation on the library can be found at
 [docs.rs/redis](https://docs.rs/redis).
 
-**Note: redis-rs requires at least Rust 1.59.**
+**Note: redis-rs requires at least Rust 1.60.**
 
 ## Basic Operation
 

--- a/redis-test/Cargo.toml
+++ b/redis-test/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/redis-rs/redis-rs"
 repository = "https://github.com/redis-rs/redis-rs"
 documentation = "https://docs.rs/redis-test"
 license = "BSD-3-Clause"
-rust-version = "1.59"
+rust-version = "1.60"
 
 [dependencies]
 redis = { version = "0.22.1", path = "../redis" }

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/redis-rs/redis-rs"
 documentation = "https://docs.rs/redis"
 license = "BSD-3-Clause"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 readme = "../README.md"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Required due to `csv` crate, dependency of
`criterion`