### PR TITLE
Fix json-module tests and CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,14 @@ jobs:
           /usr/bin/redis-server
         key: ${{ runner.os }}-redis
 
+    - name: Cache RedisJSON
+      id: cache-redisjson
+      uses: actions/cache@v2
+      with:
+        path: |
+          /tmp/librejson.so
+        key: ${{ runner.os }}-redisjson
+
     - name: Install redis
       if: steps.cache-redis.outputs.cache-hit != 'true'
       run: |
@@ -55,7 +63,11 @@ jobs:
     - uses: Swatinem/rust-cache@v1
     - uses: actions/checkout@v2
 
+    - name: Run tests
+      run: make test
+
     - name: Checkout RedisJSON
+      if: steps.cache-redisjson.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         repository: "RedisJSON/RedisJSON"
@@ -76,6 +88,7 @@ jobs:
       # This shouldn't cause issues in the future so long as no profiles or patches
       # are applied to the workspace Cargo.toml file
     - name: Compile RedisJSON
+      if: steps.cache-redisjson.outputs.cache-hit != 'true'
       run: |
         cp ./Cargo.toml ./Cargo.toml.actual
         echo $'\nexclude = [\"./__ci/redis-json\"]' >> Cargo.toml
@@ -84,8 +97,8 @@ jobs:
         rm ./Cargo.toml; mv ./Cargo.toml.actual ./Cargo.toml
         rm -rf ./__ci/redis-json
 
-    - name: Run tests
-      run: make test
+    - name: Run module-specific tests
+      run: make test-module
 
     - name: Check features
       run: |

--- a/Makefile
+++ b/Makefile
@@ -11,28 +11,34 @@ test:
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=tcp cargo test -p redis --all-features -- --nocapture --test-threads=1
+	@REDISRS_SERVER_TYPE=tcp cargo test -p redis --all-features -- --nocapture --test-threads=1 --skip test_module
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features and TLS support"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=tcp+tls cargo test -p redis --all-features -- --nocapture --test-threads=1
+	@REDISRS_SERVER_TYPE=tcp+tls cargo test -p redis --all-features -- --nocapture --test-threads=1 --skip test_module
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type UNIX"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=unix cargo test -p redis --test parser --test test_basic --test test_types --all-features -- --test-threads=1
+	@REDISRS_SERVER_TYPE=unix cargo test -p redis --test parser --test test_basic --test test_types --all-features -- --test-threads=1 --skip test_module
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type UNIX SOCKETS"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=unix cargo test -p redis --all-features -- --skip test_cluster
+	@REDISRS_SERVER_TYPE=unix cargo test -p redis --all-features -- --skip test_cluster --skip test_module
 
 	@echo "===================================================================="
 	@echo "Testing redis-test"
 	@echo "===================================================================="
 	@cargo test -p redis-test 
 
+
+test-module:
+	@echo "===================================================================="
+	@echo "Testing with module support enabled (currently only RedisJSON)"
+	@echo "===================================================================="
+	@REDISRS_SERVER_TYPE=tcp cargo test --all-features test_module
 
 test-single: test
 

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -89,7 +89,7 @@ socket2 = "0.4"
 assert_approx_eq = "1.0"
 fnv = "1.0.5"
 futures = "0.3"
-criterion = "0.3"
+criterion = "0.4"
 partial-io = { version = "0.5", features = ["tokio", "quickcheck1"] }
 quickcheck = "1.0.3"
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "time"] }

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -71,7 +71,7 @@ default = ["acl", "streams", "geospatial", "script"]
 acl = []
 aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/alloc", "futures-util/sink", "tokio/io-util", "tokio-util", "tokio-util/codec", "tokio/sync", "combine/tokio", "async-trait"]
 geospatial = []
-json = ["serde", "serde_json"]
+json = ["serde", "serde/derive", "serde_json"]
 cluster = ["crc16", "rand"]
 script = ["sha1_smol"]
 tls = ["native-tls"]
@@ -111,7 +111,7 @@ required-features = ["aio"]
 name = "test_acl"
 
 [[test]]
-name = "test_json"
+name = "test_module_json"
 required-features = ["json", "serde/derive"]
 
 [[bench]]


### PR DESCRIPTION
Fixing a couple things to avoid an unnecessary MSRV bump. 

Commit 1:

    Fix broken json-module tests
    
    Tests were broken and not actually running due to missing test
    dependency. This PR:
    * Adds the missing test dependency to the `json` feature
    * Reorganizes json tests into separate `test-module` command
      and renames tests accordingly. The goal is to not have to
      have separate redis modules in order to run core tests.


Commit 2:

    Upgrade criterion
    
    This has the side-effect of avoiding the need for
    an MSRV bump b/c the criterion crate's `csv` dependency,
    which is now optional in 0.4 and in any case not needed by
    redis-rs.


