### PR TITLE
`cluster-async` common slot parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test:
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features and TLS support"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=tcp+tls cargo test -p redis --all-features -- --nocapture --test-threads=1 --skip test_async_cluster --skip test_module
+	@REDISRS_SERVER_TYPE=tcp+tls cargo test -p redis --all-features -- --nocapture --test-threads=1 --skip test_module
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type UNIX"

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -254,7 +254,8 @@ impl ClusterConnection {
         let mut samples = connections.values_mut().choose_multiple(&mut rng, len);
 
         for conn in samples.iter_mut() {
-            if let Ok(mut slots_data) = get_slots(conn, self.tls) {
+            let value = conn.req_command(&slot_cmd())?;
+            if let Ok(mut slots_data) = parse_slots(value, self.tls) {
                 slots_data.sort_by_key(|s| s.start());
                 let last_slot = slots_data.iter().try_fold(0, |prev_end, slot_data| {
                     if prev_end != slot_data.start() {
@@ -693,16 +694,12 @@ fn get_random_connection<'a>(
     (addr, con)
 }
 
-// Get slot data from connection.
-fn get_slots(connection: &mut Connection, tls: Option<TlsMode>) -> RedisResult<Vec<Slot>> {
-    let mut cmd = Cmd::new();
-    cmd.arg("CLUSTER").arg("SLOTS");
-    let value = connection.req_command(&cmd)?;
-
+// Parse slot data from raw redis value.
+pub(crate) fn parse_slots(raw_slot_resp: Value, tls: Option<TlsMode>) -> RedisResult<Vec<Slot>> {
     // Parse response.
     let mut result = Vec::with_capacity(2);
 
-    if let Value::Bulk(items) = value {
+    if let Value::Bulk(items) = raw_slot_resp {
         let mut iter = items.into_iter();
         while let Some(Value::Bulk(item)) = iter.next() {
             if item.len() < 3 {
@@ -800,4 +797,10 @@ fn get_connection_addr(host: String, port: u16, tls: Option<TlsMode>) -> Connect
         },
         _ => ConnectionAddr::Tcp(host, port),
     }
+}
+
+pub(crate) fn slot_cmd() -> Cmd {
+    let mut cmd = Cmd::new();
+    cmd.arg("CLUSTER").arg("SLOTS");
+    cmd
 }

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -763,7 +763,10 @@ pub(crate) fn parse_slots(raw_slot_resp: Value, tls: Option<TlsMode>) -> RedisRe
 // The node string passed to this function will always be in the format host:port as it is either:
 // - Created by calling ConnectionAddr::to_string (unix connections are not supported in cluster mode)
 // - Returned from redis via the ASK/MOVED response
-fn get_connection_info(node: &str, cluster_params: ClusterParams) -> RedisResult<ConnectionInfo> {
+pub(crate) fn get_connection_info(
+    node: &str,
+    cluster_params: ClusterParams,
+) -> RedisResult<ConnectionInfo> {
     let mut split = node.split(':');
     let invalid_error = || (ErrorKind::InvalidClientConfig, "Invalid node string");
 

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -68,6 +68,7 @@ use std::{
 
 use crate::{
     aio::{ConnectionLike, MultiplexedConnection},
+    cluster::slot_cmd,
     cluster_routing::RoutingInfo,
     parse_redis_url, Cmd, ConnectionAddr, ConnectionInfo, ErrorKind, IntoConnectionInfo,
     RedisError, RedisFuture, RedisResult, Value,
@@ -1079,12 +1080,13 @@ where
     C: ConnectionLike,
 {
     trace!("get_slots");
-    let mut cmd = Cmd::new();
-    cmd.arg("CLUSTER").arg("SLOTS");
-    let value = connection.req_packed_command(&cmd).await.map_err(|err| {
-        trace!("get_slots error: {}", err);
-        err
-    })?;
+    let value = connection
+        .req_packed_command(&slot_cmd())
+        .await
+        .map_err(|err| {
+            trace!("get_slots error: {}", err);
+            err
+        })?;
     trace!("get_slots -> {:#?}", value);
     // Parse response.
     let mut result = Vec::with_capacity(2);

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -355,4 +355,26 @@ mod tests {
             assert_eq!(RoutingInfo::for_routable(cmd), expected,);
         }
     }
+
+    #[test]
+    fn test_slot_for_packed_cmd() {
+        assert!(matches!(RoutingInfo::for_routable(&parse_redis_value(&[
+                42, 50, 13, 10, 36, 54, 13, 10, 69, 88, 73, 83, 84, 83, 13, 10, 36, 49, 54, 13, 10,
+                244, 93, 23, 40, 126, 127, 253, 33, 89, 47, 185, 204, 171, 249, 96, 139, 13, 10
+            ]).unwrap()), Some(RoutingInfo::ReplicaSlot(slot)) if slot == 964));
+
+        assert!(matches!(RoutingInfo::for_routable(&parse_redis_value(&[
+                42, 54, 13, 10, 36, 51, 13, 10, 83, 69, 84, 13, 10, 36, 49, 54, 13, 10, 36, 241,
+                197, 111, 180, 254, 5, 175, 143, 146, 171, 39, 172, 23, 164, 145, 13, 10, 36, 52,
+                13, 10, 116, 114, 117, 101, 13, 10, 36, 50, 13, 10, 78, 88, 13, 10, 36, 50, 13, 10,
+                80, 88, 13, 10, 36, 55, 13, 10, 49, 56, 48, 48, 48, 48, 48, 13, 10
+            ]).unwrap()), Some(RoutingInfo::MasterSlot(slot)) if slot == 8352));
+
+        assert!(matches!(RoutingInfo::for_routable(&parse_redis_value(&[
+                42, 54, 13, 10, 36, 51, 13, 10, 83, 69, 84, 13, 10, 36, 49, 54, 13, 10, 169, 233,
+                247, 59, 50, 247, 100, 232, 123, 140, 2, 101, 125, 221, 66, 170, 13, 10, 36, 52,
+                13, 10, 116, 114, 117, 101, 13, 10, 36, 50, 13, 10, 78, 88, 13, 10, 36, 50, 13, 10,
+                80, 88, 13, 10, 36, 55, 13, 10, 49, 56, 48, 48, 48, 48, 48, 13, 10
+            ]).unwrap()), Some(RoutingInfo::MasterSlot(slot)) if slot == 5210));
+    }
 }


### PR DESCRIPTION
[Cluster slot parse refactor](https://github.com/redis-rs/redis-rs/pull/793/commits/ee249465a6fdebaf4276c72437f633dcf24c8ab0)

* Rename `get_slots` to `parse_slots`
* Make a pure function so it can be called in async code as well
* Common `slot_cmd` function

[Common slot parsing](https://github.com/redis-rs/redis-rs/pull/793/commits/870bf25dec80c7f3742881f44d7c3fd3305b5ab5)

Use common `parse_slots` command; this allows for eliminating
a lot of largely duplicate code in the cluster-async module but
requires adding support for `ClusterParams` to track connection
settings for TlsMode, username, password, etc., which was previously
(incompletely) tracked by the connection strings constituting the keys
of the ConnectionMap.

These changes also have the effect of enabling support in the cluster-
async module for insecure TLS and both usernames and passwords for
authentication.