### PR TITLE
feat(commands): introduce new generic for each key arg

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -191,12 +191,12 @@ implement_commands! {
     }
 
     /// Rename a key.
-    fn rename<K: ToRedisArgs>(key: K, new_key: K) {
+    fn rename<K: ToRedisArgs, N: ToRedisArgs>(key: K, new_key: N) {
         cmd("RENAME").arg(key).arg(new_key)
     }
 
     /// Rename a key, only if the new key does not exist.
-    fn rename_nx<K: ToRedisArgs>(key: K, new_key: K) {
+    fn rename_nx<K: ToRedisArgs, N: ToRedisArgs>(key: K, new_key: N) {
         cmd("RENAMENX").arg(key).arg(new_key)
     }
 
@@ -249,25 +249,25 @@ implement_commands! {
 
     /// Perform a bitwise AND between multiple keys (containing string values)
     /// and store the result in the destination key.
-    fn bit_and<K: ToRedisArgs>(dstkey: K, srckeys: K) {
+    fn bit_and<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) {
         cmd("BITOP").arg("AND").arg(dstkey).arg(srckeys)
     }
 
     /// Perform a bitwise OR between multiple keys (containing string values)
     /// and store the result in the destination key.
-    fn bit_or<K: ToRedisArgs>(dstkey: K, srckeys: K) {
+    fn bit_or<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) {
         cmd("BITOP").arg("OR").arg(dstkey).arg(srckeys)
     }
 
     /// Perform a bitwise XOR between multiple keys (containing string values)
     /// and store the result in the destination key.
-    fn bit_xor<K: ToRedisArgs>(dstkey: K, srckeys: K) {
+    fn bit_xor<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) {
         cmd("BITOP").arg("XOR").arg(dstkey).arg(srckeys)
     }
 
     /// Perform a bitwise NOT of the key (containing string values)
     /// and store the result in the destination key.
-    fn bit_not<K: ToRedisArgs>(dstkey: K, srckey: K) {
+    fn bit_not<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckey: S) {
         cmd("BITOP").arg("NOT").arg(dstkey).arg(srckey)
     }
 
@@ -341,7 +341,7 @@ implement_commands! {
 
     /// Pop an element from a list, push it to another list
     /// and return it; or block until one is available
-    fn blmove<K: ToRedisArgs>(srckey: K, dstkey: K, src_dir: Direction, dst_dir: Direction, timeout: usize) {
+    fn blmove<S: ToRedisArgs, D: ToRedisArgs>(srckey: S, dstkey: D, src_dir: Direction, dst_dir: Direction, timeout: usize) {
         cmd("BLMOVE").arg(srckey).arg(dstkey).arg(src_dir).arg(dst_dir).arg(timeout)
     }
 
@@ -363,7 +363,7 @@ implement_commands! {
 
     /// Pop a value from a list, push it to another list and return it;
     /// or block until one is available.
-    fn brpoplpush<K: ToRedisArgs>(srckey: K, dstkey: K, timeout: usize) {
+    fn brpoplpush<S: ToRedisArgs, D: ToRedisArgs>(srckey: S, dstkey: D, timeout: usize) {
         cmd("BRPOPLPUSH").arg(srckey).arg(dstkey).arg(timeout)
     }
 
@@ -390,7 +390,7 @@ implement_commands! {
     }
 
     /// Pop an element a list, push it to another list and return it
-    fn lmove<K: ToRedisArgs>(srckey: K, dstkey: K, src_dir: Direction, dst_dir: Direction) {
+    fn lmove<S: ToRedisArgs, D: ToRedisArgs>(srckey: S, dstkey: D, src_dir: Direction, dst_dir: Direction) {
         cmd("LMOVE").arg(srckey).arg(dstkey).arg(src_dir).arg(dst_dir)
     }
 
@@ -453,7 +453,7 @@ implement_commands! {
     }
 
     /// Pop a value from a list, push it to another list and return it.
-    fn rpoplpush<K: ToRedisArgs>(key: K, dstkey: K) {
+    fn rpoplpush<K: ToRedisArgs, D: ToRedisArgs>(key: K, dstkey: D) {
         cmd("RPOPLPUSH").arg(key).arg(dstkey)
     }
 
@@ -486,7 +486,7 @@ implement_commands! {
     }
 
     /// Subtract multiple sets and store the resulting set in a key.
-    fn sdiffstore<K: ToRedisArgs>(dstkey: K, keys: K) {
+    fn sdiffstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) {
         cmd("SDIFFSTORE").arg(dstkey).arg(keys)
     }
 
@@ -496,7 +496,7 @@ implement_commands! {
     }
 
     /// Intersect multiple sets and store the resulting set in a key.
-    fn sinterstore<K: ToRedisArgs>(dstkey: K, keys: K) {
+    fn sinterstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) {
         cmd("SINTERSTORE").arg(dstkey).arg(keys)
     }
 
@@ -511,7 +511,7 @@ implement_commands! {
     }
 
     /// Move a member from one set to another.
-    fn smove<K: ToRedisArgs, M: ToRedisArgs>(srckey: K, dstkey: K, member: M) {
+    fn smove<S: ToRedisArgs, D: ToRedisArgs, M: ToRedisArgs>(srckey: S, dstkey: D, member: M) {
         cmd("SMOVE").arg(srckey).arg(dstkey).arg(member)
     }
 
@@ -541,7 +541,7 @@ implement_commands! {
     }
 
     /// Add multiple sets and store the resulting set in a key.
-    fn sunionstore<K: ToRedisArgs>(dstkey: K, keys: K) {
+    fn sunionstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) {
         cmd("SUNIONSTORE").arg(dstkey).arg(keys)
     }
 
@@ -575,26 +575,26 @@ implement_commands! {
 
     /// Intersect multiple sorted sets and store the resulting sorted set in
     /// a new key using SUM as aggregation function.
-    fn zinterstore<K: ToRedisArgs>(dstkey: K, keys: &'a [K]) {
+    fn zinterstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: &'a [K]) {
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.len()).arg(keys)
     }
 
     /// Intersect multiple sorted sets and store the resulting sorted set in
     /// a new key using MIN as aggregation function.
-    fn zinterstore_min<K: ToRedisArgs>(dstkey: K, keys: &'a [K]) {
+    fn zinterstore_min<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: &'a [K]) {
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MIN")
     }
 
     /// Intersect multiple sorted sets and store the resulting sorted set in
     /// a new key using MAX as aggregation function.
-    fn zinterstore_max<K: ToRedisArgs>(dstkey: K, keys: &'a [K]) {
+    fn zinterstore_max<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: &'a [K]) {
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MAX")
     }
 
     /// [`Commands::zinterstore`], but with the ability to specify a
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
-    fn zinterstore_weights<K: ToRedisArgs, W: ToRedisArgs>(dstkey: K, keys: &'a [(K, W)]) {
+    fn zinterstore_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight)| (key, weight)).unzip();
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("WEIGHTS").arg(weights)
     }
@@ -602,7 +602,7 @@ implement_commands! {
     /// [`Commands::zinterstore_min`], but with the ability to specify a
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
-    fn zinterstore_min_weights<K: ToRedisArgs, W: ToRedisArgs>(dstkey: K, keys: &'a [(K, W)]) {
+    fn zinterstore_min_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight)| (key, weight)).unzip();
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MIN").arg("WEIGHTS").arg(weights)
     }
@@ -610,13 +610,13 @@ implement_commands! {
     /// [`Commands::zinterstore_max`], but with the ability to specify a
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
-    fn zinterstore_max_weights<K: ToRedisArgs, W: ToRedisArgs>(dstkey: K, keys: &'a [(K, W)]) {
+    fn zinterstore_max_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight)| (key, weight)).unzip();
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MAX").arg("WEIGHTS").arg(weights)
     }
 
     /// Count the number of members in a sorted set between a given lexicographical range.
-    fn zlexcount<K: ToRedisArgs, L: ToRedisArgs>(key: K, min: L, max: L) {
+    fn zlexcount<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) {
         cmd("ZLEXCOUNT").arg(key).arg(min).arg(max)
     }
 
@@ -786,26 +786,26 @@ implement_commands! {
 
     /// Unions multiple sorted sets and store the resulting sorted set in
     /// a new key using SUM as aggregation function.
-    fn zunionstore<K: ToRedisArgs>(dstkey: K, keys: &'a [K]) {
+    fn zunionstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: &'a [K]) {
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.len()).arg(keys)
     }
 
     /// Unions multiple sorted sets and store the resulting sorted set in
     /// a new key using MIN as aggregation function.
-    fn zunionstore_min<K: ToRedisArgs>(dstkey: K, keys: &'a [K]) {
+    fn zunionstore_min<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: &'a [K]) {
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MIN")
     }
 
     /// Unions multiple sorted sets and store the resulting sorted set in
     /// a new key using MAX as aggregation function.
-    fn zunionstore_max<K: ToRedisArgs>(dstkey: K, keys: &'a [K]) {
+    fn zunionstore_max<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: &'a [K]) {
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MAX")
     }
 
     /// [`Commands::zunionstore`], but with the ability to specify a
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
-    fn zunionstore_weights<K: ToRedisArgs, W: ToRedisArgs>(dstkey: K, keys: &'a [(K, W)]) {
+    fn zunionstore_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight)| (key, weight)).unzip();
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("WEIGHTS").arg(weights)
     }
@@ -813,7 +813,7 @@ implement_commands! {
     /// [`Commands::zunionstore_min`], but with the ability to specify a
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
-    fn zunionstore_min_weights<K: ToRedisArgs, W: ToRedisArgs>(dstkey: K, keys: &'a [(K, W)]) {
+    fn zunionstore_min_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight)| (key, weight)).unzip();
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MIN").arg("WEIGHTS").arg(weights)
     }
@@ -821,7 +821,7 @@ implement_commands! {
     /// [`Commands::zunionstore_max`], but with the ability to specify a
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
-    fn zunionstore_max_weights<K: ToRedisArgs, W: ToRedisArgs>(dstkey: K, keys: &'a [(K, W)]) {
+    fn zunionstore_max_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight)| (key, weight)).unzip();
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MAX").arg("WEIGHTS").arg(weights)
     }
@@ -840,7 +840,7 @@ implement_commands! {
     }
 
     /// Merge N different HyperLogLogs into a single one.
-    fn pfmerge<K: ToRedisArgs>(dstkey: K, srckeys: K) {
+    fn pfmerge<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) {
         cmd("PFMERGE").arg(dstkey).arg(srckeys)
     }
 

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -1173,3 +1173,14 @@ fn test_variable_length_get() {
     let data: Vec<String> = con.get(&keys).unwrap();
     assert_eq!(data, vec!["1"]);
 }
+
+#[test]
+fn test_multi_generics() {
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+
+    assert_eq!(con.sadd(b"set1", vec![5, 42]), Ok(2));
+    assert_eq!(con.sadd(999_i64, vec![42, 123]), Ok(2));
+    let _: () = con.rename(999_i64, b"set2").unwrap();
+    assert_eq!(con.sunionstore("res", &[b"set1", b"set2"]), Ok(3));
+}


### PR DESCRIPTION
Some commands needlessly restricted users by requiring passed arguments to have the same type for redis keys.

closes #125 