### PR TITLE
cluster: fix parsing ipv6 cluster nodes

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -771,7 +771,11 @@ pub(crate) fn get_connection_info(
 
     let (host, port) = node
         .rsplit_once(':')
-        .and_then(|(h, p)| Some(h).filter(|h| !h.is_empty()).zip(u16::from_str(p).ok()))
+        .and_then(|(host, port)| {
+            Some(host.trim_start_matches('[').trim_end_matches(']'))
+                .filter(|h| !h.is_empty())
+                .zip(u16::from_str(port).ok())
+        })
         .ok_or_else(invalid_error)?;
 
     Ok(ConnectionInfo {

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -767,13 +767,11 @@ pub(crate) fn get_connection_info(
     node: &str,
     cluster_params: ClusterParams,
 ) -> RedisResult<ConnectionInfo> {
-    let mut split = node.split(':');
     let invalid_error = || (ErrorKind::InvalidClientConfig, "Invalid node string");
 
-    let host = split.next().ok_or_else(invalid_error)?;
-    let port = split
-        .next()
-        .and_then(|string| u16::from_str(string).ok())
+    let (host, port) = node
+        .rsplit_once(':')
+        .and_then(|(host, port)| Some(host).zip(u16::from_str(port).ok()))
         .ok_or_else(invalid_error)?;
 
     Ok(ConnectionInfo {

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -771,7 +771,7 @@ pub(crate) fn get_connection_info(
 
     let (host, port) = node
         .rsplit_once(':')
-        .and_then(|(host, port)| Some(host).zip(u16::from_str(port).ok()))
+        .and_then(|(h, p)| Some(h).filter(|h| !h.is_empty()).zip(u16::from_str(p).ok()))
         .ok_or_else(invalid_error)?;
 
     Ok(ConnectionInfo {

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -839,10 +839,7 @@ mod tests {
             let res = get_connection_info(input, ClusterParams::default());
             assert_eq!(res.unwrap().addr, expected);
         }
-    }
 
-    #[test]
-    fn parse_cluster_node_host_port_invalid() {
         let cases = vec![":0", "[]:6379"];
         for input in cases {
             let res = get_connection_info(input, ClusterParams::default());

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -805,3 +805,56 @@ pub(crate) fn slot_cmd() -> Cmd {
     cmd.arg("CLUSTER").arg("SLOTS");
     cmd
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_cluster_node_empty_host() {
+        let res = get_connection_info(":0", ClusterParams::default());
+        assert_eq!(
+            res.err(),
+            Some(RedisError::from((
+                ErrorKind::InvalidClientConfig,
+                "Invalid node string",
+            ))),
+        );
+    }
+
+    #[test]
+    fn parse_cluster_node_hostname_port() {
+        let res = get_connection_info("localhost.localdomain:6379", ClusterParams::default());
+        assert_eq!(
+            res.unwrap().addr,
+            ConnectionAddr::Tcp("localhost.localdomain".to_string(), 6379u16)
+        );
+    }
+
+    #[test]
+    fn parse_cluster_node_ipv4_host_port() {
+        let res = get_connection_info("127.0.0.1:6379", ClusterParams::default());
+        assert_eq!(
+            res.unwrap().addr,
+            ConnectionAddr::Tcp("127.0.0.1".to_string(), 6379u16)
+        );
+    }
+
+    #[test]
+    fn parse_cluster_node_ipv6_host_port() {
+        let res = get_connection_info("dead::cafe:beef:30001", ClusterParams::default());
+        assert_eq!(
+            res.unwrap().addr,
+            ConnectionAddr::Tcp("dead::cafe:beef".to_string(), 30001u16)
+        );
+    }
+
+    #[test]
+    fn parse_cluster_node_ipv6_host_zone_port() {
+        let res = get_connection_info("fe80::cafe:beef%en1:30001", ClusterParams::default());
+        assert_eq!(
+            res.unwrap().addr,
+            ConnectionAddr::Tcp("fe80::cafe:beef%en1".to_string(), 30001u16)
+        );
+    }
+}


### PR DESCRIPTION
This function is unable to parse ipv6 hosts due to expecting <host:port> format. Fixed by using rsplit instead which may also be a bit faster.