### PR TITLE
connection_manager: retry and backoff on reconnect

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -43,6 +43,7 @@ tokio = { version = "1", features = ["rt", "net"], optional = true }
 # Only needed for the connection manager
 arc-swap = { version = "1.1.0", optional = true }
 futures = { version = "0.3.3", optional = true }
+tokio-retry = { version = "0.3.0", optional = true }
 
 # Only needed for the r2d2 feature
 r2d2 = { version = "0.8.8", optional = true }
@@ -93,7 +94,7 @@ async-std-rustls-comp = ["async-std-comp", "futures-rustls", "tls-rustls"]
 tokio-comp = ["aio", "tokio", "tokio/net"]
 tokio-native-tls-comp = ["tokio-comp", "tls-native-tls", "tokio-native-tls"]
 tokio-rustls-comp = ["tokio-comp", "tls-rustls", "tokio-rustls"]
-connection-manager = ["arc-swap", "futures", "aio"]
+connection-manager = ["arc-swap", "futures", "aio", "tokio-retry"]
 streams = []
 cluster-async = ["cluster", "futures", "futures-util", "log"]
 

--- a/redis/examples/async-connection-loss.rs
+++ b/redis/examples/async-connection-loss.rs
@@ -81,14 +81,7 @@ async fn main() -> RedisResult<()> {
     match mode {
         Mode::Default => run_single(client.get_async_connection().await?).await?,
         Mode::Multiplexed => run_multi(client.get_multiplexed_tokio_connection().await?).await?,
-        Mode::Reconnect => {
-            run_multi(
-                client
-                    .get_tokio_connection_manager_with_backoff(2, 100, 5)
-                    .await?,
-            )
-            .await?
-        }
+        Mode::Reconnect => run_multi(client.get_tokio_connection_manager().await?).await?,
     };
     Ok(())
 }

--- a/redis/examples/async-connection-loss.rs
+++ b/redis/examples/async-connection-loss.rs
@@ -81,7 +81,14 @@ async fn main() -> RedisResult<()> {
     match mode {
         Mode::Default => run_single(client.get_async_connection().await?).await?,
         Mode::Multiplexed => run_multi(client.get_multiplexed_tokio_connection().await?).await?,
-        Mode::Reconnect => run_multi(client.get_tokio_connection_manager().await?).await?,
+        Mode::Reconnect => {
+            run_multi(
+                client
+                    .get_tokio_connection_manager_with_backoff(2, 100, 5)
+                    .await?,
+            )
+            .await?
+        }
     };
     Ok(())
 }

--- a/redis/src/aio.rs
+++ b/redis/src/aio.rs
@@ -1079,13 +1079,22 @@ mod connection_manager {
     }
 
     impl ConnectionManager {
+        const DEFAULT_CONNECTION_RETRY_EXPONENT_BASE: u64 = 2;
+        const DEFAULT_CONNECTION_RETRY_FACTOR: u64 = 100;
+        const DEFAULT_NUMBER_OF_CONNECTION_RETRIESE: usize = 6;
+
         /// Connect to the server and store the connection inside the returned `ConnectionManager`.
         ///
         /// This requires the `connection-manager` feature, which will also pull in
         /// the Tokio executor.
-        #[deprecated = "use new_with_backoff"]
         pub async fn new(client: Client) -> RedisResult<Self> {
-            Self::new_with_backoff(client, 1, 1, 0).await
+            Self::new_with_backoff(
+                client,
+                Self::DEFAULT_CONNECTION_RETRY_EXPONENT_BASE,
+                Self::DEFAULT_CONNECTION_RETRY_FACTOR,
+                Self::DEFAULT_NUMBER_OF_CONNECTION_RETRIESE,
+            )
+            .await
         }
 
         /// Connect to the server and store the connection inside the returned `ConnectionManager`.

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -208,8 +208,44 @@ impl Client {
     /// [multiplexed-connection]: aio/struct.MultiplexedConnection.html
     #[cfg(feature = "connection-manager")]
     #[cfg_attr(docsrs, doc(cfg(feature = "connection-manager")))]
+    #[deprecated = "use get_tokio_connection_manager_with_backoff"]
     pub async fn get_tokio_connection_manager(&self) -> RedisResult<crate::aio::ConnectionManager> {
+        #[allow(deprecated)]
         crate::aio::ConnectionManager::new(self.clone()).await
+    }
+
+    /// Returns an async [`ConnectionManager`][connection-manager] from the client.
+    ///
+    /// The connection manager wraps a
+    /// [`MultiplexedConnection`][multiplexed-connection]. If a command to that
+    /// connection fails with a connection error, then a new connection is
+    /// established in the background and the error is returned to the caller.
+    ///
+    /// This means that on connection loss at least one command will fail, but
+    /// the connection will be re-established automatically if possible. Please
+    /// refer to the [`ConnectionManager`][connection-manager] docs for
+    /// detailed reconnecting behavior.
+    ///
+    /// A connection manager can be cloned, allowing requests to be be sent concurrently
+    /// on the same underlying connection (tcp/unix socket).
+    ///
+    /// [connection-manager]: aio/struct.ConnectionManager.html
+    /// [multiplexed-connection]: aio/struct.MultiplexedConnection.html
+    #[cfg(feature = "connection-manager")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "connection-manager")))]
+    pub async fn get_tokio_connection_manager_with_backoff(
+        &self,
+        exponent_base: u64,
+        factor: u64,
+        number_of_retries: usize,
+    ) -> RedisResult<crate::aio::ConnectionManager> {
+        crate::aio::ConnectionManager::new_with_backoff(
+            self.clone(),
+            exponent_base,
+            factor,
+            number_of_retries,
+        )
+        .await
     }
 
     async fn get_multiplexed_async_connection_inner<T>(

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -208,9 +208,7 @@ impl Client {
     /// [multiplexed-connection]: aio/struct.MultiplexedConnection.html
     #[cfg(feature = "connection-manager")]
     #[cfg_attr(docsrs, doc(cfg(feature = "connection-manager")))]
-    #[deprecated = "use get_tokio_connection_manager_with_backoff"]
     pub async fn get_tokio_connection_manager(&self) -> RedisResult<crate::aio::ConnectionManager> {
-        #[allow(deprecated)]
         crate::aio::ConnectionManager::new(self.clone()).await
     }
 

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -530,7 +530,9 @@ impl RedisError {
         match self.repr {
             ErrorRepr::IoError(ref err) => matches!(
                 err.kind(),
-                io::ErrorKind::BrokenPipe | io::ErrorKind::ConnectionReset
+                io::ErrorKind::BrokenPipe
+                    | io::ErrorKind::ConnectionReset
+                    | io::ErrorKind::UnexpectedEof
             ),
             _ => false,
         }

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -95,7 +95,7 @@ impl RedisCluster {
         for node in 0..nodes {
             let port = start_port + node;
 
-            servers.push(RedisServer::new_with_addr(
+            servers.push(RedisServer::new_with_addr_tls_modules_and_spawner(
                 ClusterType::build_addr(port),
                 tls_paths.clone(),
                 modules,

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -14,7 +14,7 @@ pub fn current_thread_runtime() -> tokio::runtime::Runtime {
     let mut builder = tokio::runtime::Builder::new_current_thread();
 
     #[cfg(feature = "aio")]
-    builder.enable_io();
+    builder.enable_all();
 
     builder.enable_time();
 
@@ -114,13 +114,22 @@ impl RedisServer {
                 redis::ConnectionAddr::Unix(PathBuf::from(&path))
             }
         };
-        RedisServer::new_with_addr(addr, None, modules, |cmd| {
+        RedisServer::new_with_addr_and_modules(addr, modules)
+    }
+
+    pub fn new_with_addr_and_modules(
+        addr: redis::ConnectionAddr,
+        modules: &[Module],
+    ) -> RedisServer {
+        RedisServer::new_with_addr_tls_modules_and_spawner(addr, None, modules, |cmd| {
             cmd.spawn()
                 .unwrap_or_else(|err| panic!("Failed to run {cmd:?}: {err}"))
         })
     }
 
-    pub fn new_with_addr<F: FnOnce(&mut process::Command) -> process::Child>(
+    pub fn new_with_addr_tls_modules_and_spawner<
+        F: FnOnce(&mut process::Command) -> process::Child,
+    >(
         addr: redis::ConnectionAddr,
         tls_paths: Option<TlsFilePaths>,
         modules: &[Module],

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -14,7 +14,7 @@ pub fn current_thread_runtime() -> tokio::runtime::Runtime {
     let mut builder = tokio::runtime::Builder::new_current_thread();
 
     #[cfg(feature = "aio")]
-    builder.enable_all();
+    builder.enable_io();
 
     builder.enable_time();
 

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -1,6 +1,5 @@
 use futures::{future, prelude::*, StreamExt};
 use redis::{aio::MultiplexedConnection, cmd, AsyncCommands, ErrorKind, RedisResult};
-use std::time::Duration;
 
 use crate::support::*;
 

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -665,7 +665,7 @@ async fn wait_for_server_to_become_ready(client: redis::Client) {
 }
 
 #[test]
-#[cfg(feature = "connection-manager")] // TODO - investigate why the test doesn't work with rust-tls
+#[cfg(feature = "connection-manager")]
 fn test_connection_manager_reconnect_after_delay() {
     let ctx = TestContext::new();
 

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -1,5 +1,6 @@
 use futures::{future, prelude::*, StreamExt};
 use redis::{aio::MultiplexedConnection, cmd, AsyncCommands, ErrorKind, RedisResult};
+use std::time::Duration;
 
 use crate::support::*;
 
@@ -637,4 +638,54 @@ mod pub_sub {
         })
         .unwrap();
     }
+}
+
+#[cfg(all(not(feature = "tls-rustls"), feature = "connection-manager"))]
+async fn wait_for_server_to_become_ready(client: redis::Client) {
+    let millisecond = Duration::from_millis(1);
+    let mut retries = 0;
+    loop {
+        match client.get_multiplexed_async_connection().await {
+            Err(err) => {
+                if err.is_connection_refusal() {
+                    tokio::time::sleep(millisecond).await;
+                    retries += 1;
+                    if retries > 100000 {
+                        panic!("Tried to connect too many times, last error: {err}");
+                    }
+                } else {
+                    panic!("Could not connect: {err}");
+                }
+            }
+            Ok(mut con) => {
+                let _: RedisResult<()> = redis::cmd("FLUSHDB").query_async(&mut con).await;
+                break;
+            }
+        }
+    }
+}
+
+#[test]
+#[cfg(all(not(feature = "tls-rustls"), feature = "connection-manager"))] // TODO - investigate why the test doesn't work with rust-tls
+fn test_connection_manager_reconnect_after_delay() {
+    let ctx = TestContext::new();
+
+    block_on_all(async move {
+        let mut manager =
+            redis::aio::ConnectionManager::new_with_backoff(ctx.client.clone(), 1, 10, 100)
+                .await
+                .unwrap();
+        let server = ctx.server;
+        let addr = server.client_addr().clone();
+        drop(server);
+
+        let _result: RedisResult<redis::Value> = manager.set("foo", "bar").await; // one call is ignored because it's required to trigger the connection manager's reconnect.
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let _new_server = RedisServer::new_with_addr_and_modules(addr.clone(), &[]);
+        wait_for_server_to_become_ready(ctx.client.clone()).await;
+
+        let result: redis::Value = manager.set("foo", "bar").await.unwrap();
+        assert_eq!(result, redis::Value::Okay);
+    });
 }


### PR DESCRIPTION
This change allows the connection manager to make multiple attempts to reconnect to the server, in case the server is temporarily unavailable during the first reconnect attempt.