### PR TITLE
Test cleanup

### DIFF
--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -130,7 +130,6 @@ impl RedisCluster {
                     cmd.current_dir(tempdir.path());
                     folders.push(tempdir);
                     addrs.push(format!("127.0.0.1:{port}"));
-                    dbg!(&cmd);
                     cmd.spawn().unwrap()
                 },
             ));
@@ -150,7 +149,7 @@ impl RedisCluster {
         if is_tls {
             cmd.arg("--tls").arg("--insecure");
         }
-        let status = dbg!(cmd).status().unwrap();
+        let status = cmd.status().unwrap();
         assert!(status.success());
 
         let cluster = RedisCluster { servers, folders };

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -344,7 +344,6 @@ fn test_cluster_rebuild_with_extra_nodes() {
         }
 
         let i = requests.fetch_add(1, atomic::Ordering::SeqCst);
-        eprintln!("{} => {}", i, String::from_utf8_lossy(cmd));
 
         match i {
             // Respond that the key exists elswehere (the slot, 123, is unused in the

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -1,12 +1,9 @@
 #![cfg(feature = "cluster-async")]
 mod support;
-use std::{
-    cell::Cell,
-    sync::{
-        atomic,
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
+use std::sync::{
+    atomic::{self, AtomicI32},
+    atomic::{AtomicBool, Ordering},
+    Arc,
 };
 
 use futures::prelude::*;
@@ -132,8 +129,7 @@ async fn do_failover(redis: &mut redis::aio::MultiplexedConnection) -> Result<()
 }
 
 async fn test_failover(env: &TestClusterContext, requests: i32, value: i32) {
-    let completed = Cell::new(0);
-    let completed = &completed;
+    let completed = Arc::new(AtomicI32::new(0));
 
     let connection = env.async_connection().await;
     let mut node_conns: Vec<MultiplexedConnection> = Vec::new();
@@ -186,6 +182,7 @@ async fn test_failover(env: &TestClusterContext, requests: i32, value: i32) {
         .map(|i| {
             let mut connection = connection.clone();
             let mut node_conns = node_conns.clone();
+            let completed = completed.clone();
             async move {
                 if i == requests / 2 {
                     // Failover all the nodes, error only if all the failover requests error
@@ -214,7 +211,7 @@ async fn test_failover(env: &TestClusterContext, requests: i32, value: i32) {
                         .query_async(&mut connection)
                         .await?;
                     assert_eq!(res, i);
-                    completed.set(completed.get() + 1);
+                    completed.fetch_add(1, Ordering::SeqCst);
                     Ok::<_, anyhow::Error>(())
                 }
             }
@@ -223,7 +220,11 @@ async fn test_failover(env: &TestClusterContext, requests: i32, value: i32) {
         .collect::<Vec<Result<(), anyhow::Error>>>()
         .await;
 
-    assert_eq!(completed.get(), requests, "Some requests never completed!");
+    assert_eq!(
+        completed.load(Ordering::SeqCst),
+        requests,
+        "Some requests never completed!"
+    );
 }
 
 static ERROR: Lazy<AtomicBool> = Lazy::new(Default::default);
@@ -407,7 +408,6 @@ fn test_async_cluster_rebuild_with_extra_nodes() {
         }
 
         let i = requests.fetch_add(1, atomic::Ordering::SeqCst);
-        eprintln!("{} => {}", i, String::from_utf8_lossy(cmd));
 
         match i {
             // Respond that the key exists elswehere (the slot, 123, is unused in the


### PR DESCRIPTION
Remove some noisy logs, attempt to fix flaky test 
with `atomic` instead of `Cell`.