### PR TITLE
Refactor tests

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -96,7 +96,6 @@ partial-io = { version = "0.5", features = ["tokio", "quickcheck1"] }
 quickcheck = "1.0.3"
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "time"] }
 tempfile = "3.2"
-proptest = "0.10"
 once_cell = "1"
 anyhow = "1"
 


### PR DESCRIPTION
* Stop burying errors in async failover test code
* Remove proptest -- it was only testing failover, which
  is already covered by another test. It's not clear to me
  that testing failover repeatedly in a proptest context
  is that valuable, and the test is extremely flaky in CI.