### PR TITLE
Parser -  make skipping of CLRF optional

### DIFF
--- a/redis/src/parser.rs
+++ b/redis/src/parser.rs
@@ -109,7 +109,7 @@ where
                         } else {
                             take(*size as usize)
                                 .map(|bs: &[u8]| Value::Data(bs.to_vec()))
-                                .skip(crlf())
+                                .skip(combine::optional(crlf()))
                                 .right()
                         }
                     })


### PR DESCRIPTION
This adds support for queries using SYNC & PSYNC commands. SYNC command's data doesn't end with \r\n for the actual RDB data.

## Sample Program using PSYNC
```rust
fn main() -> Result<(), redis::RedisError> {
    let mut conn = redis::Client::open("redis://localhost:6379")?.get_connection()?;

    conn.send_packed_command(b"PSYNC ? -1\r\n")?;

    loop {
        match conn.recv_response()? {
            redis::Value::Data(k) => {
                println!("len: {:?}", k.len());
                println!("Needle: {:?}", std::str::from_utf8(&k[..9])); // and more rdb data
            }
            l => println!("other: {:?}", l),
        }
    }
}

```

### Before:
```
;$ cargo run                                             
Error: parse error: Parse error at 0
Unexpected `42`
Expected crlf newline
;
```

### After:
```
$ cargo run                                                                
other: status("FULLRESYNC 503354b3e3145372c50c22c7499ebbf8d97d3bff 84")
len: 195
Needle: Ok("REDIS0011") // and more rdb data
other: bulk(string-data('"ping"'))
other: bulk(string-data('"ping"'))
```