### PR TITLE
Add Value::Error and some compatibility functions

### DIFF
--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -6,6 +6,7 @@ use std::pin::Pin;
 use crate::{
     connection::{connect, Connection, ConnectionInfo, ConnectionLike, IntoConnectionInfo},
     types::{RedisResult, Value},
+    ValueResult,
 };
 
 /// The client type.
@@ -260,7 +261,9 @@ use crate::aio::Runtime;
 
 impl ConnectionLike for Client {
     fn req_packed_command(&mut self, cmd: &[u8]) -> RedisResult<Value> {
-        self.get_connection()?.req_packed_command(cmd)
+        self.get_connection()?
+            .req_packed_command(cmd)
+            .map_value_error()
     }
 
     fn req_packed_commands(

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -495,7 +495,8 @@ where
                         // if we are in asking mode we want to feed a single
                         // ASKING command into the connection before what we
                         // actually want to execute.
-                        conn.req_packed_command(&b"*1\r\n$6\r\nASKING\r\n"[..])?;
+                        conn.req_packed_command(&b"*1\r\n$6\r\nASKING\r\n"[..])
+                            .map_value_error()?;
                         is_asking = false;
                     }
                     (addr.to_string(), conn)

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -12,6 +12,7 @@ use crate::pipeline::Pipeline;
 use crate::types::{
     from_redis_value, ErrorKind, FromRedisValue, RedisError, RedisResult, ToRedisArgs, Value,
 };
+use crate::ValueResult;
 
 #[cfg(unix)]
 use crate::types::HashMap;
@@ -855,7 +856,7 @@ impl ConnectionLike for Connection {
         }
 
         self.con.send_bytes(cmd)?;
-        self.read_response()
+        self.read_response().map_value_error()
     }
 
     fn req_packed_commands(

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -399,6 +399,7 @@ pub use crate::types::{
 
     // low level values
     Value,
+    ValueResult,
 };
 
 #[cfg(feature = "aio")]

--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -97,6 +97,7 @@ impl Pipeline {
         match resp.pop() {
             Some(Value::Nil) => Ok(Value::Nil),
             Some(Value::Bulk(items)) => Ok(self.make_pipeline_results(items)),
+            Some(Value::Error(kind, detail)) => Value::Error(kind, detail).wrap(),
             _ => fail!((
                 ErrorKind::ResponseError,
                 "Invalid response when parsing multi response"

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -340,6 +340,7 @@ where
         }
         Value::Okay => write!(writer, "+OK\r\n"),
         Value::Status(ref s) => write!(writer, "+{s}\r\n"),
+        Value::Error(ref kind, ref detail) => write!(writer, "-{kind:?} {detail:?}\r\n"),
     }
 }
 


### PR DESCRIPTION
:warning:  Breaking change. (Especially ignoring Values in a pipeline, now also ignores Errors)

This implements #805.

Currently this library does not allow handling of nested errors (see also #746). This was the simplest and least breaking solution, that I could come up with. This will only break (i hope), if nested errors are returned (the currently broken case) and this can be mostly fixed by calling `.first_error()` on the RedisResult, which returns the nested Error as before. Calling `.first_error()` on the `Value` will return a `Option<RedisError>`, if you want to handle a nested `Value::Error` inside a `Value::Bulk` and calling `.wrap()`  will just handle the flat case.

I needed to adapt the two tests with errors in the pipeline. The big change is, that ignored Errors are now really ignored.

PS: My next PR will be tiny and not break stuff...
