### PR TITLE
Use static dispatch if possible

### DIFF
--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -407,7 +407,7 @@ impl Cmd {
     /// result to the target redis value.  This is the general way how
     /// you can retrieve data.
     #[inline]
-    pub fn query<T: FromRedisValue>(&self, con: &mut dyn ConnectionLike) -> RedisResult<T> {
+    pub fn query<T: FromRedisValue>(&self, con: &mut impl ConnectionLike) -> RedisResult<T> {
         match con.req_command(self) {
             Ok(val) => from_redis_value(&val),
             Err(e) => Err(e),
@@ -440,7 +440,7 @@ impl Cmd {
     /// format of `KEYS` (just a list) as well as `SSCAN` (which returns a
     /// tuple of cursor and list).
     #[inline]
-    pub fn iter<T: FromRedisValue>(self, con: &mut dyn ConnectionLike) -> RedisResult<Iter<'_, T>> {
+    pub fn iter<T: FromRedisValue>(self, con: &mut impl ConnectionLike) -> RedisResult<Iter<'_, T>> {
         let rv = con.req_command(&self)?;
 
         let (cursor, batch) = if rv.looks_like_cursor() {
@@ -476,7 +476,7 @@ impl Cmd {
     #[inline]
     pub async fn iter_async<'a, T: FromRedisValue + 'a>(
         mut self,
-        con: &'a mut (dyn AsyncConnection + Send),
+        con: &'a mut (impl AsyncConnection + Send),
     ) -> RedisResult<AsyncIter<'a, T>> {
         let rv = con.req_packed_command(&self).await?;
 
@@ -513,7 +513,7 @@ impl Cmd {
     /// let _ : () = redis::cmd("PING").query(&mut con).unwrap();
     /// ```
     #[inline]
-    pub fn execute(&self, con: &mut dyn ConnectionLike) {
+    pub fn execute(&self, con: &mut impl ConnectionLike) {
         self.query::<()>(con).unwrap();
     }
 

--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -80,7 +80,7 @@ impl Pipeline {
         write_pipeline(out, &self.commands, self.transaction_mode)
     }
 
-    fn execute_pipelined(&self, con: &mut dyn ConnectionLike) -> RedisResult<Value> {
+    fn execute_pipelined(&self, con: &mut impl ConnectionLike) -> RedisResult<Value> {
         Ok(self.make_pipeline_results(con.req_packed_commands(
             &encode_pipeline(&self.commands, false),
             0,
@@ -88,7 +88,7 @@ impl Pipeline {
         )?))
     }
 
-    fn execute_transaction(&self, con: &mut dyn ConnectionLike) -> RedisResult<Value> {
+    fn execute_transaction(&self, con: &mut impl ConnectionLike) -> RedisResult<Value> {
         let mut resp = con.req_packed_commands(
             &encode_pipeline(&self.commands, true),
             self.commands.len() + 1,
@@ -122,7 +122,7 @@ impl Pipeline {
     ///       to them. In order to clear a Pipeline object with minimal memory released/allocated,
     ///       it is necessary to call the `clear()` before inserting new commands.
     #[inline]
-    pub fn query<T: FromRedisValue>(&self, con: &mut dyn ConnectionLike) -> RedisResult<T> {
+    pub fn query<T: FromRedisValue>(&self, con: &mut impl ConnectionLike) -> RedisResult<T> {
         if !con.supports_pipelining() {
             fail!((
                 ErrorKind::ResponseError,
@@ -202,7 +202,7 @@ impl Pipeline {
     ///       to them. In order to clear a Pipeline object with minimal memory released/allocated,
     ///       it is necessary to call the `clear()` before inserting new commands.
     #[inline]
-    pub fn execute(&self, con: &mut dyn ConnectionLike) {
+    pub fn execute(&self, con: &mut impl ConnectionLike) {
         self.query::<()>(con).unwrap();
     }
 }

--- a/redis/src/script.rs
+++ b/redis/src/script.rs
@@ -78,7 +78,7 @@ impl Script {
 
     /// Invokes the script directly without arguments.
     #[inline]
-    pub fn invoke<T: FromRedisValue>(&self, con: &mut dyn ConnectionLike) -> RedisResult<T> {
+    pub fn invoke<T: FromRedisValue>(&self, con: &mut impl ConnectionLike) -> RedisResult<T> {
         ScriptInvocation {
             script: self,
             args: vec![],
@@ -141,7 +141,7 @@ impl<'a> ScriptInvocation<'a> {
 
     /// Invokes the script and returns the result.
     #[inline]
-    pub fn invoke<T: FromRedisValue>(&self, con: &mut dyn ConnectionLike) -> RedisResult<T> {
+    pub fn invoke<T: FromRedisValue>(&self, con: &mut impl ConnectionLike) -> RedisResult<T> {
         let eval_cmd = self.eval_cmd();
         match eval_cmd.query(con) {
             Ok(val) => Ok(val),
@@ -184,7 +184,7 @@ impl<'a> ScriptInvocation<'a> {
 
     /// Loads the script and returns the SHA1 of it.
     #[inline]
-    pub fn load(&self, con: &mut dyn ConnectionLike) -> RedisResult<String> {
+    pub fn load(&self, con: &mut impl ConnectionLike) -> RedisResult<String> {
         let hash: String = self.load_cmd().query(con)?;
 
         debug_assert_eq!(hash, self.script.hash);


### PR DESCRIPTION
As most users will likely only use one kind of connection, the usual downside (increased binary size) will not affect many.

This might provide a tiny performance boost, but I have done this mostly, because using `#[inline]` with dynamic dispatch feels wrong (as there is not much to inline, if the connection type is determined at runtime).