### PR TITLE
Track the caller of execute

### DIFF
--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -521,6 +521,7 @@ impl Cmd {
     /// # let mut con = client.get_connection().unwrap();
     /// let _ : () = redis::cmd("PING").query(&mut con).unwrap();
     /// ```
+    #[track_caller]
     #[inline]
     pub fn execute(&self, con: &mut dyn ConnectionLike) {
         self.query::<()>(con).unwrap();


### PR DESCRIPTION
Since the unwrap can fail due to eg. a syntax error, I think we want it to fail with the caller's line number