### PR TITLE
Add connection timeout to the cluster client

### DIFF
--- a/redis-test/Cargo.toml
+++ b/redis-test/Cargo.toml
@@ -23,4 +23,4 @@ aio = ["futures", "redis/aio"]
 
 [dev-dependencies]
 redis = { version = "0.24.0", path = "../redis", features = ["aio", "tokio-comp"] }
-tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "time"] }

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -81,11 +81,12 @@ serde_json = { version = "1.0.82", optional = true }
 ahash = { version = "0.8.6", optional = true }
 
 log = { version = "0.4", optional = true }
+futures-time = { version = "3.0.0", optional = true }
 
 [features]
 default = ["acl", "streams", "geospatial", "script", "keep-alive"]
 acl = []
-aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/alloc", "futures-util/sink", "tokio/io-util", "tokio-util", "tokio-util/codec", "tokio/sync", "combine/tokio", "async-trait"]
+aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/alloc", "futures-util/sink", "tokio/io-util", "tokio-util", "tokio-util/codec", "tokio/sync", "combine/tokio", "async-trait", "futures-time"]
 geospatial = []
 json = ["serde", "serde/derive", "serde_json"]
 cluster = ["crc16", "rand"]

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -339,7 +339,7 @@ impl MultiplexedConnection {
     }
 
     /// Constructs a new `MultiplexedConnection` out of a `AsyncRead + AsyncWrite` object
-    /// and a `ConnectionInfo`. The new object will wait on opeartions for the given `response_timeout`.
+    /// and a `ConnectionInfo`. The new object will wait on operations for the given `response_timeout`.
     pub async fn new_with_response_timeout<C>(
         connection_info: &RedisConnectionInfo,
         stream: C,

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -26,18 +26,18 @@ use std::task::{self, Poll};
 use tokio_util::codec::Decoder;
 
 // Senders which the result of a single request are sent through
-type PipelineOutput<O, E> = oneshot::Sender<Result<Vec<O>, E>>;
+type PipelineOutput<O> = oneshot::Sender<Result<Vec<O>, RedisError>>;
 
-struct InFlight<O, E> {
-    output: PipelineOutput<O, E>,
+struct InFlight<O> {
+    output: PipelineOutput<O>,
     expected_response_count: usize,
     current_response_count: usize,
     buffer: Vec<O>,
-    first_err: Option<E>,
+    first_err: Option<RedisError>,
 }
 
-impl<O, E> InFlight<O, E> {
-    fn new(output: PipelineOutput<O, E>, expected_response_count: usize) -> Self {
+impl<O> InFlight<O> {
+    fn new(output: PipelineOutput<O>, expected_response_count: usize) -> Self {
         Self {
             output,
             expected_response_count,
@@ -49,9 +49,9 @@ impl<O, E> InFlight<O, E> {
 }
 
 // A single message sent through the pipeline
-struct PipelineMessage<S, I, E> {
+struct PipelineMessage<S, I> {
     input: S,
-    output: PipelineOutput<I, E>,
+    output: PipelineOutput<I>,
     response_count: usize,
 }
 
@@ -59,19 +59,18 @@ struct PipelineMessage<S, I, E> {
 /// items being output by the `Stream` (the number is specified at time of sending). With the
 /// interface provided by `Pipeline` an easy interface of request to response, hiding the `Stream`
 /// and `Sink`.
-struct Pipeline<SinkItem, I, E>(mpsc::Sender<PipelineMessage<SinkItem, I, E>>);
+struct Pipeline<SinkItem, I>(mpsc::Sender<PipelineMessage<SinkItem, I>>);
 
-impl<SinkItem, I, E> Clone for Pipeline<SinkItem, I, E> {
+impl<SinkItem, I> Clone for Pipeline<SinkItem, I> {
     fn clone(&self) -> Self {
         Pipeline(self.0.clone())
     }
 }
 
-impl<SinkItem, I, E> Debug for Pipeline<SinkItem, I, E>
+impl<SinkItem, I> Debug for Pipeline<SinkItem, I>
 where
     SinkItem: Debug,
     I: Debug,
-    E: Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Pipeline").field(&self.0).finish()
@@ -79,21 +78,21 @@ where
 }
 
 pin_project! {
-    struct PipelineSink<T, I, E> {
+    struct PipelineSink<T, I> {
         #[pin]
         sink_stream: T,
-        in_flight: VecDeque<InFlight<I, E>>,
-        error: Option<E>,
+        in_flight: VecDeque<InFlight<I>>,
+        error: Option<RedisError>,
     }
 }
 
-impl<T, I, E> PipelineSink<T, I, E>
+impl<T, I> PipelineSink<T, I>
 where
-    T: Stream<Item = Result<I, E>> + 'static,
+    T: Stream<Item = Result<I, RedisError>> + 'static,
 {
     fn new<SinkItem>(sink_stream: T) -> Self
     where
-        T: Sink<SinkItem, Error = E> + Stream<Item = Result<I, E>> + 'static,
+        T: Sink<SinkItem, Error = RedisError> + Stream<Item = Result<I, RedisError>> + 'static,
     {
         PipelineSink {
             sink_stream,
@@ -119,7 +118,7 @@ where
         }
     }
 
-    fn send_result(self: Pin<&mut Self>, result: Result<I, E>) {
+    fn send_result(self: Pin<&mut Self>, result: Result<I, RedisError>) {
         let self_ = self.project();
 
         {
@@ -159,9 +158,9 @@ where
     }
 }
 
-impl<SinkItem, T, I, E> Sink<PipelineMessage<SinkItem, I, E>> for PipelineSink<T, I, E>
+impl<SinkItem, T, I> Sink<PipelineMessage<SinkItem, I>> for PipelineSink<T, I>
 where
-    T: Sink<SinkItem, Error = E> + Stream<Item = Result<I, E>> + 'static,
+    T: Sink<SinkItem, Error = RedisError> + Stream<Item = Result<I, RedisError>> + 'static,
 {
     type Error = ();
 
@@ -185,7 +184,7 @@ where
             input,
             output,
             response_count,
-        }: PipelineMessage<SinkItem, I, E>,
+        }: PipelineMessage<SinkItem, I>,
     ) -> Result<(), Self::Error> {
         // If there is nothing to receive our output we do not need to send the message as it is
         // ambiguous whether the message will be sent anyway. Helps shed some load on the
@@ -246,15 +245,14 @@ where
     }
 }
 
-impl<SinkItem, I, E> Pipeline<SinkItem, I, E>
+impl<SinkItem, I> Pipeline<SinkItem, I>
 where
     SinkItem: Send + 'static,
     I: Send + 'static,
-    E: Send + 'static,
 {
     fn new<T>(sink_stream: T) -> (Self, impl Future<Output = ()>)
     where
-        T: Sink<SinkItem, Error = E> + Stream<Item = Result<I, E>> + 'static,
+        T: Sink<SinkItem, Error = RedisError> + Stream<Item = Result<I, RedisError>> + 'static,
         T: Send + 'static,
         T::Item: Send,
         T::Error: Send,
@@ -270,8 +268,12 @@ where
     }
 
     // `None` means that the stream was out of items causing that poll loop to shut down.
-    async fn send(&mut self, item: SinkItem) -> Result<I, Option<E>> {
-        self.send_recv_multiple(item, 1)
+    async fn send(
+        &mut self,
+        item: SinkItem,
+        timeout: futures_time::time::Duration,
+    ) -> Result<I, Option<RedisError>> {
+        self.send_recv_multiple(item, 1, timeout)
             .await
             // We can unwrap since we do a request for `1` item
             .map(|mut item| item.pop().unwrap())
@@ -281,7 +283,8 @@ where
         &mut self,
         input: SinkItem,
         count: usize,
-    ) -> Result<Vec<I>, Option<E>> {
+        timeout: futures_time::time::Duration,
+    ) -> Result<Vec<I>, Option<RedisError>> {
         let (sender, receiver) = oneshot::channel();
 
         self.0
@@ -292,13 +295,14 @@ where
             })
             .await
             .map_err(|_| None)?;
-        match receiver.await {
-            Ok(result) => result.map_err(Some),
-            Err(_) => {
+        match futures_time::future::FutureExt::timeout(receiver, timeout).await {
+            Ok(Ok(result)) => result.map_err(Some),
+            Ok(Err(_)) => {
                 // The `sender` was dropped which likely means that the stream part
                 // failed for one reason or another
                 Err(None)
             }
+            Err(elapsed) => Err(Some(RedisError::from(elapsed))),
         }
     }
 }
@@ -307,8 +311,9 @@ where
 /// on the same underlying connection (tcp/unix socket).
 #[derive(Clone)]
 pub struct MultiplexedConnection {
-    pipeline: Pipeline<Vec<u8>, Value, RedisError>,
+    pipeline: Pipeline<Vec<u8>, Value>,
     db: i64,
+    response_timeout: futures_time::time::Duration,
 }
 
 impl Debug for MultiplexedConnection {
@@ -330,6 +335,19 @@ impl MultiplexedConnection {
     where
         C: Unpin + AsyncRead + AsyncWrite + Send + 'static,
     {
+        Self::new_with_response_timeout(connection_info, stream, std::time::Duration::MAX).await
+    }
+
+    /// Constructs a new `MultiplexedConnection` out of a `AsyncRead + AsyncWrite` object
+    /// and a `ConnectionInfo`. The new object will wait on opeartions for the given `response_timeout`.
+    pub async fn new_with_response_timeout<C>(
+        connection_info: &RedisConnectionInfo,
+        stream: C,
+        response_timeout: std::time::Duration,
+    ) -> RedisResult<(Self, impl Future<Output = ()>)>
+    where
+        C: Unpin + AsyncRead + AsyncWrite + Send + 'static,
+    {
         fn boxed(
             f: impl Future<Output = ()> + Send + 'static,
         ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
@@ -347,6 +365,7 @@ impl MultiplexedConnection {
         let mut con = MultiplexedConnection {
             pipeline,
             db: connection_info.db,
+            response_timeout: response_timeout.into(),
         };
         let driver = {
             let auth = setup_connection(connection_info, &mut con);
@@ -365,17 +384,20 @@ impl MultiplexedConnection {
         Ok((con, driver))
     }
 
+    /// Sets the time that the multiplexer will wait for responses on operations before failing.
+    pub fn set_response_timeout(&mut self, timeout: std::time::Duration) {
+        self.response_timeout = timeout.into();
+    }
+
     /// Sends an already encoded (packed) command into the TCP socket and
     /// reads the single response from it.
     pub async fn send_packed_command(&mut self, cmd: &Cmd) -> RedisResult<Value> {
-        let value = self
-            .pipeline
-            .send(cmd.get_packed_command())
+        self.pipeline
+            .send(cmd.get_packed_command(), self.response_timeout)
             .await
             .map_err(|err| {
                 err.unwrap_or_else(|| RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe)))
-            })?;
-        Ok(value)
+            })
     }
 
     /// Sends multiple already encoded (packed) command into the TCP socket
@@ -389,7 +411,11 @@ impl MultiplexedConnection {
     ) -> RedisResult<Vec<Value>> {
         let mut value = self
             .pipeline
-            .send_recv_multiple(cmd.get_packed_pipeline(), offset + count)
+            .send_recv_multiple(
+                cmd.get_packed_pipeline(),
+                offset + count,
+                self.response_timeout,
+            )
             .await
             .map_err(|err| {
                 err.unwrap_or_else(|| RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe)))

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -237,7 +237,7 @@ impl Client {
     ///
     /// A multiplexed connection can be cloned, allowing requests to be be sent concurrently
     /// on the same underlying connection (tcp/unix socket).
-    /// The multiplexer will return a timeout error on any request that takes longer then [response_timeout].
+    /// The multiplexer will return a timeout error on any request that takes longer then `response_timeout`.
     #[cfg(feature = "tokio-comp")]
     #[cfg_attr(docsrs, doc(cfg(feature = "tokio-comp")))]
     pub async fn create_multiplexed_tokio_connection_with_response_timeout(

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -124,11 +124,43 @@ impl Client {
     pub async fn get_multiplexed_async_connection(
         &self,
     ) -> RedisResult<crate::aio::MultiplexedConnection> {
+        self.get_multiplexed_async_connection_with_timeouts(
+            std::time::Duration::MAX,
+            std::time::Duration::MAX,
+        )
+        .await
+    }
+
+    /// Returns an async connection from the client.
+    #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "tokio-comp", feature = "async-std-comp")))
+    )]
+    pub async fn get_multiplexed_async_connection_with_timeouts(
+        &self,
+        response_timeout: std::time::Duration,
+        connection_timeout: std::time::Duration,
+    ) -> RedisResult<crate::aio::MultiplexedConnection> {
+        use futures_time::future::FutureExt;
+        let connection_timeout: futures_time::time::Duration = connection_timeout.into();
         match Runtime::locate() {
             #[cfg(feature = "tokio-comp")]
-            Runtime::Tokio => self.get_multiplexed_tokio_connection().await,
+            Runtime::Tokio => {
+                self.get_multiplexed_async_connection_inner::<crate::aio::tokio::Tokio>(
+                    response_timeout,
+                )
+                .timeout(connection_timeout)
+                .await?
+            }
             #[cfg(feature = "async-std-comp")]
-            Runtime::AsyncStd => self.get_multiplexed_async_std_connection().await,
+            Runtime::AsyncStd => {
+                self.get_multiplexed_async_connection_inner::<crate::aio::async_std::AsyncStd>(
+                    response_timeout,
+                )
+                .timeout(connection_timeout)
+                .await?
+            }
         }
     }
 
@@ -141,8 +173,10 @@ impl Client {
     pub async fn get_multiplexed_tokio_connection(
         &self,
     ) -> RedisResult<crate::aio::MultiplexedConnection> {
-        self.get_multiplexed_async_connection_inner::<crate::aio::tokio::Tokio>()
-            .await
+        self.get_multiplexed_async_connection_inner::<crate::aio::tokio::Tokio>(
+            std::time::Duration::MAX,
+        )
+        .await
     }
 
     /// Returns an async multiplexed connection from the client.
@@ -154,8 +188,10 @@ impl Client {
     pub async fn get_multiplexed_async_std_connection(
         &self,
     ) -> RedisResult<crate::aio::MultiplexedConnection> {
-        self.get_multiplexed_async_connection_inner::<crate::aio::async_std::AsyncStd>()
-            .await
+        self.get_multiplexed_async_connection_inner::<crate::aio::async_std::AsyncStd>(
+            std::time::Duration::MAX,
+        )
+        .await
     }
 
     /// Returns an async multiplexed connection from the client and a future which must be polled
@@ -167,11 +203,12 @@ impl Client {
     #[cfg_attr(docsrs, doc(cfg(feature = "tokio-comp")))]
     pub async fn create_multiplexed_tokio_connection(
         &self,
+        response_timeout: std::time::Duration,
     ) -> RedisResult<(
         crate::aio::MultiplexedConnection,
         impl std::future::Future<Output = ()>,
     )> {
-        self.create_multiplexed_async_connection_inner::<crate::aio::tokio::Tokio>()
+        self.create_multiplexed_async_connection_inner::<crate::aio::tokio::Tokio>(response_timeout)
             .await
     }
 
@@ -184,12 +221,15 @@ impl Client {
     #[cfg_attr(docsrs, doc(cfg(feature = "async-std-comp")))]
     pub async fn create_multiplexed_async_std_connection(
         &self,
+        response_timeout: std::time::Duration,
     ) -> RedisResult<(
         crate::aio::MultiplexedConnection,
         impl std::future::Future<Output = ()>,
     )> {
-        self.create_multiplexed_async_connection_inner::<crate::aio::async_std::AsyncStd>()
-            .await
+        self.create_multiplexed_async_connection_inner::<crate::aio::async_std::AsyncStd>(
+            response_timeout,
+        )
+        .await
     }
 
     /// Returns an async [`ConnectionManager`][connection-manager] from the client.
@@ -265,11 +305,50 @@ impl Client {
         factor: u64,
         number_of_retries: usize,
     ) -> RedisResult<crate::aio::ConnectionManager> {
-        crate::aio::ConnectionManager::new_with_backoff(
+        self.get_tokio_connection_manager_with_backoff_and_timeouts(
+            exponent_base,
+            factor,
+            number_of_retries,
+            std::time::Duration::MAX,
+            std::time::Duration::MAX,
+        )
+        .await
+    }
+
+    /// Returns an async [`ConnectionManager`][connection-manager] from the client.
+    ///
+    /// The connection manager wraps a
+    /// [`MultiplexedConnection`][multiplexed-connection]. If a command to that
+    /// connection fails with a connection error, then a new connection is
+    /// established in the background and the error is returned to the caller.
+    ///
+    /// This means that on connection loss at least one command will fail, but
+    /// the connection will be re-established automatically if possible. Please
+    /// refer to the [`ConnectionManager`][connection-manager] docs for
+    /// detailed reconnecting behavior.
+    ///
+    /// A connection manager can be cloned, allowing requests to be be sent concurrently
+    /// on the same underlying connection (tcp/unix socket).
+    ///
+    /// [connection-manager]: aio/struct.ConnectionManager.html
+    /// [multiplexed-connection]: aio/struct.MultiplexedConnection.html
+    #[cfg(feature = "connection-manager")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "connection-manager")))]
+    pub async fn get_tokio_connection_manager_with_backoff_and_timeouts(
+        &self,
+        exponent_base: u64,
+        factor: u64,
+        number_of_retries: usize,
+        response_timeout: std::time::Duration,
+        connection_timeout: std::time::Duration,
+    ) -> RedisResult<crate::aio::ConnectionManager> {
+        crate::aio::ConnectionManager::new_with_backoff_and_timeouts(
             self.clone(),
             exponent_base,
             factor,
             number_of_retries,
+            response_timeout,
+            connection_timeout,
         )
         .await
     }
@@ -310,12 +389,13 @@ impl Client {
 
     async fn get_multiplexed_async_connection_inner<T>(
         &self,
+        response_timeout: std::time::Duration,
     ) -> RedisResult<crate::aio::MultiplexedConnection>
     where
         T: crate::aio::RedisRuntime,
     {
         let (connection, driver) = self
-            .create_multiplexed_async_connection_inner::<T>()
+            .create_multiplexed_async_connection_inner::<T>(response_timeout)
             .await?;
         T::spawn(driver);
         Ok(connection)
@@ -323,6 +403,7 @@ impl Client {
 
     async fn create_multiplexed_async_connection_inner<T>(
         &self,
+        response_timeout: std::time::Duration,
     ) -> RedisResult<(
         crate::aio::MultiplexedConnection,
         impl std::future::Future<Output = ()>,
@@ -331,7 +412,12 @@ impl Client {
         T: crate::aio::RedisRuntime,
     {
         let con = self.get_simple_async_connection::<T>().await?;
-        crate::aio::MultiplexedConnection::new(&self.connection_info.redis, con).await
+        crate::aio::MultiplexedConnection::new_with_response_timeout(
+            &self.connection_info.redis,
+            con,
+            response_timeout,
+        )
+        .await
     }
 
     async fn get_simple_async_connection<T>(

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -42,7 +42,6 @@ use std::thread;
 use std::time::Duration;
 
 use rand::{seq::IteratorRandom, thread_rng, Rng};
-
 use crate::cluster_pipeline::UNROUTABLE_ERROR;
 use crate::cluster_routing::{
     MultipleNodeRoutingInfo, ResponsePolicy, Routable, SingleNodeRoutingInfo, SlotAddr,

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -41,7 +41,6 @@ use std::str::FromStr;
 use std::thread;
 use std::time::Duration;
 
-use rand::{seq::IteratorRandom, thread_rng, Rng};
 use crate::cluster_pipeline::UNROUTABLE_ERROR;
 use crate::cluster_routing::{
     MultipleNodeRoutingInfo, ResponsePolicy, Routable, SingleNodeRoutingInfo, SlotAddr,
@@ -58,6 +57,7 @@ use crate::{
     cluster_client::ClusterParams,
     cluster_routing::{Redirect, Route, RoutingInfo, Slot, SlotMap, SLOT_SIZE},
 };
+use rand::{seq::IteratorRandom, thread_rng, Rng};
 
 pub use crate::cluster_client::{ClusterClient, ClusterClientBuilder};
 pub use crate::cluster_pipeline::{cluster_pipe, ClusterPipeline};

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -104,7 +104,7 @@ impl ClusterParams {
             tls: value.tls,
             retry_params: value.retries_configuration,
             tls_params,
-            connection_timeout: value.connection_timeout.unwrap_or(Duration::MAX),
+            connection_timeout: value.connection_timeout.unwrap_or(Duration::from_secs(1)),
             response_timeout: value.response_timeout.unwrap_or(Duration::MAX),
         })
     }

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -304,8 +304,8 @@ impl ClusterClientBuilder {
     /// Enables timing out on slow responses.
     ///
     /// If enabled, the cluster will only wait the given time to each response from each node.
-    pub fn response_timeout(mut self, connection_timeout: Duration) -> ClusterClientBuilder {
-        self.builder_params.response_timeout = Some(connection_timeout);
+    pub fn response_timeout(mut self, response_timeout: Duration) -> ClusterClientBuilder {
+        self.builder_params.response_timeout = Some(response_timeout);
         self
     }
 

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -35,7 +35,11 @@ pub struct MockConnection {
 
 #[cfg(feature = "cluster-async")]
 impl cluster_async::Connect for MockConnection {
-    fn connect<'a, T>(info: T) -> RedisFuture<'a, Self>
+    fn connect<'a, T>(
+        info: T,
+        _response_timeout: Duration,
+        _connection_timeout: Duration,
+    ) -> RedisFuture<'a, Self>
     where
         T: IntoConnectionInfo + Send + 'a,
     {

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -1,5 +1,8 @@
 use futures::{future, prelude::*, StreamExt};
-use redis::{aio::MultiplexedConnection, cmd, AsyncCommands, ErrorKind, RedisResult};
+use redis::{
+    aio::{ConnectionLike, MultiplexedConnection},
+    cmd, AsyncCommands, ErrorKind, RedisResult,
+};
 
 use crate::support::*;
 
@@ -312,6 +315,20 @@ fn test_async_scanning_big_batch() {
 #[test]
 fn test_async_scanning_small_batch() {
     test_async_scanning(2)
+}
+
+#[test]
+fn test_response_timeout_multiplexed_connection() {
+    let ctx = TestContext::new();
+    block_on_all(async move {
+        let mut connection = ctx.multiplexed_async_connection().await.unwrap();
+        connection.set_response_timeout(std::time::Duration::from_millis(1));
+        let mut cmd = redis::Cmd::new();
+        cmd.arg("BLPOP").arg("foo").arg(0); // 0 timeout blocks indefinitely
+        let result = connection.req_packed_command(&cmd).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_timeout());
+    });
 }
 
 #[test]

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -359,12 +359,17 @@ struct ErrorConnection {
 }
 
 impl Connect for ErrorConnection {
-    fn connect<'a, T>(info: T) -> RedisFuture<'a, Self>
+    fn connect<'a, T>(
+        info: T,
+        response_timeout: std::time::Duration,
+        connection_timeout: std::time::Duration,
+    ) -> RedisFuture<'a, Self>
     where
         T: IntoConnectionInfo + Send + 'a,
     {
-        Box::pin(async {
-            let inner = MultiplexedConnection::connect(info).await?;
+        Box::pin(async move {
+            let inner =
+                MultiplexedConnection::connect(info, response_timeout, connection_timeout).await?;
             Ok(ErrorConnection { inner })
         })
     }


### PR DESCRIPTION
This allows the users to define a connection timeout to the async cluster, which will cause the `refresh_slots` action to timeout if it takes too long to connect to a node.