### PR TITLE
Add basic Sentinel functionality

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -102,6 +102,7 @@ connection-manager = ["arc-swap", "futures", "aio", "tokio-retry"]
 streams = []
 cluster-async = ["cluster", "futures", "futures-util", "log"]
 keep-alive = ["socket2"]
+sentinel = []
 
 # Deprecated features
 tls = ["tls-native-tls"] # use "tls-native-tls" instead

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -102,7 +102,7 @@ connection-manager = ["arc-swap", "futures", "aio", "tokio-retry"]
 streams = []
 cluster-async = ["cluster", "futures", "futures-util", "log"]
 keep-alive = ["socket2"]
-sentinel = []
+sentinel = ["rand"]
 
 # Deprecated features
 tls = ["tls-native-tls"] # use "tls-native-tls" instead

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -53,6 +53,7 @@ use crate::connection::{
 use crate::parser::parse_redis_value;
 use crate::types::{ErrorKind, HashMap, RedisError, RedisResult, Value};
 use crate::IntoConnectionInfo;
+pub use crate::TlsMode; // Pub for backwards compatibility
 use crate::{
     cluster_client::ClusterParams,
     cluster_routing::{Redirect, Routable, Route, RoutingInfo, Slot, SlotMap, SLOT_SIZE},
@@ -706,16 +707,6 @@ impl NodeCmd {
             addr: a,
         }
     }
-}
-
-/// TlsMode indicates use or do not use verification of certification.
-/// Check [ConnectionAddr](ConnectionAddr::TcpTls::insecure) for more.
-#[derive(Clone, Copy)]
-pub enum TlsMode {
-    /// Secure verify certification.
-    Secure,
-    /// Insecure do not verify certification.
-    Insecure,
 }
 
 // TODO: This function can panic and should probably

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -4,7 +4,7 @@ use rand::Rng;
 
 use crate::connection::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo};
 use crate::types::{ErrorKind, RedisError, RedisResult};
-use crate::{cluster, cluster::TlsMode};
+use crate::{cluster, TlsMode};
 
 #[cfg(feature = "cluster-async")]
 use crate::cluster_async;

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -85,6 +85,16 @@ pub fn parse_redis_url(input: &str) -> Option<url::Url> {
     }
 }
 
+/// TlsMode indicates use or do not use verification of certification.
+/// Check [ConnectionAddr](ConnectionAddr::TcpTls::insecure) for more.
+#[derive(Clone, Copy)]
+pub enum TlsMode {
+    /// Secure verify certification.
+    Secure,
+    /// Insecure do not verify certification.
+    Insecure,
+}
+
 /// Defines the connection address.
 ///
 /// Not all connection addresses are supported on all platforms.  For instance

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -458,6 +458,7 @@ pub mod streams;
 #[cfg(feature = "cluster-async")]
 pub mod cluster_async;
 
+#[cfg(feature = "sentinel")]
 pub mod sentinel;
 
 mod client;

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -458,6 +458,8 @@ pub mod streams;
 #[cfg(feature = "cluster-async")]
 pub mod cluster_async;
 
+pub mod sentinel;
+
 mod client;
 mod cmd;
 mod commands;

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -369,7 +369,7 @@ pub use crate::commands::{
 };
 pub use crate::connection::{
     parse_redis_url, transaction, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike,
-    IntoConnectionInfo, Msg, PubSub, RedisConnectionInfo,
+    IntoConnectionInfo, Msg, PubSub, RedisConnectionInfo, TlsMode,
 };
 pub use crate::parser::{parse_redis_value, Parser};
 pub use crate::pipeline::Pipeline;

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -27,7 +27,7 @@
 //! use redis::sentinel::{ SentinelServerType, SentinelClient };
 //!
 //! let nodes = vec!["redis://127.0.0.1:6379/", "redis://127.0.0.1:6378/", "redis://127.0.0.1:6377/"];
-//! let mut master_client = SentinelClient::build(nodes, String::from("master_name"), None, SentinelServerType::Master).unwrap();
+//! let mut master_client = SentinelClient::build(nodes.clone(), String::from("master_name"), None, SentinelServerType::Master).unwrap();
 //! let mut replica_client = SentinelClient::build(nodes, String::from("master_name"), None, SentinelServerType::Replica).unwrap();
 //! let mut master_conn = master_client.get_connection().unwrap();
 //! let mut replica_conn = replica_client.get_connection().unwrap();
@@ -69,7 +69,7 @@
 //!     .master_for(
 //!         "master_name",
 //!         Some(&SentinelNodeConnectionInfo {
-//!             tls_mode: Some(redis::cluster::TlsMode::Secure),
+//!             tls_mode: Some(redis::sentinel::TlsMode::Secure),
 //!             redis_connection_info: None,
 //!         }),
 //!     )
@@ -83,11 +83,12 @@
 //! use redis::{ Commands, RedisConnectionInfo };
 //! use redis::sentinel::{ SentinelServerType, SentinelClient, SentinelNodeConnectionInfo };
 //!
+//! let nodes = vec!["redis://127.0.0.1:6379/", "redis://127.0.0.1:6378/", "redis://127.0.0.1:6377/"];
 //! let mut master_client = SentinelClient::build(
 //!     nodes,
 //!     String::from("master1"),
 //!     Some(SentinelNodeConnectionInfo {
-//!         tls_mode: Some(redis::cluster::TlsMode::Insecure),
+//!         tls_mode: Some(redis::sentinel::TlsMode::Insecure),
 //!         redis_connection_info: Some(RedisConnectionInfo {
 //!             db: 0,
 //!             username: Some(String::from("user")),

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -1,0 +1,558 @@
+//! Defines a Sentinel type that connects to Redis sentinels and creates clients to
+//! master or replica nodes.
+//!
+//! # Example
+//! ```rust,no_run
+//! use redis::Commands;
+//! use redis::sentinel::Sentinel;
+//!
+//! let nodes = vec!["redis://127.0.0.1:6379/", "redis://127.0.0.1:6378/", "redis://127.0.0.1:6377/"];
+//! let sentinel = Sentinel::build(nodes).unwrap();
+//! let mut master = sentinel.master_for("master_name").unwrap().get_connection().unwrap();
+//! let mut replica = sentinel.replica_for("master_name").unwrap().get_connection().unwrap();
+//!
+//! let _: () = master.set("test", "test_data").unwrap();
+//! let rv: String = replica.get("test").unwrap();
+//!
+//! assert_eq!(rv, "test_data");
+//! ```
+//!
+//! There is also a SentinelClient which acts like a regular Client, providing the
+//! `get_connection` and `get_async_connection` methods, internally using the Sentinel
+//! type to create clients on demand for the desired node type (Master or Replica).
+//!
+//! # Example
+//! ```rust,no_run
+//! use redis::Commands;
+//! use redis::sentinel::{ SentinelServerType, SentinelClient };
+//!
+//! let nodes = vec!["redis://127.0.0.1:6379/", "redis://127.0.0.1:6378/", "redis://127.0.0.1:6377/"];
+//! let master_client = SentinelClient::build(nodes, "master_name", SentinelServerType::Master).unwrap();
+//! let replica_client = SentinelClient::build(nodes, "master_name", SentinelServerType::Replica).unwrap();
+//! let mut master_conn = master_client.get_connection().unwrap();
+//! let mut replica_conn = replica_client.get_connection().unwrap();
+//!
+//! let _: () = master_conn.set("test", "test_data").unwrap();
+//! let rv: String = replica_conn.get("test").unwrap();
+//!
+//! assert_eq!(rv, "test_data");
+//! ```
+//!
+
+use std::{
+    collections::HashMap,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+#[cfg(feature = "aio")]
+use std::future::Future;
+
+#[cfg(feature = "aio")]
+use futures_util::StreamExt;
+
+use crate::{
+    connection::ConnectionInfo, types::RedisResult, Client, Connection, ErrorKind, FromRedisValue,
+    IntoConnectionInfo, Value,
+};
+
+/// The Sentinel type, serves as a special purpose client which builds other clients on
+/// demand.
+#[derive(Debug, Clone)]
+pub struct Sentinel {
+    sentinels_connection_info: Vec<ConnectionInfo>,
+    replica_start_index: usize,
+}
+
+fn sentinel_masters_cmd() -> crate::Cmd {
+    let mut cmd = crate::cmd("SENTINEL");
+    cmd.arg("MASTERS");
+    cmd
+}
+
+fn sentinel_replicas_cmd(master_name: &str) -> crate::Cmd {
+    let mut cmd = crate::cmd("SENTINEL");
+    cmd.arg("SLAVES"); // For compatibility with older redis versions
+    cmd.arg(master_name);
+    cmd
+}
+
+#[cfg(feature = "aio")]
+async fn async_try_sentinel_masters(
+    connection_info: &ConnectionInfo,
+) -> RedisResult<Vec<HashMap<String, String>>> {
+    let sentinel_client = Client::open(connection_info.clone())?;
+    let mut conn = sentinel_client.get_async_connection().await?;
+    let result: Vec<HashMap<String, String>> =
+        sentinel_masters_cmd().query_async(&mut conn).await?;
+    Ok(result)
+}
+
+#[cfg(feature = "aio")]
+async fn async_try_sentinel_replicas(
+    connection_info: &ConnectionInfo,
+    master_name: &str,
+) -> RedisResult<Vec<HashMap<String, String>>> {
+    let sentinel_client = Client::open(connection_info.clone())?;
+    let mut conn = sentinel_client.get_async_connection().await?;
+    let result: Vec<HashMap<String, String>> = sentinel_replicas_cmd(master_name)
+        .query_async(&mut conn)
+        .await?;
+    Ok(result)
+}
+
+fn try_sentinel_masters(
+    connection_info: &ConnectionInfo,
+) -> RedisResult<Vec<HashMap<String, String>>> {
+    let sentinel_client = Client::open(connection_info.clone())?;
+    let mut conn = sentinel_client.get_connection()?;
+    let result: Vec<HashMap<String, String>> = sentinel_masters_cmd().query(&mut conn)?;
+    Ok(result)
+}
+
+fn try_sentinel_replicas(
+    connection_info: &ConnectionInfo,
+    master_name: &str,
+) -> RedisResult<Vec<HashMap<String, String>>> {
+    let sentinel_client = Client::open(connection_info.clone())?;
+    let mut conn = sentinel_client.get_connection()?;
+    let result: Vec<HashMap<String, String>> =
+        sentinel_replicas_cmd(master_name).query(&mut conn)?;
+    Ok(result)
+}
+
+fn is_master_valid(master_info: &HashMap<String, String>, service_name: &str) -> bool {
+    master_info.get("name").map(|s| s.as_str()) == Some(service_name)
+        && master_info.contains_key("ip")
+        && master_info.contains_key("port")
+        && master_info.get("flags").map_or(false, |flags| {
+            flags.contains("master") && !flags.contains("s_down") && !flags.contains("o_down")
+        })
+        && master_info["port"].parse::<u16>().is_ok()
+}
+
+fn is_replica_valid(replica_info: &HashMap<String, String>) -> bool {
+    replica_info.contains_key("ip")
+        && replica_info.contains_key("port")
+        && replica_info.get("flags").map_or(false, |flags| {
+            !flags.contains("s_down") && !flags.contains("o_down")
+        })
+        && replica_info["port"].parse::<u16>().is_ok()
+}
+
+fn random_replica_index(max: usize) -> usize {
+    if max == 0 {
+        0
+    } else {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos();
+        (nanos as usize) % max
+    }
+}
+
+fn try_connect_to_first_replica(
+    addresses: &Vec<(String, u16)>,
+    start_index: usize,
+) -> Result<Client, crate::RedisError> {
+    if addresses.is_empty() {
+        fail!((
+            ErrorKind::NoValidReplicasFound,
+            "No valid replica found in sentinel for given name",
+        ));
+    }
+
+    let mut last_err = None;
+    for i in 0..addresses.len() {
+        let index = (i + start_index) % addresses.len();
+        match Client::open(addresses[index].clone()) {
+            Ok(client) => return Ok(client),
+            Err(err) => last_err = Some(err),
+        }
+    }
+
+    // We can unwrap here because we know there is at least one address.
+    Err(last_err.expect("There should be at least one address"))
+}
+
+fn valid_addrs<'a>(
+    servers_info: Vec<HashMap<String, String>>,
+    validate: impl Fn(&HashMap<String, String>) -> bool + 'a,
+) -> impl Iterator<Item = (String, u16)> {
+    servers_info
+        .into_iter()
+        .filter(move |info| validate(info))
+        .map(|mut info| {
+            // We can unwrap here because we already checked everything
+            let ip = info.remove("ip").unwrap();
+            let port = info["port"].parse::<u16>().unwrap();
+            (ip, port)
+        })
+}
+
+fn check_role_result(result: &RedisResult<Vec<Value>>, target_role: &str) -> bool {
+    if let Ok(values) = result {
+        if !values.is_empty() {
+            if let Ok(role) = String::from_redis_value(&values[0]) {
+                if role.to_ascii_lowercase() == target_role {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+fn check_role(ip: &str, port: u16, target_role: &str) -> bool {
+    if let Ok(client) = Client::open((ip, port)) {
+        if let Ok(mut conn) = client.get_connection() {
+            let result: RedisResult<Vec<Value>> = crate::cmd("ROLE").query(&mut conn);
+            if check_role_result(&result, target_role) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn get_first_valid_master(
+    masters: Vec<HashMap<String, String>>,
+    service_name: &str,
+) -> RedisResult<(String, u16)> {
+    for (ip, port) in valid_addrs(masters, |m| is_master_valid(m, service_name)) {
+        if check_role(ip.as_str(), port, "master") {
+            return Ok((ip, port));
+        }
+    }
+
+    fail!((
+        ErrorKind::MasterNameNotFound,
+        "Master with given name not found in sentinel",
+    ))
+}
+
+#[cfg(feature = "aio")]
+async fn async_check_role(ip: &str, port: u16, target_role: &str) -> bool {
+    if let Ok(client) = Client::open((ip, port)) {
+        if let Ok(mut conn) = client.get_async_connection().await {
+            let result: RedisResult<Vec<Value>> = crate::cmd("ROLE").query_async(&mut conn).await;
+            if check_role_result(&result, target_role) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(feature = "aio")]
+async fn async_get_first_valid_master(
+    masters: Vec<HashMap<String, String>>,
+    service_name: &str,
+) -> RedisResult<(String, u16)> {
+    for (ip, port) in valid_addrs(masters, |m| is_master_valid(m, service_name)) {
+        if async_check_role(ip.as_str(), port, "master").await {
+            return Ok((ip, port));
+        }
+    }
+
+    fail!((
+        ErrorKind::MasterNameNotFound,
+        "Master with given name not found in sentinel",
+    ))
+}
+
+fn get_valid_replicas_addresses(replicas: Vec<HashMap<String, String>>) -> Vec<(String, u16)> {
+    valid_addrs(replicas, is_replica_valid)
+        .filter(|(ip, port)| check_role(ip.as_str(), *port, "slave"))
+        .collect()
+}
+
+#[cfg(feature = "aio")]
+async fn async_get_valid_replicas_addresses(
+    replicas: Vec<HashMap<String, String>>,
+) -> Vec<(String, u16)> {
+    async fn is_replica_role_valid((ip, port): (String, u16)) -> Option<(String, u16)> {
+        if async_check_role(ip.clone().as_str(), port, "slave").await {
+            Some((ip, port))
+        } else {
+            None
+        }
+    }
+
+    futures_util::stream::iter(valid_addrs(replicas, is_replica_valid))
+        .filter_map(is_replica_role_valid)
+        .collect()
+        .await
+}
+
+// async methods
+#[cfg(feature = "aio")]
+impl Sentinel {
+    async fn async_try_all_sentinels<'a, F, T, Fut>(&'a self, f: F) -> RedisResult<T>
+    where
+        F: Fn(&'a ConnectionInfo) -> Fut,
+        Fut: Future<Output = RedisResult<T>>,
+    {
+        let mut last_err = None;
+        for connection_info in self.sentinels_connection_info.iter() {
+            match f(connection_info).await {
+                Ok(result) => {
+                    return Ok(result);
+                }
+                Err(err) => {
+                    last_err = Some(err);
+                }
+            }
+        }
+
+        // We can unwrap here because we know there is at least one connection info.
+        // Maybe we should have a more specific error for this situation?
+        Err(last_err.expect("There should be at least one connection info"))
+    }
+
+    async fn async_get_sentinel_masters(&self) -> RedisResult<Vec<HashMap<String, String>>> {
+        self.async_try_all_sentinels(async_try_sentinel_masters)
+            .await
+    }
+
+    async fn async_get_sentinel_replicas(
+        &self,
+        service_name: &str,
+    ) -> RedisResult<Vec<HashMap<String, String>>> {
+        self.async_try_all_sentinels(|conn_info| {
+            async_try_sentinel_replicas(conn_info, service_name)
+        })
+        .await
+    }
+
+    async fn async_find_master_address(&self, service_name: &str) -> RedisResult<(String, u16)> {
+        let masters = self.async_get_sentinel_masters().await?;
+        async_get_first_valid_master(masters, service_name).await
+    }
+
+    async fn async_find_valid_replica_addresses(
+        &self,
+        service_name: &str,
+    ) -> RedisResult<Vec<(String, u16)>> {
+        let replicas = self.async_get_sentinel_replicas(service_name).await?;
+        Ok(async_get_valid_replicas_addresses(replicas).await)
+    }
+
+    /// Determines the masters address for the given name, and returns a client for that
+    /// master.
+    ///
+    /// To determine the master we ask the sentinels one by one until one of
+    /// then correctly responds to the SENTINEL MASTERS command, and then we check to
+    /// see if there is a master with the given name; if there is, we create a
+    /// client with that address (ip and port).
+    pub async fn async_master_for(&self, service_name: &str) -> RedisResult<Client> {
+        let address = self.async_find_master_address(service_name).await?;
+        Client::open(address)
+    }
+
+    /// Connects to the first available replica of the given master name.
+    ///
+    /// After listing the valid replicas (those without a sdown or odown flag) for the
+    /// given master name, we start trying to connect to then one by one, starting at a
+    /// random index (simple random derived from the nanoseconds part of the current
+    /// unix timestamp).
+    pub async fn async_replica_for(&self, service_name: &str) -> RedisResult<Client> {
+        let addresses = self
+            .async_find_valid_replica_addresses(service_name)
+            .await?;
+        let start_index = random_replica_index(addresses.len());
+        try_connect_to_first_replica(&addresses, start_index)
+    }
+
+    /// Connects to the first available replica of the given master name, starting in a
+    /// different (incremented) index each time the function is called.
+    ///
+    /// After listing the valid replicas (those without a sdown or odown flag) for the
+    /// given master name, we start trying to connect to then one by one, starting at a
+    /// rotating index which gets incremented on each call to this function.
+    pub async fn async_replica_rotate_for(&mut self, service_name: &str) -> RedisResult<Client> {
+        let addresses = self
+            .async_find_valid_replica_addresses(service_name)
+            .await?;
+        if !addresses.is_empty() {
+            self.replica_start_index = (self.replica_start_index + 1) % addresses.len();
+        }
+        try_connect_to_first_replica(&addresses, self.replica_start_index)
+    }
+}
+
+// non-async methods
+impl Sentinel {
+    /// Creates a Sentinel client performing some basic
+    /// checks on the URLs that might make the operation fail.
+    pub fn build<T: IntoConnectionInfo>(params: Vec<T>) -> RedisResult<Sentinel> {
+        Ok(Sentinel {
+            sentinels_connection_info: params
+                .into_iter()
+                .map(|p| p.into_connection_info())
+                .collect::<RedisResult<Vec<ConnectionInfo>>>()?,
+            replica_start_index: random_replica_index(1000000),
+        })
+    }
+
+    fn try_all_sentinels<F, T>(&self, f: F) -> RedisResult<T>
+    where
+        F: Fn(&ConnectionInfo) -> RedisResult<T>,
+    {
+        let mut last_err = None;
+        for connection_info in self.sentinels_connection_info.iter() {
+            match f(connection_info) {
+                Ok(result) => {
+                    return Ok(result);
+                }
+                Err(err) => {
+                    last_err = Some(err);
+                }
+            }
+        }
+
+        // We can unwrap here because we know there is at least one connection info.
+        // Maybe we should have a more specific error for this situation?
+        Err(last_err.expect("There should be at least one connection info"))
+    }
+
+    fn get_sentinel_masters(&self) -> RedisResult<Vec<HashMap<String, String>>> {
+        self.try_all_sentinels(try_sentinel_masters)
+    }
+
+    fn get_sentinel_replicas(
+        &self,
+        service_name: &str,
+    ) -> RedisResult<Vec<HashMap<String, String>>> {
+        self.try_all_sentinels(|conn_info| try_sentinel_replicas(conn_info, service_name))
+    }
+
+    fn find_master_address(&self, service_name: &str) -> RedisResult<(String, u16)> {
+        let masters = self.get_sentinel_masters()?;
+        get_first_valid_master(masters, service_name)
+    }
+
+    fn find_valid_replica_addresses(&self, service_name: &str) -> RedisResult<Vec<(String, u16)>> {
+        let replicas = self.get_sentinel_replicas(service_name)?;
+        Ok(get_valid_replicas_addresses(replicas))
+    }
+
+    /// Determines the masters address for the given name, and returns a client for that
+    /// master.
+    ///
+    /// To determine the master we ask the sentinels one by one until one of
+    /// then correctly responds to the SENTINEL MASTERS command, and then we check to
+    /// see if there is a master with the given name; if there is, we create a
+    /// client with that address (ip and port).
+    pub fn master_for(&self, service_name: &str) -> RedisResult<Client> {
+        let address = self.find_master_address(service_name)?;
+        Client::open(address)
+    }
+
+    /// Connects to the first available replica of the given master name.
+    ///
+    /// After listing the valid replicas (those without a sdown or odown flag) for the
+    /// given master name, we start trying to connect to then one by one, starting at a
+    /// random index (simple random derived from the nanoseconds part of the current
+    /// unix timestamp).
+    pub fn replica_for(&self, service_name: &str) -> RedisResult<Client> {
+        let addresses = self.find_valid_replica_addresses(service_name)?;
+        let start_index = random_replica_index(addresses.len());
+        try_connect_to_first_replica(&addresses, start_index)
+    }
+
+    /// Connects to the first available replica of the given master name, starting in a
+    /// different (incremented) index each time the function is called.
+    ///
+    /// After listing the valid replicas (those without a sdown or odown flag) for the
+    /// given master name, we start trying to connect to then one by one, starting at a
+    /// rotating index which gets incremented on each call to this function.
+    pub fn replica_rotate_for(&mut self, service_name: &str) -> RedisResult<Client> {
+        let addresses = self.find_valid_replica_addresses(service_name)?;
+        if !addresses.is_empty() {
+            self.replica_start_index = (self.replica_start_index + 1) % addresses.len();
+        }
+        try_connect_to_first_replica(&addresses, self.replica_start_index)
+    }
+}
+
+/// Enum defining the server types from a sentinel's point of view.
+#[derive(Debug, Clone)]
+pub enum SentinelServerType {
+    /// Master connections only
+    Master,
+    /// Replica connections only
+    Replica,
+}
+
+/// An alternative to the Client type which creates connections from clients created
+/// on-demand based on information fetched from the sentinels. Uses the Sentinel type
+/// internally. This is basic an utility to help make it easier to use sentinels but
+/// with an interface similar to the client (`get_connection` and
+/// `get_async_connection`).
+#[derive(Debug, Clone)]
+pub struct SentinelClient {
+    sentinel: Sentinel,
+    service_name: String,
+    server_type: SentinelServerType,
+}
+
+impl SentinelClient {
+    /// Creates a SentinelClient performing some basic checks on the URLs that might
+    /// result in an error.
+    pub fn build<T: IntoConnectionInfo>(
+        params: Vec<T>,
+        service_name: String,
+        server_type: SentinelServerType,
+    ) -> RedisResult<Self> {
+        Ok(SentinelClient {
+            sentinel: Sentinel::build(params)?,
+            service_name,
+            server_type,
+        })
+    }
+
+    fn get_client(&self) -> RedisResult<Client> {
+        match self.server_type {
+            SentinelServerType::Master => self.sentinel.master_for(self.service_name.as_str()),
+            SentinelServerType::Replica => self.sentinel.replica_for(self.service_name.as_str()),
+        }
+    }
+
+    /// Creates a new connection to the desired type of server (based on the
+    /// service/master name, and the server type). We use a Sentinel to create a client
+    /// for the target type of server, and then create a connection using that client.
+    pub fn get_connection(&self) -> RedisResult<Connection> {
+        let client = self.get_client()?;
+        client.get_connection()
+    }
+}
+
+/// To enable async support you need to chose one of the supported runtimes and active its
+/// corresponding feature: `tokio-comp` or `async-std-comp`
+#[cfg(feature = "aio")]
+#[cfg_attr(docsrs, doc(cfg(feature = "aio")))]
+impl SentinelClient {
+    async fn async_get_client(&self) -> RedisResult<Client> {
+        match self.server_type {
+            SentinelServerType::Master => {
+                self.sentinel
+                    .async_master_for(self.service_name.as_str())
+                    .await
+            }
+            SentinelServerType::Replica => {
+                self.sentinel
+                    .async_replica_for(self.service_name.as_str())
+                    .await
+            }
+        }
+    }
+
+    /// Returns an async connection from the client, using the same logic from
+    /// `SentinelClient::get_connection`.
+    #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
+    pub async fn get_async_connection(&self) -> RedisResult<crate::aio::Connection> {
+        let client = self.async_get_client().await?;
+        client.get_async_connection().await
+    }
+}

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -108,8 +108,9 @@ use futures_util::StreamExt;
 use rand::Rng;
 
 use crate::{
-    aio::Connection as AsyncConnection, connection::ConnectionInfo, types::RedisResult, Client,
-    Cmd, Connection, ErrorKind, FromRedisValue, IntoConnectionInfo, RedisConnectionInfo, Value,
+    aio::MultiplexedConnection as AsyncConnection, connection::ConnectionInfo, types::RedisResult,
+    Client, Cmd, Connection, ErrorKind, FromRedisValue, IntoConnectionInfo, RedisConnectionInfo,
+    Value,
 };
 
 /// The Sentinel type, serves as a special purpose client which builds other clients on
@@ -365,7 +366,7 @@ async fn async_reconnect(
     connection_info: &ConnectionInfo,
 ) -> RedisResult<()> {
     let sentinel_client = Client::open(connection_info.clone())?;
-    let new_connection = sentinel_client.get_async_connection().await?;
+    let new_connection = sentinel_client.get_multiplexed_async_connection().await?;
     connection.replace(new_connection);
     Ok(())
 }
@@ -752,8 +753,8 @@ impl SentinelClient {
     /// Returns an async connection from the client, using the same logic from
     /// `SentinelClient::get_connection`.
     #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
-    pub async fn get_async_connection(&mut self) -> RedisResult<crate::aio::Connection> {
+    pub async fn get_async_connection(&mut self) -> RedisResult<AsyncConnection> {
         let client = self.async_get_client().await?;
-        client.get_async_connection().await
+        client.get_multiplexed_async_connection().await
     }
 }

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -386,6 +386,13 @@ impl Sentinel {
     /// Creates a Sentinel client performing some basic
     /// checks on the URLs that might make the operation fail.
     pub fn build<T: IntoConnectionInfo>(params: Vec<T>) -> RedisResult<Sentinel> {
+        if params.is_empty() {
+            fail!((
+                ErrorKind::EmptySentinelList,
+                "At least one sentinel is required",
+            ))
+        }
+
         Ok(Sentinel {
             sentinels_connection_info: params
                 .into_iter()

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -227,7 +227,7 @@ fn try_connect_to_first_replica(
 ) -> Result<Client, crate::RedisError> {
     if addresses.is_empty() {
         fail!((
-            ErrorKind::NoValidReplicasFound,
+            ErrorKind::NoValidReplicasFoundBySentinel,
             "No valid replica found in sentinel for given name",
         ));
     }
@@ -302,7 +302,7 @@ fn find_valid_master(
     }
 
     fail!((
-        ErrorKind::MasterNameNotFound,
+        ErrorKind::MasterNameNotFoundBySentinel,
         "Master with given name not found in sentinel",
     ))
 }
@@ -333,7 +333,7 @@ async fn async_find_valid_master(
     }
 
     fail!((
-        ErrorKind::MasterNameNotFound,
+        ErrorKind::MasterNameNotFoundBySentinel,
         "Master with given name not found in sentinel",
     ))
 }

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -101,13 +101,11 @@
 //! ```
 //!
 
-use std::{
-    collections::HashMap,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::collections::HashMap;
 
 #[cfg(feature = "aio")]
 use futures_util::StreamExt;
+use rand::Rng;
 
 use crate::{
     aio::Connection as AsyncConnection, connection::ConnectionInfo, types::RedisResult, Client,
@@ -211,15 +209,7 @@ fn is_replica_valid(replica_info: &HashMap<String, String>) -> bool {
 }
 
 fn random_replica_index(max: usize) -> usize {
-    if max == 0 {
-        0
-    } else {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .subsec_nanos();
-        (nanos as usize) % max
-    }
+    rand::thread_rng().gen_range(0..max)
 }
 
 fn try_connect_to_first_replica(

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -209,8 +209,16 @@ fn is_replica_valid(replica_info: &HashMap<String, String>) -> bool {
         && replica_info["port"].parse::<u16>().is_ok()
 }
 
+/// Generates a random value in the 0..max range. If max is zero, the returned value is
+/// also zero.
 fn random_replica_index(max: usize) -> usize {
-    rand::thread_rng().gen_range(0..max)
+    if max == 0 {
+        // This is just to avoid panicking in the gen_range function, this value does
+        // not have any special meaning, and is not expected to be used.
+        0
+    } else {
+        rand::thread_rng().gen_range(0..max)
+    }
 }
 
 fn try_connect_to_first_replica(

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -69,7 +69,7 @@
 //!     .master_for(
 //!         "master_name",
 //!         Some(&SentinelNodeConnectionInfo {
-//!             tls_mode: Some(redis::sentinel::TlsMode::Secure),
+//!             tls_mode: Some(redis::cluster::TlsMode::Secure),
 //!             redis_connection_info: None,
 //!         }),
 //!     )
@@ -88,7 +88,7 @@
 //!     nodes,
 //!     String::from("master1"),
 //!     Some(SentinelNodeConnectionInfo {
-//!         tls_mode: Some(redis::sentinel::TlsMode::Insecure),
+//!         tls_mode: Some(redis::cluster::TlsMode::Insecure),
 //!         redis_connection_info: Some(RedisConnectionInfo {
 //!             db: 0,
 //!             username: Some(String::from("user")),
@@ -108,9 +108,9 @@ use futures_util::StreamExt;
 use rand::Rng;
 
 use crate::{
-    aio::MultiplexedConnection as AsyncConnection, connection::ConnectionInfo, types::RedisResult,
-    Client, Cmd, Connection, ErrorKind, FromRedisValue, IntoConnectionInfo, RedisConnectionInfo,
-    Value,
+    aio::MultiplexedConnection as AsyncConnection, cluster::TlsMode, connection::ConnectionInfo,
+    types::RedisResult, Client, Cmd, Connection, ErrorKind, FromRedisValue, IntoConnectionInfo,
+    RedisConnectionInfo, Value,
 };
 
 /// The Sentinel type, serves as a special purpose client which builds other clients on
@@ -120,16 +120,6 @@ pub struct Sentinel {
     connections_cache: Vec<Option<Connection>>,
     async_connections_cache: Vec<Option<AsyncConnection>>,
     replica_start_index: usize,
-}
-
-/// TlsMode indicates use or do not use verification of certification.
-/// Check [ConnectionAddr](ConnectionAddr::TcpTls::insecure) for more.
-#[derive(Clone, Copy)]
-pub enum TlsMode {
-    /// Secure verify certification.
-    Secure,
-    /// Insecure do not verify certification.
-    Insecure,
 }
 
 /// Holds the connection information that a sentinel should use when connecting to the

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -109,9 +109,8 @@ use std::{
 use futures_util::StreamExt;
 
 use crate::{
-    aio::Connection as AsyncConnection, cluster::TlsMode, connection::ConnectionInfo,
-    types::RedisResult, Client, Cmd, Connection, ErrorKind, FromRedisValue, IntoConnectionInfo,
-    RedisConnectionInfo, Value,
+    aio::Connection as AsyncConnection, connection::ConnectionInfo, types::RedisResult, Client,
+    Cmd, Connection, ErrorKind, FromRedisValue, IntoConnectionInfo, RedisConnectionInfo, Value,
 };
 
 /// The Sentinel type, serves as a special purpose client which builds other clients on
@@ -121,6 +120,16 @@ pub struct Sentinel {
     connections_cache: Vec<Option<Connection>>,
     async_connections_cache: Vec<Option<AsyncConnection>>,
     replica_start_index: usize,
+}
+
+/// TlsMode indicates use or do not use verification of certification.
+/// Check [ConnectionAddr](ConnectionAddr::TcpTls::insecure) for more.
+#[derive(Clone, Copy)]
+pub enum TlsMode {
+    /// Secure verify certification.
+    Secure,
+    /// Insecure do not verify certification.
+    Insecure,
 }
 
 /// Holds the connection information that a sentinel should use when connecting to the

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -359,6 +359,7 @@ async fn async_get_valid_replicas_addresses<'a>(
         .await
 }
 
+#[cfg(feature = "aio")]
 async fn async_reconnect(
     connection: &mut Option<AsyncConnection>,
     connection_info: &ConnectionInfo,
@@ -369,6 +370,7 @@ async fn async_reconnect(
     Ok(())
 }
 
+#[cfg(feature = "aio")]
 async fn async_try_single_sentinel<T: FromRedisValue>(
     cmd: Cmd,
     connection_info: &ConnectionInfo,

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -69,7 +69,7 @@
 //!     .master_for(
 //!         "master_name",
 //!         Some(&SentinelNodeConnectionInfo {
-//!             tls_mode: Some(redis::cluster::TlsMode::Secure),
+//!             tls_mode: Some(redis::TlsMode::Secure),
 //!             redis_connection_info: None,
 //!         }),
 //!     )
@@ -88,7 +88,7 @@
 //!     nodes,
 //!     String::from("master1"),
 //!     Some(SentinelNodeConnectionInfo {
-//!         tls_mode: Some(redis::cluster::TlsMode::Insecure),
+//!         tls_mode: Some(redis::TlsMode::Insecure),
 //!         redis_connection_info: Some(RedisConnectionInfo {
 //!             db: 0,
 //!             username: Some(String::from("user")),
@@ -108,9 +108,9 @@ use futures_util::StreamExt;
 use rand::Rng;
 
 use crate::{
-    aio::MultiplexedConnection as AsyncConnection, cluster::TlsMode, connection::ConnectionInfo,
-    types::RedisResult, Client, Cmd, Connection, ErrorKind, FromRedisValue, IntoConnectionInfo,
-    RedisConnectionInfo, Value,
+    aio::MultiplexedConnection as AsyncConnection, connection::ConnectionInfo, types::RedisResult,
+    Client, Cmd, Connection, ErrorKind, FromRedisValue, IntoConnectionInfo, RedisConnectionInfo,
+    TlsMode, Value,
 };
 
 /// The Sentinel type, serves as a special purpose client which builds other clients on

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -121,10 +121,10 @@ pub enum ErrorKind {
     ExtensionError,
     /// Attempt to write to a read-only server
     ReadOnly,
-    /// Requested name not found among masters
-    MasterNameNotFound,
-    /// No valid replicas found for given master name
-    NoValidReplicasFound,
+    /// Requested name not found among masters returned by the sentinels
+    MasterNameNotFoundBySentinel,
+    /// No valid replicas found in the sentinels, for a given master name
+    NoValidReplicasFoundBySentinel,
     /// At least one sentinel connection info is required
     EmptySentinelList,
 
@@ -495,8 +495,8 @@ impl RedisError {
             ErrorKind::ExtensionError => "extension error",
             ErrorKind::ClientError => "client error",
             ErrorKind::ReadOnly => "read-only",
-            ErrorKind::MasterNameNotFound => "master name not found",
-            ErrorKind::NoValidReplicasFound => "no valid replicas found",
+            ErrorKind::MasterNameNotFoundBySentinel => "master name not found by sentinel",
+            ErrorKind::NoValidReplicasFoundBySentinel => "no valid replicas found by sentinel",
             ErrorKind::EmptySentinelList => "empty sentinel list",
             #[cfg(feature = "json")]
             ErrorKind::Serialize => "serializing",

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -635,6 +635,8 @@ impl RedisError {
             ErrorKind::IoError => true,
             ErrorKind::ReadOnly => true,
             ErrorKind::ClusterDown => true,
+            ErrorKind::MasterNameNotFoundBySentinel => true,
+            ErrorKind::NoValidReplicasFoundBySentinel => true,
 
             ErrorKind::ExtensionError => false,
             ErrorKind::ExecAbortError => false,
@@ -645,6 +647,7 @@ impl RedisError {
             ErrorKind::InvalidClientConfig => false,
             ErrorKind::CrossSlot => false,
             ErrorKind::ClientError => false,
+            ErrorKind::EmptySentinelList => false,
             #[cfg(feature = "json")]
             ErrorKind::Serialize => false,
         }

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -121,6 +121,10 @@ pub enum ErrorKind {
     ExtensionError,
     /// Attempt to write to a read-only server
     ReadOnly,
+    /// Requested name not found among masters
+    MasterNameNotFound,
+    /// No valid replicas found for given master name
+    NoValidReplicasFound,
 
     #[cfg(feature = "json")]
     /// Error Serializing a struct to JSON form
@@ -489,6 +493,8 @@ impl RedisError {
             ErrorKind::ExtensionError => "extension error",
             ErrorKind::ClientError => "client error",
             ErrorKind::ReadOnly => "read-only",
+            ErrorKind::MasterNameNotFound => "master name not found",
+            ErrorKind::NoValidReplicasFound => "no valid replicas found",
             #[cfg(feature = "json")]
             ErrorKind::Serialize => "serializing",
         }

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -125,6 +125,8 @@ pub enum ErrorKind {
     MasterNameNotFound,
     /// No valid replicas found for given master name
     NoValidReplicasFound,
+    /// At least one sentinel connection info is required
+    EmptySentinelList,
 
     #[cfg(feature = "json")]
     /// Error Serializing a struct to JSON form
@@ -495,6 +497,7 @@ impl RedisError {
             ErrorKind::ReadOnly => "read-only",
             ErrorKind::MasterNameNotFound => "master name not found",
             ErrorKind::NoValidReplicasFound => "no valid replicas found",
+            ErrorKind::EmptySentinelList => "empty sentinel list",
             #[cfg(feature = "json")]
             ErrorKind::Serialize => "serializing",
         }

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -98,6 +98,7 @@ impl RedisCluster {
 
             servers.push(RedisServer::new_with_addr_tls_modules_and_spawner(
                 ClusterType::build_addr(port),
+                None,
                 tls_paths.clone(),
                 modules,
                 |cmd| {

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -50,7 +50,10 @@ pub use self::cluster::*;
 #[cfg(any(feature = "cluster", feature = "cluster-async"))]
 pub use self::mock_cluster::*;
 
+#[cfg(feature = "sentinel")]
 mod sentinel;
+
+#[cfg(feature = "sentinel")]
 pub use self::sentinel::*;
 
 #[derive(PartialEq)]

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use std::path::Path;
 use std::{
     env, fs, io, net::SocketAddr, net::TcpListener, path::PathBuf, process, thread::sleep,
     time::Duration,
@@ -48,6 +49,9 @@ pub use self::cluster::*;
 
 #[cfg(any(feature = "cluster", feature = "cluster-async"))]
 pub use self::mock_cluster::*;
+
+mod sentinel;
+pub use self::sentinel::*;
 
 #[derive(PartialEq)]
 enum ServerType {
@@ -124,7 +128,7 @@ impl RedisServer {
         addr: redis::ConnectionAddr,
         modules: &[Module],
     ) -> RedisServer {
-        RedisServer::new_with_addr_tls_modules_and_spawner(addr, None, modules, |cmd| {
+        RedisServer::new_with_addr_tls_modules_and_spawner(addr, None, None, modules, |cmd| {
             cmd.spawn()
                 .unwrap_or_else(|err| panic!("Failed to run {cmd:?}: {err}"))
         })
@@ -134,11 +138,16 @@ impl RedisServer {
         F: FnOnce(&mut process::Command) -> process::Child,
     >(
         addr: redis::ConnectionAddr,
+        config_file: Option<&Path>,
         tls_paths: Option<TlsFilePaths>,
         modules: &[Module],
         spawner: F,
     ) -> RedisServer {
         let mut redis_cmd = process::Command::new("redis-server");
+
+        if let Some(config_path) = config_file {
+            redis_cmd.arg(config_path);
+        }
 
         // Load Redis Modules
         for module in modules {

--- a/redis/tests/support/sentinel.rs
+++ b/redis/tests/support/sentinel.rs
@@ -3,8 +3,7 @@ use std::io::Write;
 use std::thread::sleep;
 use std::time::Duration;
 
-use redis::cluster::TlsMode;
-use redis::sentinel::SentinelNodeConnectionInfo;
+use redis::sentinel::{SentinelNodeConnectionInfo, TlsMode};
 use redis::ConnectionAddr;
 use redis::ConnectionInfo;
 use tempfile::TempDir;

--- a/redis/tests/support/sentinel.rs
+++ b/redis/tests/support/sentinel.rs
@@ -240,7 +240,7 @@ impl TestSentinelContext {
         let sentinel = redis::sentinel::Sentinel::build(initial_nodes.clone());
         let sentinel = sentinel.unwrap();
 
-        let context = TestSentinelContext {
+        let mut context = TestSentinelContext {
             cluster,
             sentinel,
             sentinels_connection_info: initial_nodes,
@@ -278,10 +278,10 @@ impl TestSentinelContext {
         }
     }
 
-    pub fn wait_for_cluster_up(&self) {
-        let con = self.sentinel();
-        let rolecmd = redis::cmd("ROLE");
+    pub fn wait_for_cluster_up(&mut self) {
         let node_conn_info = self.sentinel_node_connection_info();
+        let con = self.sentinel_mut();
+        let rolecmd = redis::cmd("ROLE");
 
         for _ in 0..100 {
             let master_client = con.master_for("master1", Some(&node_conn_info));

--- a/redis/tests/support/sentinel.rs
+++ b/redis/tests/support/sentinel.rs
@@ -27,7 +27,6 @@ fn spawn_master_server(port: u16, dir: &TempDir, modules: &[Module]) -> RedisSer
         |cmd| {
             // Minimize startup delay
             cmd.arg("--repl-diskless-sync-delay").arg("0");
-            // cmd.arg("--repl-ping-replica-period").arg("1");
             cmd.arg("--appendonly").arg("yes");
             cmd.current_dir(dir.path());
             cmd.spawn().unwrap()
@@ -53,13 +52,7 @@ fn spawn_replica_server(
             cmd.arg("--replicaof")
                 .arg("127.0.0.1")
                 .arg(master_port.to_string());
-            // Minimize startup delay
-            // cmd.arg("--repl-diskless-sync-delay").arg("0");
-            // cmd.arg("--repl-ping-replica-period").arg("1");
             cmd.arg("--appendonly").arg("yes");
-            // cmd.stdout(std::process::Stdio::inherit())
-            //     .stderr(std::process::Stdio::inherit());
-            // cmd.arg("--loglevel").arg("debug");
             cmd.current_dir(dir.path());
             cmd.spawn().unwrap()
         },
@@ -79,12 +72,6 @@ fn spawn_sentinel_server(
             format!("sentinel monitor master{} 127.0.0.1 {} 1\n", i, master_port).as_bytes(),
         )
         .unwrap();
-        // file.write_all(format!("sentinel down-after-milliseconds master{} 200\n", i).as_bytes())
-        //     .unwrap();
-        // file.write_all(format!("sentinel parallel-syncs master{} 1\n", i).as_bytes())
-        //     .unwrap();
-        // file.write_all(format!("sentinel failover-timeout master{} 5000\n", i).as_bytes())
-        //     .unwrap();
     }
     file.flush().unwrap();
 
@@ -94,9 +81,6 @@ fn spawn_sentinel_server(
         None,
         modules,
         |cmd| {
-            // cmd.stdout(std::process::Stdio::inherit())
-            //     .stderr(std::process::Stdio::inherit());
-            // cmd.arg("--loglevel").arg("debug");
             cmd.arg("--sentinel");
             cmd.arg("--appendonly").arg("yes");
             cmd.current_dir(dir.path());
@@ -122,7 +106,6 @@ impl RedisSentinelCluster {
 
         for _ in 0..masters {
             let port = get_random_available_port();
-            sleep(Duration::from_millis(25));
             let tempdir = tempfile::Builder::new()
                 .prefix("redis")
                 .tempdir()
@@ -148,7 +131,6 @@ impl RedisSentinelCluster {
         let mut sentinel_servers = vec![];
         for _ in 0..sentinels {
             let port = get_random_available_port();
-            sleep(Duration::from_millis(25));
             let tempdir = tempfile::Builder::new()
                 .prefix("redis")
                 .tempdir()

--- a/redis/tests/support/sentinel.rs
+++ b/redis/tests/support/sentinel.rs
@@ -37,7 +37,7 @@ fn spawn_master_server(
     tlspaths: &TlsFilePaths,
     modules: &[Module],
 ) -> RedisServer {
-    RedisServer::new_with_addr(
+    RedisServer::new_with_addr_tls_modules_and_spawner(
         get_addr(port),
         None,
         Some(tlspaths.clone()),
@@ -65,7 +65,7 @@ fn spawn_replica_server(
     let config_file_path = dir.path().join("redis_config.conf");
     File::create(&config_file_path).unwrap();
 
-    RedisServer::new_with_addr(
+    RedisServer::new_with_addr_tls_modules_and_spawner(
         get_addr(port),
         Some(&config_file_path),
         Some(tlspaths.clone()),
@@ -101,7 +101,7 @@ fn spawn_sentinel_server(
     }
     file.flush().unwrap();
 
-    RedisServer::new_with_addr(
+    RedisServer::new_with_addr_tls_modules_and_spawner(
         get_addr(port),
         Some(&config_file_path),
         Some(tlspaths.clone()),

--- a/redis/tests/support/sentinel.rs
+++ b/redis/tests/support/sentinel.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use redis::ConnectionInfo;
 use tempfile::TempDir;
 
+use super::get_random_available_port;
 use super::Module;
 use super::RedisServer;
 
@@ -118,10 +119,10 @@ impl RedisSentinelCluster {
         let mut servers = vec![];
         let mut folders = vec![];
         let mut master_ports = vec![];
-        let start_port = 7000;
 
-        for node in 0..masters {
-            let port = start_port + (node * (replicas_per_master + 1));
+        for _ in 0..masters {
+            let port = get_random_available_port();
+            sleep(Duration::from_millis(25));
             let tempdir = tempfile::Builder::new()
                 .prefix("redis")
                 .tempdir()
@@ -130,8 +131,8 @@ impl RedisSentinelCluster {
             folders.push(tempdir);
             master_ports.push(port);
 
-            for replica in 0..replicas_per_master {
-                let replica_port = port + 1 + replica;
+            for _ in 0..replicas_per_master {
+                let replica_port = get_random_available_port();
                 let tempdir = tempfile::Builder::new()
                     .prefix("redis")
                     .tempdir()
@@ -145,9 +146,9 @@ impl RedisSentinelCluster {
         sleep(Duration::from_millis(50));
 
         let mut sentinel_servers = vec![];
-        let start_port = 27000;
-        for node in 0..sentinels {
-            let port = start_port + node;
+        for _ in 0..sentinels {
+            let port = get_random_available_port();
+            sleep(Duration::from_millis(25));
             let tempdir = tempfile::Builder::new()
                 .prefix("redis")
                 .tempdir()

--- a/redis/tests/support/sentinel.rs
+++ b/redis/tests/support/sentinel.rs
@@ -3,7 +3,8 @@ use std::io::Write;
 use std::thread::sleep;
 use std::time::Duration;
 
-use redis::sentinel::{SentinelNodeConnectionInfo, TlsMode};
+use redis::cluster::TlsMode;
+use redis::sentinel::SentinelNodeConnectionInfo;
 use redis::ConnectionAddr;
 use redis::ConnectionInfo;
 use tempfile::TempDir;

--- a/redis/tests/support/sentinel.rs
+++ b/redis/tests/support/sentinel.rs
@@ -1,0 +1,271 @@
+use std::fs::File;
+use std::io::Write;
+use std::thread::sleep;
+use std::time::Duration;
+
+use redis::ConnectionInfo;
+use tempfile::TempDir;
+
+use super::Module;
+use super::RedisServer;
+
+const LOCALHOST: &str = "127.0.0.1";
+
+pub struct RedisSentinelCluster {
+    pub servers: Vec<RedisServer>,
+    pub sentinel_servers: Vec<RedisServer>,
+    pub folders: Vec<TempDir>,
+}
+
+fn spawn_master_server(port: u16, dir: &TempDir, modules: &[Module]) -> RedisServer {
+    RedisServer::new_with_addr(
+        redis::ConnectionAddr::Tcp("127.0.0.1".into(), port),
+        None,
+        None,
+        modules,
+        |cmd| {
+            // Minimize startup delay
+            cmd.arg("--repl-diskless-sync-delay").arg("0");
+            // cmd.arg("--repl-ping-replica-period").arg("1");
+            cmd.arg("--appendonly").arg("yes");
+            cmd.current_dir(dir.path());
+            cmd.spawn().unwrap()
+        },
+    )
+}
+
+fn spawn_replica_server(
+    port: u16,
+    master_port: u16,
+    dir: &TempDir,
+    modules: &[Module],
+) -> RedisServer {
+    let config_file_path = dir.path().join("redis_config.conf");
+    File::create(&config_file_path).unwrap();
+
+    RedisServer::new_with_addr(
+        redis::ConnectionAddr::Tcp("127.0.0.1".into(), port),
+        Some(&config_file_path),
+        None,
+        modules,
+        |cmd| {
+            cmd.arg("--replicaof")
+                .arg("127.0.0.1")
+                .arg(master_port.to_string());
+            // Minimize startup delay
+            // cmd.arg("--repl-diskless-sync-delay").arg("0");
+            // cmd.arg("--repl-ping-replica-period").arg("1");
+            cmd.arg("--appendonly").arg("yes");
+            // cmd.stdout(std::process::Stdio::inherit())
+            //     .stderr(std::process::Stdio::inherit());
+            // cmd.arg("--loglevel").arg("debug");
+            cmd.current_dir(dir.path());
+            cmd.spawn().unwrap()
+        },
+    )
+}
+
+fn spawn_sentinel_server(
+    port: u16,
+    master_ports: &[u16],
+    dir: &TempDir,
+    modules: &[Module],
+) -> RedisServer {
+    let config_file_path = dir.path().join("redis_config.conf");
+    let mut file = File::create(&config_file_path).unwrap();
+    for (i, master_port) in master_ports.iter().enumerate() {
+        file.write_all(
+            format!("sentinel monitor master{} 127.0.0.1 {} 1\n", i, master_port).as_bytes(),
+        )
+        .unwrap();
+        // file.write_all(format!("sentinel down-after-milliseconds master{} 200\n", i).as_bytes())
+        //     .unwrap();
+        // file.write_all(format!("sentinel parallel-syncs master{} 1\n", i).as_bytes())
+        //     .unwrap();
+        // file.write_all(format!("sentinel failover-timeout master{} 5000\n", i).as_bytes())
+        //     .unwrap();
+    }
+    file.flush().unwrap();
+
+    RedisServer::new_with_addr(
+        redis::ConnectionAddr::Tcp("127.0.0.1".into(), port),
+        Some(&config_file_path),
+        None,
+        modules,
+        |cmd| {
+            // cmd.stdout(std::process::Stdio::inherit())
+            //     .stderr(std::process::Stdio::inherit());
+            // cmd.arg("--loglevel").arg("debug");
+            cmd.arg("--sentinel");
+            cmd.arg("--appendonly").arg("yes");
+            cmd.current_dir(dir.path());
+            cmd.spawn().unwrap()
+        },
+    )
+}
+
+impl RedisSentinelCluster {
+    pub fn new(masters: u16, replicas_per_master: u16, sentinels: u16) -> RedisSentinelCluster {
+        RedisSentinelCluster::with_modules(masters, replicas_per_master, sentinels, &[])
+    }
+
+    pub fn with_modules(
+        masters: u16,
+        replicas_per_master: u16,
+        sentinels: u16,
+        modules: &[Module],
+    ) -> RedisSentinelCluster {
+        let mut servers = vec![];
+        let mut folders = vec![];
+        let mut master_ports = vec![];
+        let start_port = 7000;
+
+        for node in 0..masters {
+            let port = start_port + (node * (replicas_per_master + 1));
+            let tempdir = tempfile::Builder::new()
+                .prefix("redis")
+                .tempdir()
+                .expect("failed to create tempdir");
+            servers.push(spawn_master_server(port, &tempdir, modules));
+            folders.push(tempdir);
+            master_ports.push(port);
+
+            for replica in 0..replicas_per_master {
+                let replica_port = port + 1 + replica;
+                let tempdir = tempfile::Builder::new()
+                    .prefix("redis")
+                    .tempdir()
+                    .expect("failed to create tempdir");
+                servers.push(spawn_replica_server(replica_port, port, &tempdir, modules));
+                folders.push(tempdir);
+            }
+        }
+
+        // Wait for replicas to sync so that the sentinels discover them on the first try
+        sleep(Duration::from_millis(50));
+
+        let mut sentinel_servers = vec![];
+        let start_port = 27000;
+        for node in 0..sentinels {
+            let port = start_port + node;
+            let tempdir = tempfile::Builder::new()
+                .prefix("redis")
+                .tempdir()
+                .expect("failed to create tempdir");
+
+            sentinel_servers.push(spawn_sentinel_server(
+                port,
+                &master_ports,
+                &tempdir,
+                modules,
+            ));
+            folders.push(tempdir);
+        }
+
+        RedisSentinelCluster {
+            servers,
+            sentinel_servers,
+            folders,
+        }
+    }
+
+    pub fn stop(&mut self) {
+        for server in &mut self.servers {
+            server.stop();
+        }
+        for server in &mut self.sentinel_servers {
+            server.stop();
+        }
+    }
+
+    pub fn iter_sentinel_servers(&self) -> impl Iterator<Item = &RedisServer> {
+        self.sentinel_servers.iter()
+    }
+}
+
+impl Drop for RedisSentinelCluster {
+    fn drop(&mut self) {
+        self.stop()
+    }
+}
+
+pub struct TestSentinelContext {
+    pub cluster: RedisSentinelCluster,
+    pub sentinel: redis::sentinel::Sentinel,
+    pub sentinels_connection_info: Vec<ConnectionInfo>,
+}
+
+impl TestSentinelContext {
+    pub fn new(nodes: u16, replicas: u16, sentinels: u16) -> TestSentinelContext {
+        Self::new_with_cluster_client_builder(nodes, replicas, sentinels)
+    }
+
+    pub fn new_with_cluster_client_builder(
+        nodes: u16,
+        replicas: u16,
+        sentinels: u16,
+    ) -> TestSentinelContext {
+        let cluster = RedisSentinelCluster::new(nodes, replicas, sentinels);
+        let initial_nodes: Vec<ConnectionInfo> = cluster
+            .iter_sentinel_servers()
+            .map(RedisServer::connection_info)
+            .collect();
+        let sentinel = redis::sentinel::Sentinel::build(initial_nodes.clone());
+        let sentinel = sentinel.unwrap();
+
+        let context = TestSentinelContext {
+            cluster,
+            sentinel,
+            sentinels_connection_info: initial_nodes,
+        };
+        context.wait_for_cluster_up();
+        context
+    }
+
+    pub fn sentinel(&self) -> &redis::sentinel::Sentinel {
+        &self.sentinel
+    }
+
+    pub fn sentinel_mut(&mut self) -> &mut redis::sentinel::Sentinel {
+        &mut self.sentinel
+    }
+
+    pub fn sentinels_connection_info(&self) -> &Vec<ConnectionInfo> {
+        &self.sentinels_connection_info
+    }
+
+    pub fn wait_for_cluster_up(&self) {
+        let con = self.sentinel();
+        let rolecmd = redis::cmd("ROLE");
+
+        for _ in 0..100 {
+            let master_client = con.master_for("master1");
+            if let Ok(master_client) = master_client {
+                let r: (String, i32, redis::Value) = rolecmd
+                    .query(&mut master_client.get_connection().unwrap())
+                    .unwrap();
+                if r.0.starts_with("master") {
+                    break;
+                }
+            }
+
+            sleep(Duration::from_millis(25));
+        }
+
+        for _ in 0..200 {
+            let replica_client = con.replica_for("master1");
+            if let Ok(client) = replica_client {
+                let r: (String, String, i32, String, i32) = rolecmd
+                    .query(&mut client.get_connection().unwrap())
+                    .unwrap();
+                if r.0.starts_with("slave") {
+                    return;
+                }
+            }
+
+            sleep(Duration::from_millis(25));
+        }
+
+        panic!("failed waiting for sentinel cluster to be ready");
+    }
+}

--- a/redis/tests/support/sentinel.rs
+++ b/redis/tests/support/sentinel.rs
@@ -120,46 +120,55 @@ fn spawn_sentinel_server(
     )
 }
 
-fn wait_for_replicas_to_sync(servers: &Vec<RedisServer>, masters: u16) {
+fn wait_for_master_server(master_addr: ConnectionInfo) {
     let rolecmd = redis::cmd("ROLE");
+    for _ in 0..100 {
+        let master_client = Client::open(master_addr.clone()).unwrap();
+        if let Ok(mut conn) = master_client.get_connection() {
+            let r: (String, i32, redis::Value) = rolecmd.query(&mut conn).unwrap();
+            if r.0.starts_with("master") {
+                return;
+            }
+        }
 
+        sleep(Duration::from_millis(25));
+    }
+
+    panic!("failed waiting for master to be ready");
+}
+
+fn wait_for_replica(replica_addr: ConnectionInfo) {
+    let rolecmd = redis::cmd("ROLE");
+    for _ in 0..200 {
+        let replica_client = Client::open(replica_addr.clone()).unwrap();
+        if let Ok(mut conn) = replica_client.get_connection() {
+            let r: (String, String, i32, String, i32) = rolecmd.query(&mut conn).unwrap();
+            if r.0.starts_with("slave") && r.3 == "connected" {
+                return;
+            }
+        }
+
+        sleep(Duration::from_millis(25));
+    }
+
+    panic!("failed waiting for replica to be ready and in sync");
+}
+
+fn wait_for_replicas_to_sync(servers: &Vec<RedisServer>, masters: u16) {
     let cluster_size = servers.len() / (masters as usize);
     let clusters = servers.len() / cluster_size;
     let replicas = cluster_size - 1;
 
     for cluster_index in 0..clusters {
         let master_addr = servers[cluster_index * cluster_size].connection_info();
-        for _ in 0..100 {
-            let master_client = Client::open(master_addr.clone()).unwrap();
-            if let Ok(mut conn) = master_client.get_connection() {
-                let r: (String, i32, redis::Value) = rolecmd.query(&mut conn).unwrap();
-                if r.0.starts_with("master") {
-                    break;
-                }
-            }
-
-            sleep(Duration::from_millis(25));
-        }
+        wait_for_master_server(master_addr);
 
         for replica_index in 0..replicas {
             let replica_addr =
                 servers[(cluster_index * cluster_size) + 1 + replica_index].connection_info();
-
-            for _ in 0..200 {
-                let replica_client = Client::open(replica_addr.clone()).unwrap();
-                if let Ok(mut conn) = replica_client.get_connection() {
-                    let r: (String, String, i32, String, i32) = rolecmd.query(&mut conn).unwrap();
-                    if r.0.starts_with("slave") {
-                        return;
-                    }
-                }
-
-                sleep(Duration::from_millis(25));
-            }
+            wait_for_replica(replica_addr);
         }
     }
-
-    panic!("failed waiting for master and replicas to be ready and in sync");
 }
 
 impl RedisSentinelCluster {

--- a/redis/tests/support/sentinel.rs
+++ b/redis/tests/support/sentinel.rs
@@ -3,11 +3,11 @@ use std::io::Write;
 use std::thread::sleep;
 use std::time::Duration;
 
-use redis::cluster::TlsMode;
 use redis::sentinel::SentinelNodeConnectionInfo;
 use redis::Client;
 use redis::ConnectionAddr;
 use redis::ConnectionInfo;
+use redis::TlsMode;
 use tempfile::TempDir;
 
 use super::build_keys_and_certs_for_tls;

--- a/redis/tests/test_sentinel.rs
+++ b/redis/tests/test_sentinel.rs
@@ -1,8 +1,53 @@
 mod support;
 
-use redis::sentinel::SentinelClient;
+use std::collections::HashMap;
+
+use redis::{sentinel::SentinelClient, Client, Connection, ConnectionAddr};
 
 use crate::support::*;
+
+fn parse_replication_info(value: &str) -> HashMap<&str, &str> {
+    let info_map: std::collections::HashMap<&str, &str> = value
+        .split("\r\n")
+        .filter(|line| !line.trim_start().starts_with('#'))
+        .filter_map(|line| line.split_once(':'))
+        .collect();
+    info_map
+}
+
+fn check_master_role(conn: &mut Connection) {
+    let info: String = redis::cmd("INFO").arg("REPLICATION").query(conn).unwrap();
+
+    let info_map = parse_replication_info(&info);
+    assert_eq!(info_map.get("role"), Some(&"master"));
+}
+
+fn check_replica_info_result(info: String, master_client: &Client) {
+    let info_map = parse_replication_info(&info);
+
+    assert_eq!(info_map.get("role"), Some(&"slave"));
+
+    let (master_host, master_port) = match &master_client.get_connection_info().addr {
+        ConnectionAddr::Tcp(host, port) => (host, port),
+        ConnectionAddr::TcpTls {
+            host,
+            port,
+            insecure: _,
+        } => (host, port),
+        ConnectionAddr::Unix(..) => panic!("Unexpected master connection type"),
+    };
+
+    assert_eq!(info_map.get("master_host"), Some(&master_host.as_str()));
+    assert_eq!(
+        info_map.get("master_port"),
+        Some(&master_port.to_string().as_str())
+    );
+}
+
+fn check_replica_role_and_master(conn: &mut Connection, master_client: &Client) {
+    let info: String = redis::cmd("INFO").arg("REPLICATION").query(conn).unwrap();
+    check_replica_info_result(info, master_client);
+}
 
 #[test]
 fn test_sentinel_basics() {
@@ -15,20 +60,7 @@ fn test_sentinel_basics() {
         .get_connection()
         .unwrap();
 
-    redis::cmd("SET")
-        .arg("{x}key1")
-        .arg(b"foo")
-        .execute(&mut master_con);
-    redis::cmd("SET")
-        .arg(&["{x}key2", "bar"])
-        .execute(&mut master_con);
-
-    assert_eq!(
-        redis::cmd("MGET")
-            .arg(&["{x}key1", "{x}key2"])
-            .query(&mut master_con),
-        Ok(("foo".to_string(), b"bar".to_vec()))
-    );
+    check_master_role(&mut master_con);
 }
 
 #[test]
@@ -36,11 +68,8 @@ fn test_sentinel_read_from_random_replica() {
     let cluster = TestSentinelContext::new(3, 1, 3);
     let sentinel = cluster.sentinel();
 
-    let mut master_con = sentinel
-        .master_for("master1")
-        .unwrap()
-        .get_connection()
-        .unwrap();
+    let master_client = sentinel.master_for("master1").unwrap();
+    let mut master_con = master_client.get_connection().unwrap();
 
     let mut replica_con = sentinel
         .replica_for("master1")
@@ -48,22 +77,8 @@ fn test_sentinel_read_from_random_replica() {
         .get_connection()
         .unwrap();
 
-    // Write commands would go to the primary nodes
-    redis::cmd("SET")
-        .arg("{x}key1")
-        .arg(b"foo")
-        .execute(&mut master_con);
-    redis::cmd("SET")
-        .arg(&["{x}key2", "bar"])
-        .execute(&mut master_con);
-
-    // Read commands would go to the replica nodes
-    assert_eq!(
-        redis::cmd("MGET")
-            .arg(&["{x}key1", "{x}key2"])
-            .query(&mut replica_con),
-        Ok(("foo".to_string(), b"bar".to_vec()))
-    );
+    check_master_role(&mut master_con);
+    check_replica_role_and_master(&mut replica_con, &master_client);
 }
 
 #[test]
@@ -71,20 +86,10 @@ fn test_sentinel_read_from_multiple_replicas() {
     let mut cluster = TestSentinelContext::new(3, 1, 3);
     let sentinel = cluster.sentinel_mut();
 
-    let mut master_con = sentinel
-        .master_for("master1")
-        .unwrap()
-        .get_connection()
-        .unwrap();
+    let master_client = sentinel.master_for("master1").unwrap();
+    let mut master_con = master_client.get_connection().unwrap();
 
-    // Write commands would go to the primary nodes
-    redis::cmd("SET")
-        .arg("{x}key1")
-        .arg(b"foo")
-        .execute(&mut master_con);
-    redis::cmd("SET")
-        .arg(&["{x}key2", "bar"])
-        .execute(&mut master_con);
+    check_master_role(&mut master_con);
 
     for _ in 0..20 {
         let mut replica_con = sentinel
@@ -93,12 +98,7 @@ fn test_sentinel_read_from_multiple_replicas() {
             .get_connection()
             .unwrap();
 
-        assert_eq!(
-            redis::cmd("MGET")
-                .arg(&["{x}key1", "{x}key2"])
-                .query(&mut replica_con),
-            Ok(("foo".to_string(), b"bar".to_vec()))
-        );
+        check_replica_role_and_master(&mut replica_con, &master_client);
     }
 }
 
@@ -107,20 +107,10 @@ fn test_sentinel_server_down() {
     let mut context = TestSentinelContext::new(3, 1, 3);
     let sentinel = context.sentinel_mut();
 
-    let mut master_con = sentinel
-        .master_for("master1")
-        .unwrap()
-        .get_connection()
-        .unwrap();
+    let master_client = sentinel.master_for("master1").unwrap();
+    let mut master_con = master_client.get_connection().unwrap();
 
-    // Write commands would go to the primary nodes
-    redis::cmd("SET")
-        .arg("{x}key1")
-        .arg(b"foo")
-        .execute(&mut master_con);
-    redis::cmd("SET")
-        .arg(&["{x}key2", "bar"])
-        .execute(&mut master_con);
+    check_master_role(&mut master_con);
 
     context.cluster.sentinel_servers[0].stop();
     std::thread::sleep(std::time::Duration::from_millis(25));
@@ -134,18 +124,13 @@ fn test_sentinel_server_down() {
             .get_connection()
             .unwrap();
 
-        assert_eq!(
-            redis::cmd("MGET")
-                .arg(&["{x}key1", "{x}key2"])
-                .query(&mut replica_con),
-            Ok(("foo".to_string(), b"bar".to_vec()))
-        );
+        check_replica_role_and_master(&mut replica_con, &master_client);
     }
 }
 
 #[test]
 fn test_sentinel_client() {
-    let context = TestSentinelContext::new(3, 1, 3);
+    let mut context = TestSentinelContext::new(3, 1, 3);
     let master_client = SentinelClient::build(
         context.sentinels_connection_info().clone(),
         String::from("master1"),
@@ -162,32 +147,44 @@ fn test_sentinel_client() {
 
     let mut master_con = master_client.get_connection().unwrap();
 
-    // Write commands would go to the primary nodes
-    redis::cmd("SET")
-        .arg("{x}key1")
-        .arg(b"foo")
-        .execute(&mut master_con);
-    redis::cmd("SET")
-        .arg(&["{x}key2", "bar"])
-        .execute(&mut master_con);
+    check_master_role(&mut master_con);
+
+    let sentinel = context.sentinel_mut();
+    let master_client = sentinel.master_for("master1").unwrap();
 
     for _ in 0..20 {
         let mut replica_con = replica_client.get_connection().unwrap();
 
-        assert_eq!(
-            redis::cmd("MGET")
-                .arg(&["{x}key1", "{x}key2"])
-                .query(&mut replica_con),
-            Ok(("foo".to_string(), b"bar".to_vec()))
-        );
+        check_replica_role_and_master(&mut replica_con, &master_client);
     }
 }
 
 #[cfg(feature = "aio")]
 pub mod async_tests {
-    use redis::{sentinel::SentinelClient, RedisError, RedisResult};
+    use redis::{aio::Connection, sentinel::SentinelClient, Client, RedisError};
 
-    use crate::support::*;
+    use crate::{check_replica_info_result, parse_replication_info, support::*};
+
+    async fn async_check_master_role(conn: &mut Connection) {
+        let info: String = redis::cmd("INFO")
+            .arg("REPLICATION")
+            .query_async(conn)
+            .await
+            .unwrap();
+
+        let info_map = parse_replication_info(&info);
+        assert_eq!(info_map.get("role"), Some(&"master"));
+    }
+
+    async fn async_check_replica_role_and_master(conn: &mut Connection, master_client: &Client) {
+        let info: String = redis::cmd("INFO")
+            .arg("REPLICATION")
+            .query_async(conn)
+            .await
+            .unwrap();
+
+        check_replica_info_result(info, master_client);
+    }
 
     #[test]
     fn test_sentinel_basics_async() {
@@ -201,21 +198,7 @@ pub mod async_tests {
                 .get_async_connection()
                 .await?;
 
-            redis::cmd("SET")
-                .arg("{x}key1")
-                .arg(b"foo")
-                .query_async(&mut master_con)
-                .await?;
-            redis::cmd("SET")
-                .arg(&["{x}key2", "bar"])
-                .query_async(&mut master_con)
-                .await?;
-
-            let mget_result: RedisResult<(String, Vec<u8>)> = redis::cmd("MGET")
-                .arg(&["{x}key1", "{x}key2"])
-                .query_async(&mut master_con)
-                .await;
-            assert_eq!(mget_result, Ok(("foo".to_string(), b"bar".to_vec())));
+            async_check_master_role(&mut master_con).await;
 
             Ok::<(), RedisError>(())
         })
@@ -228,11 +211,8 @@ pub mod async_tests {
         let sentinel = cluster.sentinel();
 
         block_on_all(async move {
-            let mut master_con = sentinel
-                .async_master_for("master1")
-                .await?
-                .get_async_connection()
-                .await?;
+            let master_client = sentinel.async_master_for("master1").await?;
+            let mut master_con = master_client.get_async_connection().await?;
 
             let mut replica_con = sentinel
                 .async_replica_for("master1")
@@ -240,23 +220,8 @@ pub mod async_tests {
                 .get_async_connection()
                 .await?;
 
-            // Write commands would go to the primary nodes
-            redis::cmd("SET")
-                .arg("{x}key1")
-                .arg(b"foo")
-                .query_async(&mut master_con)
-                .await?;
-            redis::cmd("SET")
-                .arg(&["{x}key2", "bar"])
-                .query_async(&mut master_con)
-                .await?;
-
-            // Read commands to the replica node
-            let mget_result: RedisResult<(String, Vec<u8>)> = redis::cmd("MGET")
-                .arg(&["{x}key1", "{x}key2"])
-                .query_async(&mut replica_con)
-                .await;
-            assert_eq!(mget_result, Ok(("foo".to_string(), b"bar".to_vec())));
+            async_check_master_role(&mut master_con).await;
+            async_check_replica_role_and_master(&mut replica_con, &master_client).await;
 
             Ok::<(), RedisError>(())
         })
@@ -269,22 +234,10 @@ pub mod async_tests {
         let sentinel = cluster.sentinel_mut();
 
         block_on_all(async move {
-            let mut master_con = sentinel
-                .async_master_for("master1")
-                .await?
-                .get_async_connection()
-                .await?;
+            let master_client = sentinel.async_master_for("master1").await?;
+            let mut master_con = master_client.get_async_connection().await?;
 
-            // Write commands would go to the primary nodes
-            redis::cmd("SET")
-                .arg("{x}key1")
-                .arg(b"foo")
-                .query_async(&mut master_con)
-                .await?;
-            redis::cmd("SET")
-                .arg(&["{x}key2", "bar"])
-                .query_async(&mut master_con)
-                .await?;
+            async_check_master_role(&mut master_con).await;
 
             // Read commands to the replica node
             for _ in 0..20 {
@@ -294,11 +247,7 @@ pub mod async_tests {
                     .get_async_connection()
                     .await?;
 
-                let mget_result: RedisResult<(String, Vec<u8>)> = redis::cmd("MGET")
-                    .arg(&["{x}key1", "{x}key2"])
-                    .query_async(&mut replica_con)
-                    .await;
-                assert_eq!(mget_result, Ok(("foo".to_string(), b"bar".to_vec())));
+                async_check_replica_role_and_master(&mut replica_con, &master_client).await;
             }
 
             Ok::<(), RedisError>(())
@@ -313,22 +262,10 @@ pub mod async_tests {
         block_on_all(async move {
             let sentinel = context.sentinel_mut();
 
-            let mut master_con = sentinel
-                .async_master_for("master1")
-                .await?
-                .get_async_connection()
-                .await?;
+            let master_client = sentinel.async_master_for("master1").await?;
+            let mut master_con = master_client.get_async_connection().await?;
 
-            // Write commands would go to the primary nodes
-            redis::cmd("SET")
-                .arg("{x}key1")
-                .arg(b"foo")
-                .query_async(&mut master_con)
-                .await?;
-            redis::cmd("SET")
-                .arg(&["{x}key2", "bar"])
-                .query_async(&mut master_con)
-                .await?;
+            async_check_master_role(&mut master_con).await;
 
             context.cluster.sentinel_servers[0].stop();
             std::thread::sleep(std::time::Duration::from_millis(25));
@@ -343,11 +280,7 @@ pub mod async_tests {
                     .get_async_connection()
                     .await?;
 
-                let mget_result: RedisResult<(String, Vec<u8>)> = redis::cmd("MGET")
-                    .arg(&["{x}key1", "{x}key2"])
-                    .query_async(&mut replica_con)
-                    .await;
-                assert_eq!(mget_result, Ok(("foo".to_string(), b"bar".to_vec())));
+                async_check_replica_role_and_master(&mut replica_con, &master_client).await;
             }
 
             Ok::<(), RedisError>(())
@@ -357,7 +290,7 @@ pub mod async_tests {
 
     #[test]
     fn test_sentinel_client_async() {
-        let context = TestSentinelContext::new(3, 1, 3);
+        let mut context = TestSentinelContext::new(3, 1, 3);
         let master_client = SentinelClient::build(
             context.sentinels_connection_info().clone(),
             String::from("master1"),
@@ -375,26 +308,16 @@ pub mod async_tests {
         block_on_all(async move {
             let mut master_con = master_client.get_async_connection().await?;
 
-            // Write commands would go to the primary nodes
-            redis::cmd("SET")
-                .arg("{x}key1")
-                .arg(b"foo")
-                .query_async(&mut master_con)
-                .await?;
-            redis::cmd("SET")
-                .arg(&["{x}key2", "bar"])
-                .query_async(&mut master_con)
-                .await?;
+            async_check_master_role(&mut master_con).await;
+
+            let sentinel = context.sentinel_mut();
+            let master_client = sentinel.async_master_for("master1").await?;
 
             // Read commands to the replica node
             for _ in 0..20 {
                 let mut replica_con = replica_client.get_async_connection().await?;
 
-                let mget_result: RedisResult<(String, Vec<u8>)> = redis::cmd("MGET")
-                    .arg(&["{x}key1", "{x}key2"])
-                    .query_async(&mut replica_con)
-                    .await;
-                assert_eq!(mget_result, Ok(("foo".to_string(), b"bar".to_vec())));
+                async_check_replica_role_and_master(&mut replica_con, &master_client).await;
             }
 
             Ok::<(), RedisError>(())

--- a/redis/tests/test_sentinel.rs
+++ b/redis/tests/test_sentinel.rs
@@ -83,7 +83,7 @@ fn connect_to_all_replicas(
 
 fn assert_connect_to_known_replicas(
     sentinel: &mut Sentinel,
-    replica_conn_infos: &Vec<ConnectionAddr>,
+    replica_conn_infos: &[ConnectionAddr],
     master_name: &str,
     master_client: &Client,
     node_conn_info: &SentinelNodeConnectionInfo,
@@ -293,7 +293,7 @@ pub mod async_tests {
 
     async fn async_assert_connect_to_known_replicas(
         sentinel: &mut Sentinel,
-        replica_conn_infos: &Vec<ConnectionAddr>,
+        replica_conn_infos: &[ConnectionAddr],
         master_name: &str,
         master_client: &Client,
         node_conn_info: &SentinelNodeConnectionInfo,

--- a/redis/tests/test_sentinel.rs
+++ b/redis/tests/test_sentinel.rs
@@ -101,9 +101,9 @@ fn assert_connect_to_known_replicas(
 
 #[test]
 fn test_sentinel_connect_to_random_replica() {
-    let cluster = TestSentinelContext::new(2, 3, 3);
-    let sentinel = cluster.sentinel();
-    let node_conn_info = cluster.sentinel_node_connection_info();
+    let mut context = TestSentinelContext::new(2, 3, 3);
+    let node_conn_info: SentinelNodeConnectionInfo = context.sentinel_node_connection_info();
+    let sentinel = context.sentinel_mut();
 
     let master_client = sentinel
         .master_for("master1", Some(&node_conn_info))
@@ -188,7 +188,7 @@ fn test_sentinel_server_down() {
 #[test]
 fn test_sentinel_client() {
     let mut context = TestSentinelContext::new(2, 3, 3);
-    let master_client = SentinelClient::build(
+    let mut master_client = SentinelClient::build(
         context.sentinels_connection_info().clone(),
         String::from("master1"),
         Some(context.sentinel_node_connection_info()),
@@ -196,7 +196,7 @@ fn test_sentinel_client() {
     )
     .unwrap();
 
-    let replica_client = SentinelClient::build(
+    let mut replica_client = SentinelClient::build(
         context.sentinels_connection_info().clone(),
         String::from("master1"),
         Some(context.sentinel_node_connection_info()),
@@ -303,9 +303,9 @@ pub mod async_tests {
 
     #[test]
     fn test_sentinel_connect_to_random_replica_async() {
-        let cluster = TestSentinelContext::new(2, 3, 3);
-        let node_conn_info = cluster.sentinel_node_connection_info();
-        let sentinel = cluster.sentinel();
+        let mut context = TestSentinelContext::new(2, 3, 3);
+        let node_conn_info = context.sentinel_node_connection_info();
+        let sentinel = context.sentinel_mut();
 
         block_on_all(async move {
             let master_client = sentinel
@@ -411,7 +411,7 @@ pub mod async_tests {
     #[test]
     fn test_sentinel_client_async() {
         let mut context = TestSentinelContext::new(2, 3, 3);
-        let master_client = SentinelClient::build(
+        let mut master_client = SentinelClient::build(
             context.sentinels_connection_info().clone(),
             String::from("master1"),
             Some(context.sentinel_node_connection_info()),
@@ -419,7 +419,7 @@ pub mod async_tests {
         )
         .unwrap();
 
-        let replica_client = SentinelClient::build(
+        let mut replica_client = SentinelClient::build(
             context.sentinels_connection_info().clone(),
             String::from("master1"),
             Some(context.sentinel_node_connection_info()),

--- a/redis/tests/test_sentinel.rs
+++ b/redis/tests/test_sentinel.rs
@@ -1,0 +1,404 @@
+mod support;
+
+use redis::sentinel::SentinelClient;
+
+use crate::support::*;
+
+#[test]
+fn test_sentinel_basics() {
+    let cluster = TestSentinelContext::new(3, 1, 3);
+    let sentinel = cluster.sentinel();
+
+    let mut master_con = sentinel
+        .master_for("master1")
+        .unwrap()
+        .get_connection()
+        .unwrap();
+
+    redis::cmd("SET")
+        .arg("{x}key1")
+        .arg(b"foo")
+        .execute(&mut master_con);
+    redis::cmd("SET")
+        .arg(&["{x}key2", "bar"])
+        .execute(&mut master_con);
+
+    assert_eq!(
+        redis::cmd("MGET")
+            .arg(&["{x}key1", "{x}key2"])
+            .query(&mut master_con),
+        Ok(("foo".to_string(), b"bar".to_vec()))
+    );
+}
+
+#[test]
+fn test_sentinel_read_from_random_replica() {
+    let cluster = TestSentinelContext::new(3, 1, 3);
+    let sentinel = cluster.sentinel();
+
+    let mut master_con = sentinel
+        .master_for("master1")
+        .unwrap()
+        .get_connection()
+        .unwrap();
+
+    let mut replica_con = sentinel
+        .replica_for("master1")
+        .unwrap()
+        .get_connection()
+        .unwrap();
+
+    // Write commands would go to the primary nodes
+    redis::cmd("SET")
+        .arg("{x}key1")
+        .arg(b"foo")
+        .execute(&mut master_con);
+    redis::cmd("SET")
+        .arg(&["{x}key2", "bar"])
+        .execute(&mut master_con);
+
+    // Read commands would go to the replica nodes
+    assert_eq!(
+        redis::cmd("MGET")
+            .arg(&["{x}key1", "{x}key2"])
+            .query(&mut replica_con),
+        Ok(("foo".to_string(), b"bar".to_vec()))
+    );
+}
+
+#[test]
+fn test_sentinel_read_from_multiple_replicas() {
+    let mut cluster = TestSentinelContext::new(3, 1, 3);
+    let sentinel = cluster.sentinel_mut();
+
+    let mut master_con = sentinel
+        .master_for("master1")
+        .unwrap()
+        .get_connection()
+        .unwrap();
+
+    // Write commands would go to the primary nodes
+    redis::cmd("SET")
+        .arg("{x}key1")
+        .arg(b"foo")
+        .execute(&mut master_con);
+    redis::cmd("SET")
+        .arg(&["{x}key2", "bar"])
+        .execute(&mut master_con);
+
+    for _ in 0..20 {
+        let mut replica_con = sentinel
+            .replica_rotate_for("master1")
+            .unwrap()
+            .get_connection()
+            .unwrap();
+
+        assert_eq!(
+            redis::cmd("MGET")
+                .arg(&["{x}key1", "{x}key2"])
+                .query(&mut replica_con),
+            Ok(("foo".to_string(), b"bar".to_vec()))
+        );
+    }
+}
+
+#[test]
+fn test_sentinel_server_down() {
+    let mut context = TestSentinelContext::new(3, 1, 3);
+    let sentinel = context.sentinel_mut();
+
+    let mut master_con = sentinel
+        .master_for("master1")
+        .unwrap()
+        .get_connection()
+        .unwrap();
+
+    // Write commands would go to the primary nodes
+    redis::cmd("SET")
+        .arg("{x}key1")
+        .arg(b"foo")
+        .execute(&mut master_con);
+    redis::cmd("SET")
+        .arg(&["{x}key2", "bar"])
+        .execute(&mut master_con);
+
+    context.cluster.sentinel_servers[0].stop();
+    std::thread::sleep(std::time::Duration::from_millis(25));
+
+    let sentinel = context.sentinel_mut();
+
+    for _ in 0..20 {
+        let mut replica_con = sentinel
+            .replica_rotate_for("master1")
+            .unwrap()
+            .get_connection()
+            .unwrap();
+
+        assert_eq!(
+            redis::cmd("MGET")
+                .arg(&["{x}key1", "{x}key2"])
+                .query(&mut replica_con),
+            Ok(("foo".to_string(), b"bar".to_vec()))
+        );
+    }
+}
+
+#[test]
+fn test_sentinel_client() {
+    let context = TestSentinelContext::new(3, 1, 3);
+    let master_client = SentinelClient::build(
+        context.sentinels_connection_info().clone(),
+        String::from("master1"),
+        redis::sentinel::SentinelServerType::Master,
+    )
+    .unwrap();
+
+    let replica_client = SentinelClient::build(
+        context.sentinels_connection_info().clone(),
+        String::from("master1"),
+        redis::sentinel::SentinelServerType::Replica,
+    )
+    .unwrap();
+
+    let mut master_con = master_client.get_connection().unwrap();
+
+    // Write commands would go to the primary nodes
+    redis::cmd("SET")
+        .arg("{x}key1")
+        .arg(b"foo")
+        .execute(&mut master_con);
+    redis::cmd("SET")
+        .arg(&["{x}key2", "bar"])
+        .execute(&mut master_con);
+
+    for _ in 0..20 {
+        let mut replica_con = replica_client.get_connection().unwrap();
+
+        assert_eq!(
+            redis::cmd("MGET")
+                .arg(&["{x}key1", "{x}key2"])
+                .query(&mut replica_con),
+            Ok(("foo".to_string(), b"bar".to_vec()))
+        );
+    }
+}
+
+#[cfg(feature = "aio")]
+pub mod async_tests {
+    use redis::{sentinel::SentinelClient, RedisError, RedisResult};
+
+    use crate::support::*;
+
+    #[test]
+    fn test_sentinel_basics_async() {
+        let cluster = TestSentinelContext::new(3, 1, 3);
+        let sentinel = cluster.sentinel();
+
+        block_on_all(async move {
+            let mut master_con = sentinel
+                .async_master_for("master1")
+                .await?
+                .get_async_connection()
+                .await?;
+
+            redis::cmd("SET")
+                .arg("{x}key1")
+                .arg(b"foo")
+                .query_async(&mut master_con)
+                .await?;
+            redis::cmd("SET")
+                .arg(&["{x}key2", "bar"])
+                .query_async(&mut master_con)
+                .await?;
+
+            let mget_result: RedisResult<(String, Vec<u8>)> = redis::cmd("MGET")
+                .arg(&["{x}key1", "{x}key2"])
+                .query_async(&mut master_con)
+                .await;
+            assert_eq!(mget_result, Ok(("foo".to_string(), b"bar".to_vec())));
+
+            Ok::<(), RedisError>(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_sentinel_read_from_random_replica_async() {
+        let cluster = TestSentinelContext::new(3, 1, 3);
+        let sentinel = cluster.sentinel();
+
+        block_on_all(async move {
+            let mut master_con = sentinel
+                .async_master_for("master1")
+                .await?
+                .get_async_connection()
+                .await?;
+
+            let mut replica_con = sentinel
+                .async_replica_for("master1")
+                .await?
+                .get_async_connection()
+                .await?;
+
+            // Write commands would go to the primary nodes
+            redis::cmd("SET")
+                .arg("{x}key1")
+                .arg(b"foo")
+                .query_async(&mut master_con)
+                .await?;
+            redis::cmd("SET")
+                .arg(&["{x}key2", "bar"])
+                .query_async(&mut master_con)
+                .await?;
+
+            // Read commands to the replica node
+            let mget_result: RedisResult<(String, Vec<u8>)> = redis::cmd("MGET")
+                .arg(&["{x}key1", "{x}key2"])
+                .query_async(&mut replica_con)
+                .await;
+            assert_eq!(mget_result, Ok(("foo".to_string(), b"bar".to_vec())));
+
+            Ok::<(), RedisError>(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_sentinel_read_from_multiple_replicas_async() {
+        let mut cluster = TestSentinelContext::new(3, 1, 3);
+        let sentinel = cluster.sentinel_mut();
+
+        block_on_all(async move {
+            let mut master_con = sentinel
+                .async_master_for("master1")
+                .await?
+                .get_async_connection()
+                .await?;
+
+            // Write commands would go to the primary nodes
+            redis::cmd("SET")
+                .arg("{x}key1")
+                .arg(b"foo")
+                .query_async(&mut master_con)
+                .await?;
+            redis::cmd("SET")
+                .arg(&["{x}key2", "bar"])
+                .query_async(&mut master_con)
+                .await?;
+
+            // Read commands to the replica node
+            for _ in 0..20 {
+                let mut replica_con = sentinel
+                    .async_replica_rotate_for("master1")
+                    .await?
+                    .get_async_connection()
+                    .await?;
+
+                let mget_result: RedisResult<(String, Vec<u8>)> = redis::cmd("MGET")
+                    .arg(&["{x}key1", "{x}key2"])
+                    .query_async(&mut replica_con)
+                    .await;
+                assert_eq!(mget_result, Ok(("foo".to_string(), b"bar".to_vec())));
+            }
+
+            Ok::<(), RedisError>(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_sentinel_server_down_async() {
+        let mut context = TestSentinelContext::new(3, 1, 3);
+
+        block_on_all(async move {
+            let sentinel = context.sentinel_mut();
+
+            let mut master_con = sentinel
+                .async_master_for("master1")
+                .await?
+                .get_async_connection()
+                .await?;
+
+            // Write commands would go to the primary nodes
+            redis::cmd("SET")
+                .arg("{x}key1")
+                .arg(b"foo")
+                .query_async(&mut master_con)
+                .await?;
+            redis::cmd("SET")
+                .arg(&["{x}key2", "bar"])
+                .query_async(&mut master_con)
+                .await?;
+
+            context.cluster.sentinel_servers[0].stop();
+            std::thread::sleep(std::time::Duration::from_millis(25));
+
+            let sentinel = context.sentinel_mut();
+
+            // Read commands to the replica node
+            for _ in 0..20 {
+                let mut replica_con = sentinel
+                    .async_replica_rotate_for("master1")
+                    .await?
+                    .get_async_connection()
+                    .await?;
+
+                let mget_result: RedisResult<(String, Vec<u8>)> = redis::cmd("MGET")
+                    .arg(&["{x}key1", "{x}key2"])
+                    .query_async(&mut replica_con)
+                    .await;
+                assert_eq!(mget_result, Ok(("foo".to_string(), b"bar".to_vec())));
+            }
+
+            Ok::<(), RedisError>(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_sentinel_client_async() {
+        let context = TestSentinelContext::new(3, 1, 3);
+        let master_client = SentinelClient::build(
+            context.sentinels_connection_info().clone(),
+            String::from("master1"),
+            redis::sentinel::SentinelServerType::Master,
+        )
+        .unwrap();
+
+        let replica_client = SentinelClient::build(
+            context.sentinels_connection_info().clone(),
+            String::from("master1"),
+            redis::sentinel::SentinelServerType::Replica,
+        )
+        .unwrap();
+
+        block_on_all(async move {
+            let mut master_con = master_client.get_async_connection().await?;
+
+            // Write commands would go to the primary nodes
+            redis::cmd("SET")
+                .arg("{x}key1")
+                .arg(b"foo")
+                .query_async(&mut master_con)
+                .await?;
+            redis::cmd("SET")
+                .arg(&["{x}key2", "bar"])
+                .query_async(&mut master_con)
+                .await?;
+
+            // Read commands to the replica node
+            for _ in 0..20 {
+                let mut replica_con = replica_client.get_async_connection().await?;
+
+                let mget_result: RedisResult<(String, Vec<u8>)> = redis::cmd("MGET")
+                    .arg(&["{x}key1", "{x}key2"])
+                    .query_async(&mut replica_con)
+                    .await;
+                assert_eq!(mget_result, Ok(("foo".to_string(), b"bar".to_vec())));
+            }
+
+            Ok::<(), RedisError>(())
+        })
+        .unwrap();
+    }
+}

--- a/redis/tests/test_sentinel.rs
+++ b/redis/tests/test_sentinel.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "sentinel")]
 mod support;
 
 use std::collections::HashMap;


### PR DESCRIPTION
Hi! I've created this implementation of some Redis Sentinel logic, which I think would be a nice addition to this crate. I'm going to need something like this anyway for my projects, so I've decided to try and contribute it here first.

This is my first Rust open-source contribution, and I have very little Rust experience, so if anything seems weird please enlighten me!

Before doing this, I've seen that there are two issues about adding sentinel support:
https://github.com/redis-rs/redis-rs/issues/539
https://github.com/redis-rs/redis-rs/issues/703

And two attempts to implement this, one in a fork, and one in a separate crate:
https://github.com/redis-rs/redis-rs/compare/main...doyshinda:redis-rs:sentinel
https://github.com/aljazerzen/redis-sentinel-rs/blob/main/src/client.rs

Both are quite old and not quite the way I'd like then to be. Also, I've been wanting to practice writing some Rust code, so I decided to implement something myself, which got me to this PR.

I'm not very confident I got the API structured in a good way, so any suggestions on how to improve it would be greatly appreciated. I tried to come up with something along the lines of the Python client (https://github.com/redis/redis-py) but also trying the follow the recommendations for sentinel clients (https://redis.io/docs/reference/sentinel-clients).
