### PR TITLE
Xinfo groups lag and entries-read support

### DIFF
--- a/redis/src/streams.rs
+++ b/redis/src/streams.rs
@@ -673,7 +673,11 @@ impl FromRedisValue for StreamInfoGroupsReply {
                 g.last_delivered_id = from_redis_value(v)?;
             }
             if let Some(v) = &map.get("entries-read") {
-                g.entries_read = Some(from_redis_value(v)?);
+                g.entries_read = if let Value::Nil = v {
+                    None
+                } else {
+                    Some(from_redis_value(v)?)
+                };
             }
             if let Some(v) = &map.get("lag") {
                 g.lag = if let Value::Nil = v {


### PR DESCRIPTION
This PR adds support for `lag` and `entries-read` values in `XINFO GROUPOS` replies.
It handles missing values, which can happen either because the server cannot determine the values (especially for `lag`) or because the server version does not yet support them.