### PR TITLE
Improve error logging.

### DIFF
--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -1418,19 +1418,17 @@ mod tests {
             ),
         ];
         for (url, expected) in cases.into_iter() {
-            let res = url_to_tcp_connection_info(url);
+            let res = url_to_tcp_connection_info(url).unwrap_err();
             assert_eq!(
-                res.as_ref().unwrap_err().kind(),
+                res.kind(),
                 crate::ErrorKind::InvalidClientConfig,
                 "{}",
-                res.as_ref().unwrap_err(),
+                &res,
             );
-            assert_eq!(
-                res.as_ref().unwrap_err().to_string(),
-                expected,
-                "{}",
-                res.as_ref().unwrap_err(),
-            );
+            #[allow(deprecated)]
+            let desc = std::error::Error::description(&res);
+            assert_eq!(desc, expected, "{}", &res);
+            assert_eq!(res.detail(), None, "{}", &res);
         }
     }
 

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -377,9 +377,15 @@ impl error::Error for RedisError {
 impl fmt::Display for RedisError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self.repr {
-            ErrorRepr::WithDescription(_, desc) => desc.fmt(f),
-            ErrorRepr::WithDescriptionAndDetail(_, desc, ref detail) => {
+            ErrorRepr::WithDescription(kind, desc) => {
                 desc.fmt(f)?;
+                f.write_str("- ")?;
+                fmt::Debug::fmt(&kind, f)
+            }
+            ErrorRepr::WithDescriptionAndDetail(kind, desc, ref detail) => {
+                desc.fmt(f)?;
+                f.write_str(" - ")?;
+                fmt::Debug::fmt(&kind, f)?;
                 f.write_str(": ")?;
                 detail.fmt(f)
             }

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -194,14 +194,14 @@ fn test_cluster_pipeline_invalid_command() {
 
     assert_eq!(
         err.to_string(),
-        "This command cannot be safely routed in cluster mode: Command 'SCRIPT KILL' can't be executed in a cluster pipeline."
+        "This command cannot be safely routed in cluster mode - ClientError: Command 'SCRIPT KILL' can't be executed in a cluster pipeline."
     );
 
     let err = cluster_pipe().keys("*").query::<()>(&mut con).unwrap_err();
 
     assert_eq!(
         err.to_string(),
-        "This command cannot be safely routed in cluster mode: Command 'KEYS' can't be executed in a cluster pipeline."
+        "This command cannot be safely routed in cluster mode - ClientError: Command 'KEYS' can't be executed in a cluster pipeline."
     );
 }
 
@@ -318,7 +318,7 @@ fn test_cluster_exhaust_retries() {
 
     assert_eq!(
         result.map_err(|err| err.to_string()),
-        Err("An error was signalled by the server: mock".to_string())
+        Err("An error was signalled by the server - TryAgain: mock".to_string())
     );
     assert_eq!(requests.load(atomic::Ordering::SeqCst), 3);
 }

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -368,7 +368,7 @@ fn test_async_cluster_tryagain_exhaust_retries() {
 
     assert_eq!(
         result.map_err(|err| err.to_string()),
-        Err("An error was signalled by the server: mock".to_string())
+        Err("An error was signalled by the server - TryAgain: mock".to_string())
     );
     assert_eq!(requests.load(atomic::Ordering::SeqCst), 3);
 }


### PR DESCRIPTION
This change adds the error's kind to the string representation of the error. So the error that was
`An error was signalled by the server: 10279 127.0.0.1:39192` 
will now be
`An error was signalled by the server - Moved: 10279 127.0.0.1:39192` 
which makes the error much clearer.