### PR TITLE
Fix AllMasters routing in sync cluster

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -446,17 +446,10 @@ where
         let mut results = HashMap::new();
 
         // TODO: reconnect and shit
-        for slot in slots.values() {
-            let addr = slot.slot_addr(&SlotAddr::Master).to_string();
+        for addr in slots.all_unique_addresses(only_primaries) {
+            let addr = addr.to_string();
             if let Some(connection) = connections.get_mut(&addr) {
                 results.insert(addr, func(connection)?);
-            }
-
-            if !only_primaries {
-                let addr = slot.slot_addr(&SlotAddr::Replica).to_string();
-                if let Some(connection) = connections.get_mut(&addr) {
-                    results.insert(addr, func(connection)?);
-                }
             }
         }
 

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::iter::Iterator;
 
 use rand::seq::SliceRandom;
@@ -240,6 +240,18 @@ impl SlotMap {
 
     pub fn len(&self) -> usize {
         self.0.len()
+    }
+
+    pub fn all_unique_addresses(&self, only_primaries: bool) -> HashSet<&str> {
+        let mut addresses = HashSet::new();
+        for slot in self.values() {
+            addresses.insert(slot.slot_addr(&SlotAddr::Master));
+
+            if !only_primaries {
+                addresses.insert(slot.slot_addr(&SlotAddr::Replica));
+            }
+        }
+        addresses
     }
 }
 

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -121,65 +121,81 @@ pub fn respond_startup(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>>
     }
 }
 
-pub fn respond_startup_two_nodes(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>> {
-    if contains_slice(cmd, b"PING") {
-        Err(Ok(Value::Status("OK".into())))
-    } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
-        Err(Ok(Value::Bulk(vec![
-            Value::Bulk(vec![
-                Value::Int(0),
-                Value::Int(8191),
-                Value::Bulk(vec![
-                    Value::Data(name.as_bytes().to_vec()),
-                    Value::Int(6379),
-                ]),
-            ]),
-            Value::Bulk(vec![
-                Value::Int(8192),
-                Value::Int(16383),
-                Value::Bulk(vec![
-                    Value::Data(name.as_bytes().to_vec()),
-                    Value::Int(6380),
-                ]),
-            ]),
-        ])))
-    } else if contains_slice(cmd, b"READONLY") {
-        Err(Ok(Value::Status("OK".into())))
-    } else {
-        Ok(())
-    }
+#[derive(Clone)]
+pub struct MockSlotRange {
+    pub primary_port: u16,
+    pub replica_ports: Vec<u16>,
+    pub slot_range: std::ops::Range<u16>,
 }
 
 pub fn respond_startup_with_replica(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>> {
+    respond_startup_with_replica_using_config(name, cmd, None)
+}
+
+pub fn respond_startup_two_nodes(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>> {
+    respond_startup_with_replica_using_config(
+        name,
+        cmd,
+        Some(vec![
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: vec![],
+                slot_range: (0..8191),
+            },
+            MockSlotRange {
+                primary_port: 6380,
+                replica_ports: vec![],
+                slot_range: (8192..16383),
+            },
+        ]),
+    )
+}
+
+pub fn respond_startup_with_replica_using_config(
+    name: &str,
+    cmd: &[u8],
+    slots_config: Option<Vec<MockSlotRange>>,
+) -> Result<(), RedisResult<Value>> {
+    let slots_config = slots_config.unwrap_or(vec![
+        MockSlotRange {
+            primary_port: 6379,
+            replica_ports: vec![6380],
+            slot_range: (0..8191),
+        },
+        MockSlotRange {
+            primary_port: 6381,
+            replica_ports: vec![6382],
+            slot_range: (8192..16383),
+        },
+    ]);
     if contains_slice(cmd, b"PING") {
         Err(Ok(Value::Status("OK".into())))
     } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
-        Err(Ok(Value::Bulk(vec![
-            Value::Bulk(vec![
-                Value::Int(0),
-                Value::Int(8191),
+        let slots = slots_config
+            .into_iter()
+            .map(|slot_config| {
+                let replicas = slot_config
+                    .replica_ports
+                    .into_iter()
+                    .flat_map(|replica_port| {
+                        vec![
+                            Value::Data(name.as_bytes().to_vec()),
+                            Value::Int(replica_port as i64),
+                        ]
+                    })
+                    .collect();
                 Value::Bulk(vec![
-                    Value::Data(name.as_bytes().to_vec()),
-                    Value::Int(6379),
-                ]),
-                Value::Bulk(vec![
-                    Value::Data(name.as_bytes().to_vec()),
-                    Value::Int(6380),
-                ]),
-            ]),
-            Value::Bulk(vec![
-                Value::Int(8192),
-                Value::Int(16383),
-                Value::Bulk(vec![
-                    Value::Data(name.as_bytes().to_vec()),
-                    Value::Int(6381),
-                ]),
-                Value::Bulk(vec![
-                    Value::Data(name.as_bytes().to_vec()),
-                    Value::Int(6382),
-                ]),
-            ]),
-        ])))
+                    Value::Int(slot_config.slot_range.start as i64),
+                    Value::Int(slot_config.slot_range.end as i64),
+                    Value::Bulk(vec![
+                        Value::Data(name.as_bytes().to_vec()),
+                        Value::Int(slot_config.primary_port as i64),
+                    ]),
+                    Value::Bulk(replicas),
+                ])
+            })
+            .collect();
+        Err(Ok(Value::Bulk(slots)))
     } else if contains_slice(cmd, b"READONLY") {
         Err(Ok(Value::Status("OK".into())))
     } else {

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -507,3 +507,34 @@ fn test_cluster_non_retryable_error_should_not_retry() {
     }
     assert_eq!(completed.load(Ordering::SeqCst), 1);
 }
+
+#[test]
+fn test_cluster_fan_out() {
+    let name = "node";
+    let found_ports = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let ports_clone = found_ports.clone();
+    // requests should route to replica
+    let MockEnv {
+        mut connection,
+        handler: _handler,
+        ..
+    } = MockEnv::with_client_builder(
+        ClusterClient::builder(vec![&*format!("redis://{name}")])
+            .retries(0)
+            .read_from_replicas(),
+        name,
+        move |cmd: &[u8], port| {
+            respond_startup_with_replica(name, cmd)?;
+            if (cmd[8..]).starts_with("FLUSHALL".as_bytes()) {
+                ports_clone.lock().unwrap().push(port);
+                return Err(Ok(Value::Status("OK".into())));
+            }
+            Ok(())
+        },
+    );
+
+    let _ = cmd("FLUSHALL").query::<Option<()>>(&mut connection);
+    found_ports.lock().unwrap().sort();
+    // MockEnv creates 2 mock connections.
+    assert_eq!(*found_ports.lock().unwrap(), vec![6379, 6381]);
+}

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -508,8 +508,11 @@ fn test_cluster_non_retryable_error_should_not_retry() {
     assert_eq!(completed.load(Ordering::SeqCst), 1);
 }
 
-#[test]
-fn test_cluster_fan_out() {
+fn test_cluster_fan_out(
+    command: &'static str,
+    expected_ports: Vec<u16>,
+    slots_config: Option<Vec<MockSlotRange>>,
+) {
     let name = "node";
     let found_ports = Arc::new(std::sync::Mutex::new(Vec::new()));
     let ports_clone = found_ports.clone();
@@ -524,8 +527,8 @@ fn test_cluster_fan_out() {
             .read_from_replicas(),
         name,
         move |cmd: &[u8], port| {
-            respond_startup_with_replica(name, cmd)?;
-            if (cmd[8..]).starts_with("FLUSHALL".as_bytes()) {
+            respond_startup_with_replica_using_config(name, cmd, slots_config.clone())?;
+            if (cmd[8..]).starts_with(command.as_bytes()) {
                 ports_clone.lock().unwrap().push(port);
                 return Err(Ok(Value::Status("OK".into())));
             }
@@ -533,8 +536,68 @@ fn test_cluster_fan_out() {
         },
     );
 
-    let _ = cmd("FLUSHALL").query::<Option<()>>(&mut connection);
+    let _ = cmd(command).query::<Option<()>>(&mut connection);
     found_ports.lock().unwrap().sort();
     // MockEnv creates 2 mock connections.
-    assert_eq!(*found_ports.lock().unwrap(), vec![6379, 6381]);
+    assert_eq!(*found_ports.lock().unwrap(), expected_ports);
+}
+
+#[test]
+fn test_cluster_fan_out_to_all_primaries() {
+    test_cluster_fan_out("FLUSHALL", vec![6379, 6381], None);
+}
+
+#[test]
+fn test_cluster_fan_out_to_all_nodes() {
+    test_cluster_fan_out("ECHO", vec![6379, 6380, 6381, 6382], None);
+}
+
+#[test]
+fn test_cluster_fan_out_out_once_to_each_primary_when_no_replicas_are_available() {
+    test_cluster_fan_out(
+        "ECHO",
+        vec![6379, 6381],
+        Some(vec![
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: Vec::new(),
+                slot_range: (0..8191),
+            },
+            MockSlotRange {
+                primary_port: 6381,
+                replica_ports: Vec::new(),
+                slot_range: (8192..16383),
+            },
+        ]),
+    );
+}
+
+#[test]
+fn test_cluster_fan_out_out_once_even_if_primary_has_multiple_slot_ranges() {
+    test_cluster_fan_out(
+        "ECHO",
+        vec![6379, 6380, 6381, 6382],
+        Some(vec![
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: vec![6380],
+                slot_range: (0..4000),
+            },
+            MockSlotRange {
+                primary_port: 6381,
+                replica_ports: vec![6382],
+                slot_range: (4001..8191),
+            },
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: vec![6380],
+                slot_range: (8192..8200),
+            },
+            MockSlotRange {
+                primary_port: 6381,
+                replica_ports: vec![6382],
+                slot_range: (8201..16383),
+            },
+        ]),
+    );
 }


### PR DESCRIPTION
This fix ensures that commands that should only be routed to master won't be routed to replicas.