### PR TITLE
Support fan-out commands in cluster-async

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -447,17 +447,10 @@ where
         let mut results = HashMap::new();
 
         // TODO: reconnect and shit
-        for slot in slots.values() {
-            let addr = slot.slot_addr(&SlotAddr::Master).to_string();
+        for addr in slots.all_unique_addresses(only_primaries) {
+            let addr = addr.to_string();
             if let Some(connection) = connections.get_mut(&addr) {
                 results.insert(addr, func(connection)?);
-            }
-
-            if !only_primaries {
-                let addr = slot.slot_addr(&SlotAddr::Replica).to_string();
-                if let Some(connection) = connections.get_mut(&addr) {
-                    results.insert(addr, func(connection)?);
-                }
             }
         }
 

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -437,17 +437,28 @@ where
         Ok(result)
     }
 
-    fn execute_on_all_nodes<T, F>(&self, mut func: F) -> RedisResult<T>
+    fn execute_on_all_nodes<T, F>(&self, mut func: F, only_primaries: bool) -> RedisResult<T>
     where
         T: MergeResults,
         F: FnMut(&mut C) -> RedisResult<T>,
     {
         let mut connections = self.connections.borrow_mut();
+        let slots = self.slots.borrow_mut();
         let mut results = HashMap::new();
 
         // TODO: reconnect and shit
-        for (addr, connection) in connections.iter_mut() {
-            results.insert(addr.as_str(), func(connection)?);
+        for slot in slots.values() {
+            let addr = slot.slot_addr(&SlotAddr::Master).to_string();
+            if let Some(connection) = connections.get_mut(&addr) {
+                results.insert(addr, func(connection)?);
+            }
+
+            if !only_primaries {
+                let addr = slot.slot_addr(&SlotAddr::Replica).to_string();
+                if let Some(connection) = connections.get_mut(&addr) {
+                    results.insert(addr, func(connection)?);
+                }
+            }
         }
 
         Ok(T::merge_results(results))
@@ -464,8 +475,11 @@ where
             Some(RoutingInfo::Random) => None,
             Some(RoutingInfo::MasterSlot(slot)) => Some(Route::new(slot, SlotAddr::Master)),
             Some(RoutingInfo::ReplicaSlot(slot)) => Some(Route::new(slot, SlotAddr::Replica)),
-            Some(RoutingInfo::AllNodes) | Some(RoutingInfo::AllMasters) => {
-                return self.execute_on_all_nodes(func);
+            Some(RoutingInfo::AllMasters) => {
+                return self.execute_on_all_nodes(func, true);
+            }
+            Some(RoutingInfo::AllNodes) => {
+                return self.execute_on_all_nodes(func, false);
             }
             None => fail!(UNROUTABLE_ERROR),
         };
@@ -665,26 +679,23 @@ impl<C: Connect + ConnectionLike> ConnectionLike for ClusterConnection<C> {
 }
 
 trait MergeResults {
-    fn merge_results(_values: HashMap<&str, Self>) -> Self
+    fn merge_results(_values: HashMap<String, Self>) -> Self
     where
         Self: Sized;
 }
 
 impl MergeResults for Value {
-    fn merge_results(values: HashMap<&str, Value>) -> Value {
+    fn merge_results(values: HashMap<String, Value>) -> Value {
         let mut items = vec![];
         for (addr, value) in values.into_iter() {
-            items.push(Value::Bulk(vec![
-                Value::Data(addr.as_bytes().to_vec()),
-                value,
-            ]));
+            items.push(Value::Bulk(vec![Value::Data(addr.into_bytes()), value]));
         }
         Value::Bulk(items)
     }
 }
 
 impl MergeResults for Vec<Value> {
-    fn merge_results(_values: HashMap<&str, Vec<Value>>) -> Vec<Value> {
+    fn merge_results(_values: HashMap<String, Vec<Value>>) -> Vec<Value> {
         unreachable!("attempted to merge a pipeline. This should not happen");
     }
 }

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -36,7 +36,7 @@ use crate::{
     aio::{ConnectionLike, MultiplexedConnection},
     cluster::{get_connection_info, parse_slots, slot_cmd},
     cluster_client::{ClusterParams, RetryParams},
-    cluster_routing::{Redirect, Route, RoutingInfo, Slot, SlotAddr, SlotMap},
+    cluster_routing::{Redirect, Route, RoutingInfo, Slot, SlotMap},
     Cmd, ConnectionInfo, ErrorKind, IntoConnectionInfo, RedisError, RedisFuture, RedisResult,
     Value,
 };
@@ -141,8 +141,7 @@ impl<C> CmdArg<C> {
         fn route_for_command(cmd: &Cmd) -> Option<Route> {
             match RoutingInfo::for_routable(cmd) {
                 Some(RoutingInfo::Random) => None,
-                Some(RoutingInfo::MasterSlot(slot)) => Some(Route::new(slot, SlotAddr::Master)),
-                Some(RoutingInfo::ReplicaSlot(slot)) => Some(Route::new(slot, SlotAddr::Replica)),
+                Some(RoutingInfo::SpecificNode(route)) => Some(route),
                 Some(RoutingInfo::AllNodes) | Some(RoutingInfo::AllMasters) => None,
                 _ => None,
             }

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -104,7 +104,9 @@ struct ClusterConnInner<C> {
     state: ConnectionState,
     #[allow(clippy::complexity)]
     in_flight_requests: stream::FuturesUnordered<
-        Pin<Box<Request<BoxFuture<'static, (String, RedisResult<Response>)>, Response, C>>>,
+        Pin<
+            Box<Request<BoxFuture<'static, (OperationTarget, RedisResult<Response>)>, Response, C>>,
+        >,
     >,
     refresh_error: Option<RedisError>,
     pending_requests: Vec<PendingRequest<Response, C>>,
@@ -115,57 +117,51 @@ enum CmdArg<C> {
     Cmd {
         cmd: Arc<Cmd>,
         func: fn(C, Arc<Cmd>) -> RedisFuture<'static, Response>,
+        routing: Option<RoutingInfo>,
     },
     Pipeline {
         pipeline: Arc<crate::Pipeline>,
         offset: usize,
         count: usize,
         func: fn(C, Arc<crate::Pipeline>, usize, usize) -> RedisFuture<'static, Response>,
+        route: Option<Route>,
     },
 }
 
-impl<C> CmdArg<C> {
-    fn exec(&self, con: C) -> RedisFuture<'static, Response> {
-        match self {
-            Self::Cmd { cmd, func } => func(con, cmd.clone()),
-            Self::Pipeline {
-                pipeline,
-                offset,
-                count,
-                func,
-            } => func(con, pipeline.clone(), *offset, *count),
+fn route_pipeline(pipeline: &crate::Pipeline) -> Option<Route> {
+    fn route_for_command(cmd: &Cmd) -> Option<Route> {
+        match RoutingInfo::for_routable(cmd) {
+            Some(RoutingInfo::Random) => None,
+            Some(RoutingInfo::SpecificNode(route)) => Some(route),
+            Some(RoutingInfo::AllNodes) | Some(RoutingInfo::AllMasters) => None,
+            _ => None,
         }
     }
 
-    fn route(&self) -> Option<Route> {
-        fn route_for_command(cmd: &Cmd) -> Option<Route> {
-            match RoutingInfo::for_routable(cmd) {
-                Some(RoutingInfo::Random) => None,
-                Some(RoutingInfo::SpecificNode(route)) => Some(route),
-                Some(RoutingInfo::AllNodes) | Some(RoutingInfo::AllMasters) => None,
-                _ => None,
-            }
-        }
-
-        match self {
-            Self::Cmd { ref cmd, .. } => route_for_command(cmd),
-            Self::Pipeline { ref pipeline, .. } => {
-                let mut iter = pipeline.cmd_iter();
-                let route = iter.next().map(route_for_command)?;
-                for cmd in iter {
-                    if route != route_for_command(cmd) {
-                        return None;
-                    }
-                }
-                route
-            }
+    let mut iter = pipeline.cmd_iter();
+    let slot = iter.next().map(route_for_command)?;
+    for cmd in iter {
+        if slot != route_for_command(cmd) {
+            return None;
         }
     }
+    slot
 }
 
 enum Response {
     Single(Value),
     Multiple(Vec<Value>),
+}
+
+enum OperationTarget {
+    Node { address: String },
+    FanOut,
+}
+
+impl From<String> for OperationTarget {
+    fn from(address: String) -> Self {
+        OperationTarget::Node { address }
+    }
 }
 
 struct Message<C> {
@@ -199,7 +195,6 @@ impl fmt::Debug for ConnectionState {
 #[derive(Clone)]
 struct RequestInfo<C> {
     cmd: CmdArg<C>,
-    route: Option<Route>,
     redirect: Option<Redirect>,
 }
 
@@ -240,7 +235,7 @@ enum Next<I, C> {
     },
     Reconnect {
         request: PendingRequest<I, C>,
-        addr: String,
+        target: OperationTarget,
     },
     RefreshSlots {
         request: PendingRequest<I, C>,
@@ -250,7 +245,7 @@ enum Next<I, C> {
 
 impl<F, I, C> Future for Request<F, I, C>
 where
-    F: Future<Output = (String, RedisResult<I>)>,
+    F: Future<Output = (OperationTarget, RedisResult<I>)>,
     C: ConnectionLike,
 {
     type Output = Next<I, C>;
@@ -277,8 +272,17 @@ where
                 self.respond(Ok(item));
                 Next::Done.into()
             }
-            (addr, Err(err)) => {
+            (target, Err(err)) => {
                 trace!("Request error {}", err);
+
+                let address = match target {
+                    OperationTarget::Node { address } => address,
+                    OperationTarget::FanOut => {
+                        // TODO - implement retries on fan-out operations
+                        self.respond(Err(err));
+                        return Next::Done.into();
+                    }
+                };
 
                 let request = this.request.as_mut().unwrap();
 
@@ -317,7 +321,7 @@ where
                     }
                     ErrorKind::IoError => Next::Reconnect {
                         request: this.request.take().unwrap(),
-                        addr,
+                        target: OperationTarget::Node { address },
                     }
                     .into(),
                     _ => {
@@ -339,7 +343,7 @@ where
 
 impl<F, I, C> Request<F, I, C>
 where
-    F: Future<Output = (String, RedisResult<I>)>,
+    F: Future<Output = (OperationTarget, RedisResult<I>)>,
     C: ConnectionLike,
 {
     fn respond(self: Pin<&mut Self>, msg: RedisResult<I>) {
@@ -531,13 +535,120 @@ where
         Ok(())
     }
 
-    async fn try_request(
-        mut info: RequestInfo<C>,
+    async fn execute_on_all_nodes(
+        func: fn(C, Arc<Cmd>) -> RedisFuture<'static, Response>,
+        cmd: &Arc<Cmd>,
+        only_primaries: bool,
         core: Core<C>,
-    ) -> (String, RedisResult<Response>) {
-        let cmd = info.cmd;
-        let asking = matches!(info.redirect, Some(Redirect::Ask(_)));
+    ) -> (OperationTarget, RedisResult<Response>) {
+        let read_guard = core.conn_lock.read().await;
+        let results = future::join_all(
+            read_guard
+                .1
+                .all_unique_addresses(only_primaries)
+                .into_iter()
+                .filter_map(|addr| read_guard.0.get(addr).cloned())
+                .map(|conn| {
+                    (async {
+                        let conn = conn.await;
+                        func(conn, cmd.clone()).await
+                    })
+                    .boxed()
+                }),
+        )
+        .await;
+        drop(read_guard);
+        let mut merged_results = Vec::with_capacity(results.len());
 
+        // TODO - we can have better error reporting here if we had an Error variant on Value.
+        for result in results {
+            match result {
+                Ok(response) => match response {
+                    Response::Single(value) => merged_results.push(value),
+                    Response::Multiple(_) => unreachable!(),
+                },
+                Err(_) => {
+                    return (OperationTarget::FanOut, result);
+                }
+            }
+        }
+
+        (
+            OperationTarget::FanOut,
+            Ok(Response::Single(Value::Bulk(merged_results))),
+        )
+    }
+
+    async fn try_cmd_request(
+        cmd: Arc<Cmd>,
+        func: fn(C, Arc<Cmd>) -> RedisFuture<'static, Response>,
+        redirect: Option<Redirect>,
+        routing: Option<RoutingInfo>,
+        core: Core<C>,
+        asking: bool,
+    ) -> (OperationTarget, RedisResult<Response>) {
+        let route_option = match routing.as_ref().unwrap_or(&RoutingInfo::Random) {
+            RoutingInfo::AllNodes => {
+                return Self::execute_on_all_nodes(func, &cmd, false, core).await
+            }
+            RoutingInfo::AllMasters => {
+                return Self::execute_on_all_nodes(func, &cmd, true, core).await
+            }
+            RoutingInfo::Random => None,
+            RoutingInfo::SpecificNode(route) => Some(route),
+        };
+        let (addr, conn) = Self::get_connection(redirect, route_option, core, asking).await;
+        let result = func(conn, cmd).await;
+        (addr.into(), result)
+    }
+
+    async fn try_pipeline_request(
+        pipeline: Arc<crate::Pipeline>,
+        offset: usize,
+        count: usize,
+        func: fn(C, Arc<crate::Pipeline>, usize, usize) -> RedisFuture<'static, Response>,
+        conn: impl Future<Output = (String, C)>,
+    ) -> (OperationTarget, RedisResult<Response>) {
+        let (addr, conn) = conn.await;
+        let result = func(conn, pipeline, offset, count).await;
+        (OperationTarget::Node { address: addr }, result)
+    }
+
+    async fn try_request(
+        info: RequestInfo<C>,
+        core: Core<C>,
+    ) -> (OperationTarget, RedisResult<Response>) {
+        let asking = matches!(&info.redirect, Some(Redirect::Ask(_)));
+
+        match info.cmd {
+            CmdArg::Cmd { cmd, func, routing } => {
+                Self::try_cmd_request(cmd, func, info.redirect, routing, core, asking).await
+            }
+            CmdArg::Pipeline {
+                pipeline,
+                offset,
+                count,
+                func,
+                route,
+            } => {
+                Self::try_pipeline_request(
+                    pipeline,
+                    offset,
+                    count,
+                    func,
+                    Self::get_connection(info.redirect, route.as_ref(), core, asking),
+                )
+                .await
+            }
+        }
+    }
+
+    async fn get_connection(
+        mut redirect: Option<Redirect>,
+        route: Option<&Route>,
+        core: Core<C>,
+        asking: bool,
+    ) -> (String, C) {
         let read_guard = core.conn_lock.read().await;
         // Ideally we would get a random conn only after other means failed,
         // but we have to release the lock before any `await`, otherwise the
@@ -545,11 +656,10 @@ where
         // which will be blocked on the lock:
         let (random_addr, random_conn_future) = get_random_connection(&read_guard.0);
 
-        let conn = match info.redirect.take() {
+        let conn = match redirect.take() {
             Some(Redirect::Moved(moved_addr)) => Some(moved_addr),
             Some(Redirect::Ask(ask_addr)) => Some(ask_addr),
-            None => info
-                .route
+            None => route
                 .as_ref()
                 .and_then(|route| read_guard.1.slot_addr_for_route(route))
                 .map(|addr| addr.to_string()),
@@ -576,8 +686,7 @@ where
         if asking {
             let _ = conn.req_packed_command(&crate::cmd::cmd("ASKING")).await;
         }
-        let result = cmd.exec(conn).await;
-        (addr, result)
+        (addr, conn)
     }
 
     fn poll_recover(
@@ -671,9 +780,16 @@ where
                         },
                     }));
                 }
-                Next::Reconnect { request, addr, .. } => {
-                    poll_flush_action =
-                        poll_flush_action.change_state(PollFlushAction::Reconnect(vec![addr]));
+                Next::Reconnect {
+                    request, target, ..
+                } => {
+                    poll_flush_action = match target {
+                        OperationTarget::Node { address } => poll_flush_action
+                            .change_state(PollFlushAction::Reconnect(vec![address])),
+                        OperationTarget::FanOut => {
+                            poll_flush_action.change_state(PollFlushAction::RebuildSlots)
+                        }
+                    };
                     self.pending_requests.push(request);
                 }
             }
@@ -785,13 +901,8 @@ where
         trace!("start_send");
         let Message { cmd, sender } = msg;
 
-        let route = cmd.route();
         let redirect = None;
-        let info = RequestInfo {
-            cmd,
-            route,
-            redirect,
-        };
+        let info = RequestInfo { cmd, redirect };
 
         self.pending_requests.push(PendingRequest {
             retry: 0,
@@ -883,6 +994,7 @@ where
                                 conn.req_packed_command(&cmd).await.map(Response::Single)
                             })
                         },
+                        routing: RoutingInfo::for_routable(cmd),
                     },
                     sender,
                 })
@@ -929,6 +1041,7 @@ where
                                     .map(Response::Multiple)
                             })
                         },
+                        route: route_pipeline(pipeline),
                     },
                     sender,
                 })

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::iter::Iterator;
 
 use rand::seq::SliceRandom;
@@ -253,6 +253,18 @@ impl SlotMap {
 
     pub fn values(&self) -> std::collections::btree_map::Values<u16, SlotAddrs> {
         self.0.values()
+    }
+
+    pub fn all_unique_addresses(&self, only_primaries: bool) -> HashSet<&str> {
+        let mut addresses = HashSet::new();
+        for slot in self.values() {
+            addresses.insert(slot.slot_addr(&SlotAddr::Master));
+
+            if !only_primaries {
+                addresses.insert(slot.slot_addr(&SlotAddr::Replica));
+            }
+        }
+        addresses
     }
 }
 

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -121,65 +121,81 @@ pub fn respond_startup(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>>
     }
 }
 
-pub fn respond_startup_two_nodes(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>> {
-    if contains_slice(cmd, b"PING") {
-        Err(Ok(Value::Status("OK".into())))
-    } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
-        Err(Ok(Value::Bulk(vec![
-            Value::Bulk(vec![
-                Value::Int(0),
-                Value::Int(8191),
-                Value::Bulk(vec![
-                    Value::Data(name.as_bytes().to_vec()),
-                    Value::Int(6379),
-                ]),
-            ]),
-            Value::Bulk(vec![
-                Value::Int(8192),
-                Value::Int(16383),
-                Value::Bulk(vec![
-                    Value::Data(name.as_bytes().to_vec()),
-                    Value::Int(6380),
-                ]),
-            ]),
-        ])))
-    } else if contains_slice(cmd, b"READONLY") {
-        Err(Ok(Value::Status("OK".into())))
-    } else {
-        Ok(())
-    }
+#[derive(Clone)]
+pub struct MockSlotRange {
+    pub primary_port: u16,
+    pub replica_ports: Vec<u16>,
+    pub slot_range: std::ops::Range<u16>,
 }
 
 pub fn respond_startup_with_replica(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>> {
+    respond_startup_with_replica_using_config(name, cmd, None)
+}
+
+pub fn respond_startup_two_nodes(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>> {
+    respond_startup_with_replica_using_config(
+        name,
+        cmd,
+        Some(vec![
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: vec![],
+                slot_range: (0..8191),
+            },
+            MockSlotRange {
+                primary_port: 6380,
+                replica_ports: vec![],
+                slot_range: (8192..16383),
+            },
+        ]),
+    )
+}
+
+pub fn respond_startup_with_replica_using_config(
+    name: &str,
+    cmd: &[u8],
+    slots_config: Option<Vec<MockSlotRange>>,
+) -> Result<(), RedisResult<Value>> {
+    let slots_config = slots_config.unwrap_or(vec![
+        MockSlotRange {
+            primary_port: 6379,
+            replica_ports: vec![6380],
+            slot_range: (0..8191),
+        },
+        MockSlotRange {
+            primary_port: 6381,
+            replica_ports: vec![6382],
+            slot_range: (8192..16383),
+        },
+    ]);
     if contains_slice(cmd, b"PING") {
         Err(Ok(Value::Status("OK".into())))
     } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
-        Err(Ok(Value::Bulk(vec![
-            Value::Bulk(vec![
-                Value::Int(0),
-                Value::Int(8191),
+        let slots = slots_config
+            .into_iter()
+            .map(|slot_config| {
+                let replicas = slot_config
+                    .replica_ports
+                    .into_iter()
+                    .flat_map(|replica_port| {
+                        vec![
+                            Value::Data(name.as_bytes().to_vec()),
+                            Value::Int(replica_port as i64),
+                        ]
+                    })
+                    .collect();
                 Value::Bulk(vec![
-                    Value::Data(name.as_bytes().to_vec()),
-                    Value::Int(6379),
-                ]),
-                Value::Bulk(vec![
-                    Value::Data(name.as_bytes().to_vec()),
-                    Value::Int(6380),
-                ]),
-            ]),
-            Value::Bulk(vec![
-                Value::Int(8192),
-                Value::Int(16383),
-                Value::Bulk(vec![
-                    Value::Data(name.as_bytes().to_vec()),
-                    Value::Int(6381),
-                ]),
-                Value::Bulk(vec![
-                    Value::Data(name.as_bytes().to_vec()),
-                    Value::Int(6382),
-                ]),
-            ]),
-        ])))
+                    Value::Int(slot_config.slot_range.start as i64),
+                    Value::Int(slot_config.slot_range.end as i64),
+                    Value::Bulk(vec![
+                        Value::Data(name.as_bytes().to_vec()),
+                        Value::Int(slot_config.primary_port as i64),
+                    ]),
+                    Value::Bulk(replicas),
+                ])
+            })
+            .collect();
+        Err(Ok(Value::Bulk(slots)))
     } else if contains_slice(cmd, b"READONLY") {
         Err(Ok(Value::Status("OK".into())))
     } else {

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -600,8 +600,11 @@ fn test_cluster_non_retryable_error_should_not_retry() {
     assert_eq!(completed.load(Ordering::SeqCst), 1);
 }
 
-#[test]
-fn test_cluster_fan_out() {
+fn test_cluster_fan_out(
+    command: &'static str,
+    expected_ports: Vec<u16>,
+    slots_config: Option<Vec<MockSlotRange>>,
+) {
     let name = "node";
     let found_ports = Arc::new(std::sync::Mutex::new(Vec::new()));
     let ports_clone = found_ports.clone();
@@ -616,8 +619,8 @@ fn test_cluster_fan_out() {
             .read_from_replicas(),
         name,
         move |cmd: &[u8], port| {
-            respond_startup_with_replica(name, cmd)?;
-            if (cmd[8..]).starts_with("FLUSHALL".as_bytes()) {
+            respond_startup_with_replica_using_config(name, cmd, slots_config.clone())?;
+            if (cmd[8..]).starts_with(command.as_bytes()) {
                 ports_clone.lock().unwrap().push(port);
                 return Err(Ok(Value::Status("OK".into())));
             }
@@ -625,8 +628,68 @@ fn test_cluster_fan_out() {
         },
     );
 
-    let _ = cmd("FLUSHALL").query::<Option<()>>(&mut connection);
+    let _ = cmd(command).query::<Option<()>>(&mut connection);
     found_ports.lock().unwrap().sort();
     // MockEnv creates 2 mock connections.
-    assert_eq!(*found_ports.lock().unwrap(), vec![6379, 6381]);
+    assert_eq!(*found_ports.lock().unwrap(), expected_ports);
+}
+
+#[test]
+fn test_cluster_fan_out_to_all_primaries() {
+    test_cluster_fan_out("FLUSHALL", vec![6379, 6381], None);
+}
+
+#[test]
+fn test_cluster_fan_out_to_all_nodes() {
+    test_cluster_fan_out("ECHO", vec![6379, 6380, 6381, 6382], None);
+}
+
+#[test]
+fn test_cluster_fan_out_out_once_to_each_primary_when_no_replicas_are_available() {
+    test_cluster_fan_out(
+        "ECHO",
+        vec![6379, 6381],
+        Some(vec![
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: Vec::new(),
+                slot_range: (0..8191),
+            },
+            MockSlotRange {
+                primary_port: 6381,
+                replica_ports: Vec::new(),
+                slot_range: (8192..16383),
+            },
+        ]),
+    );
+}
+
+#[test]
+fn test_cluster_fan_out_out_once_even_if_primary_has_multiple_slot_ranges() {
+    test_cluster_fan_out(
+        "ECHO",
+        vec![6379, 6380, 6381, 6382],
+        Some(vec![
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: vec![6380],
+                slot_range: (0..4000),
+            },
+            MockSlotRange {
+                primary_port: 6381,
+                replica_ports: vec![6382],
+                slot_range: (4001..8191),
+            },
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: vec![6380],
+                slot_range: (8192..8200),
+            },
+            MockSlotRange {
+                primary_port: 6381,
+                replica_ports: vec![6382],
+                slot_range: (8201..16383),
+            },
+        ]),
+    );
 }

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -60,7 +60,6 @@ fn test_async_cluster_basic_eval() {
     .unwrap();
 }
 
-#[ignore] // TODO Handle running SCRIPT LOAD on all masters
 #[test]
 fn test_async_cluster_basic_script() {
     let cluster = TestClusterContext::new(3, 0);


### PR DESCRIPTION
Commands that should be routed to all nodes or all masters will now be routed correctly.

This Pr includes:
1. https://github.com/redis-rs/redis-rs/pull/842, in order to maintain consistent behavior between cluster clients.
2. Moved the `Route` struct into `RoutingInfo` as the `SpecificNode` variant, instead of the `ReplicaSlot`/`MasterSlot` variants. This was done because the current `RoutingInfo`->`Route` mapping functions lost information from `RoutingInfo` in variants that don't map to a specific route.
3. Instead of returning a `(String, RedisResult<Response>)`, cluster_async operations now return `(OperationTarget, RedisResult<Response>)`, where operation target disambiguates single node operations from fan-out operations. This is required, since fan-out operations can't return a single address, and so error handling has to know how to handle this.
4. Moved the routing information from `RequestInfo` into the `CmdArg` variants. This is done because the two variants require different routing information - pipelines can only be routed to single nodes, while Cmd can also be fanned-out.
5. Moved the structs required for getting connections into a `ConnectionsAndMetadata` struct, which is wrapped in an `Arc`. This allows us to moved the objects between functions without using `self`, which allows us to create futures that can run in parallel - in order to fan out concurrently, instead of serially like in the sync cluster. The `Arc` also ensures that clones are cheap, and we only clone/create expensive structs at the last possible moment.