### PR TITLE
Refactor cluster error handling

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -50,7 +50,7 @@ use crate::connection::{
     connect, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, RedisConnectionInfo,
 };
 use crate::parser::parse_redis_value;
-use crate::types::{ErrorKind, HashMap, HashSet, RedisError, RedisResult, Value};
+use crate::types::{ErrorKind, HashMap, RedisError, RedisResult, Value};
 use crate::IntoConnectionInfo;
 use crate::{
     cluster_client::ClusterParams,
@@ -329,7 +329,6 @@ where
                 }
 
                 new_slots = Some(SlotMap::from_slots(&slots_data, self.read_from_replicas));
-
                 break;
             }
         }
@@ -375,7 +374,7 @@ where
         } else {
             // try a random node next.  This is safe if slots are involved
             // as a wrong node would reject the request.
-            Ok(get_random_connection(connections, None))
+            Ok(get_random_connection(connections))
         }
     }
 
@@ -472,7 +471,6 @@ where
         };
 
         let mut retries = self.retries;
-        let mut excludes = HashSet::new();
         let mut redirected = None::<String>;
         let mut is_asking = false;
         loop {
@@ -489,8 +487,8 @@ where
                         is_asking = false;
                     }
                     (addr.to_string(), conn)
-                } else if !excludes.is_empty() || route.is_none() {
-                    get_random_connection(&mut connections, Some(&excludes))
+                } else if route.is_none() {
+                    get_random_connection(&mut connections)
                 } else {
                     self.get_connection(&mut connections, route.as_ref().unwrap())?
                 };
@@ -505,41 +503,41 @@ where
                     }
                     retries -= 1;
 
-                    if err.is_cluster_error() {
-                        let kind = err.kind();
-
-                        if kind == ErrorKind::Ask {
+                    match err.kind() {
+                        ErrorKind::Ask => {
                             redirected = err.redirect_node().map(|(node, _slot)| node.to_string());
                             is_asking = true;
-                        } else if kind == ErrorKind::Moved {
+                        }
+                        ErrorKind::Moved => {
                             // Refresh slots.
                             self.refresh_slots()?;
-                            excludes.clear();
-
                             // Request again.
                             redirected = err.redirect_node().map(|(node, _slot)| node.to_string());
                             is_asking = false;
-                            continue;
-                        } else if kind == ErrorKind::TryAgain || kind == ErrorKind::ClusterDown {
+                        }
+                        ErrorKind::TryAgain | ErrorKind::ClusterDown => {
                             // Sleep and retry.
                             let sleep_time = 2u64.pow(16 - retries.max(9)) * 10;
                             thread::sleep(Duration::from_millis(sleep_time));
-                            excludes.clear();
-                            continue;
                         }
-                    } else if *self.auto_reconnect.borrow() && err.is_io_error() {
-                        self.create_initial_connections()?;
-                        excludes.clear();
-                        continue;
-                    } else {
-                        return Err(err);
-                    }
-
-                    excludes.insert(addr);
-
-                    let connections = self.connections.borrow();
-                    if excludes.len() >= connections.len() {
-                        return Err(err);
+                        ErrorKind::IoError => {
+                            if *self.auto_reconnect.borrow() {
+                                if let Ok(mut conn) = self.connect(&addr) {
+                                    // FIXME: Duplicated from `refresh_slots`
+                                    if conn.check_connection() {
+                                        conn.set_read_timeout(*self.read_timeout.borrow()).unwrap();
+                                        conn.set_write_timeout(*self.write_timeout.borrow())
+                                            .unwrap();
+                                        self.connections.borrow_mut().insert(addr, conn);
+                                    }
+                                }
+                            }
+                        }
+                        _ => {
+                            if !err.is_retryable() {
+                                return Err(err);
+                            }
+                        }
                     }
                 }
             }
@@ -718,22 +716,17 @@ pub enum TlsMode {
     Insecure,
 }
 
-fn get_random_connection<'a, C: ConnectionLike + Connect + Sized>(
-    connections: &'a mut HashMap<String, C>,
-    excludes: Option<&'a HashSet<String>>,
-) -> (String, &'a mut C) {
-    let mut rng = thread_rng();
-    let addr = match excludes {
-        Some(excludes) if excludes.len() < connections.len() => connections
-            .keys()
-            .filter(|key| !excludes.contains(*key))
-            .choose(&mut rng)
-            .unwrap()
-            .to_string(),
-        _ => connections.keys().choose(&mut rng).unwrap().to_string(),
-    };
-
-    let con = connections.get_mut(&addr).unwrap();
+// FIXME -- This function can panic and should probably
+// return an Option instead:
+fn get_random_connection<C: ConnectionLike + Connect + Sized>(
+    connections: &mut HashMap<String, C>,
+) -> (String, &mut C) {
+    let addr = connections
+        .keys()
+        .choose(&mut thread_rng())
+        .expect("Connections is empty")
+        .to_string();
+    let con = connections.get_mut(&addr).expect("Connections is empty");
     (addr, con)
 }
 

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -22,7 +22,7 @@
 //! }
 //! ```
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     fmt, io,
     iter::Iterator,
     marker::Unpin,
@@ -149,13 +149,13 @@ impl<C> CmdArg<C> {
             Self::Cmd { ref cmd, .. } => route_for_command(cmd),
             Self::Pipeline { ref pipeline, .. } => {
                 let mut iter = pipeline.cmd_iter();
-                let slot = iter.next().map(route_for_command)?;
+                let route = iter.next().map(route_for_command)?;
                 for cmd in iter {
-                    if slot != route_for_command(cmd) {
+                    if route != route_for_command(cmd) {
                         return None;
                     }
                 }
-                slot
+                route
             }
         }
     }
@@ -171,8 +171,13 @@ struct Message<C> {
     sender: oneshot::Sender<RedisResult<Response>>,
 }
 
-type RecoverFuture<C> =
-    BoxFuture<'static, Result<(SlotMap, ConnectionMap<C>), (RedisError, ConnectionMap<C>)>>;
+enum RecoverFuture<C> {
+    RecoverSlots(
+        #[allow(clippy::complexity)]
+        BoxFuture<'static, Result<(SlotMap, ConnectionMap<C>), (RedisError, ConnectionMap<C>)>>,
+    ),
+    Reconnect(BoxFuture<'static, ConnectionMap<C>>),
+}
 
 enum ConnectionState<C> {
     PollComplete,
@@ -195,7 +200,6 @@ impl<C> fmt::Debug for ConnectionState<C> {
 struct RequestInfo<C> {
     cmd: CmdArg<C>,
     route: Option<Route>,
-    excludes: HashSet<String>,
 }
 
 pin_project! {
@@ -230,13 +234,15 @@ pin_project! {
 
 #[must_use]
 enum Next<I, C> {
-    TryNewConnection {
+    Retry {
         request: PendingRequest<I, C>,
-        error: Option<RedisError>,
     },
-    Err {
+    Reconnect {
         request: PendingRequest<I, C>,
-        error: RedisError,
+        addr: String,
+    },
+    RefreshSlots {
+        request: PendingRequest<I, C>,
     },
     Done,
 }
@@ -257,9 +263,8 @@ where
             RequestStateProj::Future { future } => future,
             RequestStateProj::Sleep { sleep } => {
                 ready!(sleep.poll(cx));
-                return Next::TryNewConnection {
+                return Next::Retry {
                     request: self.project().request.take().unwrap(),
-                    error: None,
                 }
                 .into();
             }
@@ -282,20 +287,16 @@ where
                 }
                 request.retry = request.retry.saturating_add(1);
 
-                if let Some(error_code) = err.code() {
-                    if error_code == "MOVED" || error_code == "ASK" {
-                        // Refresh slots and request again.
-                        request.info.excludes.clear();
-                        return Next::Err {
-                            request: this.request.take().unwrap(),
-                            error: err,
-                        }
-                        .into();
-                    } else if error_code == "TRYAGAIN" || error_code == "CLUSTERDOWN" {
+                match err.kind() {
+                    // TODO: Proper Ask implementation
+                    ErrorKind::Moved | ErrorKind::Ask => Next::RefreshSlots {
+                        request: this.request.take().unwrap(),
+                    }
+                    .into(),
+                    ErrorKind::TryAgain | ErrorKind::ClusterDown => {
                         // Sleep and retry.
                         let sleep_duration =
                             Duration::from_millis(2u64.pow(request.retry.clamp(7, 16)) * 10);
-                        request.info.excludes.clear();
                         this.future.set(RequestState::Sleep {
                             #[cfg(feature = "tokio-comp")]
                             sleep: Box::pin(tokio::time::sleep(sleep_duration)),
@@ -303,17 +304,25 @@ where
                             #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
                             sleep: Box::pin(async_std::task::sleep(sleep_duration)),
                         });
-                        return self.poll(cx);
+                        self.poll(cx)
+                    }
+                    ErrorKind::IoError => Next::Reconnect {
+                        request: this.request.take().unwrap(),
+                        addr,
+                    }
+                    .into(),
+                    _ => {
+                        if err.is_retryable() {
+                            Next::Retry {
+                                request: this.request.take().unwrap(),
+                            }
+                            .into()
+                        } else {
+                            self.respond(Err(err));
+                            Next::Done.into()
+                        }
                     }
                 }
-
-                request.info.excludes.insert(addr);
-
-                Next::TryNewConnection {
-                    request: this.request.take().unwrap(),
-                    error: Some(err),
-                }
-                .into()
             }
         }
     }
@@ -398,6 +407,25 @@ where
         Ok(connections)
     }
 
+    fn refresh_connections(
+        &mut self,
+        addrs: Vec<String>,
+    ) -> impl Future<Output = ConnectionMap<C>> {
+        let mut connections = mem::take(&mut self.connections);
+        let params = self.cluster_params.clone();
+        async move {
+            for addr in addrs {
+                let conn =
+                    Self::get_or_create_conn(&addr, connections.remove(&addr), params.clone())
+                        .await;
+                if let Ok(conn) = conn {
+                    connections.insert(addr, async { conn }.boxed().shared());
+                }
+            }
+            connections
+        }
+    }
+
     // Query a node to discover slot-> master mappings.
     fn refresh_slots(
         &mut self,
@@ -405,7 +433,6 @@ where
     {
         let mut connections = mem::take(&mut self.connections);
         let cluster_params = self.cluster_params.clone();
-
         async move {
             let mut result = Ok(SlotMap::new());
             for (_, conn) in connections.iter_mut() {
@@ -439,26 +466,16 @@ where
             // Remove dead connections and connect to new nodes if necessary
             let mut new_connections = HashMap::with_capacity(slots.len());
 
+            // TODO: Parallelize this again:
             for addr in nodes {
-                if !new_connections.contains_key(addr) {
-                    let new_connection = if let Some(conn) = connections.remove(addr) {
-                        let mut conn = conn.await;
-                        match check_connection(&mut conn).await {
-                            Ok(_) => Some((addr.to_string(), conn)),
-                            Err(_) => match connect_and_check(addr, cluster_params.clone()).await {
-                                Ok(conn) => Some((addr.to_string(), conn)),
-                                Err(_) => None,
-                            },
-                        }
-                    } else {
-                        match connect_and_check(addr, cluster_params.clone()).await {
-                            Ok(conn) => Some((addr.to_string(), conn)),
-                            Err(_) => None,
-                        }
-                    };
-                    if let Some((addr, new_connection)) = new_connection {
-                        new_connections.insert(addr, async { new_connection }.boxed().shared());
-                    }
+                let conn = Self::get_or_create_conn(
+                    addr,
+                    connections.remove(addr),
+                    cluster_params.clone(),
+                )
+                .await;
+                if let Ok(conn) = conn {
+                    new_connections.insert(addr.to_string(), async { conn }.boxed().shared());
                 }
             }
 
@@ -496,47 +513,26 @@ where
         Ok(slot_map)
     }
 
-    fn get_connection(&mut self, route: &Route) -> (String, ConnectionFuture<C>) {
-        if let Some(addr) = self.slots.slot_addr_for_route(route) {
-            let addr = addr.to_string();
-            if let Some(conn) = self.connections.get(&addr) {
-                return (addr, conn.clone());
-            }
-
-            // Create new connection.
-            //
-            let (_, random_conn) = get_random_connection(&self.connections, None); // TODO Only do this lookup if the first check fails
-            let connection_future = {
-                let addr = addr.clone();
-                let params = self.cluster_params.clone();
-                async move {
-                    match connect_and_check(&addr, params).await {
-                        Ok(conn) => conn,
-                        Err(_) => random_conn.await,
-                    }
-                }
-            }
-            .boxed()
-            .shared();
-            self.connections
-                .insert(addr.clone(), connection_future.clone());
-            (addr, connection_future)
-        } else {
-            // Return a random connection
-            get_random_connection(&self.connections, None)
-        }
-    }
-
     fn try_request(
         &mut self,
         info: &RequestInfo<C>,
     ) -> impl Future<Output = (String, RedisResult<Response>)> {
         // TODO remove clone by changing the ConnectionLike trait
         let cmd = info.cmd.clone();
-        let (addr, conn) = if !info.excludes.is_empty() || info.route.is_none() {
-            get_random_connection(&self.connections, Some(&info.excludes))
+        let (addr, conn) = if info.route.is_none() {
+            get_random_connection(&self.connections)
         } else {
-            self.get_connection(info.route.as_ref().unwrap())
+            let route = info.route.as_ref().unwrap();
+            if let Some(addr) = self.slots.slot_addr_for_route(route) {
+                let addr = addr.to_string();
+                if let Some(conn) = self.connections.get(&addr) {
+                    (addr, conn.clone())
+                } else {
+                    get_random_connection(&self.connections)
+                }
+            } else {
+                get_random_connection(&self.connections)
+            }
         };
         async move {
             let conn = conn.await;
@@ -548,31 +544,48 @@ where
     fn poll_recover(
         &mut self,
         cx: &mut task::Context<'_>,
-        mut future: RecoverFuture<C>,
+        future: RecoverFuture<C>,
     ) -> Poll<Result<(), RedisError>> {
-        match future.as_mut().poll(cx) {
-            Poll::Ready(Ok((slots, connections))) => {
-                trace!("Recovered with {} connections!", connections.len());
-                self.slots = slots;
-                self.connections = connections;
-                self.state = ConnectionState::PollComplete;
-                Poll::Ready(Ok(()))
-            }
-            Poll::Pending => {
-                self.state = ConnectionState::Recover(future);
-                trace!("Recover not ready");
-                Poll::Pending
-            }
-            Poll::Ready(Err((err, connections))) => {
-                self.connections = connections;
-                self.state = ConnectionState::Recover(Box::pin(self.refresh_slots()));
-                Poll::Ready(Err(err))
-            }
+        match future {
+            RecoverFuture::RecoverSlots(mut future) => match future.as_mut().poll(cx) {
+                Poll::Ready(Ok((slots, connections))) => {
+                    trace!("Recovered with {} connections!", connections.len());
+                    self.slots = slots;
+                    self.connections = connections;
+                    self.state = ConnectionState::PollComplete;
+                    Poll::Ready(Ok(()))
+                }
+                Poll::Pending => {
+                    self.state = ConnectionState::Recover(RecoverFuture::RecoverSlots(future));
+                    trace!("Recover not ready");
+                    Poll::Pending
+                }
+                Poll::Ready(Err((err, connections))) => {
+                    self.connections = connections;
+                    self.state = ConnectionState::Recover(RecoverFuture::RecoverSlots(Box::pin(
+                        self.refresh_slots(),
+                    )));
+                    Poll::Ready(Err(err))
+                }
+            },
+            RecoverFuture::Reconnect(mut future) => match future.as_mut().poll(cx) {
+                Poll::Ready(connections) => {
+                    trace!("Reconnected: {} connections", connections.len());
+                    self.connections = connections;
+                    self.state = ConnectionState::PollComplete;
+                    Poll::Ready(Ok(()))
+                }
+                Poll::Pending => {
+                    self.state = ConnectionState::Recover(RecoverFuture::Reconnect(future));
+                    trace!("Recover not ready");
+                    Poll::Pending
+                }
+            },
         }
     }
 
-    fn poll_complete(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), RedisError>> {
-        let mut connection_error = None;
+    fn poll_complete(&mut self, cx: &mut task::Context<'_>) -> Poll<PollFlushAction> {
+        let mut poll_flush_action = PollFlushAction::None;
 
         if !self.pending_requests.is_empty() {
             let mut pending_requests = mem::take(&mut self.pending_requests);
@@ -601,16 +614,9 @@ where
                 Poll::Ready(Some(result)) => result,
                 Poll::Ready(None) | Poll::Pending => break,
             };
-            let self_ = &mut *self;
             match result {
                 Next::Done => {}
-                Next::TryNewConnection { request, error } => {
-                    if let Some(error) = error {
-                        if request.info.excludes.len() >= self_.connections.len() {
-                            let _ = request.sender.send(Err(error));
-                            continue;
-                        }
-                    }
+                Next::Retry { request } => {
                     let future = self.try_request(&request.info);
                     self.in_flight_requests.push(Box::pin(Request {
                         max_retries: self.cluster_params.retries,
@@ -620,19 +626,29 @@ where
                         },
                     }));
                 }
-                Next::Err { request, error } => {
-                    connection_error = Some(error);
+                Next::RefreshSlots { request } => {
+                    poll_flush_action =
+                        poll_flush_action.change_state(PollFlushAction::RebuildSlots);
+                    self.pending_requests.push(request);
+                }
+                Next::Reconnect { request, addr, .. } => {
+                    poll_flush_action =
+                        poll_flush_action.change_state(PollFlushAction::Reconnect(vec![addr]));
                     self.pending_requests.push(request);
                 }
             }
         }
 
-        if let Some(err) = connection_error {
-            Poll::Ready(Err(err))
-        } else if self.in_flight_requests.is_empty() {
-            Poll::Ready(Ok(()))
-        } else {
-            Poll::Pending
+        match poll_flush_action {
+            PollFlushAction::None => {
+                if self.in_flight_requests.is_empty() {
+                    Poll::Ready(poll_flush_action)
+                } else {
+                    Poll::Pending
+                }
+            }
+            rebuild @ PollFlushAction::RebuildSlots => Poll::Ready(rebuild),
+            reestablish @ PollFlushAction::Reconnect(_) => Poll::Ready(reestablish),
         }
     }
 
@@ -648,6 +664,45 @@ where
             } else if let Some(request) = self.pending_requests.pop() {
                 let _ = request.sender.send(Err(self.refresh_error.take().unwrap()));
             }
+        }
+    }
+
+    async fn get_or_create_conn(
+        addr: &str,
+        conn_option: Option<ConnectionFuture<C>>,
+        params: ClusterParams,
+    ) -> RedisResult<C> {
+        if let Some(conn) = conn_option {
+            let mut conn = conn.await;
+            match check_connection(&mut conn).await {
+                Ok(_) => Ok(conn),
+                Err(_) => connect_and_check(addr, params.clone()).await,
+            }
+        } else {
+            connect_and_check(addr, params.clone()).await
+        }
+    }
+}
+
+enum PollFlushAction {
+    None,
+    RebuildSlots,
+    Reconnect(Vec<String>),
+}
+
+impl PollFlushAction {
+    fn change_state(self, next_state: PollFlushAction) -> PollFlushAction {
+        match self {
+            Self::None => next_state,
+            rebuild @ Self::RebuildSlots => rebuild,
+            Self::Reconnect(mut addrs) => match next_state {
+                rebuild @ Self::RebuildSlots => rebuild,
+                Self::Reconnect(new_addrs) => {
+                    addrs.extend(new_addrs);
+                    Self::Reconnect(addrs)
+                }
+                Self::None => Self::Reconnect(addrs),
+            },
         }
     }
 }
@@ -690,14 +745,9 @@ where
         trace!("start_send");
         let Message { cmd, sender } = msg;
 
-        let excludes = HashSet::new();
-        let slot = cmd.route();
+        let route = cmd.route();
 
-        let info = RequestInfo {
-            cmd,
-            route: slot,
-            excludes,
-        };
+        let info = RequestInfo { cmd, route };
 
         self.pending_requests.push(PendingRequest {
             retry: 0,
@@ -734,10 +784,16 @@ where
                     }
                 }
                 ConnectionState::PollComplete => match ready!(self.poll_complete(cx)) {
-                    Ok(()) => return Poll::Ready(Ok(())),
-                    Err(err) => {
-                        trace!("Recovering {}", err);
-                        self.state = ConnectionState::Recover(Box::pin(self.refresh_slots()));
+                    PollFlushAction::None => return Poll::Ready(Ok(())),
+                    PollFlushAction::RebuildSlots => {
+                        self.state = ConnectionState::Recover(RecoverFuture::RecoverSlots(
+                            Box::pin(self.refresh_slots()),
+                        ));
+                    }
+                    PollFlushAction::Reconnect(addrs) => {
+                        self.state = ConnectionState::Recover(RecoverFuture::Reconnect(Box::pin(
+                            self.refresh_connections(addrs),
+                        )));
                     }
                 },
             }
@@ -750,9 +806,10 @@ where
     ) -> Poll<Result<(), Self::Error>> {
         // Try to drive any in flight requests to completion
         match self.poll_complete(cx) {
-            Poll::Ready(result) => {
-                result.map_err(|_| ())?;
-            }
+            Poll::Ready(poll_flush_action) => match poll_flush_action {
+                PollFlushAction::None => (),
+                _ => Err(()).map_err(|_| ())?,
+            },
             Poll::Pending => (),
         };
         // If we no longer have any requests in flight we are done (skips any reconnection
@@ -903,24 +960,20 @@ where
     Ok(())
 }
 
-fn get_random_connection<'a, C>(
-    connections: &'a ConnectionMap<C>,
-    excludes: Option<&'a HashSet<String>>,
-) -> (String, ConnectionFuture<C>)
+// FIXME -- This function can panic and should probably
+// return an Option instead:
+fn get_random_connection<C>(connections: &ConnectionMap<C>) -> (String, ConnectionFuture<C>)
 where
     C: Clone,
 {
-    debug_assert!(!connections.is_empty());
-
-    let mut rng = thread_rng();
-    let sample = match excludes {
-        Some(excludes) if excludes.len() < connections.len() => {
-            let target_keys = connections.keys().filter(|key| !excludes.contains(*key));
-            target_keys.choose(&mut rng)
-        }
-        _ => connections.keys().choose(&mut rng),
-    };
-
-    let addr = sample.expect("No targets to choose from");
-    (addr.to_string(), connections.get(addr).unwrap().clone())
+    let addr = connections
+        .keys()
+        .choose(&mut thread_rng())
+        .expect("Connections is empty")
+        .to_string();
+    let conn = connections
+        .get(&addr)
+        .expect("Connections is empty")
+        .clone();
+    (addr, conn)
 }

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -960,7 +960,7 @@ where
     Ok(())
 }
 
-// FIXME -- This function can panic and should probably
+// TODO: This function can panic and should probably
 // return an Option instead:
 fn get_random_connection<C>(connections: &ConnectionMap<C>) -> (String, ConnectionFuture<C>)
 where

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -237,10 +237,6 @@ impl SlotMap {
     pub fn values(&self) -> std::collections::btree_map::Values<u16, SlotAddrs> {
         self.0.values()
     }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
 }
 
 /// Defines the slot and the [`SlotAddr`] to which

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -237,6 +237,10 @@ impl SlotMap {
     pub fn values(&self) -> std::collections::btree_map::Values<u16, SlotAddrs> {
         self.0.values()
     }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
 }
 
 /// Defines the slot and the [`SlotAddr`] to which

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -591,7 +591,6 @@ impl RedisError {
     #[cfg(feature = "cluster")] // Used to avoid "unused method" warning
     pub(crate) fn is_retryable(&self) -> bool {
         match self.kind() {
-            ErrorKind::ExecAbortError => true,
             ErrorKind::BusyLoadingError => true,
             ErrorKind::Moved => true,
             ErrorKind::Ask => true,
@@ -602,6 +601,7 @@ impl RedisError {
             ErrorKind::ReadOnly => true,
             ErrorKind::ClusterDown => true,
 
+            ErrorKind::ExecAbortError => false,
             ErrorKind::ResponseError => false,
             ErrorKind::AuthenticationFailed => false,
             ErrorKind::TypeError => false,

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -588,6 +588,9 @@ impl RedisError {
         Self { repr }
     }
 
+    // TODO: In addition to/instead of returning a bool here, consider a method
+    // that returns an enum with more detail about _how_ to retry errors, e.g.,
+    // `RetryImmediately`, `WaitAndRetry`, etc.
     #[cfg(feature = "cluster")] // Used to avoid "unused method" warning
     pub(crate) fn is_retryable(&self) -> bool {
         match self.kind() {

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -597,10 +597,10 @@ impl RedisError {
             ErrorKind::TryAgain => true,
             ErrorKind::MasterDown => true,
             ErrorKind::IoError => true,
-            ErrorKind::ExtensionError => true,
             ErrorKind::ReadOnly => true,
             ErrorKind::ClusterDown => true,
 
+            ErrorKind::ExtensionError => false,
             ErrorKind::ExecAbortError => false,
             ErrorKind::ResponseError => false,
             ErrorKind::AuthenticationFailed => false,

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -587,6 +587,32 @@ impl RedisError {
         };
         Self { repr }
     }
+
+    #[cfg(feature = "cluster")] // Used to avoid "unused method" warning
+    pub(crate) fn is_retryable(&self) -> bool {
+        match self.kind() {
+            ErrorKind::ExecAbortError => true,
+            ErrorKind::BusyLoadingError => true,
+            ErrorKind::Moved => true,
+            ErrorKind::Ask => true,
+            ErrorKind::TryAgain => true,
+            ErrorKind::MasterDown => true,
+            ErrorKind::IoError => true,
+            ErrorKind::ExtensionError => true,
+            ErrorKind::ReadOnly => true,
+            ErrorKind::ClusterDown => true,
+
+            ErrorKind::ResponseError => false,
+            ErrorKind::AuthenticationFailed => false,
+            ErrorKind::TypeError => false,
+            ErrorKind::NoScriptError => false,
+            ErrorKind::InvalidClientConfig => false,
+            ErrorKind::CrossSlot => false,
+            ErrorKind::ClientError => false,
+            #[cfg(feature = "json")]
+            ErrorKind::Serialize => false,
+        }
+    }
 }
 
 pub fn make_extension_error(code: &str, detail: Option<&str>) -> RedisError {

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -121,22 +121,65 @@ pub fn respond_startup(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>>
     }
 }
 
+pub fn respond_startup_two_nodes(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>> {
+    if contains_slice(cmd, b"PING") {
+        Err(Ok(Value::Status("OK".into())))
+    } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+        Err(Ok(Value::Bulk(vec![
+            Value::Bulk(vec![
+                Value::Int(0),
+                Value::Int(8191),
+                Value::Bulk(vec![
+                    Value::Data(name.as_bytes().to_vec()),
+                    Value::Int(6379),
+                ]),
+            ]),
+            Value::Bulk(vec![
+                Value::Int(8192),
+                Value::Int(16383),
+                Value::Bulk(vec![
+                    Value::Data(name.as_bytes().to_vec()),
+                    Value::Int(6380),
+                ]),
+            ]),
+        ])))
+    } else if contains_slice(cmd, b"READONLY") {
+        Err(Ok(Value::Status("OK".into())))
+    } else {
+        Ok(())
+    }
+}
+
 pub fn respond_startup_with_replica(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>> {
     if contains_slice(cmd, b"PING") {
         Err(Ok(Value::Status("OK".into())))
     } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
-        Err(Ok(Value::Bulk(vec![Value::Bulk(vec![
-            Value::Int(0),
-            Value::Int(16383),
+        Err(Ok(Value::Bulk(vec![
             Value::Bulk(vec![
-                Value::Data(name.as_bytes().to_vec()),
-                Value::Int(6379),
+                Value::Int(0),
+                Value::Int(8191),
+                Value::Bulk(vec![
+                    Value::Data(name.as_bytes().to_vec()),
+                    Value::Int(6379),
+                ]),
+                Value::Bulk(vec![
+                    Value::Data(name.as_bytes().to_vec()),
+                    Value::Int(6380),
+                ]),
             ]),
             Value::Bulk(vec![
-                Value::Data(name.as_bytes().to_vec()),
-                Value::Int(6380),
+                Value::Int(8192),
+                Value::Int(16383),
+                Value::Bulk(vec![
+                    Value::Data(name.as_bytes().to_vec()),
+                    Value::Int(6381),
+                ]),
+                Value::Bulk(vec![
+                    Value::Data(name.as_bytes().to_vec()),
+                    Value::Int(6382),
+                ]),
             ]),
-        ])])))
+        ])))
     } else if contains_slice(cmd, b"READONLY") {
         Err(Ok(Value::Status("OK".into())))
     } else {

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -1,11 +1,14 @@
 #![cfg(feature = "cluster")]
 mod support;
-use std::sync::{atomic, Arc};
+use std::sync::{
+    atomic::{self, AtomicI32, Ordering},
+    Arc,
+};
 
 use crate::support::*;
 use redis::{
     cluster::{cluster_pipe, ClusterClient},
-    cmd, parse_redis_value, Value,
+    cmd, parse_redis_value, ErrorKind, RedisError, Value,
 };
 
 #[test]
@@ -316,10 +319,13 @@ fn test_cluster_exhaust_retries() {
 
     let result = cmd("GET").arg("test").query::<Option<i32>>(&mut connection);
 
-    assert_eq!(
-        result.map_err(|err| err.to_string()),
-        Err("An error was signalled by the server - TryAgain: mock".to_string())
-    );
+    match result {
+        Ok(_) => panic!("This is not ok, man"),
+        Err(e) => match e.kind() {
+            ErrorKind::TryAgain => {}
+            _ => panic!("Unpexected error type"),
+        },
+    }
     assert_eq!(requests.load(atomic::Ordering::SeqCst), 3);
 }
 
@@ -432,4 +438,72 @@ fn test_cluster_replica_read() {
         .arg("123")
         .query::<Option<Value>>(&mut connection);
     assert_eq!(value, Ok(Some(Value::Status("OK".to_owned()))));
+}
+
+#[test]
+fn test_cluster_io_error() {
+    let name = "node";
+    let completed = Arc::new(AtomicI32::new(0));
+    let MockEnv {
+        mut connection,
+        handler: _handler,
+        ..
+    } = MockEnv::with_client_builder(
+        ClusterClient::builder(vec![&*format!("redis://{name}")]).retries(2),
+        name,
+        move |cmd: &[u8], port| {
+            respond_startup_two_nodes(name, cmd)?;
+            // Error twice with io-error, ensure connection is reestablished w/out calling
+            // other node (i.e., not doing a full slot rebuild)
+            match port {
+                6380 => panic!("Node should not be called"),
+                _ => match completed.fetch_add(1, Ordering::SeqCst) {
+                    0..=1 => Err(Err(RedisError::from(std::io::Error::new(
+                        std::io::ErrorKind::ConnectionReset,
+                        "mock-io-error",
+                    )))),
+                    _ => Err(Ok(Value::Data(b"123".to_vec()))),
+                },
+            }
+        },
+    );
+
+    let value = cmd("GET").arg("test").query::<Option<i32>>(&mut connection);
+
+    assert_eq!(value, Ok(Some(123)));
+}
+
+#[test]
+fn test_cluster_non_retryable_error_should_not_retry() {
+    let name = "node";
+    let completed = Arc::new(AtomicI32::new(0));
+    let MockEnv {
+        mut connection,
+        handler: _handler,
+        ..
+    } = MockEnv::with_client_builder(
+        ClusterClient::builder(vec![&*format!("redis://{name}")]),
+        name,
+        {
+            let completed = completed.clone();
+            move |cmd: &[u8], _| {
+                respond_startup_two_nodes(name, cmd)?;
+                // Error twice with io-error, ensure connection is reestablished w/out calling
+                // other node (i.e., not doing a full slot rebuild)
+                completed.fetch_add(1, Ordering::SeqCst);
+                Err(parse_redis_value(b"-ERR mock\r\n"))
+            }
+        },
+    );
+
+    let value = cmd("GET").arg("test").query::<Option<i32>>(&mut connection);
+
+    match value {
+        Ok(_) => panic!("This is not ok, man"),
+        Err(e) => match e.kind() {
+            ErrorKind::ResponseError => {}
+            _ => panic!("Unpexected error type"),
+        },
+    }
+    assert_eq!(completed.load(Ordering::SeqCst), 1);
 }

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -320,10 +320,10 @@ fn test_cluster_exhaust_retries() {
     let result = cmd("GET").arg("test").query::<Option<i32>>(&mut connection);
 
     match result {
-        Ok(_) => panic!("This is not ok, man"),
+        Ok(_) => panic!("result should be an error"),
         Err(e) => match e.kind() {
             ErrorKind::TryAgain => {}
-            _ => panic!("Unpexected error type"),
+            _ => panic!("Expected TryAgain but got {:?}", e.kind()),
         },
     }
     assert_eq!(requests.load(atomic::Ordering::SeqCst), 3);
@@ -499,10 +499,10 @@ fn test_cluster_non_retryable_error_should_not_retry() {
     let value = cmd("GET").arg("test").query::<Option<i32>>(&mut connection);
 
     match value {
-        Ok(_) => panic!("This is not ok, man"),
+        Ok(_) => panic!("result should be an error"),
         Err(e) => match e.kind() {
             ErrorKind::ResponseError => {}
-            _ => panic!("Unpexected error type"),
+            _ => panic!("Expected ResponseError but got {:?}", e.kind()),
         },
     }
     assert_eq!(completed.load(Ordering::SeqCst), 1);

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -13,8 +13,8 @@ use redis::{
     aio::{ConnectionLike, MultiplexedConnection},
     cluster::ClusterClient,
     cluster_async::Connect,
-    cmd, parse_redis_value, AsyncCommands, Cmd, InfoDict, IntoConnectionInfo, RedisError,
-    RedisFuture, RedisResult, Script, Value,
+    cmd, parse_redis_value, AsyncCommands, Cmd, ErrorKind, InfoDict, IntoConnectionInfo,
+    RedisError, RedisFuture, RedisResult, Script, Value,
 };
 
 use crate::support::*;
@@ -366,10 +366,13 @@ fn test_async_cluster_tryagain_exhaust_retries() {
             .query_async::<_, Option<i32>>(&mut connection),
     );
 
-    assert_eq!(
-        result.map_err(|err| err.to_string()),
-        Err("An error was signalled by the server - TryAgain: mock".to_string())
-    );
+    match result {
+        Ok(_) => panic!("This is not ok, man"),
+        Err(e) => match e.kind() {
+            ErrorKind::TryAgain => {}
+            _ => panic!("Unpexected error type"),
+        },
+    }
     assert_eq!(requests.load(atomic::Ordering::SeqCst), 3);
 }
 
@@ -522,4 +525,82 @@ fn test_async_cluster_with_username_and_password() {
         Ok::<_, RedisError>(())
     })
     .unwrap();
+}
+
+#[test]
+fn test_async_cluster_io_error() {
+    let name = "node";
+    let completed = Arc::new(AtomicI32::new(0));
+    let MockEnv {
+        runtime,
+        async_connection: mut connection,
+        handler: _handler,
+        ..
+    } = MockEnv::with_client_builder(
+        ClusterClient::builder(vec![&*format!("redis://{name}")]).retries(2),
+        name,
+        move |cmd: &[u8], port| {
+            respond_startup_two_nodes(name, cmd)?;
+            // Error twice with io-error, ensure connection is reestablished w/out calling
+            // other node (i.e., not doing a full slot rebuild)
+            match port {
+                6380 => panic!("Node should not be called"),
+                _ => match completed.fetch_add(1, Ordering::SeqCst) {
+                    0..=1 => Err(Err(RedisError::from(std::io::Error::new(
+                        std::io::ErrorKind::ConnectionReset,
+                        "mock-io-error",
+                    )))),
+                    _ => Err(Ok(Value::Data(b"123".to_vec()))),
+                },
+            }
+        },
+    );
+
+    let value = runtime.block_on(
+        cmd("GET")
+            .arg("test")
+            .query_async::<_, Option<i32>>(&mut connection),
+    );
+
+    assert_eq!(value, Ok(Some(123)));
+}
+
+#[test]
+fn test_async_cluster_non_retryable_error_should_not_retry() {
+    let name = "node";
+    let completed = Arc::new(AtomicI32::new(0));
+    let MockEnv {
+        async_connection: mut connection,
+        handler: _handler,
+        runtime,
+        ..
+    } = MockEnv::with_client_builder(
+        ClusterClient::builder(vec![&*format!("redis://{name}")]),
+        name,
+        {
+            let completed = completed.clone();
+            move |cmd: &[u8], _| {
+                respond_startup_two_nodes(name, cmd)?;
+                // Error twice with io-error, ensure connection is reestablished w/out calling
+                // other node (i.e., not doing a full slot rebuild)
+                completed.fetch_add(1, Ordering::SeqCst);
+                Err(parse_redis_value(b"-ERR mock\r\n"))
+            }
+        },
+    );
+
+    let value = runtime.block_on(
+        cmd("GET")
+            .arg("test")
+            .query_async::<_, Option<i32>>(&mut connection),
+    );
+
+    match value {
+        Ok(_) => panic!("This is not ok, man"),
+        Err(e) => match e.kind() {
+            ErrorKind::ResponseError => {}
+            _ => panic!("Unpexected error type"),
+        },
+    }
+    assert_eq!(completed.load(Ordering::SeqCst), 1);
 }

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -367,10 +367,10 @@ fn test_async_cluster_tryagain_exhaust_retries() {
     );
 
     match result {
-        Ok(_) => panic!("This is not ok, man"),
+        Ok(_) => panic!("result should be an error"),
         Err(e) => match e.kind() {
             ErrorKind::TryAgain => {}
-            _ => panic!("Unpexected error type"),
+            _ => panic!("Expected TryAgain but got {:?}", e.kind()),
         },
     }
     assert_eq!(requests.load(atomic::Ordering::SeqCst), 3);
@@ -596,10 +596,10 @@ fn test_async_cluster_non_retryable_error_should_not_retry() {
     );
 
     match value {
-        Ok(_) => panic!("This is not ok, man"),
+        Ok(_) => panic!("result should be an error"),
         Err(e) => match e.kind() {
             ErrorKind::ResponseError => {}
-            _ => panic!("Unpexected error type"),
+            _ => panic!("Expected ResponseError but got {:?}", e.kind()),
         },
     }
     assert_eq!(completed.load(Ordering::SeqCst), 1);


### PR DESCRIPTION
This make some changes to how errors are handled in the redis cluster clients, most notably:
* Remove exclusions -- in practice, exclusions create a lot of unnecessary connection rebuilding/slot refreshes when a failed command results in a `MOVED` error.
* Attempt to refresh failed connections when IO errors occur instead of adding exclusions and ultimately refreshing slots due to the above-described scenario
* Only retry given a subset of error types, otherwise return error immediately.