### PR TITLE
fix: unnecessarily mutable variable

### DIFF
--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -152,7 +152,7 @@ impl<'a, T: FromRedisValue + Unpin + Send + 'a> Stream for AsyncIter<'a, T> {
     type Item = T;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
-        let mut this = self.get_mut();
+        let this = self.get_mut();
         let inner = std::mem::replace(&mut this.inner, IterOrFuture::Empty);
         match inner {
             IterOrFuture::Iter(mut iter) => {


### PR DESCRIPTION
newer Rust versions warn of a variable, that is unnecessarily mut

Just removed the `mut`