### PR TITLE
Allow configuration of cluster retry wait duration

### DIFF
--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -59,7 +59,7 @@ pub enum Module {
 
 pub struct RedisServer {
     pub process: process::Child,
-    tempdir: Option<tempfile::TempDir>,
+    tempdir: tempfile::TempDir,
     addr: redis::ConnectionAddr,
 }
 
@@ -157,6 +157,7 @@ impl RedisServer {
             .prefix("redis")
             .tempdir()
             .expect("failed to create tempdir");
+        redis_cmd.arg("--logfile").arg(Self::log_file(&tempdir));
         match addr {
             redis::ConnectionAddr::Tcp(ref bind, server_port) => {
                 redis_cmd
@@ -167,7 +168,7 @@ impl RedisServer {
 
                 RedisServer {
                     process: spawner(&mut redis_cmd),
-                    tempdir: None,
+                    tempdir,
                     addr,
                 }
             }
@@ -199,7 +200,7 @@ impl RedisServer {
 
                 RedisServer {
                     process: spawner(&mut redis_cmd),
-                    tempdir: Some(tempdir),
+                    tempdir,
                     addr,
                 }
             }
@@ -211,7 +212,7 @@ impl RedisServer {
                     .arg(path);
                 RedisServer {
                     process: spawner(&mut redis_cmd),
-                    tempdir: Some(tempdir),
+                    tempdir,
                     addr,
                 }
             }
@@ -235,6 +236,10 @@ impl RedisServer {
         if let redis::ConnectionAddr::Unix(ref path) = *self.client_addr() {
             fs::remove_file(path).ok();
         }
+    }
+
+    pub fn log_file(tempdir: &TempDir) -> PathBuf {
+        tempdir.path().join("redis.log")
     }
 }
 


### PR DESCRIPTION
This change allows the user to configure the wait duration between retry
attempts in the cluster clients. The change doesn't the current wait time,
but it does contain a fix to the tests, which will allow us to reduce the defaults
without breaking the tests.

This change also introduces jitter, so that if multiple requests
are waiting, they won't be all sent at exactly the same time.