### PR TITLE
Fix minor async client bug.

### DIFF
--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -237,10 +237,6 @@ impl SlotMap {
     pub fn values(&self) -> std::collections::btree_map::Values<u16, SlotAddrs> {
         self.0.values()
     }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
 }
 
 /// Defines the slot and the [`SlotAddr`] to which


### PR DESCRIPTION
`connections.remove(addr),` in the old code always returned `None`, because `connections` in the fold operation was an empty map. This change ensures that connections from the external `connections` variable will be used in the fold operation.

`len` was removed from SlotMap because it's no longer in use.