### PR TITLE
Add modules to async tests.

### DIFF
--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "aio")]
 use futures::{future, prelude::*, StreamExt};
 use redis::{aio::MultiplexedConnection, cmd, AsyncCommands, ErrorKind, RedisResult};
 
@@ -5,498 +6,509 @@ use crate::support::*;
 
 mod support;
 
-#[test]
-fn test_args() {
-    let ctx = TestContext::new();
-    let connect = ctx.async_connection();
+mod async_connection {
+    use super::*;
 
-    block_on_all(connect.and_then(|mut con| async move {
-        redis::cmd("SET")
-            .arg("key1")
-            .arg(b"foo")
-            .query_async(&mut con)
-            .await?;
-        redis::cmd("SET")
-            .arg(&["key2", "bar"])
-            .query_async(&mut con)
-            .await?;
-        let result = redis::cmd("MGET")
-            .arg(&["key1", "key2"])
-            .query_async(&mut con)
-            .await;
-        assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
-        result
-    }))
-    .unwrap();
-}
+    #[test]
+    fn test_args() {
+        let ctx = TestContext::new();
+        let connect = ctx.async_connection();
 
-#[test]
-fn dont_panic_on_closed_multiplexed_connection() {
-    let ctx = TestContext::new();
-    let connect = ctx.multiplexed_async_connection();
-    drop(ctx);
+        block_on_all(connect.and_then(|mut con| async move {
+            redis::cmd("SET")
+                .arg("key1")
+                .arg(b"foo")
+                .query_async(&mut con)
+                .await?;
+            redis::cmd("SET")
+                .arg(&["key2", "bar"])
+                .query_async(&mut con)
+                .await?;
+            let result = redis::cmd("MGET")
+                .arg(&["key1", "key2"])
+                .query_async(&mut con)
+                .await;
+            assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
+            result
+        }))
+        .unwrap();
+    }
 
-    block_on_all(async move {
-        connect
-            .and_then(|con| async move {
-                let cmd = move || {
-                    let mut con = con.clone();
-                    async move {
-                        redis::cmd("SET")
-                            .arg("key1")
-                            .arg(b"foo")
-                            .query_async(&mut con)
-                            .await
-                    }
-                };
-                let result: RedisResult<()> = cmd().await;
-                assert_eq!(
-                    result.as_ref().unwrap_err().kind(),
-                    redis::ErrorKind::IoError,
-                    "{}",
-                    result.as_ref().unwrap_err()
-                );
-                cmd().await
-            })
-            .map(|result| {
-                assert_eq!(
-                    result.as_ref().unwrap_err().kind(),
-                    redis::ErrorKind::IoError,
-                    "{}",
-                    result.as_ref().unwrap_err()
-                );
-            })
-            .await
-    });
-}
+    #[test]
+    fn test_pipeline_transaction() {
+        let ctx = TestContext::new();
+        block_on_all(async move {
+            let mut con = ctx.async_connection().await?;
+            let mut pipe = redis::pipe();
+            pipe.atomic()
+                .cmd("SET")
+                .arg("key_1")
+                .arg(42)
+                .ignore()
+                .cmd("SET")
+                .arg("key_2")
+                .arg(43)
+                .ignore()
+                .cmd("MGET")
+                .arg(&["key_1", "key_2"]);
+            pipe.query_async(&mut con)
+                .map_ok(|((k1, k2),): ((i32, i32),)| {
+                    assert_eq!(k1, 42);
+                    assert_eq!(k2, 43);
+                })
+                .await
+        })
+        .unwrap();
+    }
 
-#[test]
-fn test_pipeline_transaction() {
-    let ctx = TestContext::new();
-    block_on_all(async move {
-        let mut con = ctx.async_connection().await?;
-        let mut pipe = redis::pipe();
-        pipe.atomic()
-            .cmd("SET")
-            .arg("key_1")
-            .arg(42)
-            .ignore()
-            .cmd("SET")
-            .arg("key_2")
-            .arg(43)
-            .ignore()
-            .cmd("MGET")
-            .arg(&["key_1", "key_2"]);
-        pipe.query_async(&mut con)
-            .map_ok(|((k1, k2),): ((i32, i32),)| {
-                assert_eq!(k1, 42);
-                assert_eq!(k2, 43);
-            })
-            .await
-    })
-    .unwrap();
-}
+    #[test]
+    fn test_pipeline_transaction_with_errors() {
+        use redis::RedisError;
+        let ctx = TestContext::new();
 
-#[test]
-fn test_pipeline_transaction_with_errors() {
-    use redis::RedisError;
-    let ctx = TestContext::new();
+        block_on_all(async move {
+            let mut con = ctx.async_connection().await?;
+            con.set::<_, _, ()>("x", 42).await.unwrap();
 
-    block_on_all(async move {
-        let mut con = ctx.async_connection().await?;
-        con.set::<_, _, ()>("x", 42).await.unwrap();
+            // Make Redis a replica of a nonexistent master, thereby making it read-only.
+            redis::cmd("slaveof")
+                .arg("1.1.1.1")
+                .arg("1")
+                .query_async::<_, ()>(&mut con)
+                .await
+                .unwrap();
 
-        // Make Redis a replica of a nonexistent master, thereby making it read-only.
-        redis::cmd("slaveof")
-            .arg("1.1.1.1")
-            .arg("1")
-            .query_async::<_, ()>(&mut con)
+            // Ensure that a write command fails with a READONLY error
+            let err: RedisResult<()> = redis::pipe()
+                .atomic()
+                .set("x", 142)
+                .ignore()
+                .get("x")
+                .query_async(&mut con)
+                .await;
+
+            assert_eq!(err.unwrap_err().kind(), ErrorKind::ReadOnly);
+
+            let x: i32 = con.get("x").await.unwrap();
+            assert_eq!(x, 42);
+
+            Ok::<_, RedisError>(())
+        })
+        .unwrap();
+    }
+
+    // Allowing `nth(0)` for similarity with the following `nth(1)`.
+    // Allowing `let ()` as `query_async` requries the type it converts the result to.
+    #[allow(clippy::let_unit_value, clippy::iter_nth_zero)]
+    #[tokio::test]
+    async fn io_error_on_kill_issue_320() {
+        let ctx = TestContext::new();
+
+        let mut conn_to_kill = ctx.async_connection().await.unwrap();
+        cmd("CLIENT")
+            .arg("SETNAME")
+            .arg("to-kill")
+            .query_async::<_, ()>(&mut conn_to_kill)
             .await
             .unwrap();
 
-        // Ensure that a write command fails with a READONLY error
-        let err: RedisResult<()> = redis::pipe()
-            .atomic()
-            .set("x", 142)
-            .ignore()
-            .get("x")
-            .query_async(&mut con)
-            .await;
-
-        assert_eq!(err.unwrap_err().kind(), ErrorKind::ReadOnly);
-
-        let x: i32 = con.get("x").await.unwrap();
-        assert_eq!(x, 42);
-
-        Ok::<_, RedisError>(())
-    })
-    .unwrap();
-}
-
-fn test_cmd(con: &MultiplexedConnection, i: i32) -> impl Future<Output = RedisResult<()>> + Send {
-    let mut con = con.clone();
-    async move {
-        let key = format!("key{i}");
-        let key_2 = key.clone();
-        let key2 = format!("key{i}_2");
-        let key2_2 = key2.clone();
-
-        let foo_val = format!("foo{i}");
-
-        redis::cmd("SET")
-            .arg(&key[..])
-            .arg(foo_val.as_bytes())
-            .query_async(&mut con)
-            .await?;
-        redis::cmd("SET")
-            .arg(&[&key2, "bar"])
-            .query_async(&mut con)
-            .await?;
-        redis::cmd("MGET")
-            .arg(&[&key_2, &key2_2])
-            .query_async(&mut con)
-            .map(|result| {
-                assert_eq!(Ok((foo_val, b"bar".to_vec())), result);
-                Ok(())
-            })
+        let client_list: String = cmd("CLIENT")
+            .arg("LIST")
+            .query_async(&mut conn_to_kill)
             .await
+            .unwrap();
+
+        eprintln!("{client_list}");
+        let client_to_kill = client_list
+            .split('\n')
+            .find(|line| line.contains("to-kill"))
+            .expect("line")
+            .split(' ')
+            .nth(0)
+            .expect("id")
+            .split('=')
+            .nth(1)
+            .expect("id value");
+
+        let mut killer_conn = ctx.async_connection().await.unwrap();
+        let () = cmd("CLIENT")
+            .arg("KILL")
+            .arg("ID")
+            .arg(client_to_kill)
+            .query_async(&mut killer_conn)
+            .await
+            .unwrap();
+        let mut killed_client = conn_to_kill;
+
+        let err = loop {
+            match killed_client.get::<_, Option<String>>("a").await {
+                // We are racing against the server being shutdown so try until we a get an io error
+                Ok(_) => tokio::time::sleep(std::time::Duration::from_millis(50)).await,
+                Err(err) => break err,
+            }
+        };
+        assert_eq!(err.kind(), ErrorKind::IoError); // Shouldn't this be IoError?
     }
-}
 
-fn test_error(con: &MultiplexedConnection) -> impl Future<Output = RedisResult<()>> {
-    let mut con = con.clone();
-    async move {
-        redis::cmd("SET")
-            .query_async(&mut con)
-            .map(|result| match result {
-                Ok(()) => panic!("Expected redis to return an error"),
-                Err(_) => Ok(()),
-            })
-            .await
-    }
-}
-
-#[test]
-fn test_args_multiplexed_connection() {
-    let ctx = TestContext::new();
-    block_on_all(async move {
-        ctx.multiplexed_async_connection()
-            .and_then(|con| {
-                let cmds = (0..100).map(move |i| test_cmd(&con, i));
-                future::try_join_all(cmds).map_ok(|results| {
-                    assert_eq!(results.len(), 100);
-                })
-            })
-            .map_err(|err| panic!("{}", err))
-            .await
-    })
-    .unwrap();
-}
-
-#[test]
-fn test_args_with_errors_multiplexed_connection() {
-    let ctx = TestContext::new();
-    block_on_all(async move {
-        ctx.multiplexed_async_connection()
-            .and_then(|con| {
-                let cmds = (0..100).map(move |i| {
-                    let con = con.clone();
-                    async move {
-                        if i % 2 == 0 {
-                            test_cmd(&con, i).await
-                        } else {
-                            test_error(&con).await
-                        }
-                    }
-                });
-                future::try_join_all(cmds).map_ok(|results| {
-                    assert_eq!(results.len(), 100);
-                })
-            })
-            .map_err(|err| panic!("{}", err))
-            .await
-    })
-    .unwrap();
-}
-
-#[test]
-fn test_transaction_multiplexed_connection() {
-    let ctx = TestContext::new();
-    block_on_all(async move {
-        ctx.multiplexed_async_connection()
-            .and_then(|con| {
-                let cmds = (0..100).map(move |i| {
-                    let mut con = con.clone();
-                    async move {
-                        let foo_val = i;
-                        let bar_val = format!("bar{i}");
-
-                        let mut pipe = redis::pipe();
-                        pipe.atomic()
-                            .cmd("SET")
-                            .arg("key")
-                            .arg(foo_val)
-                            .ignore()
-                            .cmd("SET")
-                            .arg(&["key2", &bar_val[..]])
-                            .ignore()
-                            .cmd("MGET")
-                            .arg(&["key", "key2"]);
-
-                        pipe.query_async(&mut con)
-                            .map(move |result| {
-                                assert_eq!(Ok(((foo_val, bar_val.into_bytes()),)), result);
-                                result
-                            })
-                            .await
-                    }
-                });
-                future::try_join_all(cmds)
-            })
-            .map_ok(|results| {
-                assert_eq!(results.len(), 100);
-            })
-            .map_err(|err| panic!("{}", err))
-            .await
-    })
-    .unwrap();
-}
-
-fn test_async_scanning(batch_size: usize) {
-    let ctx = TestContext::new();
-    block_on_all(async move {
-        ctx.multiplexed_async_connection()
-            .and_then(|mut con| {
-                async move {
-                    let mut unseen = std::collections::HashSet::new();
-
-                    for x in 0..batch_size {
-                        redis::cmd("SADD")
-                            .arg("foo")
-                            .arg(x)
-                            .query_async(&mut con)
-                            .await?;
-                        unseen.insert(x);
-                    }
-
-                    let mut iter = redis::cmd("SSCAN")
-                        .arg("foo")
-                        .cursor_arg(0)
-                        .clone()
-                        .iter_async(&mut con)
-                        .await
-                        .unwrap();
-
-                    while let Some(x) = iter.next_item().await {
-                        // type inference limitations
-                        let x: usize = x;
-                        // if this assertion fails, too many items were returned by the iterator.
-                        assert!(unseen.remove(&x));
-                    }
-
-                    assert_eq!(unseen.len(), 0);
-                    Ok(())
-                }
-            })
-            .map_err(|err| panic!("{}", err))
-            .await
-    })
-    .unwrap();
-}
-
-#[test]
-fn test_async_scanning_big_batch() {
-    test_async_scanning(1000)
-}
-
-#[test]
-fn test_async_scanning_small_batch() {
-    test_async_scanning(2)
-}
-
-#[test]
-#[cfg(feature = "script")]
-fn test_script() {
-    use redis::RedisError;
-
-    // Note this test runs both scripts twice to test when they have already been loaded
-    // into Redis and when they need to be loaded in
-    let script1 = redis::Script::new("return redis.call('SET', KEYS[1], ARGV[1])");
-    let script2 = redis::Script::new("return redis.call('GET', KEYS[1])");
-    let script3 = redis::Script::new("return redis.call('KEYS', '*')");
-
-    let ctx = TestContext::new();
-
-    block_on_all(async move {
-        let mut con = ctx.multiplexed_async_connection().await?;
-        script1
-            .key("key1")
-            .arg("foo")
-            .invoke_async(&mut con)
-            .await?;
-        let val: String = script2.key("key1").invoke_async(&mut con).await?;
-        assert_eq!(val, "foo");
-        let keys: Vec<String> = script3.invoke_async(&mut con).await?;
-        assert_eq!(keys, ["key1"]);
-        script1
-            .key("key1")
-            .arg("bar")
-            .invoke_async(&mut con)
-            .await?;
-        let val: String = script2.key("key1").invoke_async(&mut con).await?;
-        assert_eq!(val, "bar");
-        let keys: Vec<String> = script3.invoke_async(&mut con).await?;
-        assert_eq!(keys, ["key1"]);
-        Ok::<_, RedisError>(())
-    })
-    .unwrap();
-}
-
-#[test]
-#[cfg(feature = "script")]
-fn test_script_load() {
-    let ctx = TestContext::new();
-    let script = redis::Script::new("return 'Hello World'");
-
-    block_on_all(async move {
-        let mut con = ctx.multiplexed_async_connection().await.unwrap();
-
-        let hash = script.prepare_invoke().load_async(&mut con).await.unwrap();
-        assert_eq!(hash, script.get_hash().to_string());
-    });
-}
-
-#[test]
-#[cfg(feature = "script")]
-fn test_script_returning_complex_type() {
-    let ctx = TestContext::new();
-    block_on_all(async {
-        let mut con = ctx.multiplexed_async_connection().await?;
-        redis::Script::new("return {1, ARGV[1], true}")
-            .arg("hello")
-            .invoke_async(&mut con)
-            .map_ok(|(i, s, b): (i32, String, bool)| {
-                assert_eq!(i, 1);
-                assert_eq!(s, "hello");
-                assert!(b);
-            })
-            .await
-    })
-    .unwrap();
-}
-
-// Allowing `nth(0)` for similarity with the following `nth(1)`.
-// Allowing `let ()` as `query_async` requries the type it converts the result to.
-#[allow(clippy::let_unit_value, clippy::iter_nth_zero)]
-#[tokio::test]
-async fn io_error_on_kill_issue_320() {
-    let ctx = TestContext::new();
-
-    let mut conn_to_kill = ctx.async_connection().await.unwrap();
-    cmd("CLIENT")
-        .arg("SETNAME")
-        .arg("to-kill")
-        .query_async::<_, ()>(&mut conn_to_kill)
-        .await
-        .unwrap();
-
-    let client_list: String = cmd("CLIENT")
-        .arg("LIST")
-        .query_async(&mut conn_to_kill)
-        .await
-        .unwrap();
-
-    eprintln!("{client_list}");
-    let client_to_kill = client_list
-        .split('\n')
-        .find(|line| line.contains("to-kill"))
-        .expect("line")
-        .split(' ')
-        .nth(0)
-        .expect("id")
-        .split('=')
-        .nth(1)
-        .expect("id value");
-
-    let mut killer_conn = ctx.async_connection().await.unwrap();
-    let () = cmd("CLIENT")
-        .arg("KILL")
-        .arg("ID")
-        .arg(client_to_kill)
-        .query_async(&mut killer_conn)
-        .await
-        .unwrap();
-    let mut killed_client = conn_to_kill;
-
-    let err = loop {
-        match killed_client.get::<_, Option<String>>("a").await {
-            // We are racing against the server being shutdown so try until we a get an io error
-            Ok(_) => tokio::time::sleep(std::time::Duration::from_millis(50)).await,
-            Err(err) => break err,
+    // Test issue of AsyncCommands::scan returning the wrong number of keys
+    // https://github.com/redis-rs/redis-rs/issues/759
+    #[tokio::test]
+    async fn test_issue_async_commands_scan_broken() {
+        let ctx = TestContext::new();
+        let mut con = ctx.async_connection().await.unwrap();
+        let mut keys: Vec<String> = (0..100).map(|k| format!("async-key{k}")).collect();
+        keys.sort();
+        for key in &keys {
+            let _: () = con.set(key, b"foo").await.unwrap();
         }
-    };
-    assert_eq!(err.kind(), ErrorKind::IoError); // Shouldn't this be IoError?
+
+        let iter: redis::AsyncIter<String> = con.scan().await.unwrap();
+        let mut keys_from_redis: Vec<_> = iter.collect().await;
+        keys_from_redis.sort();
+        assert_eq!(keys, keys_from_redis);
+        assert_eq!(keys.len(), 100);
+    }
 }
 
-#[tokio::test]
-async fn invalid_password_issue_343() {
-    let ctx = TestContext::new();
-    let coninfo = redis::ConnectionInfo {
-        addr: ctx.server.client_addr().clone(),
-        redis: redis::RedisConnectionInfo {
-            db: 0,
-            username: None,
-            password: Some("asdcasc".to_string()),
-        },
-    };
-    let client = redis::Client::open(coninfo).unwrap();
-    let err = client
-        .get_multiplexed_tokio_connection()
-        .await
-        .err()
+mod multiplexed_connection {
+    use super::*;
+
+    #[test]
+    fn dont_panic_on_closed_multiplexed_connection() {
+        let ctx = TestContext::new();
+        let connect = ctx.multiplexed_async_connection();
+        drop(ctx);
+
+        block_on_all(async move {
+            connect
+                .and_then(|con| async move {
+                    let cmd = move || {
+                        let mut con = con.clone();
+                        async move {
+                            redis::cmd("SET")
+                                .arg("key1")
+                                .arg(b"foo")
+                                .query_async(&mut con)
+                                .await
+                        }
+                    };
+                    let result: RedisResult<()> = cmd().await;
+                    assert_eq!(
+                        result.as_ref().unwrap_err().kind(),
+                        redis::ErrorKind::IoError,
+                        "{}",
+                        result.as_ref().unwrap_err()
+                    );
+                    cmd().await
+                })
+                .map(|result| {
+                    assert_eq!(
+                        result.as_ref().unwrap_err().kind(),
+                        redis::ErrorKind::IoError,
+                        "{}",
+                        result.as_ref().unwrap_err()
+                    );
+                })
+                .await
+        });
+    }
+
+    fn test_cmd(
+        con: &MultiplexedConnection,
+        i: i32,
+    ) -> impl Future<Output = RedisResult<()>> + Send {
+        let mut con = con.clone();
+        async move {
+            let key = format!("key{i}");
+            let key_2 = key.clone();
+            let key2 = format!("key{i}_2");
+            let key2_2 = key2.clone();
+
+            let foo_val = format!("foo{i}");
+
+            redis::cmd("SET")
+                .arg(&key[..])
+                .arg(foo_val.as_bytes())
+                .query_async(&mut con)
+                .await?;
+            redis::cmd("SET")
+                .arg(&[&key2, "bar"])
+                .query_async(&mut con)
+                .await?;
+            redis::cmd("MGET")
+                .arg(&[&key_2, &key2_2])
+                .query_async(&mut con)
+                .map(|result| {
+                    assert_eq!(Ok((foo_val, b"bar".to_vec())), result);
+                    Ok(())
+                })
+                .await
+        }
+    }
+
+    fn test_error(con: &MultiplexedConnection) -> impl Future<Output = RedisResult<()>> {
+        let mut con = con.clone();
+        async move {
+            redis::cmd("SET")
+                .query_async(&mut con)
+                .map(|result| match result {
+                    Ok(()) => panic!("Expected redis to return an error"),
+                    Err(_) => Ok(()),
+                })
+                .await
+        }
+    }
+
+    #[test]
+    fn test_args_multiplexed_connection() {
+        let ctx = TestContext::new();
+        block_on_all(async move {
+            ctx.multiplexed_async_connection()
+                .and_then(|con| {
+                    let cmds = (0..100).map(move |i| test_cmd(&con, i));
+                    future::try_join_all(cmds).map_ok(|results| {
+                        assert_eq!(results.len(), 100);
+                    })
+                })
+                .map_err(|err| panic!("{}", err))
+                .await
+        })
         .unwrap();
-    assert_eq!(
-        err.kind(),
-        ErrorKind::AuthenticationFailed,
-        "Unexpected error: {err}",
-    );
-}
-
-// Test issue of Stream trait blocking if we try to iterate more than 10 items
-// https://github.com/mitsuhiko/redis-rs/issues/537 and https://github.com/mitsuhiko/redis-rs/issues/583
-#[tokio::test]
-async fn test_issue_stream_blocks() {
-    let ctx = TestContext::new();
-    let mut con = ctx.multiplexed_async_connection().await.unwrap();
-    for i in 0..20usize {
-        let _: () = con.append(format!("test/{i}"), i).await.unwrap();
-    }
-    let values = con.scan_match::<&str, String>("test/*").await.unwrap();
-    tokio::time::timeout(std::time::Duration::from_millis(100), async move {
-        let values: Vec<_> = values.collect().await;
-        assert_eq!(values.len(), 20);
-    })
-    .await
-    .unwrap();
-}
-
-// Test issue of AsyncCommands::scan returning the wrong number of keys
-// https://github.com/redis-rs/redis-rs/issues/759
-#[tokio::test]
-async fn test_issue_async_commands_scan_broken() {
-    let ctx = TestContext::new();
-    let mut con = ctx.async_connection().await.unwrap();
-    let mut keys: Vec<String> = (0..100).map(|k| format!("async-key{k}")).collect();
-    keys.sort();
-    for key in &keys {
-        let _: () = con.set(key, b"foo").await.unwrap();
     }
 
-    let iter: redis::AsyncIter<String> = con.scan().await.unwrap();
-    let mut keys_from_redis: Vec<_> = iter.collect().await;
-    keys_from_redis.sort();
-    assert_eq!(keys, keys_from_redis);
-    assert_eq!(keys.len(), 100);
+    #[test]
+    fn test_args_with_errors_multiplexed_connection() {
+        let ctx = TestContext::new();
+        block_on_all(async move {
+            ctx.multiplexed_async_connection()
+                .and_then(|con| {
+                    let cmds = (0..100).map(move |i| {
+                        let con = con.clone();
+                        async move {
+                            if i % 2 == 0 {
+                                test_cmd(&con, i).await
+                            } else {
+                                test_error(&con).await
+                            }
+                        }
+                    });
+                    future::try_join_all(cmds).map_ok(|results| {
+                        assert_eq!(results.len(), 100);
+                    })
+                })
+                .map_err(|err| panic!("{}", err))
+                .await
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_transaction_multiplexed_connection() {
+        let ctx = TestContext::new();
+        block_on_all(async move {
+            ctx.multiplexed_async_connection()
+                .and_then(|con| {
+                    let cmds = (0..100).map(move |i| {
+                        let mut con = con.clone();
+                        async move {
+                            let foo_val = i;
+                            let bar_val = format!("bar{i}");
+
+                            let mut pipe = redis::pipe();
+                            pipe.atomic()
+                                .cmd("SET")
+                                .arg("key")
+                                .arg(foo_val)
+                                .ignore()
+                                .cmd("SET")
+                                .arg(&["key2", &bar_val[..]])
+                                .ignore()
+                                .cmd("MGET")
+                                .arg(&["key", "key2"]);
+
+                            pipe.query_async(&mut con)
+                                .map(move |result| {
+                                    assert_eq!(Ok(((foo_val, bar_val.into_bytes()),)), result);
+                                    result
+                                })
+                                .await
+                        }
+                    });
+                    future::try_join_all(cmds)
+                })
+                .map_ok(|results| {
+                    assert_eq!(results.len(), 100);
+                })
+                .map_err(|err| panic!("{}", err))
+                .await
+        })
+        .unwrap();
+    }
+
+    fn test_async_scanning(batch_size: usize) {
+        let ctx = TestContext::new();
+        block_on_all(async move {
+            ctx.multiplexed_async_connection()
+                .and_then(|mut con| {
+                    async move {
+                        let mut unseen = std::collections::HashSet::new();
+
+                        for x in 0..batch_size {
+                            redis::cmd("SADD")
+                                .arg("foo")
+                                .arg(x)
+                                .query_async(&mut con)
+                                .await?;
+                            unseen.insert(x);
+                        }
+
+                        let mut iter = redis::cmd("SSCAN")
+                            .arg("foo")
+                            .cursor_arg(0)
+                            .clone()
+                            .iter_async(&mut con)
+                            .await
+                            .unwrap();
+
+                        while let Some(x) = iter.next_item().await {
+                            // type inference limitations
+                            let x: usize = x;
+                            // if this assertion fails, too many items were returned by the iterator.
+                            assert!(unseen.remove(&x));
+                        }
+
+                        assert_eq!(unseen.len(), 0);
+                        Ok(())
+                    }
+                })
+                .map_err(|err| panic!("{}", err))
+                .await
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_async_scanning_big_batch() {
+        test_async_scanning(1000)
+    }
+
+    #[test]
+    fn test_async_scanning_small_batch() {
+        test_async_scanning(2)
+    }
+
+    #[test]
+    #[cfg(feature = "script")]
+    fn test_script() {
+        use redis::RedisError;
+
+        // Note this test runs both scripts twice to test when they have already been loaded
+        // into Redis and when they need to be loaded in
+        let script1 = redis::Script::new("return redis.call('SET', KEYS[1], ARGV[1])");
+        let script2 = redis::Script::new("return redis.call('GET', KEYS[1])");
+        let script3 = redis::Script::new("return redis.call('KEYS', '*')");
+
+        let ctx = TestContext::new();
+
+        block_on_all(async move {
+            let mut con = ctx.multiplexed_async_connection().await?;
+            script1
+                .key("key1")
+                .arg("foo")
+                .invoke_async(&mut con)
+                .await?;
+            let val: String = script2.key("key1").invoke_async(&mut con).await?;
+            assert_eq!(val, "foo");
+            let keys: Vec<String> = script3.invoke_async(&mut con).await?;
+            assert_eq!(keys, ["key1"]);
+            script1
+                .key("key1")
+                .arg("bar")
+                .invoke_async(&mut con)
+                .await?;
+            let val: String = script2.key("key1").invoke_async(&mut con).await?;
+            assert_eq!(val, "bar");
+            let keys: Vec<String> = script3.invoke_async(&mut con).await?;
+            assert_eq!(keys, ["key1"]);
+            Ok::<_, RedisError>(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    #[cfg(feature = "script")]
+    fn test_script_load() {
+        let ctx = TestContext::new();
+        let script = redis::Script::new("return 'Hello World'");
+
+        block_on_all(async move {
+            let mut con = ctx.multiplexed_async_connection().await.unwrap();
+
+            let hash = script.prepare_invoke().load_async(&mut con).await.unwrap();
+            assert_eq!(hash, script.get_hash().to_string());
+        });
+    }
+
+    #[test]
+    #[cfg(feature = "script")]
+    fn test_script_returning_complex_type() {
+        let ctx = TestContext::new();
+        block_on_all(async {
+            let mut con = ctx.multiplexed_async_connection().await?;
+            redis::Script::new("return {1, ARGV[1], true}")
+                .arg("hello")
+                .invoke_async(&mut con)
+                .map_ok(|(i, s, b): (i32, String, bool)| {
+                    assert_eq!(i, 1);
+                    assert_eq!(s, "hello");
+                    assert!(b);
+                })
+                .await
+        })
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn invalid_password_issue_343() {
+        let ctx = TestContext::new();
+        let coninfo = redis::ConnectionInfo {
+            addr: ctx.server.client_addr().clone(),
+            redis: redis::RedisConnectionInfo {
+                db: 0,
+                username: None,
+                password: Some("asdcasc".to_string()),
+            },
+        };
+        let client = redis::Client::open(coninfo).unwrap();
+        let err = client
+            .get_multiplexed_tokio_connection()
+            .await
+            .err()
+            .unwrap();
+        assert_eq!(
+            err.kind(),
+            ErrorKind::AuthenticationFailed,
+            "Unexpected error: {err}",
+        );
+    }
+
+    // Test issue of Stream trait blocking if we try to iterate more than 10 items
+    // https://github.com/mitsuhiko/redis-rs/issues/537 and https://github.com/mitsuhiko/redis-rs/issues/583
+    #[tokio::test]
+    async fn test_issue_stream_blocks() {
+        let ctx = TestContext::new();
+        let mut con = ctx.multiplexed_async_connection().await.unwrap();
+        for i in 0..20usize {
+            let _: () = con.append(format!("test/{i}"), i).await.unwrap();
+        }
+        let values = con.scan_match::<&str, String>("test/*").await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_millis(100), async move {
+            let values: Vec<_> = values.collect().await;
+            assert_eq!(values.len(), 20);
+        })
+        .await
+        .unwrap();
+    }
 }
 
 mod pub_sub {
@@ -640,50 +652,53 @@ mod pub_sub {
 }
 
 #[cfg(feature = "connection-manager")]
-async fn wait_for_server_to_become_ready(client: redis::Client) {
-    let millisecond = std::time::Duration::from_millis(1);
-    let mut retries = 0;
-    loop {
-        match client.get_multiplexed_async_connection().await {
-            Err(err) => {
-                if err.is_connection_refusal() {
-                    tokio::time::sleep(millisecond).await;
-                    retries += 1;
-                    if retries > 100000 {
-                        panic!("Tried to connect too many times, last error: {err}");
+mod connection_manager {
+    use super::*;
+
+    async fn wait_for_server_to_become_ready(client: redis::Client) {
+        let millisecond = std::time::Duration::from_millis(1);
+        let mut retries = 0;
+        loop {
+            match client.get_multiplexed_async_connection().await {
+                Err(err) => {
+                    if err.is_connection_refusal() {
+                        tokio::time::sleep(millisecond).await;
+                        retries += 1;
+                        if retries > 100000 {
+                            panic!("Tried to connect too many times, last error: {err}");
+                        }
+                    } else {
+                        panic!("Could not connect: {err}");
                     }
-                } else {
-                    panic!("Could not connect: {err}");
                 }
-            }
-            Ok(mut con) => {
-                let _: RedisResult<()> = redis::cmd("FLUSHDB").query_async(&mut con).await;
-                break;
+                Ok(mut con) => {
+                    let _: RedisResult<()> = redis::cmd("FLUSHDB").query_async(&mut con).await;
+                    break;
+                }
             }
         }
     }
-}
 
-#[test]
-#[cfg(feature = "connection-manager")]
-fn test_connection_manager_reconnect_after_delay() {
-    let ctx = TestContext::new();
+    #[test]
+    fn test_connection_manager_reconnect_after_delay() {
+        let ctx = TestContext::new();
 
-    block_on_all(async move {
-        let mut manager = redis::aio::ConnectionManager::new(ctx.client.clone())
-            .await
-            .unwrap();
-        let server = ctx.server;
-        let addr = server.client_addr().clone();
-        drop(server);
+        block_on_all(async move {
+            let mut manager = redis::aio::ConnectionManager::new(ctx.client.clone())
+                .await
+                .unwrap();
+            let server = ctx.server;
+            let addr = server.client_addr().clone();
+            drop(server);
 
-        let _result: RedisResult<redis::Value> = manager.set("foo", "bar").await; // one call is ignored because it's required to trigger the connection manager's reconnect.
+            let _result: RedisResult<redis::Value> = manager.set("foo", "bar").await; // one call is ignored because it's required to trigger the connection manager's reconnect.
 
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        let _new_server = RedisServer::new_with_addr_and_modules(addr.clone(), &[]);
-        wait_for_server_to_become_ready(ctx.client.clone()).await;
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            let _new_server = RedisServer::new_with_addr_and_modules(addr.clone(), &[]);
+            wait_for_server_to_become_ready(ctx.client.clone()).await;
 
-        let result: redis::Value = manager.set("foo", "bar").await.unwrap();
-        assert_eq!(result, redis::Value::Okay);
-    });
+            let result: redis::Value = manager.set("foo", "bar").await.unwrap();
+            assert_eq!(result, redis::Value::Okay);
+        });
+    }
 }

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -1,769 +1,774 @@
 #![cfg(feature = "cluster-async")]
 mod support;
-use std::sync::{
-    atomic::{self, AtomicI32},
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
 
-use futures::prelude::*;
-use futures::stream;
-use once_cell::sync::Lazy;
-use redis::{
-    aio::{ConnectionLike, MultiplexedConnection},
-    cluster::ClusterClient,
-    cluster_async::Connect,
-    cmd, parse_redis_value, AsyncCommands, Cmd, ErrorKind, InfoDict, IntoConnectionInfo,
-    RedisError, RedisFuture, RedisResult, Script, Value,
-};
+mod cluster_async {
+    use std::sync::{
+        atomic::{self, AtomicI32},
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
 
-use crate::support::*;
+    use futures::prelude::*;
+    use futures::stream;
+    use once_cell::sync::Lazy;
+    use redis::{
+        aio::{ConnectionLike, MultiplexedConnection},
+        cluster::ClusterClient,
+        cluster_async::Connect,
+        cmd, parse_redis_value, AsyncCommands, Cmd, ErrorKind, InfoDict, IntoConnectionInfo,
+        RedisError, RedisFuture, RedisResult, Script, Value,
+    };
 
-#[test]
-fn test_async_cluster_basic_cmd() {
-    let cluster = TestClusterContext::new(3, 0);
+    use crate::support::*;
 
-    block_on_all(async move {
-        let mut connection = cluster.async_connection().await;
-        cmd("SET")
-            .arg("test")
-            .arg("test_data")
-            .query_async(&mut connection)
-            .await?;
-        let res: String = cmd("GET")
-            .arg("test")
-            .clone()
-            .query_async(&mut connection)
-            .await?;
-        assert_eq!(res, "test_data");
-        Ok::<_, RedisError>(())
-    })
-    .unwrap();
-}
+    #[test]
+    fn test_async_cluster_basic_cmd() {
+        let cluster = TestClusterContext::new(3, 0);
 
-#[test]
-fn test_async_cluster_basic_eval() {
-    let cluster = TestClusterContext::new(3, 0);
-
-    block_on_all(async move {
-        let mut connection = cluster.async_connection().await;
-        let res: String = cmd("EVAL")
-            .arg(r#"redis.call("SET", KEYS[1], ARGV[1]); return redis.call("GET", KEYS[1])"#)
-            .arg(1)
-            .arg("key")
-            .arg("test")
-            .query_async(&mut connection)
-            .await?;
-        assert_eq!(res, "test");
-        Ok::<_, RedisError>(())
-    })
-    .unwrap();
-}
-
-#[ignore] // TODO Handle running SCRIPT LOAD on all masters
-#[test]
-fn test_async_cluster_basic_script() {
-    let cluster = TestClusterContext::new(3, 0);
-
-    block_on_all(async move {
-        let mut connection = cluster.async_connection().await;
-        let res: String = Script::new(
-            r#"redis.call("SET", KEYS[1], ARGV[1]); return redis.call("GET", KEYS[1])"#,
-        )
-        .key("key")
-        .arg("test")
-        .invoke_async(&mut connection)
-        .await?;
-        assert_eq!(res, "test");
-        Ok::<_, RedisError>(())
-    })
-    .unwrap();
-}
-
-#[ignore] // TODO Handle pipe where the keys do not all go to the same node
-#[test]
-fn test_async_cluster_basic_pipe() {
-    let cluster = TestClusterContext::new(3, 0);
-
-    block_on_all(async move {
-        let mut connection = cluster.async_connection().await;
-        let mut pipe = redis::pipe();
-        pipe.add_command(cmd("SET").arg("test").arg("test_data").clone());
-        pipe.add_command(cmd("SET").arg("test3").arg("test_data3").clone());
-        pipe.query_async(&mut connection).await?;
-        let res: String = connection.get("test").await?;
-        assert_eq!(res, "test_data");
-        let res: String = connection.get("test3").await?;
-        assert_eq!(res, "test_data3");
-        Ok::<_, RedisError>(())
-    })
-    .unwrap()
-}
-
-#[test]
-fn test_async_cluster_basic_failover() {
-    block_on_all(async move {
-        test_failover(&TestClusterContext::new(6, 1), 10, 123).await;
-        Ok::<_, RedisError>(())
-    })
-    .unwrap()
-}
-
-async fn do_failover(redis: &mut redis::aio::MultiplexedConnection) -> Result<(), anyhow::Error> {
-    cmd("CLUSTER").arg("FAILOVER").query_async(redis).await?;
-    Ok(())
-}
-
-async fn test_failover(env: &TestClusterContext, requests: i32, value: i32) {
-    let completed = Arc::new(AtomicI32::new(0));
-
-    let connection = env.async_connection().await;
-    let mut node_conns: Vec<MultiplexedConnection> = Vec::new();
-
-    'outer: loop {
-        node_conns.clear();
-        let cleared_nodes = async {
-            for server in env.cluster.iter_servers() {
-                let addr = server.client_addr();
-                let client = redis::Client::open(server.connection_info())
-                    .unwrap_or_else(|e| panic!("Failed to connect to '{addr}': {e}"));
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .unwrap_or_else(|e| panic!("Failed to get connection: {e}"));
-
-                let info: InfoDict = redis::Cmd::new()
-                    .arg("INFO")
-                    .query_async(&mut conn)
-                    .await
-                    .expect("INFO");
-                let role: String = info.get("role").expect("cluster role");
-
-                if role == "master" {
-                    tokio::time::timeout(std::time::Duration::from_secs(3), async {
-                        Ok(redis::Cmd::new()
-                            .arg("FLUSHALL")
-                            .query_async(&mut conn)
-                            .await?)
-                    })
-                    .await
-                    .unwrap_or_else(|err| Err(anyhow::Error::from(err)))?;
-                }
-
-                node_conns.push(conn);
-            }
-            Ok::<_, anyhow::Error>(())
-        }
-        .await;
-        match cleared_nodes {
-            Ok(()) => break 'outer,
-            Err(err) => {
-                // Failed to clear the databases, retry
-                log::warn!("{}", err);
-            }
-        }
+        block_on_all(async move {
+            let mut connection = cluster.async_connection().await;
+            cmd("SET")
+                .arg("test")
+                .arg("test_data")
+                .query_async(&mut connection)
+                .await?;
+            let res: String = cmd("GET")
+                .arg("test")
+                .clone()
+                .query_async(&mut connection)
+                .await?;
+            assert_eq!(res, "test_data");
+            Ok::<_, RedisError>(())
+        })
+        .unwrap();
     }
 
-    (0..requests + 1)
-        .map(|i| {
-            let mut connection = connection.clone();
-            let mut node_conns = node_conns.clone();
-            let completed = completed.clone();
-            async move {
-                if i == requests / 2 {
-                    // Failover all the nodes, error only if all the failover requests error
-                    node_conns
-                        .iter_mut()
-                        .map(do_failover)
-                        .collect::<stream::FuturesUnordered<_>>()
-                        .fold(
-                            Err(anyhow::anyhow!("None")),
-                            |acc: Result<(), _>, result: Result<(), _>| async move {
-                                acc.or(result)
-                            },
-                        )
+    #[test]
+    fn test_async_cluster_basic_eval() {
+        let cluster = TestClusterContext::new(3, 0);
+
+        block_on_all(async move {
+            let mut connection = cluster.async_connection().await;
+            let res: String = cmd("EVAL")
+                .arg(r#"redis.call("SET", KEYS[1], ARGV[1]); return redis.call("GET", KEYS[1])"#)
+                .arg(1)
+                .arg("key")
+                .arg("test")
+                .query_async(&mut connection)
+                .await?;
+            assert_eq!(res, "test");
+            Ok::<_, RedisError>(())
+        })
+        .unwrap();
+    }
+
+    #[ignore] // TODO Handle running SCRIPT LOAD on all masters
+    #[test]
+    fn test_async_cluster_basic_script() {
+        let cluster = TestClusterContext::new(3, 0);
+
+        block_on_all(async move {
+            let mut connection = cluster.async_connection().await;
+            let res: String = Script::new(
+                r#"redis.call("SET", KEYS[1], ARGV[1]); return redis.call("GET", KEYS[1])"#,
+            )
+            .key("key")
+            .arg("test")
+            .invoke_async(&mut connection)
+            .await?;
+            assert_eq!(res, "test");
+            Ok::<_, RedisError>(())
+        })
+        .unwrap();
+    }
+
+    #[ignore] // TODO Handle pipe where the keys do not all go to the same node
+    #[test]
+    fn test_async_cluster_basic_pipe() {
+        let cluster = TestClusterContext::new(3, 0);
+
+        block_on_all(async move {
+            let mut connection = cluster.async_connection().await;
+            let mut pipe = redis::pipe();
+            pipe.add_command(cmd("SET").arg("test").arg("test_data").clone());
+            pipe.add_command(cmd("SET").arg("test3").arg("test_data3").clone());
+            pipe.query_async(&mut connection).await?;
+            let res: String = connection.get("test").await?;
+            assert_eq!(res, "test_data");
+            let res: String = connection.get("test3").await?;
+            assert_eq!(res, "test_data3");
+            Ok::<_, RedisError>(())
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn test_async_cluster_basic_failover() {
+        block_on_all(async move {
+            test_failover(&TestClusterContext::new(6, 1), 10, 123).await;
+            Ok::<_, RedisError>(())
+        })
+        .unwrap()
+    }
+
+    async fn do_failover(
+        redis: &mut redis::aio::MultiplexedConnection,
+    ) -> Result<(), anyhow::Error> {
+        cmd("CLUSTER").arg("FAILOVER").query_async(redis).await?;
+        Ok(())
+    }
+
+    async fn test_failover(env: &TestClusterContext, requests: i32, value: i32) {
+        let completed = Arc::new(AtomicI32::new(0));
+
+        let connection = env.async_connection().await;
+        let mut node_conns: Vec<MultiplexedConnection> = Vec::new();
+
+        'outer: loop {
+            node_conns.clear();
+            let cleared_nodes = async {
+                for server in env.cluster.iter_servers() {
+                    let addr = server.client_addr();
+                    let client = redis::Client::open(server.connection_info())
+                        .unwrap_or_else(|e| panic!("Failed to connect to '{addr}': {e}"));
+                    let mut conn = client
+                        .get_multiplexed_async_connection()
                         .await
-                } else {
-                    let key = format!("test-{value}-{i}");
-                    cmd("SET")
-                        .arg(&key)
-                        .arg(i)
-                        .clone()
-                        .query_async(&mut connection)
-                        .await?;
-                    let res: i32 = cmd("GET")
-                        .arg(key)
-                        .clone()
-                        .query_async(&mut connection)
-                        .await?;
-                    assert_eq!(res, i);
-                    completed.fetch_add(1, Ordering::SeqCst);
-                    Ok::<_, anyhow::Error>(())
+                        .unwrap_or_else(|e| panic!("Failed to get connection: {e}"));
+
+                    let info: InfoDict = redis::Cmd::new()
+                        .arg("INFO")
+                        .query_async(&mut conn)
+                        .await
+                        .expect("INFO");
+                    let role: String = info.get("role").expect("cluster role");
+
+                    if role == "master" {
+                        tokio::time::timeout(std::time::Duration::from_secs(3), async {
+                            Ok(redis::Cmd::new()
+                                .arg("FLUSHALL")
+                                .query_async(&mut conn)
+                                .await?)
+                        })
+                        .await
+                        .unwrap_or_else(|err| Err(anyhow::Error::from(err)))?;
+                    }
+
+                    node_conns.push(conn);
+                }
+                Ok::<_, anyhow::Error>(())
+            }
+            .await;
+            match cleared_nodes {
+                Ok(()) => break 'outer,
+                Err(err) => {
+                    // Failed to clear the databases, retry
+                    log::warn!("{}", err);
                 }
             }
-        })
-        .collect::<stream::FuturesUnordered<_>>()
-        .try_collect()
-        .await
-        .unwrap_or_else(|e| panic!("{e}"));
+        }
 
-    assert_eq!(
-        completed.load(Ordering::SeqCst),
-        requests,
-        "Some requests never completed!"
-    );
-}
+        (0..requests + 1)
+            .map(|i| {
+                let mut connection = connection.clone();
+                let mut node_conns = node_conns.clone();
+                let completed = completed.clone();
+                async move {
+                    if i == requests / 2 {
+                        // Failover all the nodes, error only if all the failover requests error
+                        node_conns
+                            .iter_mut()
+                            .map(do_failover)
+                            .collect::<stream::FuturesUnordered<_>>()
+                            .fold(
+                                Err(anyhow::anyhow!("None")),
+                                |acc: Result<(), _>, result: Result<(), _>| async move {
+                                    acc.or(result)
+                                },
+                            )
+                            .await
+                    } else {
+                        let key = format!("test-{value}-{i}");
+                        cmd("SET")
+                            .arg(&key)
+                            .arg(i)
+                            .clone()
+                            .query_async(&mut connection)
+                            .await?;
+                        let res: i32 = cmd("GET")
+                            .arg(key)
+                            .clone()
+                            .query_async(&mut connection)
+                            .await?;
+                        assert_eq!(res, i);
+                        completed.fetch_add(1, Ordering::SeqCst);
+                        Ok::<_, anyhow::Error>(())
+                    }
+                }
+            })
+            .collect::<stream::FuturesUnordered<_>>()
+            .try_collect()
+            .await
+            .unwrap_or_else(|e| panic!("{e}"));
 
-static ERROR: Lazy<AtomicBool> = Lazy::new(Default::default);
-
-#[derive(Clone)]
-struct ErrorConnection {
-    inner: MultiplexedConnection,
-}
-
-impl Connect for ErrorConnection {
-    fn connect<'a, T>(info: T) -> RedisFuture<'a, Self>
-    where
-        T: IntoConnectionInfo + Send + 'a,
-    {
-        Box::pin(async {
-            let inner = MultiplexedConnection::connect(info).await?;
-            Ok(ErrorConnection { inner })
-        })
+        assert_eq!(
+            completed.load(Ordering::SeqCst),
+            requests,
+            "Some requests never completed!"
+        );
     }
-}
 
-impl ConnectionLike for ErrorConnection {
-    fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
-        if ERROR.load(Ordering::SeqCst) {
-            Box::pin(async move { Err(RedisError::from((redis::ErrorKind::Moved, "ERROR"))) })
-        } else {
-            self.inner.req_packed_command(cmd)
+    static ERROR: Lazy<AtomicBool> = Lazy::new(Default::default);
+
+    #[derive(Clone)]
+    struct ErrorConnection {
+        inner: MultiplexedConnection,
+    }
+
+    impl Connect for ErrorConnection {
+        fn connect<'a, T>(info: T) -> RedisFuture<'a, Self>
+        where
+            T: IntoConnectionInfo + Send + 'a,
+        {
+            Box::pin(async {
+                let inner = MultiplexedConnection::connect(info).await?;
+                Ok(ErrorConnection { inner })
+            })
         }
     }
 
-    fn req_packed_commands<'a>(
-        &'a mut self,
-        pipeline: &'a redis::Pipeline,
-        offset: usize,
-        count: usize,
-    ) -> RedisFuture<'a, Vec<Value>> {
-        self.inner.req_packed_commands(pipeline, offset, count)
-    }
-
-    fn get_db(&self) -> i64 {
-        self.inner.get_db()
-    }
-}
-
-#[test]
-fn test_async_cluster_error_in_inner_connection() {
-    let cluster = TestClusterContext::new(3, 0);
-
-    block_on_all(async move {
-        let mut con = cluster.async_generic_connection::<ErrorConnection>().await;
-
-        ERROR.store(false, Ordering::SeqCst);
-        let r: Option<i32> = con.get("test").await?;
-        assert_eq!(r, None::<i32>);
-
-        ERROR.store(true, Ordering::SeqCst);
-
-        let result: RedisResult<()> = con.get("test").await;
-        assert_eq!(
-            result,
-            Err(RedisError::from((redis::ErrorKind::Moved, "ERROR")))
-        );
-
-        Ok::<_, RedisError>(())
-    })
-    .unwrap();
-}
-
-#[test]
-#[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
-fn test_async_cluster_async_std_basic_cmd() {
-    let cluster = TestClusterContext::new(3, 0);
-
-    block_on_all_using_async_std(async {
-        let mut connection = cluster.async_connection().await;
-        redis::cmd("SET")
-            .arg("test")
-            .arg("test_data")
-            .query_async(&mut connection)
-            .await?;
-        redis::cmd("GET")
-            .arg("test")
-            .clone()
-            .query_async(&mut connection)
-            .map_ok(|res: String| {
-                assert_eq!(res, "test_data");
-            })
-            .await
-    })
-    .unwrap();
-}
-
-#[test]
-fn test_async_cluster_retries() {
-    let name = "tryagain";
-
-    let requests = atomic::AtomicUsize::new(0);
-    let MockEnv {
-        runtime,
-        async_connection: mut connection,
-        handler: _handler,
-        ..
-    } = MockEnv::with_client_builder(
-        ClusterClient::builder(vec![&*format!("redis://{name}")]).retries(5),
-        name,
-        move |cmd: &[u8], _| {
-            respond_startup(name, cmd)?;
-
-            match requests.fetch_add(1, atomic::Ordering::SeqCst) {
-                0..=4 => Err(parse_redis_value(b"-TRYAGAIN mock\r\n")),
-                _ => Err(Ok(Value::Data(b"123".to_vec()))),
+    impl ConnectionLike for ErrorConnection {
+        fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
+            if ERROR.load(Ordering::SeqCst) {
+                Box::pin(async move { Err(RedisError::from((redis::ErrorKind::Moved, "ERROR"))) })
+            } else {
+                self.inner.req_packed_command(cmd)
             }
-        },
-    );
+        }
 
-    let value = runtime.block_on(
-        cmd("GET")
-            .arg("test")
-            .query_async::<_, Option<i32>>(&mut connection),
-    );
+        fn req_packed_commands<'a>(
+            &'a mut self,
+            pipeline: &'a redis::Pipeline,
+            offset: usize,
+            count: usize,
+        ) -> RedisFuture<'a, Vec<Value>> {
+            self.inner.req_packed_commands(pipeline, offset, count)
+        }
 
-    assert_eq!(value, Ok(Some(123)));
-}
+        fn get_db(&self) -> i64 {
+            self.inner.get_db()
+        }
+    }
 
-#[test]
-fn test_async_cluster_tryagain_exhaust_retries() {
-    let name = "tryagain_exhaust_retries";
+    #[test]
+    fn test_async_cluster_error_in_inner_connection() {
+        let cluster = TestClusterContext::new(3, 0);
 
-    let requests = Arc::new(atomic::AtomicUsize::new(0));
+        block_on_all(async move {
+            let mut con = cluster.async_generic_connection::<ErrorConnection>().await;
 
-    let MockEnv {
-        runtime,
-        async_connection: mut connection,
-        handler: _handler,
-        ..
-    } = MockEnv::with_client_builder(
-        ClusterClient::builder(vec![&*format!("redis://{name}")]).retries(2),
-        name,
-        {
-            let requests = requests.clone();
+            ERROR.store(false, Ordering::SeqCst);
+            let r: Option<i32> = con.get("test").await?;
+            assert_eq!(r, None::<i32>);
+
+            ERROR.store(true, Ordering::SeqCst);
+
+            let result: RedisResult<()> = con.get("test").await;
+            assert_eq!(
+                result,
+                Err(RedisError::from((redis::ErrorKind::Moved, "ERROR")))
+            );
+
+            Ok::<_, RedisError>(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
+    fn test_async_cluster_async_std_basic_cmd() {
+        let cluster = TestClusterContext::new(3, 0);
+
+        block_on_all_using_async_std(async {
+            let mut connection = cluster.async_connection().await;
+            redis::cmd("SET")
+                .arg("test")
+                .arg("test_data")
+                .query_async(&mut connection)
+                .await?;
+            redis::cmd("GET")
+                .arg("test")
+                .clone()
+                .query_async(&mut connection)
+                .map_ok(|res: String| {
+                    assert_eq!(res, "test_data");
+                })
+                .await
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_async_cluster_retries() {
+        let name = "tryagain";
+
+        let requests = atomic::AtomicUsize::new(0);
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")]).retries(5),
+            name,
             move |cmd: &[u8], _| {
                 respond_startup(name, cmd)?;
-                requests.fetch_add(1, atomic::Ordering::SeqCst);
-                Err(parse_redis_value(b"-TRYAGAIN mock\r\n"))
-            }
-        },
-    );
 
-    let result = runtime.block_on(
-        cmd("GET")
-            .arg("test")
-            .query_async::<_, Option<i32>>(&mut connection),
-    );
-
-    match result {
-        Ok(_) => panic!("result should be an error"),
-        Err(e) => match e.kind() {
-            ErrorKind::TryAgain => {}
-            _ => panic!("Expected TryAgain but got {:?}", e.kind()),
-        },
-    }
-    assert_eq!(requests.load(atomic::Ordering::SeqCst), 3);
-}
-
-#[test]
-fn test_async_cluster_move_error_when_new_node_is_added() {
-    let name = "rebuild_with_extra_nodes";
-
-    let requests = atomic::AtomicUsize::new(0);
-    let started = atomic::AtomicBool::new(false);
-    let refreshed = atomic::AtomicBool::new(false);
-
-    let MockEnv {
-        runtime,
-        async_connection: mut connection,
-        handler: _handler,
-        ..
-    } = MockEnv::new(name, move |cmd: &[u8], port| {
-        if !started.load(atomic::Ordering::SeqCst) {
-            respond_startup(name, cmd)?;
-        }
-        started.store(true, atomic::Ordering::SeqCst);
-
-        if contains_slice(cmd, b"PING") {
-            return Err(Ok(Value::Status("OK".into())));
-        }
-
-        let i = requests.fetch_add(1, atomic::Ordering::SeqCst);
-
-        let is_get_cmd = contains_slice(cmd, b"GET");
-        let get_response = Err(Ok(Value::Data(b"123".to_vec())));
-        match i {
-            // Respond that the key exists on a node that does not yet have a connection:
-            0 => Err(parse_redis_value(
-                format!("-MOVED 123 {name}:6380\r\n").as_bytes(),
-            )),
-            _ => {
-                if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
-                    // Should not attempt to refresh slots more than once:
-                    assert!(!refreshed.swap(true, Ordering::SeqCst));
-                    Err(Ok(Value::Bulk(vec![
-                        Value::Bulk(vec![
-                            Value::Int(0),
-                            Value::Int(1),
-                            Value::Bulk(vec![
-                                Value::Data(name.as_bytes().to_vec()),
-                                Value::Int(6379),
-                            ]),
-                        ]),
-                        Value::Bulk(vec![
-                            Value::Int(2),
-                            Value::Int(16383),
-                            Value::Bulk(vec![
-                                Value::Data(name.as_bytes().to_vec()),
-                                Value::Int(6380),
-                            ]),
-                        ]),
-                    ])))
-                } else {
-                    assert_eq!(port, 6380);
-                    assert!(is_get_cmd);
-                    get_response
-                }
-            }
-        }
-    });
-
-    let value = runtime.block_on(
-        cmd("GET")
-            .arg("test")
-            .query_async::<_, Option<i32>>(&mut connection),
-    );
-
-    assert_eq!(value, Ok(Some(123)));
-}
-
-#[test]
-fn test_async_cluster_ask_redirect() {
-    let name = "node";
-    let completed = Arc::new(AtomicI32::new(0));
-    let MockEnv {
-        async_connection: mut connection,
-        handler: _handler,
-        runtime,
-        ..
-    } = MockEnv::with_client_builder(
-        ClusterClient::builder(vec![&*format!("redis://{name}")]),
-        name,
-        {
-            move |cmd: &[u8], port| {
-                respond_startup_two_nodes(name, cmd)?;
-                // Error twice with io-error, ensure connection is reestablished w/out calling
-                // other node (i.e., not doing a full slot rebuild)
-                let count = completed.fetch_add(1, Ordering::SeqCst);
-                match port {
-                    6379 => match count {
-                        0 => Err(parse_redis_value(b"-ASK 14000 node:6380\r\n")),
-                        _ => panic!("Node should not be called now"),
-                    },
-                    6380 => match count {
-                        1 => {
-                            assert!(contains_slice(cmd, b"ASKING"));
-                            Err(Ok(Value::Okay))
-                        }
-                        2 => {
-                            assert!(contains_slice(cmd, b"GET"));
-                            Err(Ok(Value::Data(b"123".to_vec())))
-                        }
-                        _ => panic!("Node should not be called now"),
-                    },
-                    _ => panic!("Wrong node"),
-                }
-            }
-        },
-    );
-
-    let value = runtime.block_on(
-        cmd("GET")
-            .arg("test")
-            .query_async::<_, Option<i32>>(&mut connection),
-    );
-
-    assert_eq!(value, Ok(Some(123)));
-}
-
-#[test]
-fn test_async_cluster_ask_redirect_even_if_original_call_had_no_route() {
-    let name = "node";
-    let completed = Arc::new(AtomicI32::new(0));
-    let MockEnv {
-        async_connection: mut connection,
-        handler: _handler,
-        runtime,
-        ..
-    } = MockEnv::with_client_builder(
-        ClusterClient::builder(vec![&*format!("redis://{name}")]),
-        name,
-        {
-            move |cmd: &[u8], port| {
-                respond_startup_two_nodes(name, cmd)?;
-                // Error twice with io-error, ensure connection is reestablished w/out calling
-                // other node (i.e., not doing a full slot rebuild)
-                let count = completed.fetch_add(1, Ordering::SeqCst);
-                if count == 0 {
-                    return Err(parse_redis_value(b"-ASK 14000 node:6380\r\n"));
-                }
-                match port {
-                    6380 => match count {
-                        1 => {
-                            assert!(
-                                contains_slice(cmd, b"ASKING"),
-                                "{:?}",
-                                std::str::from_utf8(cmd)
-                            );
-                            Err(Ok(Value::Okay))
-                        }
-                        2 => {
-                            assert!(contains_slice(cmd, b"EVAL"));
-                            Err(Ok(Value::Okay))
-                        }
-                        _ => panic!("Node should not be called now"),
-                    },
-                    _ => panic!("Wrong node"),
-                }
-            }
-        },
-    );
-
-    let value = runtime.block_on(
-        cmd("EVAL") // Eval command has no directed, and so is redirected randomly
-            .query_async::<_, Value>(&mut connection),
-    );
-
-    assert_eq!(value, Ok(Value::Okay));
-}
-
-#[test]
-fn test_async_cluster_ask_error_when_new_node_is_added() {
-    let name = "ask_with_extra_nodes";
-
-    let requests = atomic::AtomicUsize::new(0);
-    let started = atomic::AtomicBool::new(false);
-
-    let MockEnv {
-        runtime,
-        async_connection: mut connection,
-        handler: _handler,
-        ..
-    } = MockEnv::new(name, move |cmd: &[u8], port| {
-        if !started.load(atomic::Ordering::SeqCst) {
-            respond_startup(name, cmd)?;
-        }
-        started.store(true, atomic::Ordering::SeqCst);
-
-        if contains_slice(cmd, b"PING") {
-            return Err(Ok(Value::Status("OK".into())));
-        }
-
-        let i = requests.fetch_add(1, atomic::Ordering::SeqCst);
-
-        match i {
-            // Respond that the key exists on a node that does not yet have a connection:
-            0 => Err(parse_redis_value(
-                format!("-ASK 123 {name}:6380\r\n").as_bytes(),
-            )),
-            1 => {
-                assert_eq!(port, 6380);
-                assert!(contains_slice(cmd, b"ASKING"));
-                Err(Ok(Value::Okay))
-            }
-            2 => {
-                assert_eq!(port, 6380);
-                assert!(contains_slice(cmd, b"GET"));
-                Err(Ok(Value::Data(b"123".to_vec())))
-            }
-            _ => {
-                panic!("Unexpected request: {:?}", cmd);
-            }
-        }
-    });
-
-    let value = runtime.block_on(
-        cmd("GET")
-            .arg("test")
-            .query_async::<_, Option<i32>>(&mut connection),
-    );
-
-    assert_eq!(value, Ok(Some(123)));
-}
-
-#[test]
-fn test_async_cluster_replica_read() {
-    let name = "node";
-
-    // requests should route to replica
-    let MockEnv {
-        runtime,
-        async_connection: mut connection,
-        handler: _handler,
-        ..
-    } = MockEnv::with_client_builder(
-        ClusterClient::builder(vec![&*format!("redis://{name}")])
-            .retries(0)
-            .read_from_replicas(),
-        name,
-        move |cmd: &[u8], port| {
-            respond_startup_with_replica(name, cmd)?;
-
-            match port {
-                6380 => Err(Ok(Value::Data(b"123".to_vec()))),
-                _ => panic!("Wrong node"),
-            }
-        },
-    );
-
-    let value = runtime.block_on(
-        cmd("GET")
-            .arg("test")
-            .query_async::<_, Option<i32>>(&mut connection),
-    );
-    assert_eq!(value, Ok(Some(123)));
-
-    // requests should route to primary
-    let MockEnv {
-        runtime,
-        async_connection: mut connection,
-        handler: _handler,
-        ..
-    } = MockEnv::with_client_builder(
-        ClusterClient::builder(vec![&*format!("redis://{name}")])
-            .retries(0)
-            .read_from_replicas(),
-        name,
-        move |cmd: &[u8], port| {
-            respond_startup_with_replica(name, cmd)?;
-            match port {
-                6379 => Err(Ok(Value::Status("OK".into()))),
-                _ => panic!("Wrong node"),
-            }
-        },
-    );
-
-    let value = runtime.block_on(
-        cmd("SET")
-            .arg("test")
-            .arg("123")
-            .query_async::<_, Option<Value>>(&mut connection),
-    );
-    assert_eq!(value, Ok(Some(Value::Status("OK".to_owned()))));
-}
-
-#[test]
-fn test_async_cluster_with_username_and_password() {
-    let cluster = TestClusterContext::new_with_cluster_client_builder(3, 0, |builder| {
-        builder
-            .username(RedisCluster::username().to_string())
-            .password(RedisCluster::password().to_string())
-    });
-    cluster.disable_default_user();
-
-    block_on_all(async move {
-        let mut connection = cluster.async_connection().await;
-        cmd("SET")
-            .arg("test")
-            .arg("test_data")
-            .query_async(&mut connection)
-            .await?;
-        let res: String = cmd("GET")
-            .arg("test")
-            .clone()
-            .query_async(&mut connection)
-            .await?;
-        assert_eq!(res, "test_data");
-        Ok::<_, RedisError>(())
-    })
-    .unwrap();
-}
-
-#[test]
-fn test_async_cluster_io_error() {
-    let name = "node";
-    let completed = Arc::new(AtomicI32::new(0));
-    let MockEnv {
-        runtime,
-        async_connection: mut connection,
-        handler: _handler,
-        ..
-    } = MockEnv::with_client_builder(
-        ClusterClient::builder(vec![&*format!("redis://{name}")]).retries(2),
-        name,
-        move |cmd: &[u8], port| {
-            respond_startup_two_nodes(name, cmd)?;
-            // Error twice with io-error, ensure connection is reestablished w/out calling
-            // other node (i.e., not doing a full slot rebuild)
-            match port {
-                6380 => panic!("Node should not be called"),
-                _ => match completed.fetch_add(1, Ordering::SeqCst) {
-                    0..=1 => Err(Err(RedisError::from(std::io::Error::new(
-                        std::io::ErrorKind::ConnectionReset,
-                        "mock-io-error",
-                    )))),
+                match requests.fetch_add(1, atomic::Ordering::SeqCst) {
+                    0..=4 => Err(parse_redis_value(b"-TRYAGAIN mock\r\n")),
                     _ => Err(Ok(Value::Data(b"123".to_vec()))),
-                },
+                }
+            },
+        );
+
+        let value = runtime.block_on(
+            cmd("GET")
+                .arg("test")
+                .query_async::<_, Option<i32>>(&mut connection),
+        );
+
+        assert_eq!(value, Ok(Some(123)));
+    }
+
+    #[test]
+    fn test_async_cluster_tryagain_exhaust_retries() {
+        let name = "tryagain_exhaust_retries";
+
+        let requests = Arc::new(atomic::AtomicUsize::new(0));
+
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")]).retries(2),
+            name,
+            {
+                let requests = requests.clone();
+                move |cmd: &[u8], _| {
+                    respond_startup(name, cmd)?;
+                    requests.fetch_add(1, atomic::Ordering::SeqCst);
+                    Err(parse_redis_value(b"-TRYAGAIN mock\r\n"))
+                }
+            },
+        );
+
+        let result = runtime.block_on(
+            cmd("GET")
+                .arg("test")
+                .query_async::<_, Option<i32>>(&mut connection),
+        );
+
+        match result {
+            Ok(_) => panic!("result should be an error"),
+            Err(e) => match e.kind() {
+                ErrorKind::TryAgain => {}
+                _ => panic!("Expected TryAgain but got {:?}", e.kind()),
+            },
+        }
+        assert_eq!(requests.load(atomic::Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn test_async_cluster_move_error_when_new_node_is_added() {
+        let name = "rebuild_with_extra_nodes";
+
+        let requests = atomic::AtomicUsize::new(0);
+        let started = atomic::AtomicBool::new(false);
+        let refreshed = atomic::AtomicBool::new(false);
+
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::new(name, move |cmd: &[u8], port| {
+            if !started.load(atomic::Ordering::SeqCst) {
+                respond_startup(name, cmd)?;
             }
-        },
-    );
+            started.store(true, atomic::Ordering::SeqCst);
 
-    let value = runtime.block_on(
-        cmd("GET")
-            .arg("test")
-            .query_async::<_, Option<i32>>(&mut connection),
-    );
+            if contains_slice(cmd, b"PING") {
+                return Err(Ok(Value::Status("OK".into())));
+            }
 
-    assert_eq!(value, Ok(Some(123)));
-}
+            let i = requests.fetch_add(1, atomic::Ordering::SeqCst);
 
-#[test]
-fn test_async_cluster_non_retryable_error_should_not_retry() {
-    let name = "node";
-    let completed = Arc::new(AtomicI32::new(0));
-    let MockEnv {
-        async_connection: mut connection,
-        handler: _handler,
-        runtime,
-        ..
-    } = MockEnv::with_client_builder(
-        ClusterClient::builder(vec![&*format!("redis://{name}")]),
-        name,
-        {
-            let completed = completed.clone();
-            move |cmd: &[u8], _| {
+            let is_get_cmd = contains_slice(cmd, b"GET");
+            let get_response = Err(Ok(Value::Data(b"123".to_vec())));
+            match i {
+                // Respond that the key exists on a node that does not yet have a connection:
+                0 => Err(parse_redis_value(
+                    format!("-MOVED 123 {name}:6380\r\n").as_bytes(),
+                )),
+                _ => {
+                    if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+                        // Should not attempt to refresh slots more than once:
+                        assert!(!refreshed.swap(true, Ordering::SeqCst));
+                        Err(Ok(Value::Bulk(vec![
+                            Value::Bulk(vec![
+                                Value::Int(0),
+                                Value::Int(1),
+                                Value::Bulk(vec![
+                                    Value::Data(name.as_bytes().to_vec()),
+                                    Value::Int(6379),
+                                ]),
+                            ]),
+                            Value::Bulk(vec![
+                                Value::Int(2),
+                                Value::Int(16383),
+                                Value::Bulk(vec![
+                                    Value::Data(name.as_bytes().to_vec()),
+                                    Value::Int(6380),
+                                ]),
+                            ]),
+                        ])))
+                    } else {
+                        assert_eq!(port, 6380);
+                        assert!(is_get_cmd);
+                        get_response
+                    }
+                }
+            }
+        });
+
+        let value = runtime.block_on(
+            cmd("GET")
+                .arg("test")
+                .query_async::<_, Option<i32>>(&mut connection),
+        );
+
+        assert_eq!(value, Ok(Some(123)));
+    }
+
+    #[test]
+    fn test_async_cluster_ask_redirect() {
+        let name = "node";
+        let completed = Arc::new(AtomicI32::new(0));
+        let MockEnv {
+            async_connection: mut connection,
+            handler: _handler,
+            runtime,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")]),
+            name,
+            {
+                move |cmd: &[u8], port| {
+                    respond_startup_two_nodes(name, cmd)?;
+                    // Error twice with io-error, ensure connection is reestablished w/out calling
+                    // other node (i.e., not doing a full slot rebuild)
+                    let count = completed.fetch_add(1, Ordering::SeqCst);
+                    match port {
+                        6379 => match count {
+                            0 => Err(parse_redis_value(b"-ASK 14000 node:6380\r\n")),
+                            _ => panic!("Node should not be called now"),
+                        },
+                        6380 => match count {
+                            1 => {
+                                assert!(contains_slice(cmd, b"ASKING"));
+                                Err(Ok(Value::Okay))
+                            }
+                            2 => {
+                                assert!(contains_slice(cmd, b"GET"));
+                                Err(Ok(Value::Data(b"123".to_vec())))
+                            }
+                            _ => panic!("Node should not be called now"),
+                        },
+                        _ => panic!("Wrong node"),
+                    }
+                }
+            },
+        );
+
+        let value = runtime.block_on(
+            cmd("GET")
+                .arg("test")
+                .query_async::<_, Option<i32>>(&mut connection),
+        );
+
+        assert_eq!(value, Ok(Some(123)));
+    }
+
+    #[test]
+    fn test_async_cluster_ask_redirect_even_if_original_call_had_no_route() {
+        let name = "node";
+        let completed = Arc::new(AtomicI32::new(0));
+        let MockEnv {
+            async_connection: mut connection,
+            handler: _handler,
+            runtime,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")]),
+            name,
+            {
+                move |cmd: &[u8], port| {
+                    respond_startup_two_nodes(name, cmd)?;
+                    // Error twice with io-error, ensure connection is reestablished w/out calling
+                    // other node (i.e., not doing a full slot rebuild)
+                    let count = completed.fetch_add(1, Ordering::SeqCst);
+                    if count == 0 {
+                        return Err(parse_redis_value(b"-ASK 14000 node:6380\r\n"));
+                    }
+                    match port {
+                        6380 => match count {
+                            1 => {
+                                assert!(
+                                    contains_slice(cmd, b"ASKING"),
+                                    "{:?}",
+                                    std::str::from_utf8(cmd)
+                                );
+                                Err(Ok(Value::Okay))
+                            }
+                            2 => {
+                                assert!(contains_slice(cmd, b"EVAL"));
+                                Err(Ok(Value::Okay))
+                            }
+                            _ => panic!("Node should not be called now"),
+                        },
+                        _ => panic!("Wrong node"),
+                    }
+                }
+            },
+        );
+
+        let value = runtime.block_on(
+            cmd("EVAL") // Eval command has no directed, and so is redirected randomly
+                .query_async::<_, Value>(&mut connection),
+        );
+
+        assert_eq!(value, Ok(Value::Okay));
+    }
+
+    #[test]
+    fn test_async_cluster_ask_error_when_new_node_is_added() {
+        let name = "ask_with_extra_nodes";
+
+        let requests = atomic::AtomicUsize::new(0);
+        let started = atomic::AtomicBool::new(false);
+
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::new(name, move |cmd: &[u8], port| {
+            if !started.load(atomic::Ordering::SeqCst) {
+                respond_startup(name, cmd)?;
+            }
+            started.store(true, atomic::Ordering::SeqCst);
+
+            if contains_slice(cmd, b"PING") {
+                return Err(Ok(Value::Status("OK".into())));
+            }
+
+            let i = requests.fetch_add(1, atomic::Ordering::SeqCst);
+
+            match i {
+                // Respond that the key exists on a node that does not yet have a connection:
+                0 => Err(parse_redis_value(
+                    format!("-ASK 123 {name}:6380\r\n").as_bytes(),
+                )),
+                1 => {
+                    assert_eq!(port, 6380);
+                    assert!(contains_slice(cmd, b"ASKING"));
+                    Err(Ok(Value::Okay))
+                }
+                2 => {
+                    assert_eq!(port, 6380);
+                    assert!(contains_slice(cmd, b"GET"));
+                    Err(Ok(Value::Data(b"123".to_vec())))
+                }
+                _ => {
+                    panic!("Unexpected request: {:?}", cmd);
+                }
+            }
+        });
+
+        let value = runtime.block_on(
+            cmd("GET")
+                .arg("test")
+                .query_async::<_, Option<i32>>(&mut connection),
+        );
+
+        assert_eq!(value, Ok(Some(123)));
+    }
+
+    #[test]
+    fn test_async_cluster_replica_read() {
+        let name = "node";
+
+        // requests should route to replica
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .retries(0)
+                .read_from_replicas(),
+            name,
+            move |cmd: &[u8], port| {
+                respond_startup_with_replica(name, cmd)?;
+
+                match port {
+                    6380 => Err(Ok(Value::Data(b"123".to_vec()))),
+                    _ => panic!("Wrong node"),
+                }
+            },
+        );
+
+        let value = runtime.block_on(
+            cmd("GET")
+                .arg("test")
+                .query_async::<_, Option<i32>>(&mut connection),
+        );
+        assert_eq!(value, Ok(Some(123)));
+
+        // requests should route to primary
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .retries(0)
+                .read_from_replicas(),
+            name,
+            move |cmd: &[u8], port| {
+                respond_startup_with_replica(name, cmd)?;
+                match port {
+                    6379 => Err(Ok(Value::Status("OK".into()))),
+                    _ => panic!("Wrong node"),
+                }
+            },
+        );
+
+        let value = runtime.block_on(
+            cmd("SET")
+                .arg("test")
+                .arg("123")
+                .query_async::<_, Option<Value>>(&mut connection),
+        );
+        assert_eq!(value, Ok(Some(Value::Status("OK".to_owned()))));
+    }
+
+    #[test]
+    fn test_async_cluster_with_username_and_password() {
+        let cluster = TestClusterContext::new_with_cluster_client_builder(3, 0, |builder| {
+            builder
+                .username(RedisCluster::username().to_string())
+                .password(RedisCluster::password().to_string())
+        });
+        cluster.disable_default_user();
+
+        block_on_all(async move {
+            let mut connection = cluster.async_connection().await;
+            cmd("SET")
+                .arg("test")
+                .arg("test_data")
+                .query_async(&mut connection)
+                .await?;
+            let res: String = cmd("GET")
+                .arg("test")
+                .clone()
+                .query_async(&mut connection)
+                .await?;
+            assert_eq!(res, "test_data");
+            Ok::<_, RedisError>(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_async_cluster_io_error() {
+        let name = "node";
+        let completed = Arc::new(AtomicI32::new(0));
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")]).retries(2),
+            name,
+            move |cmd: &[u8], port| {
                 respond_startup_two_nodes(name, cmd)?;
                 // Error twice with io-error, ensure connection is reestablished w/out calling
                 // other node (i.e., not doing a full slot rebuild)
-                completed.fetch_add(1, Ordering::SeqCst);
-                Err(parse_redis_value(b"-ERR mock\r\n"))
-            }
-        },
-    );
+                match port {
+                    6380 => panic!("Node should not be called"),
+                    _ => match completed.fetch_add(1, Ordering::SeqCst) {
+                        0..=1 => Err(Err(RedisError::from(std::io::Error::new(
+                            std::io::ErrorKind::ConnectionReset,
+                            "mock-io-error",
+                        )))),
+                        _ => Err(Ok(Value::Data(b"123".to_vec()))),
+                    },
+                }
+            },
+        );
 
-    let value = runtime.block_on(
-        cmd("GET")
-            .arg("test")
-            .query_async::<_, Option<i32>>(&mut connection),
-    );
+        let value = runtime.block_on(
+            cmd("GET")
+                .arg("test")
+                .query_async::<_, Option<i32>>(&mut connection),
+        );
 
-    match value {
-        Ok(_) => panic!("result should be an error"),
-        Err(e) => match e.kind() {
-            ErrorKind::ResponseError => {}
-            _ => panic!("Expected ResponseError but got {:?}", e.kind()),
-        },
+        assert_eq!(value, Ok(Some(123)));
     }
-    assert_eq!(completed.load(Ordering::SeqCst), 1);
+
+    #[test]
+    fn test_async_cluster_non_retryable_error_should_not_retry() {
+        let name = "node";
+        let completed = Arc::new(AtomicI32::new(0));
+        let MockEnv {
+            async_connection: mut connection,
+            handler: _handler,
+            runtime,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")]),
+            name,
+            {
+                let completed = completed.clone();
+                move |cmd: &[u8], _| {
+                    respond_startup_two_nodes(name, cmd)?;
+                    // Error twice with io-error, ensure connection is reestablished w/out calling
+                    // other node (i.e., not doing a full slot rebuild)
+                    completed.fetch_add(1, Ordering::SeqCst);
+                    Err(parse_redis_value(b"-ERR mock\r\n"))
+                }
+            },
+        );
+
+        let value = runtime.block_on(
+            cmd("GET")
+                .arg("test")
+                .query_async::<_, Option<i32>>(&mut connection),
+        );
+
+        match value {
+            Ok(_) => panic!("result should be an error"),
+            Err(e) => match e.kind() {
+                ErrorKind::ResponseError => {}
+                _ => panic!("Expected ResponseError but got {:?}", e.kind()),
+            },
+        }
+        assert_eq!(completed.load(Ordering::SeqCst), 1);
+    }
 }


### PR DESCRIPTION
This will allow us to run groups of async tests separately - `cargo test cluster_async` / `cargo test multiplexed_connection`, etc.
I want this change, because I keep running the cluster_async tests, and haven't found another convenient of running all of them and only them.

The PR doesn't modify the behavior of any test - the only code change is indentation, and reordering of tests in `test_async.rs` so that the tests will be grouped by tested type.