### PR TITLE
Exclude bench from test crate

### DIFF
--- a/redis-test/Cargo.toml
+++ b/redis-test/Cargo.toml
@@ -9,6 +9,9 @@ documentation = "https://docs.rs/redis-test"
 license = "BSD-3-Clause"
 rust-version = "1.60"
 
+[lib]
+bench = false
+
 [dependencies]
 redis = { version = "0.23.0", path = "../redis" }
 


### PR DESCRIPTION
Apparently needed to get criterion-compare action working; should be harmless in any case