### PR TITLE
Enable keep alive on tcp connections via feature

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -42,6 +42,7 @@ futures-util = { version = "0.3.15", default-features = false, optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 tokio-util = { version = "0.7", optional = true }
 tokio = { version = "1", features = ["rt", "net", "time"], optional = true }
+socket2 = { version = "0.4", default-features = false, optional = true }
 
 # Only needed for the connection manager
 arc-swap = { version = "1.1.0", optional = true }
@@ -100,6 +101,7 @@ tokio-rustls-comp = ["tokio-comp", "tls-rustls", "tokio-rustls"]
 connection-manager = ["arc-swap", "futures", "aio", "tokio-retry"]
 streams = []
 cluster-async = ["cluster", "futures", "futures-util", "log"]
+keep-alive = ["socket2"]
 
 # Deprecated features
 tls = ["tls-native-tls"] # use "tls-native-tls" instead

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -81,7 +81,7 @@ ahash = { version = "0.7.6", optional = true }
 log = { version = "0.4", optional = true }
 
 [features]
-default = ["acl", "streams", "geospatial", "script"]
+default = ["acl", "streams", "geospatial", "script", "keep-alive"]
 acl = []
 aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/alloc", "futures-util/sink", "tokio/io-util", "tokio-util", "tokio-util/codec", "tokio/sync", "combine/tokio", "async-trait"]
 geospatial = []

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -62,6 +62,7 @@
 //! * `cluster-async`: enables async redis cluster support (optional)
 //! * `tokio-comp`: enables support for tokio (optional)
 //! * `connection-manager`: enables support for automatic reconnection (optional)
+//! * `keep-alive`: enables keep-alive option on socket by means of `socket2` crate (optional)
 //!
 //! ## Connection Parameters
 //!


### PR DESCRIPTION
This enables keep alive on tcp sockets via `keep-alive` feature

~Do you want to have it configurable so that only `ConnectionManager` would enable it?
There is no harm in enabling it for short living connections as default intervals are quite long~

Note that this doesn't really fix anything, but for long living connections it will speed up failure detection

Related to #885

> package `socket2 v0.5.3` cannot be built because it requires rustc 1.63 or newer, while the currently active rustc version is 1.60.0

Unfortunate sad state of rust networking

Just for reference redis(server) default value for keep-alive is 300 seconds ([Ref](https://raw.githubusercontent.com/redis/redis/7.0/redis.conf))
