### PR TITLE
async cluster: Group responses by response_policy. 

### DIFF
--- a/redis/src/parser.rs
+++ b/redis/src/parser.rs
@@ -144,6 +144,7 @@ where
                             "CROSSSLOT" => ErrorKind::CrossSlot,
                             "MASTERDOWN" => ErrorKind::MasterDown,
                             "READONLY" => ErrorKind::ReadOnly,
+                            "NOTBUSY" => ErrorKind::NotBusy,
                             code => return make_extension_error(code, pieces.next()),
                         };
                         match pieces.next() {

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -127,6 +127,8 @@ pub enum ErrorKind {
     NoValidReplicasFoundBySentinel,
     /// At least one sentinel connection info is required
     EmptySentinelList,
+    /// Attempted to kill a script/function while they werent' executing
+    NotBusy,
 
     #[cfg(feature = "json")]
     /// Error Serializing a struct to JSON form
@@ -468,6 +470,7 @@ impl RedisError {
             ErrorKind::CrossSlot => Some("CROSSSLOT"),
             ErrorKind::MasterDown => Some("MASTERDOWN"),
             ErrorKind::ReadOnly => Some("READONLY"),
+            ErrorKind::NotBusy => Some("NOTBUSY"),
             _ => match self.repr {
                 ErrorRepr::ExtensionError(ref code, _) => Some(code),
                 _ => None,
@@ -498,6 +501,7 @@ impl RedisError {
             ErrorKind::MasterNameNotFoundBySentinel => "master name not found by sentinel",
             ErrorKind::NoValidReplicasFoundBySentinel => "no valid replicas found by sentinel",
             ErrorKind::EmptySentinelList => "empty sentinel list",
+            ErrorKind::NotBusy => "not busy",
             #[cfg(feature = "json")]
             ErrorKind::Serialize => "serializing",
         }
@@ -648,6 +652,7 @@ impl RedisError {
             ErrorKind::CrossSlot => false,
             ErrorKind::ClientError => false,
             ErrorKind::EmptySentinelList => false,
+            ErrorKind::NotBusy => false,
             #[cfg(feature = "json")]
             ErrorKind::Serialize => false,
         }


### PR DESCRIPTION
This change implements the response_policy tip in the async cluster.
https://redis.io/docs/reference/command-tips/#response_policy

This means that the results from fan-out commands will be aggregated
differently, based on the sent command.