### PR TITLE
Deprecate `aio::Connection`

### DIFF
--- a/redis/examples/async-await.rs
+++ b/redis/examples/async-await.rs
@@ -3,7 +3,7 @@ use redis::AsyncCommands;
 #[tokio::main]
 async fn main() -> redis::RedisResult<()> {
     let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-    let mut con = client.get_async_connection().await?;
+    let mut con = client.get_multiplexed_async_connection().await?;
 
     con.set("key1", b"foo").await?;
 

--- a/redis/examples/async-pub-sub.rs
+++ b/redis/examples/async-pub-sub.rs
@@ -4,8 +4,8 @@ use redis::AsyncCommands;
 #[tokio::main]
 async fn main() -> redis::RedisResult<()> {
     let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-    let mut publish_conn = client.get_async_connection().await?;
-    let mut pubsub_conn = client.get_async_connection().await?.into_pubsub();
+    let mut publish_conn = client.get_multiplexed_async_connection().await?;
+    let mut pubsub_conn = client.get_async_pubsub().await?;
 
     pubsub_conn.subscribe("wavephone").await?;
     let mut pubsub_stream = pubsub_conn.on_message();

--- a/redis/examples/async-scan.rs
+++ b/redis/examples/async-scan.rs
@@ -4,7 +4,7 @@ use redis::{AsyncCommands, AsyncIter};
 #[tokio::main]
 async fn main() -> redis::RedisResult<()> {
     let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-    let mut con = client.get_async_connection().await?;
+    let mut con = client.get_multiplexed_async_connection().await?;
 
     con.set("async-key1", b"foo").await?;
     con.set("async-key2", b"foo").await?;

--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 #[cfg(feature = "async-std-comp")]
 use super::async_std;
 use super::ConnectionLike;
@@ -25,6 +27,7 @@ use std::pin::Pin;
 use tokio_util::codec::Decoder;
 
 /// Represents a stateful redis TCP connection.
+#[deprecated(note = "aio::Connection is deprecated. Use aio::MultiplexedConnection instead.")]
 pub struct Connection<C = Pin<Box<dyn AsyncStream + Send + Sync>>> {
     con: C,
     buf: Vec<u8>,
@@ -322,6 +325,7 @@ where
     }
 
     /// Exits from `PubSub` mode and converts [`PubSub`] into [`Connection`].
+    #[deprecated(note = "aio::Connection is deprecated")]
     pub async fn into_connection(mut self) -> Connection<C> {
         self.0.exit_pubsub().await.ok();
 

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -609,7 +609,7 @@ impl Client {
 
         inner_build_with_tls(connection_info, tls_certs)
     }
-    
+
     /// Returns an async receiver for pub-sub messages.
     #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
     // TODO - do we want to type-erase pubsub using a trait, to allow us to replace it with a different implementation later?

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -75,6 +75,10 @@ impl Client {
 impl Client {
     /// Returns an async connection from the client.
     #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
+    #[deprecated(
+        note = "aio::Connection is deprecated. Use client::get_multiplexed_async_connection instead."
+    )]
+    #[allow(deprecated)]
     pub async fn get_async_connection(&self) -> RedisResult<crate::aio::Connection> {
         let con = match Runtime::locate() {
             #[cfg(feature = "tokio-comp")]
@@ -95,6 +99,10 @@ impl Client {
     /// Returns an async connection from the client.
     #[cfg(feature = "tokio-comp")]
     #[cfg_attr(docsrs, doc(cfg(feature = "tokio-comp")))]
+    #[deprecated(
+        note = "aio::Connection is deprecated. Use client::get_multiplexed_tokio_connection instead."
+    )]
+    #[allow(deprecated)]
     pub async fn get_tokio_connection(&self) -> RedisResult<crate::aio::Connection> {
         use crate::aio::RedisRuntime;
         Ok(
@@ -107,6 +115,10 @@ impl Client {
     /// Returns an async connection from the client.
     #[cfg(feature = "async-std-comp")]
     #[cfg_attr(docsrs, doc(cfg(feature = "async-std-comp")))]
+    #[deprecated(
+        note = "aio::Connection is deprecated. Use client::get_multiplexed_async_std_connection instead."
+    )]
+    #[allow(deprecated)]
     pub async fn get_async_std_connection(&self) -> RedisResult<crate::aio::Connection> {
         use crate::aio::RedisRuntime;
         Ok(
@@ -596,6 +608,26 @@ impl Client {
         let connection_info = conn_info.into_connection_info()?;
 
         inner_build_with_tls(connection_info, tls_certs)
+    }
+    
+    /// Returns an async receiver for pub-sub messages.
+    #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
+    // TODO - do we want to type-erase pubsub using a trait, to allow us to replace it with a different implementation later?
+    pub async fn get_async_pubsub(&self) -> RedisResult<crate::aio::PubSub> {
+        #[allow(deprecated)]
+        self.get_async_connection()
+            .await
+            .map(|connection| connection.into_pubsub())
+    }
+
+    /// Returns an async receiver for monitor messages.
+    #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
+    // TODO - do we want to type-erase monitor using a trait, to allow us to replace it with a different implementation later?
+    pub async fn get_async_monitor(&self) -> RedisResult<crate::aio::Monitor> {
+        #[allow(deprecated)]
+        self.get_async_connection()
+            .await
+            .map(|connection| connection.into_monitor())
     }
 }
 

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -300,7 +300,7 @@ fn find_valid_master(
 #[cfg(feature = "aio")]
 async fn async_check_role(connection_info: &ConnectionInfo, target_role: &str) -> bool {
     if let Ok(client) = Client::open(connection_info.clone()) {
-        if let Ok(mut conn) = client.get_async_connection().await {
+        if let Ok(mut conn) = client.get_multiplexed_async_connection().await {
             let result: RedisResult<Vec<Value>> = crate::cmd("ROLE").query_async(&mut conn).await;
             return check_role_result(&result, target_role);
         }

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -487,11 +487,13 @@ impl TestContext {
     }
 
     #[cfg(feature = "aio")]
+    #[allow(deprecated)]
     pub async fn async_connection(&self) -> redis::RedisResult<redis::aio::Connection> {
         self.client.get_async_connection().await
     }
 
     #[cfg(feature = "async-std-comp")]
+    #[allow(deprecated)]
     pub async fn async_connection_async_std(&self) -> redis::RedisResult<redis::aio::Connection> {
         self.client.get_async_std_connection().await
     }

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -620,6 +620,7 @@ mod pub_sub {
             pubsub_conn.subscribe("phonewave").await?;
             pubsub_conn.psubscribe("*").await?;
 
+            #[allow(deprecated)]
             let mut conn = pubsub_conn.into_connection().await;
             redis::cmd("SET")
                 .arg("foo")
@@ -730,7 +731,7 @@ mod mtls_test {
 
         let client =
             build_single_client(ctx.server.connection_info(), &ctx.server.tls_paths, true).unwrap();
-        let connect = client.get_async_connection();
+        let connect = client.get_multiplexed_async_connection();
         block_on_all(connect.and_then(|mut con| async move {
             redis::cmd("SET")
                 .arg("key1")
@@ -751,7 +752,7 @@ mod mtls_test {
         let client =
             build_single_client(ctx.server.connection_info(), &ctx.server.tls_paths, false)
                 .unwrap();
-        let connect = client.get_async_connection();
+        let connect = client.get_multiplexed_async_connection();
         let result = block_on_all(connect.and_then(|mut con| async move {
             redis::cmd("SET")
                 .arg("key1")


### PR DESCRIPTION
`aio::Connection` is deprecated due to it entering erroneous state when user drops its futures before they complete (similar to OpenAI's [RedisPy issue](https://openai.com/blog/march-20-chatgpt-outage)). `PubSub` & `Monitor`, which are built on top of `aio::Connection`, are now exposed for direct creation from a `client`, in order to allow us to transition their implementation to another backing connection.