### PR TITLE
Allow passing routing information to cluster.

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -90,6 +90,89 @@ where
                 ClusterConnection(tx)
             })
     }
+
+    /// Send a command to the given `routing`, and aggregate the response according to `response_policy`.
+    /// If `routing` is [None], the request will be sent to a random node.
+    pub async fn send_packed_command(
+        &mut self,
+        cmd: &Cmd,
+        routing: Option<RoutingInfo>,
+        response_policy: Option<ResponsePolicy>,
+    ) -> RedisResult<Value> {
+        trace!("send_packed_command");
+        let (sender, receiver) = oneshot::channel();
+        self.0
+            .send(Message {
+                cmd: CmdArg::Cmd {
+                    cmd: Arc::new(cmd.clone()), // TODO Remove this clone?
+                    func: |mut conn, cmd| {
+                        Box::pin(async move {
+                            conn.req_packed_command(&cmd).await.map(Response::Single)
+                        })
+                    },
+                    routing,
+                    response_policy,
+                },
+                sender,
+            })
+            .await
+            .map_err(|_| {
+                RedisError::from(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "redis_cluster: Unable to send command",
+                ))
+            })?;
+        receiver
+            .await
+            .unwrap_or_else(|_| {
+                Err(RedisError::from(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "redis_cluster: Unable to receive command",
+                )))
+            })
+            .map(|response| match response {
+                Response::Single(value) => value,
+                Response::Multiple(_) => unreachable!(),
+            })
+    }
+
+    /// Send commands in `pipeline` to the given `route`. If `route` is [None], it will be sent to a random node.
+    pub async fn send_packed_commands<'a>(
+        &'a mut self,
+        pipeline: &'a crate::Pipeline,
+        offset: usize,
+        count: usize,
+        route: Option<Route>,
+    ) -> RedisResult<Vec<Value>> {
+        let (sender, receiver) = oneshot::channel();
+        self.0
+            .send(Message {
+                cmd: CmdArg::Pipeline {
+                    pipeline: Arc::new(pipeline.clone()), // TODO Remove this clone?
+                    offset,
+                    count,
+                    func: |mut conn, pipeline, offset, count| {
+                        Box::pin(async move {
+                            conn.req_packed_commands(&pipeline, offset, count)
+                                .await
+                                .map(Response::Multiple)
+                        })
+                    },
+                    route,
+                },
+                sender,
+            })
+            .await
+            .map_err(|_| RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe)))?;
+
+        receiver
+            .await
+            .unwrap_or_else(|_| Err(RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe))))
+            .map(|response| match response {
+                Response::Multiple(values) => values,
+                Response::Single(_) => unreachable!(),
+            })
+    }
 }
 
 type ConnectionFuture<C> = future::Shared<BoxFuture<'static, C>>;
@@ -1076,46 +1159,13 @@ where
 
 impl<C> ConnectionLike for ClusterConnection<C>
 where
-    C: ConnectionLike + Send + 'static,
+    C: ConnectionLike + Send + Clone + Unpin + Sync + Connect + 'static,
 {
     fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
-        trace!("req_packed_command");
-        let (sender, receiver) = oneshot::channel();
-        Box::pin(async move {
-            self.0
-                .send(Message {
-                    cmd: CmdArg::Cmd {
-                        cmd: Arc::new(cmd.clone()), // TODO Remove this clone?
-                        func: |mut conn, cmd| {
-                            Box::pin(async move {
-                                conn.req_packed_command(&cmd).await.map(Response::Single)
-                            })
-                        },
-                        routing: RoutingInfo::for_routable(cmd),
-                        response_policy: RoutingInfo::response_policy(cmd),
-                    },
-                    sender,
-                })
-                .await
-                .map_err(|_| {
-                    RedisError::from(io::Error::new(
-                        io::ErrorKind::BrokenPipe,
-                        "redis_cluster: Unable to send command",
-                    ))
-                })?;
-            receiver
-                .await
-                .unwrap_or_else(|_| {
-                    Err(RedisError::from(io::Error::new(
-                        io::ErrorKind::BrokenPipe,
-                        "redis_cluster: Unable to receive command",
-                    )))
-                })
-                .map(|response| match response {
-                    Response::Single(value) => value,
-                    Response::Multiple(_) => unreachable!(),
-                })
-        })
+        let routing = RoutingInfo::for_routable(cmd);
+        let response_policy = ResponsePolicy::for_routable(cmd);
+        self.send_packed_command(cmd, routing, response_policy)
+            .boxed()
     }
 
     fn req_packed_commands<'a>(
@@ -1124,38 +1174,9 @@ where
         offset: usize,
         count: usize,
     ) -> RedisFuture<'a, Vec<Value>> {
-        let (sender, receiver) = oneshot::channel();
-        Box::pin(async move {
-            self.0
-                .send(Message {
-                    cmd: CmdArg::Pipeline {
-                        pipeline: Arc::new(pipeline.clone()), // TODO Remove this clone?
-                        offset,
-                        count,
-                        func: |mut conn, pipeline, offset, count| {
-                            Box::pin(async move {
-                                conn.req_packed_commands(&pipeline, offset, count)
-                                    .await
-                                    .map(Response::Multiple)
-                            })
-                        },
-                        route: route_pipeline(pipeline),
-                    },
-                    sender,
-                })
-                .await
-                .map_err(|_| RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe)))?;
-
-            receiver
-                .await
-                .unwrap_or_else(|_| {
-                    Err(RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe)))
-                })
-                .map(|response| match response {
-                    Response::Multiple(values) => values,
-                    Response::Single(_) => unreachable!(),
-                })
-        })
+        let route = route_pipeline(pipeline);
+        self.send_packed_commands(pipeline, offset, count, route)
+            .boxed()
     }
 
     fn get_db(&self) -> i64 {

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -93,7 +93,7 @@ where
 
     /// Send a command to the given `routing`, and aggregate the response according to `response_policy`.
     /// If `routing` is [None], the request will be sent to a random node.
-    pub async fn send_packed_command(
+    pub async fn route_command(
         &mut self,
         cmd: &Cmd,
         routing: RoutingInfo,
@@ -137,7 +137,7 @@ where
     }
 
     /// Send commands in `pipeline` to the given `route`. If `route` is [None], it will be sent to a random node.
-    pub async fn send_packed_commands<'a>(
+    pub async fn route_pipeline<'a>(
         &'a mut self,
         pipeline: &'a crate::Pipeline,
         offset: usize,
@@ -1165,8 +1165,7 @@ where
         let routing = RoutingInfo::for_routable(cmd)
             .unwrap_or(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random));
         let response_policy = ResponsePolicy::for_routable(cmd);
-        self.send_packed_command(cmd, routing, response_policy)
-            .boxed()
+        self.route_command(cmd, routing, response_policy).boxed()
     }
 
     fn req_packed_commands<'a>(
@@ -1176,8 +1175,7 @@ where
         count: usize,
     ) -> RedisFuture<'a, Vec<Value>> {
         let route = route_pipeline(pipeline).into();
-        self.send_packed_commands(pipeline, offset, count, route)
-            .boxed()
+        self.route_pipeline(pipeline, offset, count, route).boxed()
     }
 
     fn get_db(&self) -> i64 {

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -22,27 +22,40 @@ pub(crate) enum Redirect {
     Ask(String),
 }
 
+/// Logical bitwise aggregating operators.
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum LogicalAggregateOp {
+pub enum LogicalAggregateOp {
+    /// Aggregate by bitwise &&
     And,
     // Or, omitted due to dead code warnings. ATM this value isn't constructed anywhere
 }
 
+/// Numerical aggreagting operators.
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum AggregateOp {
+pub enum AggregateOp {
+    /// Choose minimal value
     Min,
+    /// Sum all values
     Sum,
     // Max, omitted due to dead code warnings. ATM this value isn't constructed anywhere
 }
 
+/// Policy on how to combine multiple responses into one.
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum ResponsePolicy {
+pub enum ResponsePolicy {
+    /// Waits for one request to succeed, and return its results. Return error if all requests fail.
     OneSucceeded,
+    /// Waits for one request to succeed with a non-empty value. Returns error if all requests fail or return `Nil`.
     OneSucceededNonEmpty,
+    /// Waits for all requests to succeed, and the returns one of the successes. Returns the error on the first received error.
     AllSucceeded,
+    /// Aggregates success results according to a logical bitwise operator. Returns error on any failed request, or on a response that doesn't conform to 0 or 1.
     AggregateLogical(LogicalAggregateOp),
+    /// Aggregates success results according to a numeric operator. Returns error on any failed request, or on a response that isn't an integer.
     Aggregate(AggregateOp),
+    /// Aggreagte array responses into a single array. Returns error on any failed request, or on a response that isn't an array.
     CombineArrays,
+    /// Handling is not defined by the Redis standard. Will receive a special case
     Special,
 }
 
@@ -252,8 +265,8 @@ where
     })
 }
 
-impl RoutingInfo {
-    pub(crate) fn response_policy<R>(r: &R) -> Option<ResponsePolicy>
+impl ResponsePolicy {
+    pub(crate) fn for_routable<R>(r: &R) -> Option<ResponsePolicy>
     where
         R: Routable + ?Sized,
     {
@@ -293,8 +306,11 @@ impl RoutingInfo {
             _ => None,
         }
     }
+}
 
-    pub(crate) fn for_routable<R>(r: &R) -> Option<RoutingInfo>
+impl RoutingInfo {
+    /// Returns the routing info for `r`.
+    pub fn for_routable<R>(r: &R) -> Option<RoutingInfo>
     where
         R: Routable + ?Sized,
     {

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -77,6 +77,14 @@ pub enum SingleNodeRoutingInfo {
     SpecificNode(Route),
 }
 
+impl From<Option<Route>> for SingleNodeRoutingInfo {
+    fn from(value: Option<Route>) -> Self {
+        value
+            .map(SingleNodeRoutingInfo::SpecificNode)
+            .unwrap_or(SingleNodeRoutingInfo::Random)
+    }
+}
+
 /// Defines which collection of nodes should receive a request
 #[derive(Debug, Clone, PartialEq)]
 pub enum MultipleNodeRoutingInfo {

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -40,20 +40,20 @@ pub enum AggregateOp {
     // Max, omitted due to dead code warnings. ATM this value isn't constructed anywhere
 }
 
-/// Policy on how to combine multiple responses into one.
+/// Policy for combining multiple responses into one.
 #[derive(Debug, Clone, Copy)]
 pub enum ResponsePolicy {
-    /// Waits for one request to succeed, and return its results. Return error if all requests fail.
+    /// Wait for one request to succeed and return its results. Return error if all requests fail.
     OneSucceeded,
-    /// Waits for one request to succeed with a non-empty value. Returns error if all requests fail or return `Nil`.
+    /// Wait for one request to succeed with a non-empty value. Return error if all requests fail or return `Nil`.
     OneSucceededNonEmpty,
     /// Waits for all requests to succeed, and the returns one of the successes. Returns the error on the first received error.
     AllSucceeded,
-    /// Aggregates success results according to a logical bitwise operator. Returns error on any failed request, or on a response that doesn't conform to 0 or 1.
+    /// Aggregate success results according to a logical bitwise operator. Return error on any failed request or on a response that doesn't conform to 0 or 1.
     AggregateLogical(LogicalAggregateOp),
-    /// Aggregates success results according to a numeric operator. Returns error on any failed request, or on a response that isn't an integer.
+    /// Aggregate success results according to a numeric operator. Return error on any failed request or on a response that isn't an integer.
     Aggregate(AggregateOp),
-    /// Aggreagte array responses into a single array. Returns error on any failed request, or on a response that isn't an array.
+    /// Aggregate array responses into a single array. Return error on any failed request or on a response that isn't an array.
     CombineArrays,
     /// Handling is not defined by the Redis standard. Will receive a special case
     Special,
@@ -88,11 +88,11 @@ impl From<Option<Route>> for SingleNodeRoutingInfo {
 /// Defines which collection of nodes should receive a request
 #[derive(Debug, Clone, PartialEq)]
 pub enum MultipleNodeRoutingInfo {
-    /// route to all nodes in the clusters
+    /// Route to all nodes in the clusters
     AllNodes,
     /// Route to all primaries in the cluster
     AllMasters,
-    /// Instructions on how to split a multi-slot command (e.g. MGET, MSET) into sub-commands. Each tuple is the route for each subcommand and the indices of the arguments from the original command that should be copied to the subcommand.
+    /// Instructions for how to split a multi-slot command (e.g. MGET, MSET) into sub-commands. Each tuple is the route for each subcommand, and the indices of the arguments from the original command that should be copied to the subcommand.
     MultiSlot(Vec<(Route, Vec<usize>)>),
 }
 

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -444,8 +444,9 @@ mod cluster_client;
 #[cfg(feature = "cluster")]
 mod cluster_pipeline;
 
+/// Routing information for cluster commands.
 #[cfg(feature = "cluster")]
-mod cluster_routing;
+pub mod cluster_routing;
 
 #[cfg(feature = "r2d2")]
 #[cfg_attr(docsrs, doc(cfg(feature = "r2d2")))]

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -809,7 +809,7 @@ fn test_async_cluster_route_according_to_passed_argument() {
     cmd.arg("test");
     let _ = runtime.block_on(connection.send_packed_command(
         &cmd,
-        Some(RoutingInfo::MultiNode(MultipleNodeRoutingInfo::AllMasters)),
+        RoutingInfo::MultiNode(MultipleNodeRoutingInfo::AllMasters),
         None,
     ));
     {
@@ -821,7 +821,7 @@ fn test_async_cluster_route_according_to_passed_argument() {
 
     let _ = runtime.block_on(connection.send_packed_command(
         &cmd,
-        Some(RoutingInfo::MultiNode(MultipleNodeRoutingInfo::AllNodes)),
+        RoutingInfo::MultiNode(MultipleNodeRoutingInfo::AllNodes),
         None,
     ));
     {

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -810,6 +810,7 @@ fn test_async_cluster_route_according_to_passed_argument() {
     let _ = runtime.block_on(connection.send_packed_command(
         &cmd,
         Some(RoutingInfo::MultiNode(MultipleNodeRoutingInfo::AllMasters)),
+        None,
     ));
     {
         let mut touched_ports = touched_ports.lock().unwrap();
@@ -821,6 +822,7 @@ fn test_async_cluster_route_according_to_passed_argument() {
     let _ = runtime.block_on(connection.send_packed_command(
         &cmd,
         Some(RoutingInfo::MultiNode(MultipleNodeRoutingInfo::AllNodes)),
+        None,
     ));
     {
         let mut touched_ports = touched_ports.lock().unwrap();

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -80,6 +80,109 @@ fn test_async_cluster_basic_script() {
     .unwrap();
 }
 
+#[test]
+fn test_async_route_flush_to_specific_node() {
+    let cluster = TestClusterContext::new(3, 0);
+
+    block_on_all(async move {
+        let mut connection = cluster.async_connection().await;
+        let _: () = connection.set("foo", "bar").await.unwrap();
+        let _: () = connection.set("bar", "foo").await.unwrap();
+
+        let route = redis::cluster_routing::Route::new(1, redis::cluster_routing::SlotAddr::Master);
+        let single_node_route = redis::cluster_routing::SingleNodeRoutingInfo::SpecificNode(route);
+        let routing = RoutingInfo::SingleNode(single_node_route);
+        assert_eq!(
+            connection
+                .route_command(&redis::cmd("FLUSHALL"), routing, None)
+                .await
+                .unwrap(),
+            Value::Okay
+        );
+        let res: String = connection.get("foo").await.unwrap();
+        assert_eq!(res, "bar".to_string());
+        let res2: Option<String> = connection.get("bar").await.unwrap();
+        assert_eq!(res2, None);
+        Ok::<_, RedisError>(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn test_async_route_info_to_nodes() {
+    let cluster = TestClusterContext::new(12, 1);
+
+    let split_to_addresses_and_info = |res| -> (Vec<String>, Vec<String>) {
+        if let Value::Bulk(values) = res {
+            let mut pairs: Vec<_> = values
+                .into_iter()
+                .map(|value| redis::from_redis_value::<(String, String)>(&value).unwrap())
+                .collect();
+            pairs.sort_by(|(address1, _), (address2, _)| address1.cmp(address2));
+            pairs.into_iter().unzip()
+        } else {
+            unreachable!("{:?}", res);
+        }
+    };
+
+    block_on_all(async move {
+        let cluster_addresses: Vec<_> = cluster
+            .cluster
+            .servers
+            .iter()
+            .map(|server| server.connection_info())
+            .collect();
+        let client = ClusterClient::builder(cluster_addresses.clone())
+            .read_from_replicas()
+            .build()?;
+        let mut connection = client.get_async_connection().await?;
+
+        let route_to_all_nodes = redis::cluster_routing::MultipleNodeRoutingInfo::AllNodes;
+        let routing = RoutingInfo::MultiNode(route_to_all_nodes);
+        let res = connection
+            .route_command(&redis::cmd("INFO"), routing, None)
+            .await
+            .unwrap();
+        let (addresses, infos) = split_to_addresses_and_info(res);
+
+        let mut cluster_addresses: Vec<_> = cluster_addresses
+            .into_iter()
+            .map(|info| info.addr.to_string())
+            .collect();
+        cluster_addresses.sort();
+
+        assert_eq!(addresses.len(), 12);
+        assert_eq!(addresses, cluster_addresses);
+        assert_eq!(infos.len(), 12);
+        for i in 0..12 {
+            let split: Vec<_> = addresses[i].split(":").collect();
+            assert!(infos[i].contains(&format!("bind={}", split[0])));
+            assert!(infos[i].contains(&format!("port={}", split[1])));
+        }
+
+        let route_to_all_primaries = redis::cluster_routing::MultipleNodeRoutingInfo::AllMasters;
+        let routing = RoutingInfo::MultiNode(route_to_all_primaries);
+        let res = connection
+            .route_command(&redis::cmd("INFO"), routing, None)
+            .await
+            .unwrap();
+        let (addresses, infos) = split_to_addresses_and_info(res);
+        assert_eq!(addresses.len(), 6);
+        assert_eq!(infos.len(), 6);
+        // verify that all primaries have the correct port & host, and are marked as primaries.
+        for i in 0..6 {
+            assert!(cluster_addresses.contains(&addresses[i]));
+            let split: Vec<_> = addresses[i].split(":").collect();
+            assert!(infos[i].contains(&format!("bind={}", split[0])));
+            assert!(infos[i].contains(&format!("port={}", split[1])));
+            assert!(infos[i].contains("role:primary") || infos[i].contains("role:master"));
+        }
+
+        Ok::<_, RedisError>(())
+    })
+    .unwrap();
+}
+
 #[ignore] // TODO Handle pipe where the keys do not all go to the same node
 #[test]
 fn test_async_cluster_basic_pipe() {

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -807,7 +807,7 @@ fn test_async_cluster_route_according_to_passed_argument() {
 
     let mut cmd = cmd("GET");
     cmd.arg("test");
-    let _ = runtime.block_on(connection.send_packed_command(
+    let _ = runtime.block_on(connection.route_command(
         &cmd,
         RoutingInfo::MultiNode(MultipleNodeRoutingInfo::AllMasters),
         None,
@@ -819,7 +819,7 @@ fn test_async_cluster_route_according_to_passed_argument() {
         touched_ports.clear();
     }
 
-    let _ = runtime.block_on(connection.send_packed_command(
+    let _ = runtime.block_on(connection.route_command(
         &cmd,
         RoutingInfo::MultiNode(MultipleNodeRoutingInfo::AllNodes),
         None,

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -81,7 +81,7 @@ fn test_async_cluster_basic_script() {
 }
 
 #[test]
-fn test_async_route_flush_to_specific_node() {
+fn test_async_cluster_route_flush_to_specific_node() {
     let cluster = TestClusterContext::new(3, 0);
 
     block_on_all(async move {
@@ -114,7 +114,7 @@ fn test_async_route_flush_to_specific_node() {
 }
 
 #[test]
-fn test_async_route_info_to_nodes() {
+fn test_async_cluster_route_info_to_nodes() {
     let cluster = TestClusterContext::new(12, 1);
 
     let split_to_addresses_and_info = |res| -> (Vec<String>, Vec<String>) {
@@ -161,8 +161,7 @@ fn test_async_route_info_to_nodes() {
         assert_eq!(infos.len(), 12);
         for i in 0..12 {
             let split: Vec<_> = addresses[i].split(':').collect();
-            assert!(infos[i].contains(&format!("bind={}", split[0])));
-            assert!(infos[i].contains(&format!("port={}", split[1])));
+            assert!(infos[i].contains(&format!("tcp_port:{}", split[1])));
         }
 
         let route_to_all_primaries = redis::cluster_routing::MultipleNodeRoutingInfo::AllMasters;
@@ -178,8 +177,7 @@ fn test_async_route_info_to_nodes() {
         for i in 0..6 {
             assert!(cluster_addresses.contains(&addresses[i]));
             let split: Vec<_> = addresses[i].split(':').collect();
-            assert!(infos[i].contains(&format!("bind={}", split[0])));
-            assert!(infos[i].contains(&format!("port={}", split[1])));
+            assert!(infos[i].contains(&format!("tcp_port:{}", split[1])));
             assert!(infos[i].contains("role:primary") || infos[i].contains("role:master"));
         }
 

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -89,6 +89,11 @@ fn test_async_route_flush_to_specific_node() {
         let _: () = connection.set("foo", "bar").await.unwrap();
         let _: () = connection.set("bar", "foo").await.unwrap();
 
+        let res: String = connection.get("foo").await.unwrap();
+        assert_eq!(res, "bar".to_string());
+        let res2: Option<String> = connection.get("bar").await.unwrap();
+        assert_eq!(res2, Some("foo".to_string()));
+
         let route = redis::cluster_routing::Route::new(1, redis::cluster_routing::SlotAddr::Master);
         let single_node_route = redis::cluster_routing::SingleNodeRoutingInfo::SpecificNode(route);
         let routing = RoutingInfo::SingleNode(single_node_route);

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -160,7 +160,7 @@ fn test_async_route_info_to_nodes() {
         assert_eq!(addresses, cluster_addresses);
         assert_eq!(infos.len(), 12);
         for i in 0..12 {
-            let split: Vec<_> = addresses[i].split(":").collect();
+            let split: Vec<_> = addresses[i].split(':').collect();
             assert!(infos[i].contains(&format!("bind={}", split[0])));
             assert!(infos[i].contains(&format!("port={}", split[1])));
         }
@@ -177,7 +177,7 @@ fn test_async_route_info_to_nodes() {
         // verify that all primaries have the correct port & host, and are marked as primaries.
         for i in 0..6 {
             assert!(cluster_addresses.contains(&addresses[i]));
-            let split: Vec<_> = addresses[i].split(":").collect();
+            let split: Vec<_> = addresses[i].split(':').collect();
             assert!(infos[i].contains(&format!("bind={}", split[0])));
             assert!(infos[i].contains(&format!("port={}", split[1])));
             assert!(infos[i].contains("role:primary") || infos[i].contains("role:master"));


### PR DESCRIPTION
This PR is based over https://github.com/redis-rs/redis-rs/pull/900 .

This change allows the user to specify routing information for commands. This is especially helpful for commands that don't have an explicit request policy, such as BGSAVE, and so are sent to a random node.