### PR TITLE
Add support for multi-shard commands.

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -557,10 +557,11 @@ where
                     let cmd = match routing {
                         MultipleNodeRoutingInfo::MultiSlot(vec) => {
                             let mut new_cmd = Cmd::new();
+                            let command_length = 1; // TODO - the +1 should change if we have multi-slot commands with 2 command words.
                             new_cmd.arg(cmd.arg_idx(0));
                             let (_, indices) = vec.get(index).unwrap();
                             for index in indices {
-                                new_cmd.arg(cmd.arg_idx(*index));
+                                new_cmd.arg(cmd.arg_idx(*index + command_length));
                             }
                             Arc::new(new_cmd)
                         }

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -36,7 +36,10 @@ use crate::{
     aio::{ConnectionLike, MultiplexedConnection},
     cluster::{get_connection_info, parse_slots, slot_cmd},
     cluster_client::{ClusterParams, RetryParams},
-    cluster_routing::{Redirect, ResponsePolicy, Route, RoutingInfo, Slot, SlotMap},
+    cluster_routing::{
+        MultipleNodeRoutingInfo, Redirect, ResponsePolicy, Route, RoutingInfo,
+        SingleNodeRoutingInfo, Slot, SlotMap,
+    },
     Cmd, ConnectionInfo, ErrorKind, IntoConnectionInfo, RedisError, RedisFuture, RedisResult,
     Value,
 };
@@ -132,10 +135,12 @@ enum CmdArg<C> {
 fn route_pipeline(pipeline: &crate::Pipeline) -> Option<Route> {
     fn route_for_command(cmd: &Cmd) -> Option<Route> {
         match RoutingInfo::for_routable(cmd) {
-            Some(RoutingInfo::Random) => None,
-            Some(RoutingInfo::SpecificNode(route)) => Some(route),
-            Some(RoutingInfo::AllNodes) | Some(RoutingInfo::AllMasters) => None,
-            _ => None,
+            Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)) => None,
+            Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(route))) => {
+                Some(route)
+            }
+            Some(RoutingInfo::MultiNode(_)) => None,
+            None => None,
         }
     }
 
@@ -537,14 +542,14 @@ where
     async fn execute_on_multiple_nodes(
         func: fn(C, Arc<Cmd>) -> RedisFuture<'static, Response>,
         cmd: &Arc<Cmd>,
-        only_primaries: bool,
+        routing: &MultipleNodeRoutingInfo,
         core: Core<C>,
         response_policy: Option<ResponsePolicy>,
     ) -> (OperationTarget, RedisResult<Response>) {
         let read_guard = core.conn_lock.read().await;
         let connections: Vec<(String, ConnectionFuture<C>)> = read_guard
             .1
-            .all_unique_addresses(only_primaries)
+            .addresses_for_multi_routing(routing)
             .into_iter()
             .filter_map(|addr| {
                 read_guard
@@ -637,18 +642,24 @@ where
         core: Core<C>,
         asking: bool,
     ) -> (OperationTarget, RedisResult<Response>) {
-        let route_option = match routing.as_ref().unwrap_or(&RoutingInfo::Random) {
-            RoutingInfo::AllNodes => {
-                return Self::execute_on_multiple_nodes(func, &cmd, false, core, response_policy)
-                    .await
+        let route_option = match routing
+            .as_ref()
+            .unwrap_or(&RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random))
+        {
+            RoutingInfo::MultiNode(multi_node_routing) => {
+                return Self::execute_on_multiple_nodes(
+                    func,
+                    &cmd,
+                    multi_node_routing,
+                    core,
+                    response_policy,
+                )
+                .await
             }
-            RoutingInfo::AllMasters => {
-                return Self::execute_on_multiple_nodes(func, &cmd, true, core, response_policy)
-                    .await
-            }
-            RoutingInfo::Random => None,
-            RoutingInfo::SpecificNode(route) => Some(route),
+            RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random) => None,
+            RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(route)) => Some(route),
         };
+
         let (addr, conn) = Self::get_connection(redirect, route_option, core, asking).await;
         let result = func(conn, cmd).await;
         (addr.into(), result)

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -539,24 +539,35 @@ where
         Ok(())
     }
 
-    async fn execute_on_multiple_nodes(
+    async fn execute_on_multiple_nodes<'a>(
         func: fn(C, Arc<Cmd>) -> RedisFuture<'static, Response>,
-        cmd: &Arc<Cmd>,
-        routing: &MultipleNodeRoutingInfo,
+        cmd: &'a Arc<Cmd>,
+        routing: &'a MultipleNodeRoutingInfo,
         core: Core<C>,
         response_policy: Option<ResponsePolicy>,
     ) -> (OperationTarget, RedisResult<Response>) {
         let read_guard = core.conn_lock.read().await;
-        let connections: Vec<(String, ConnectionFuture<C>)> = read_guard
+        let connections: Vec<_> = read_guard
             .1
             .addresses_for_multi_routing(routing)
             .into_iter()
-            .filter_map(|addr| {
-                read_guard
-                    .0
-                    .get(addr)
-                    .cloned()
-                    .map(|conn| (addr.to_string(), conn))
+            .enumerate()
+            .filter_map(|(index, addr)| {
+                read_guard.0.get(addr).cloned().map(|conn| {
+                    let cmd = match routing {
+                        MultipleNodeRoutingInfo::MultiSlot(vec) => {
+                            let mut new_cmd = Cmd::new();
+                            new_cmd.arg(cmd.arg_idx(0));
+                            let (_, indices) = vec.get(index).unwrap();
+                            for index in indices {
+                                new_cmd.arg(cmd.arg_idx(*index));
+                            }
+                            Arc::new(new_cmd)
+                        }
+                        _ => cmd.clone(),
+                    };
+                    (addr.to_string(), conn, cmd)
+                })
             })
             .collect();
         drop(read_guard);
@@ -566,10 +577,10 @@ where
             Response::Multiple(_) => unreachable!(),
         };
 
-        let run_func = |(_, conn)| {
+        let run_func = |(_, conn, cmd)| {
             Box::pin(async move {
                 let conn = conn.await;
-                Ok(extract_result(func(conn, cmd.clone()).await?))
+                Ok(extract_result(func(conn, cmd).await?))
             })
         };
 
@@ -611,17 +622,25 @@ where
             Some(ResponsePolicy::CombineArrays) => {
                 future::try_join_all(connections.into_iter().map(run_func))
                     .await
-                    .and_then(crate::cluster_routing::combine_array_results)
+                    .and_then(|results| match routing {
+                        MultipleNodeRoutingInfo::MultiSlot(vec) => {
+                            crate::cluster_routing::combine_and_sort_array_results(
+                                results,
+                                vec.iter().map(|(_, indices)| indices),
+                            )
+                        }
+                        _ => crate::cluster_routing::combine_array_results(results),
+                    })
             }
             Some(ResponsePolicy::Special) | None => {
                 // This is our assumption - if there's no coherent way to aggregate the responses, we just map each response to the sender, and pass it to the user.
                 // TODO - once RESP3 is merged, return a map value here.
                 // TODO - once Value::Error is merged, we can use join_all and report separate errors and also pass successes.
-                future::try_join_all(connections.into_iter().map(|(addr, conn)| async move {
+                future::try_join_all(connections.into_iter().map(|(addr, conn, cmd)| async move {
                     let conn = conn.await;
                     Ok(Value::Bulk(vec![
                         Value::Data(addr.into_bytes()),
-                        extract_result(func(conn, cmd.clone()).await?),
+                        extract_result(func(conn, cmd).await?),
                     ]))
                 }))
                 .await

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -46,12 +46,22 @@ pub(crate) enum ResponsePolicy {
     Special,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum RoutingInfo {
-    AllNodes,
-    AllMasters,
+    SingleNode(SingleNodeRoutingInfo),
+    MultiNode(MultipleNodeRoutingInfo),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum SingleNodeRoutingInfo {
     Random,
     SpecificNode(Route),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum MultipleNodeRoutingInfo {
+    AllNodes,
+    AllMasters,
 }
 
 pub(crate) fn aggregate(values: Vec<Value>, op: AggregateOp) -> RedisResult<Value> {
@@ -143,6 +153,24 @@ pub(crate) fn combine_array_results(values: Vec<Value>) -> RedisResult<Value> {
     Ok(Value::Bulk(results))
 }
 
+fn get_slot(key: &[u8]) -> u16 {
+    let key = match get_hashtag(key) {
+        Some(tag) => tag,
+        None => key,
+    };
+
+    slot(key)
+}
+
+fn get_route(is_readonly: bool, key: &[u8]) -> Route {
+    let slot = get_slot(key);
+    if is_readonly {
+        Route::new(slot, SlotAddr::Replica)
+    } else {
+        Route::new(slot, SlotAddr::Master)
+    }
+}
+
 impl RoutingInfo {
     pub(crate) fn response_policy<R>(r: &R) -> Option<ResponsePolicy>
     where
@@ -210,12 +238,12 @@ impl RoutingInfo {
             | b"MEMORY MALLOC-STATS"
             | b"MEMORY DOCTOR"
             | b"MEMORY STATS"
-            | b"INFO" => Some(RoutingInfo::AllMasters),
+            | b"INFO" => Some(RoutingInfo::MultiNode(MultipleNodeRoutingInfo::AllMasters)),
 
             b"SLOWLOG GET" | b"SLOWLOG LEN" | b"SLOWLOG RESET" | b"CONFIG SET"
             | b"SCRIPT FLUSH" | b"SCRIPT LOAD" | b"LATENCY RESET" | b"LATENCY GRAPH"
             | b"LATENCY HISTOGRAM" | b"LATENCY HISTORY" | b"LATENCY DOCTOR" | b"LATENCY LATEST" => {
-                Some(RoutingInfo::AllNodes)
+                Some(RoutingInfo::MultiNode(MultipleNodeRoutingInfo::AllNodes))
             }
 
             // TODO - multi shard handling - b"MGET" |b"MSETNX" |b"DEL" |b"EXISTS" |b"UNLINK" |b"TOUCH" |b"MSET"
@@ -228,7 +256,7 @@ impl RoutingInfo {
                     .and_then(|x| std::str::from_utf8(x).ok())
                     .and_then(|x| x.parse::<u64>().ok())?;
                 if key_count == 0 {
-                    Some(RoutingInfo::Random)
+                    Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random))
                 } else {
                     r.arg_idx(3).map(|key| RoutingInfo::for_key(cmd, key))
                 }
@@ -248,23 +276,16 @@ impl RoutingInfo {
             }
             _ => match r.arg_idx(1) {
                 Some(key) => Some(RoutingInfo::for_key(cmd, key)),
-                None => Some(RoutingInfo::Random),
+                None => Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)),
             },
         }
     }
 
     pub fn for_key(cmd: &[u8], key: &[u8]) -> RoutingInfo {
-        let key = match get_hashtag(key) {
-            Some(tag) => tag,
-            None => key,
-        };
-
-        let slot = slot(key);
-        if is_readonly_cmd(cmd) {
-            RoutingInfo::SpecificNode(Route::new(slot, SlotAddr::Replica))
-        } else {
-            RoutingInfo::SpecificNode(Route::new(slot, SlotAddr::Master))
-        }
+        RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(get_route(
+            is_readonly_cmd(cmd),
+            key,
+        )))
     }
 }
 
@@ -461,7 +482,7 @@ impl SlotMap {
         self.0.values()
     }
 
-    pub fn all_unique_addresses(&self, only_primaries: bool) -> HashSet<&str> {
+    fn all_unique_addresses(&self, only_primaries: bool) -> HashSet<&str> {
         let mut addresses = HashSet::new();
         for slot in self.values() {
             addresses.insert(slot.slot_addr(&SlotAddr::Master));
@@ -471,6 +492,17 @@ impl SlotMap {
             }
         }
         addresses
+    }
+
+    pub fn addresses_for_multi_routing(&self, routing: &MultipleNodeRoutingInfo) -> Vec<&str> {
+        match routing {
+            MultipleNodeRoutingInfo::AllNodes => {
+                self.all_unique_addresses(false).into_iter().collect()
+            }
+            MultipleNodeRoutingInfo::AllMasters => {
+                self.all_unique_addresses(true).into_iter().collect()
+            }
+        }
     }
 }
 
@@ -516,8 +548,11 @@ fn get_hashtag(key: &[u8]) -> Option<&[u8]> {
 
 #[cfg(test)]
 mod tests {
-    use super::{get_hashtag, slot, Route, RoutingInfo, Slot, SlotMap};
-    use crate::{cluster_routing::SlotAddr, cmd, parser::parse_redis_value};
+    use super::{
+        get_hashtag, slot, MultipleNodeRoutingInfo, Route, RoutingInfo, SingleNodeRoutingInfo,
+        Slot, SlotAddr, SlotMap,
+    };
+    use crate::{cmd, parser::parse_redis_value};
 
     #[test]
     fn test_get_hashtag() {
@@ -572,7 +607,7 @@ mod tests {
         test_cmd.arg("GROUPS").arg("FOOBAR");
         test_cmds.push(test_cmd);
 
-        // Routing key is 3rd or 4th arg (3rd = "0" == RoutingInfo::Random)
+        // Routing key is 3rd or 4th arg (3rd = "0" == RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random))
         test_cmd = cmd("EVAL");
         test_cmd.arg("FOO").arg("0").arg("BAR");
         test_cmds.push(test_cmd);
@@ -613,7 +648,7 @@ mod tests {
         ] {
             assert_eq!(
                 RoutingInfo::for_routable(&cmd),
-                Some(RoutingInfo::AllMasters)
+                Some(RoutingInfo::MultiNode(MultipleNodeRoutingInfo::AllMasters))
             );
         }
 
@@ -638,7 +673,10 @@ mod tests {
             cmd("EVAL").arg(r#"redis.call("PING");"#).arg(0),
             cmd("EVALSHA").arg(r#"redis.call("PING");"#).arg(0),
         ] {
-            assert_eq!(RoutingInfo::for_routable(cmd), Some(RoutingInfo::Random));
+            assert_eq!(
+                RoutingInfo::for_routable(cmd),
+                Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random))
+            );
         }
 
         for (cmd, expected) in [
@@ -647,10 +685,9 @@ mod tests {
                     .arg(r#"redis.call("GET, KEYS[1]");"#)
                     .arg(1)
                     .arg("foo"),
-                Some(RoutingInfo::SpecificNode(Route::new(
-                    slot(b"foo"),
-                    SlotAddr::Master,
-                ))),
+                Some(RoutingInfo::SingleNode(
+                    SingleNodeRoutingInfo::SpecificNode(Route::new(slot(b"foo"), SlotAddr::Master)),
+                )),
             ),
             (
                 cmd("XGROUP")
@@ -659,17 +696,21 @@ mod tests {
                     .arg("workers")
                     .arg("$")
                     .arg("MKSTREAM"),
-                Some(RoutingInfo::SpecificNode(Route::new(
-                    slot(b"mystream"),
-                    SlotAddr::Master,
-                ))),
+                Some(RoutingInfo::SingleNode(
+                    SingleNodeRoutingInfo::SpecificNode(Route::new(
+                        slot(b"mystream"),
+                        SlotAddr::Master,
+                    )),
+                )),
             ),
             (
                 cmd("XINFO").arg("GROUPS").arg("foo"),
-                Some(RoutingInfo::SpecificNode(Route::new(
-                    slot(b"foo"),
-                    SlotAddr::Replica,
-                ))),
+                Some(RoutingInfo::SingleNode(
+                    SingleNodeRoutingInfo::SpecificNode(Route::new(
+                        slot(b"foo"),
+                        SlotAddr::Replica,
+                    )),
+                )),
             ),
             (
                 cmd("XREADGROUP")
@@ -678,10 +719,12 @@ mod tests {
                     .arg("consmrs")
                     .arg("STREAMS")
                     .arg("mystream"),
-                Some(RoutingInfo::SpecificNode(Route::new(
-                    slot(b"mystream"),
-                    SlotAddr::Master,
-                ))),
+                Some(RoutingInfo::SingleNode(
+                    SingleNodeRoutingInfo::SpecificNode(Route::new(
+                        slot(b"mystream"),
+                        SlotAddr::Master,
+                    )),
+                )),
             ),
             (
                 cmd("XREAD")
@@ -692,10 +735,12 @@ mod tests {
                     .arg("writers")
                     .arg("0-0")
                     .arg("0-0"),
-                Some(RoutingInfo::SpecificNode(Route::new(
-                    slot(b"mystream"),
-                    SlotAddr::Replica,
-                ))),
+                Some(RoutingInfo::SingleNode(
+                    SingleNodeRoutingInfo::SpecificNode(Route::new(
+                        slot(b"mystream"),
+                        SlotAddr::Replica,
+                    )),
+                )),
             ),
         ] {
             assert_eq!(
@@ -712,21 +757,21 @@ mod tests {
         assert!(matches!(RoutingInfo::for_routable(&parse_redis_value(&[
                 42, 50, 13, 10, 36, 54, 13, 10, 69, 88, 73, 83, 84, 83, 13, 10, 36, 49, 54, 13, 10,
                 244, 93, 23, 40, 126, 127, 253, 33, 89, 47, 185, 204, 171, 249, 96, 139, 13, 10
-            ]).unwrap()), Some(RoutingInfo::SpecificNode(Route(slot, SlotAddr::Replica))) if slot == 964));
+            ]).unwrap()), Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(Route(slot, SlotAddr::Replica)))) if slot == 964));
 
         assert!(matches!(RoutingInfo::for_routable(&parse_redis_value(&[
                 42, 54, 13, 10, 36, 51, 13, 10, 83, 69, 84, 13, 10, 36, 49, 54, 13, 10, 36, 241,
                 197, 111, 180, 254, 5, 175, 143, 146, 171, 39, 172, 23, 164, 145, 13, 10, 36, 52,
                 13, 10, 116, 114, 117, 101, 13, 10, 36, 50, 13, 10, 78, 88, 13, 10, 36, 50, 13, 10,
                 80, 88, 13, 10, 36, 55, 13, 10, 49, 56, 48, 48, 48, 48, 48, 13, 10
-            ]).unwrap()), Some(RoutingInfo::SpecificNode(Route(slot, SlotAddr::Master))) if slot == 8352));
+            ]).unwrap()), Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(Route(slot, SlotAddr::Master)))) if slot == 8352));
 
         assert!(matches!(RoutingInfo::for_routable(&parse_redis_value(&[
                 42, 54, 13, 10, 36, 51, 13, 10, 83, 69, 84, 13, 10, 36, 49, 54, 13, 10, 169, 233,
                 247, 59, 50, 247, 100, 232, 123, 140, 2, 101, 125, 221, 66, 170, 13, 10, 36, 52,
                 13, 10, 116, 114, 117, 101, 13, 10, 36, 50, 13, 10, 78, 88, 13, 10, 36, 50, 13, 10,
                 80, 88, 13, 10, 36, 55, 13, 10, 49, 56, 48, 48, 48, 48, 48, 13, 10
-            ]).unwrap()), Some(RoutingInfo::SpecificNode(Route(slot, SlotAddr::Master))) if slot == 5210));
+            ]).unwrap()), Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(Route(slot, SlotAddr::Master)))) if slot == 5210));
     }
 
     #[test]


### PR DESCRIPTION
This PR is based over https://github.com/redis-rs/redis-rs/pull/888 .

This allows the async cluster client to split keyed commands so that
keys will be grouped by the slot they belong in, and sent only to the
relevant shard.