### PR TITLE
Changed cluster creation to wait for all servers to change their state to OK

### DIFF
--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -202,7 +202,7 @@ impl RedisCluster {
 }
 
 fn wait_for_status_ok(cluster: &RedisCluster) {
-    'servers: for server in &cluster.servers {
+    'server: for server in &cluster.servers {
         let log_file = RedisServer::log_file(&server.tempdir);
 
         for _ in 1..500 {
@@ -210,7 +210,7 @@ fn wait_for_status_ok(cluster: &RedisCluster) {
                 std::fs::read_to_string(&log_file).expect("Should have been able to read the file");
 
             if contents.contains("Cluster state changed: ok") {
-                break 'servers;
+                continue 'server;
             }
             sleep(Duration::from_millis(20));
         }


### PR DESCRIPTION
It is now required that the cluster creation waits for all servers to change their state to OK before it returns, rather than waiting only for the first one to change its state.

This change prevents flaky tests due to CLUSTER DOWN errors by not starting testing before all servers are ready.