### PR TITLE
Pin `tempfile` dependency

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -117,7 +117,7 @@ criterion = "0.4"
 partial-io = { version = "0.5", features = ["tokio", "quickcheck1"] }
 quickcheck = "1.0.3"
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "time"] }
-tempfile = "3.2"
+tempfile = "=3.6.0"
 once_cell = "1"
 anyhow = "1"
 


### PR DESCRIPTION
Trying to avoid bumping MSRV to 1.63 just for a
dev dependency.