### PR TITLE
async transaction support

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -56,7 +56,7 @@ r2d2 = { version = "0.8.8", optional = true }
 crc16 = { version = "0.4", optional = true }
 rand = { version = "0.8", optional = true }
 # Only needed for async_std support
-async-std = { version = "1.8.0", optional = true}
+async-std = { version = "1.8.0", optional = true }
 async-trait = { version = "0.1.24", optional = true }
 
 # Only needed for native tls
@@ -83,7 +83,19 @@ log = { version = "0.4", optional = true }
 [features]
 default = ["acl", "streams", "geospatial", "script", "keep-alive"]
 acl = []
-aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/alloc", "futures-util/sink", "tokio/io-util", "tokio-util", "tokio-util/codec", "tokio/sync", "combine/tokio", "async-trait"]
+aio = [
+    "bytes",
+    "pin-project-lite",
+    "futures-util",
+    "futures-util/alloc",
+    "futures-util/sink",
+    "tokio/io-util",
+    "tokio-util",
+    "tokio-util/codec",
+    "tokio/sync",
+    "combine/tokio",
+    "async-trait",
+]
 geospatial = []
 json = ["serde", "serde/derive", "serde_json"]
 cluster = ["crc16", "rand"]
@@ -93,7 +105,11 @@ tls-rustls = ["rustls", "rustls-native-certs"]
 tls-rustls-insecure = ["tls-rustls", "rustls/dangerous_configuration"]
 tls-rustls-webpki-roots = ["tls-rustls", "webpki-roots"]
 async-std-comp = ["aio", "async-std"]
-async-std-native-tls-comp = ["async-std-comp", "async-native-tls", "tls-native-tls"]
+async-std-native-tls-comp = [
+    "async-std-comp",
+    "async-native-tls",
+    "tls-native-tls",
+]
 async-std-rustls-comp = ["async-std-comp", "futures-rustls", "tls-rustls"]
 tokio-comp = ["aio", "tokio", "tokio/net"]
 tokio-native-tls-comp = ["tokio-comp", "tls-native-tls", "tokio-native-tls"]
@@ -106,7 +122,9 @@ sentinel = ["rand"]
 
 # Deprecated features
 tls = ["tls-native-tls"] # use "tls-native-tls" instead
-async-std-tls-comp = ["async-std-native-tls-comp"] # use "async-std-native-tls-comp" instead
+async-std-tls-comp = [
+    "async-std-native-tls-comp",
+] # use "async-std-native-tls-comp" instead
 
 [dev-dependencies]
 rand = "0.8"
@@ -117,7 +135,12 @@ futures = "0.3"
 criterion = "0.4"
 partial-io = { version = "0.5", features = ["tokio", "quickcheck1"] }
 quickcheck = "1.0.3"
-tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "time"] }
+tokio = { version = "1", features = [
+    "rt",
+    "macros",
+    "rt-multi-thread",
+    "time",
+] }
 tempfile = "=3.6.0"
 once_cell = "1"
 anyhow = "1"
@@ -129,6 +152,11 @@ required-features = ["tokio-comp"]
 [[test]]
 name = "test_async_async_std"
 required-features = ["async-std-comp"]
+
+[[test]]
+name = "test_async_transaction"
+required-features = ["aio", "tokio-comp", "connection-manager"]
+
 
 [[test]]
 name = "parser"

--- a/redis/src/aio/async_transactions.rs
+++ b/redis/src/aio/async_transactions.rs
@@ -1,0 +1,127 @@
+use std::pin::Pin;
+
+use crate::{aio::ConnectionManager, cmd, pipe, Pipeline, RedisError, ToRedisArgs};
+use futures::Future;
+
+/// This function encapsulates the boilerplate required to establish a Redis transaction.
+/// Do not use it directly but use the `transaction_async!` macro instead.
+/// See the `transaction_async!` macro for more details.
+pub async fn transaction_async<
+    T,
+    E: From<RedisError>,
+    K: ToRedisArgs,
+    F: FnMut(
+        ConnectionManager,
+        &mut Pipeline,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<T>, E>> + Send>>,
+>(
+    mut mgr: ConnectionManager,
+    keys: &[K],
+    mut func: F,
+) -> Result<T, E> {
+    loop {
+        cmd("WATCH").arg(keys).query_async(&mut mgr).await?;
+        let mut p = pipe();
+        let response: Option<T> = func(mgr.clone(), p.atomic()).await?;
+        match response {
+            None => {
+                println!("retrying transaction");
+                continue;
+            }
+            Some(response) => {
+                // make sure no watch is left in the connection, even if
+                // someone forgot to use the pipeline.
+                cmd("UNWATCH").query_async(&mut mgr).await?;
+                return Ok(response);
+            }
+        }
+    }
+}
+
+/// Asynchronous transaction macro for Redis operations.
+///
+/// This macro encapsulates the boilerplate required to establish a Redis transaction
+/// and apply a function to it. What it
+/// does is automatically watching keys and then going into a transaction
+/// loop util it succeeds.  Once it goes through the results are
+/// returned.
+///
+/// To use the transaction two pieces of information are needed: a list
+/// of all the keys that need to be watched for modifications and a
+/// closure with the code that should be execute in the context of the
+/// transaction.  The closure is invoked with a fresh pipeline in atomic
+/// mode.  To use the transaction the function needs to return the result
+/// from querying the pipeline with the connection.
+///
+/// The end result of the transaction is then available as the return
+/// value from the function call.
+///
+/// # Parameters
+///
+/// - `$mgr`: A cloned connection manager for Redis.
+/// - `$key`: A key (or array of keys) for the Redis operation.
+/// - `$func`: Either a path to a function or a lambda function. This function
+///   should have the signature `async fn(ConnectionManager, Pipeline) -> Result<Option<T>, RedisError>`
+///   where `T` is the expected return type.
+///
+/// # Examples
+///
+/// Example with function path:
+///
+/// ```
+///async fn return_blah(
+///     mut mgr: ConnectionManager,
+///     mut pipeline: Pipeline,
+///) -> Result<Option<Vec<String>>, RedisError> {
+///     pipeline
+///         .set("key", "blah")
+///         .ignore()
+///         .get("key")
+///         .query_async(&mut mgr)
+///     .await
+///}
+///
+/// let res = transaction_async!(mgr.clone(), &["key"], return_blah)?;
+/// assert_eq!(res, vec!["blah".to_string()]);
+/// ```
+///
+/// Example with lambda function:
+///
+/// ```
+/// let res: Vec<String> = transaction_async!(
+///     mgr.clone(),
+///     &["key"],
+///     |mut mgr: ConnectionManager, mut pipeline: Pipeline| async move {
+///         pipeline
+///             .set("key", "blah")
+///             .ignore()
+///             .get("key")
+///             .query_async(&mut mgr)
+///             .await
+///     }
+/// )?;
+/// assert_eq!(res, vec!["blah".to_string()]);
+/// ```
+///
+/// # Returns
+///
+/// Returns a `Result` containing the return value of the passed function, or an error.
+///
+/// Note: This macro is exported so it can be used in other modules.
+#[macro_export]
+macro_rules! transaction_async {
+    ($mgr:expr, $key:expr, $func:path) => {{
+        $crate::aio::async_transactions::transaction_async($mgr, $key, |mgr, pipeline| {
+            let pipeline = pipeline.clone();
+            Box::pin(async move { $func(mgr, pipeline).await })
+        })
+        .await
+    }};
+    ($mgr:expr, $key:expr, $func:expr) => {{
+        $crate::aio::async_transactions::transaction_async($mgr, $key, |mgr, pipeline| {
+            let pipeline = pipeline.clone();
+            Box::pin($func(mgr, pipeline))
+        })
+        .await
+    }};
+}

--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -141,3 +141,7 @@ mod connection_manager;
 pub use connection_manager::*;
 mod runtime;
 pub(super) use runtime::*;
+
+#[cfg(feature = "connection-manager")]
+/// Asynchronous transactions support
+pub mod async_transactions;

--- a/redis/tests/test_async_transaction.rs
+++ b/redis/tests/test_async_transaction.rs
@@ -1,0 +1,63 @@
+use redis::{
+    aio::ConnectionManager, transaction_async, AsyncCommands, Client, Pipeline, RedisError,
+    RedisResult,
+};
+
+const REDIS_URL: &str = "redis://localhost:6379";
+
+#[tokio::test]
+pub async fn test_async_transaction() -> RedisResult<()> {
+    let client = Client::open(REDIS_URL)?;
+    let mgr = ConnectionManager::new(client).await?;
+
+    async fn return_blah(
+        mut mgr: ConnectionManager,
+        mut pipeline: Pipeline,
+    ) -> Result<Option<Vec<String>>, RedisError> {
+        pipeline
+            .set("key", "blah")
+            .ignore()
+            .get("key")
+            .query_async(&mut mgr)
+            .await
+    }
+
+    let res = transaction_async!(mgr.clone(), &["key"], return_blah)?;
+    assert_eq!(res, vec!["blah".to_string()]);
+
+    let res: Vec<String> = transaction_async!(
+        mgr.clone(),
+        &["key"],
+        |mut mgr: ConnectionManager, mut pipeline: Pipeline| async move {
+            pipeline
+                .set("key", "blah")
+                .ignore()
+                .get("key")
+                .query_async(&mut mgr)
+                .await
+        }
+    )?;
+    assert_eq!(res, vec!["blah".to_string()]);
+
+    // now insert a key/value and modify it in a transaction
+    mgr.clone().set("key", "value").await?;
+    async fn modify_key(
+        mut mgr: ConnectionManager,
+        mut pipeline: Pipeline,
+    ) -> Result<Option<Vec<String>>, RedisError> {
+        let value: String = mgr.get("key").await?;
+        // do some dummy stuff
+        let new_value = format!("{}{}", value, value);
+        pipeline
+            .set("key", &new_value)
+            .ignore()
+            .get("key")
+            .query_async(&mut mgr)
+            .await
+    }
+    let new_value: Vec<String> = transaction_async!(mgr.clone(), &["key"], modify_key)?;
+    let actual_value: String = mgr.clone().get("key").await?;
+    assert_eq!(new_value[0], actual_value);
+
+    Ok(())
+}


### PR DESCRIPTION
Hello,

This is a proposal to support `async` transactions (because I could not figure out how to do it otherwise).

```rust
let res: Vec<String> = transaction_async!(
        mgr.clone(),
        &["key"],
        |mut mgr: ConnectionManager, mut pipeline: Pipeline| async move {
            pipeline
                .set("key", "blah")
                .ignore()
                .get("key")
                .query_async(&mut mgr)
                .await
        }
    )?;
    assert_eq!(res, vec!["blah".to_string()]);
```

I am unsure what features must be enabled to support this; the test passes with the current list, but that needs review.

Also, the way the test is written in `redis/tests/test_async_transaction.rs` is probably not what you want (It expects a local running Redis server with storage enabled)