### PR TITLE
Add buffered write methods to RedisWrite

### DIFF
--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -279,12 +279,25 @@ impl RedisWrite for Cmd {
         self.args.push(Arg::Simple(self.data.len()));
     }
 
-    fn start_buffered_arg(&mut self) {}
-    fn write_buffered_arg(&mut self, arg: &[u8]) {
-        self.data.extend_from_slice(arg);
-    }
-    fn finish_buffered_arg(&mut self) {
-        self.args.push(Arg::Simple(self.data.len()));
+    fn writer_for_next_arg(&mut self) -> impl std::io::Write + '_ {
+        struct CmdBufferedArgGuard<'a>(&'a mut Cmd);
+        impl Drop for CmdBufferedArgGuard<'_> {
+            fn drop(&mut self) {
+                self.0.args.push(Arg::Simple(self.0.data.len()));
+            }
+        }
+        impl std::io::Write for CmdBufferedArgGuard<'_> {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.data.extend_from_slice(buf);
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        CmdBufferedArgGuard(self)
     }
 }
 
@@ -654,11 +667,78 @@ pub fn pipe() -> Pipeline {
 }
 
 #[cfg(test)]
-#[cfg(feature = "cluster")]
 mod tests {
     use super::Cmd;
 
     #[test]
+    fn test_cmd_writer_for_next_arg() {
+        use crate::RedisWrite;
+        use std::io::Write;
+
+        // Test that a write split across multiple calls to `write` produces the
+        // same result as a single call to `write_arg`
+        {
+            let mut c1 = Cmd::new();
+            {
+                let mut c1_writer = c1.writer_for_next_arg();
+                c1_writer.write_all(b"foo").unwrap();
+                c1_writer.write_all(b"bar").unwrap();
+                c1_writer.flush().unwrap();
+            }
+            let v1 = c1.get_packed_command();
+
+            let mut c2 = Cmd::new();
+            c2.write_arg(b"foobar");
+            let v2 = c2.get_packed_command();
+
+            assert_eq!(v1, v2);
+        }
+
+        // Test that multiple writers to the same command produce the same
+        // result as the same multiple calls to `write_arg`
+        {
+            let mut c1 = Cmd::new();
+            {
+                let mut c1_writer = c1.writer_for_next_arg();
+                c1_writer.write_all(b"foo").unwrap();
+                c1_writer.write_all(b"bar").unwrap();
+                c1_writer.flush().unwrap();
+            }
+            {
+                let mut c1_writer = c1.writer_for_next_arg();
+                c1_writer.write_all(b"baz").unwrap();
+                c1_writer.write_all(b"qux").unwrap();
+                c1_writer.flush().unwrap();
+            }
+            let v1 = c1.get_packed_command();
+
+            let mut c2 = Cmd::new();
+            c2.write_arg(b"foobar");
+            c2.write_arg(b"bazqux");
+            let v2 = c2.get_packed_command();
+
+            assert_eq!(v1, v2);
+        }
+
+        // Test that an "empty" write produces the equivalent to `write_arg(b"")`
+        {
+            let mut c1 = Cmd::new();
+            {
+                let mut c1_writer = c1.writer_for_next_arg();
+                c1_writer.flush().unwrap();
+            }
+            let v1 = c1.get_packed_command();
+
+            let mut c2 = Cmd::new();
+            c2.write_arg(b"");
+            let v2 = c2.get_packed_command();
+
+            assert_eq!(v1, v2);
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "cluster")]
     fn test_cmd_arg_idx() {
         let mut c = Cmd::new();
         assert_eq!(c.arg_idx(0), None);

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -670,71 +670,71 @@ pub fn pipe() -> Pipeline {
 mod tests {
     use super::Cmd;
 
+    use crate::RedisWrite;
+    use std::io::Write;
+
     #[test]
     fn test_cmd_writer_for_next_arg() {
-        use crate::RedisWrite;
-        use std::io::Write;
-
         // Test that a write split across multiple calls to `write` produces the
         // same result as a single call to `write_arg`
+        let mut c1 = Cmd::new();
         {
-            let mut c1 = Cmd::new();
-            {
-                let mut c1_writer = c1.writer_for_next_arg();
-                c1_writer.write_all(b"foo").unwrap();
-                c1_writer.write_all(b"bar").unwrap();
-                c1_writer.flush().unwrap();
-            }
-            let v1 = c1.get_packed_command();
-
-            let mut c2 = Cmd::new();
-            c2.write_arg(b"foobar");
-            let v2 = c2.get_packed_command();
-
-            assert_eq!(v1, v2);
+            let mut c1_writer = c1.writer_for_next_arg();
+            c1_writer.write_all(b"foo").unwrap();
+            c1_writer.write_all(b"bar").unwrap();
+            c1_writer.flush().unwrap();
         }
+        let v1 = c1.get_packed_command();
 
-        // Test that multiple writers to the same command produce the same
-        // result as the same multiple calls to `write_arg`
+        let mut c2 = Cmd::new();
+        c2.write_arg(b"foobar");
+        let v2 = c2.get_packed_command();
+
+        assert_eq!(v1, v2);
+    }
+
+    // Test that multiple writers to the same command produce the same
+    // result as the same multiple calls to `write_arg`
+    #[test]
+    fn test_cmd_writer_for_next_arg_multiple() {
+        let mut c1 = Cmd::new();
         {
-            let mut c1 = Cmd::new();
-            {
-                let mut c1_writer = c1.writer_for_next_arg();
-                c1_writer.write_all(b"foo").unwrap();
-                c1_writer.write_all(b"bar").unwrap();
-                c1_writer.flush().unwrap();
-            }
-            {
-                let mut c1_writer = c1.writer_for_next_arg();
-                c1_writer.write_all(b"baz").unwrap();
-                c1_writer.write_all(b"qux").unwrap();
-                c1_writer.flush().unwrap();
-            }
-            let v1 = c1.get_packed_command();
-
-            let mut c2 = Cmd::new();
-            c2.write_arg(b"foobar");
-            c2.write_arg(b"bazqux");
-            let v2 = c2.get_packed_command();
-
-            assert_eq!(v1, v2);
+            let mut c1_writer = c1.writer_for_next_arg();
+            c1_writer.write_all(b"foo").unwrap();
+            c1_writer.write_all(b"bar").unwrap();
+            c1_writer.flush().unwrap();
         }
-
-        // Test that an "empty" write produces the equivalent to `write_arg(b"")`
         {
-            let mut c1 = Cmd::new();
-            {
-                let mut c1_writer = c1.writer_for_next_arg();
-                c1_writer.flush().unwrap();
-            }
-            let v1 = c1.get_packed_command();
-
-            let mut c2 = Cmd::new();
-            c2.write_arg(b"");
-            let v2 = c2.get_packed_command();
-
-            assert_eq!(v1, v2);
+            let mut c1_writer = c1.writer_for_next_arg();
+            c1_writer.write_all(b"baz").unwrap();
+            c1_writer.write_all(b"qux").unwrap();
+            c1_writer.flush().unwrap();
         }
+        let v1 = c1.get_packed_command();
+
+        let mut c2 = Cmd::new();
+        c2.write_arg(b"foobar");
+        c2.write_arg(b"bazqux");
+        let v2 = c2.get_packed_command();
+
+        assert_eq!(v1, v2);
+    }
+
+    // Test that an "empty" write produces the equivalent to `write_arg(b"")`
+    #[test]
+    fn test_cmd_writer_for_next_arg_empty() {
+        let mut c1 = Cmd::new();
+        {
+            let mut c1_writer = c1.writer_for_next_arg();
+            c1_writer.flush().unwrap();
+        }
+        let v1 = c1.get_packed_command();
+
+        let mut c2 = Cmd::new();
+        c2.write_arg(b"");
+        let v2 = c2.get_packed_command();
+
+        assert_eq!(v1, v2);
     }
 
     #[test]

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -278,6 +278,14 @@ impl RedisWrite for Cmd {
         write!(self.data, "{arg}").unwrap();
         self.args.push(Arg::Simple(self.data.len()));
     }
+
+    fn start_buffered_arg(&mut self) {}
+    fn write_buffered_arg(&mut self, arg: &[u8]) {
+        self.data.extend_from_slice(arg);
+    }
+    fn finish_buffered_arg(&mut self) {
+        self.args.push(Arg::Simple(self.data.len()));
+    }
 }
 
 impl Default for Cmd {


### PR DESCRIPTION
As discussed in #890.

The goal of this is to allow compatibility with `std::io::Write`-based serializers in `ToRedisArgs` implementations, and more generally to allow serializers that write to a buffer in chunks to be able to write directly to `redis::Cmd`'s internal buffer, instead of having to write it to an external buffer, then copy that into `redis::Cmd`'s internal buffer.

This does not affect `redis::Cmd`'s own serialization behavior, which will still copy that internal buffer once. However, one copy is better than two for this use case.

I also have a guard implementation for `std::io::Write` here https://gist.github.com/swwu/f3e21a5c939e06c20f445735ee75d358 that I'd be happy to throw in, but it's a bit more opinionated and I'm not completely clear on where it would go.

I'm not certain about the method names, and am happy to change them if people have better suggestions.