### PR TITLE
add timeouts to tests github action.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 35    
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This adds ~10 minutes to previous test run time, in order to leave a comfortable margin, while still significantly reducing the run time of the task in case it gets stuck. Without defining this, the task runs for 6 hours.