### PR TITLE
Split async pubsub connection into SplitSink

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -173,6 +173,10 @@ name = "async-pub-sub"
 required-features = ["aio"]
 
 [[example]]
+name = "async-monitor"
+required-features = ["aio"]
+
+[[example]]
 name = "async-scan"
 required-features = ["aio"]
 

--- a/redis/examples/async-monitor.rs
+++ b/redis/examples/async-monitor.rs
@@ -1,0 +1,21 @@
+use futures_util::StreamExt as _;
+use redis::{AsyncCommands, Value};
+
+#[tokio::main]
+async fn main() -> redis::RedisResult<()> {
+    let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+    let mut publish_conn = client.get_async_connection().await?;
+    let (mut sink, mut stream) = client.get_async_connection().await?.into_monitor();
+
+    sink.monitor().await?;
+
+    publish_conn.set("key", b"value").await?;
+
+    let _ = stream.next().await;
+
+    while let Some(Ok(Value::Status(msg))) = stream.next().await {
+        println!("{}", msg);
+    }
+
+    Ok(())
+}

--- a/redis/examples/async-pub-sub.rs
+++ b/redis/examples/async-pub-sub.rs
@@ -5,14 +5,12 @@ use redis::AsyncCommands;
 async fn main() -> redis::RedisResult<()> {
     let client = redis::Client::open("redis://127.0.0.1/").unwrap();
     let mut publish_conn = client.get_async_connection().await?;
-    let mut pubsub_conn = client.get_async_connection().await?.into_pubsub();
+    let (mut sink, mut stream) = client.get_async_connection().await?.into_pubsub();
 
-    pubsub_conn.subscribe("wavephone").await?;
-    let mut pubsub_stream = pubsub_conn.on_message();
-
+    sink.subscribe("wavephone").await?;
     publish_conn.publish("wavephone", "banana").await?;
 
-    let pubsub_msg: String = pubsub_stream.next().await.unwrap().get_payload()?;
+    let pubsub_msg: String = stream.next().await.unwrap()?.unwrap().get_payload()?;
     assert_eq!(&pubsub_msg, "banana");
 
     Ok(())

--- a/redis/examples/async-pub-sub.rs
+++ b/redis/examples/async-pub-sub.rs
@@ -10,8 +10,13 @@ async fn main() -> redis::RedisResult<()> {
     sink.subscribe("wavephone").await?;
     publish_conn.publish("wavephone", "banana").await?;
 
+    // consume the response to the subscription
+    let _ = stream.next().await;
+
     let pubsub_msg: String = stream.next().await.unwrap()?.unwrap().get_payload()?;
     assert_eq!(&pubsub_msg, "banana");
+
+    println!("Received the message: {}", pubsub_msg);
 
     Ok(())
 }

--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -97,7 +97,7 @@ where
         )
     }
 
-    /// Converts this [`Connection`] into [`MonitorSink`] and a [`Stream`] of [`Msg`].
+    /// Converts this [`Connection`] into [`MonitorSink`] and a [`Stream`] of [`Value`].
     pub fn into_monitor(
         self,
     ) -> (

--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -6,7 +6,7 @@ use crate::cmd::{cmd, Cmd};
 use crate::connection::{ConnectionAddr, ConnectionInfo, Msg, RedisConnectionInfo};
 #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
 use crate::parser::ValueCodec;
-use crate::types::{ErrorKind, FromRedisValue, RedisError, RedisFuture, RedisResult, Value};
+use crate::types::{ErrorKind, RedisError, RedisFuture, RedisResult, Value};
 use crate::{from_redis_value, ToRedisArgs};
 #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
 use ::async_std::net::ToSocketAddrs;

--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -94,7 +94,6 @@ where
         (
             PubSubSink::new(sink),
             stream.map(|msg| msg.and_then(|msg| msg.map(|msg| Msg::from_value(&msg)))),
-            // stream.map(|msg| Msg::from_value(&msg)),
         )
     }
 

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -910,22 +910,6 @@ impl Connection {
         Ok(())
     }
 
-    fn packed_command(&mut self, cmd: &[u8]) -> RedisResult<()> {
-        if self.pubsub {
-            self.exit_pubsub()?;
-        }
-
-        self.con.send_bytes(cmd)?;
-
-        Ok(())
-    }
-
-    // Sends a [Cmd](Cmd) into the TCP socket and does not read a response from it.
-    fn command(&mut self, cmd: &Cmd) -> RedisResult<()> {
-        let pcmd = cmd.get_packed_command();
-        self.packed_command(&pcmd)
-    }
-
     /// Fetches a single response from the connection.  This is useful
     /// if used in combination with `send_packed_command`.
     pub fn recv_response(&mut self) -> RedisResult<Value> {

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -910,6 +910,22 @@ impl Connection {
         Ok(())
     }
 
+    fn packed_command(&mut self, cmd: &[u8]) -> RedisResult<()> {
+        if self.pubsub {
+            self.exit_pubsub()?;
+        }
+
+        self.con.send_bytes(cmd)?;
+
+        Ok(())
+    }
+
+    // Sends a [Cmd](Cmd) into the TCP socket and does not read a response from it.
+    fn command(&mut self, cmd: &Cmd) -> RedisResult<()> {
+        let pcmd = cmd.get_packed_command();
+        self.packed_command(&pcmd)
+    }
+
     /// Fetches a single response from the connection.  This is useful
     /// if used in combination with `send_packed_command`.
     pub fn recv_response(&mut self) -> RedisResult<Value> {


### PR DESCRIPTION
This is a rebase and some tweaks to: https://github.com/redis-rs/redis-rs/pull/633

To be able to subscribe or unsubscribe to channels in redis pub sub, we need to be able to split the connection into stream / sink, so that we can own each half of the connection to be able to send a subscription message on the sink while the stream is waiting for messages.

This means we must remove the on_message() functionality and return a tuple for sink / stream from the into_pubsub() function on the async connection.

This will fix issues such as: https://github.com/redis-rs/redis-rs/issues/852


Changes to the original pull request: 

- rebased with latest main branch
- some changes to some of the code in reference to using tokio's decoder to split the stream
- Changed the MONITOR command stream to return a stream of Values instead of pubsub Msgs
- Added an example for usage of the async monitor command
- Left out the parser changes as they did not seem to be relevant to changes needed