### PR TITLE
Remove redundancy from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Many commands are implemented through the `Commands` trait but manual
 command creation is also possible.
 
 ```rust
-extern crate redis;
 use redis::Commands;
 
 fn fetch_an_integer() -> redis::RedisResult<isize> {


### PR DESCRIPTION
The extern crate statement used to be an important part of rust, several years ago.

These days it's a point of confusion for newcomers without adding any value, and should be omitted.