### PR TITLE
Execute multi-node requests using try_request.

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -615,64 +615,19 @@ where
         Ok(())
     }
 
-    async fn execute_on_multiple_nodes<'a>(
-        cmd: &'a Arc<Cmd>,
-        routing: &'a MultipleNodeRoutingInfo,
-        core: Core<C>,
+    async fn aggregate_results(
+        receivers: Vec<(String, oneshot::Receiver<RedisResult<Response>>)>,
+        routing: &MultipleNodeRoutingInfo,
         response_policy: Option<ResponsePolicy>,
-    ) -> (OperationTarget, RedisResult<Response>) {
-        let read_guard = core.conn_lock.read().await;
-        let (receivers, requests): (Vec<_>, Vec<_>) = read_guard
-            .1
-            .addresses_for_multi_routing(routing)
-            .into_iter()
-            .enumerate()
-            .filter_map(|(index, addr)| {
-                read_guard.0.get(addr).cloned().map(|conn| {
-                    let cmd = match routing {
-                        MultipleNodeRoutingInfo::MultiSlot(vec) => {
-                            let mut new_cmd = Cmd::new();
-                            let command_length = 1; // TODO - the +1 should change if we have multi-slot commands with 2 command words.
-                            new_cmd.arg(cmd.arg_idx(0));
-                            let (_, indices) = vec.get(index).unwrap();
-                            for index in indices {
-                                new_cmd.arg(cmd.arg_idx(*index + command_length));
-                            }
-                            Arc::new(new_cmd)
-                        }
-                        _ => cmd.clone(),
-                    };
-                    let (sender, receiver) = oneshot::channel();
-                    let addr = addr.to_string();
-                    (
-                        (addr.clone(), receiver),
-                        PendingRequest {
-                            retry: 0,
-                            sender,
-                            info: RequestInfo {
-                                cmd: CmdArg::Cmd {
-                                    cmd,
-                                    routing: CommandRouting::Connection { addr, conn },
-                                    response_policy: None,
-                                },
-                                redirect: None,
-                            },
-                        },
-                    )
-                })
-            })
-            .unzip();
-        drop(read_guard);
-        core.pending_requests.lock().unwrap().extend(requests);
-
+    ) -> RedisResult<Value> {
         let extract_result = |response| match response {
             Response::Single(value) => value,
             Response::Multiple(_) => unreachable!(),
         };
 
         let convert_result = |res: Result<RedisResult<Response>, _>| {
-            res.map_err(|_| RedisError::from((ErrorKind::ResponseError, "request wasn't handled")))
-                .and_then(|res| res.map(extract_result))
+            res.map_err(|_| RedisError::from((ErrorKind::ResponseError, "request wasn't handled due to internal failure"))) // this happens only if the result sender is dropped before usage.
+            .and_then(|res| res.map(extract_result))
         };
 
         let get_receiver = |(_, receiver): (_, oneshot::Receiver<RedisResult<Response>>)| async {
@@ -680,7 +635,7 @@ where
         };
 
         // TODO - once Value::Error will be merged, these will need to be updated to handle this new value.
-        let result = match response_policy {
+        match response_policy {
             Some(ResponsePolicy::AllSucceeded) => {
                 future::try_join_all(receivers.into_iter().map(get_receiver))
                     .await
@@ -741,7 +696,61 @@ where
                 .map(Value::Bulk)
             }
         }
-        .map(Response::Single);
+    }
+
+    async fn execute_on_multiple_nodes<'a>(
+        cmd: &'a Arc<Cmd>,
+        routing: &'a MultipleNodeRoutingInfo,
+        core: Core<C>,
+        response_policy: Option<ResponsePolicy>,
+    ) -> (OperationTarget, RedisResult<Response>) {
+        let read_guard = core.conn_lock.read().await;
+        let (receivers, requests): (Vec<_>, Vec<_>) = read_guard
+            .1
+            .addresses_for_multi_routing(routing)
+            .into_iter()
+            .enumerate()
+            .filter_map(|(index, addr)| {
+                read_guard.0.get(addr).cloned().map(|conn| {
+                    let cmd = match routing {
+                        MultipleNodeRoutingInfo::MultiSlot(vec) => {
+                            let mut new_cmd = Cmd::new();
+                            let command_length = 1; // TODO - the +1 should change if we have multi-slot commands with 2 command words.
+                            new_cmd.arg(cmd.arg_idx(0));
+                            let (_, indices) = vec.get(index).unwrap();
+                            for index in indices {
+                                new_cmd.arg(cmd.arg_idx(*index + command_length));
+                            }
+                            Arc::new(new_cmd)
+                        }
+                        _ => cmd.clone(),
+                    };
+                    let (sender, receiver) = oneshot::channel();
+                    let addr = addr.to_string();
+                    (
+                        (addr.clone(), receiver),
+                        PendingRequest {
+                            retry: 0,
+                            sender,
+                            info: RequestInfo {
+                                cmd: CmdArg::Cmd {
+                                    cmd,
+                                    routing: CommandRouting::Connection { addr, conn },
+                                    response_policy: None,
+                                },
+                                redirect: None,
+                            },
+                        },
+                    )
+                })
+            })
+            .unzip();
+        drop(read_guard);
+        core.pending_requests.lock().unwrap().extend(requests);
+
+        let result = Self::aggregate_results(receivers, routing, response_policy)
+            .await
+            .map(Response::Single);
 
         (OperationTarget::FanOut, result)
     }
@@ -754,34 +763,38 @@ where
         core: Core<C>,
         asking: bool,
     ) -> (OperationTarget, RedisResult<Response>) {
-        let routing = match routing {
-            CommandRouting::Route(routing) => routing,
-            CommandRouting::Connection { addr, conn } => {
-                if !asking {
+        let route = if redirect.is_some() {
+            // if we have a redirect, we don't take info from `routing`.
+            // TODO - combine the info in `routing` and `redirect` and `asking` into a single structure, so there won't be this question of which field takes precedence.
+            SingleNodeRoutingInfo::Random
+        } else {
+            match routing {
+                // commands that are sent to multiple nodes are handled here.
+                CommandRouting::Route(RoutingInfo::MultiNode(multi_node_routing)) => {
+                    assert!(!asking);
+                    assert!(redirect.is_none());
+                    return Self::execute_on_multiple_nodes(
+                        &cmd,
+                        &multi_node_routing,
+                        core,
+                        response_policy,
+                    )
+                    .await;
+                }
+                CommandRouting::Route(RoutingInfo::SingleNode(single_node_routing)) => {
+                    single_node_routing
+                }
+
+                // commands that have concrete connections, and don't require redirection, are handled here.
+                CommandRouting::Connection { addr, conn } => {
                     let mut conn = conn.await;
                     let result = conn.req_packed_command(&cmd).await.map(Response::Single);
                     return (addr.into(), result);
                 }
-                RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)
             }
         };
 
-        let route_option = match routing {
-            RoutingInfo::MultiNode(multi_node_routing) => {
-                return Self::execute_on_multiple_nodes(
-                    &cmd,
-                    &multi_node_routing,
-                    core,
-                    response_policy,
-                )
-                .await
-            }
-            RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random) => None,
-            RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(route)) => Some(route),
-        };
-
-        let (addr, mut conn) =
-            Self::get_connection(redirect, route_option.into(), core, asking).await;
+        let (addr, mut conn) = Self::get_connection(redirect, route, core, asking).await;
         let result = conn.req_packed_command(&cmd).await.map(Response::Single);
         (addr.into(), result)
     }

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "cluster-async")]
 mod support;
 use std::sync::{
-    atomic::{self, AtomicI32},
+    atomic::{self, AtomicI32, AtomicU16},
     atomic::{AtomicBool, Ordering},
     Arc,
 };
@@ -1282,6 +1282,53 @@ fn test_cluster_split_multi_shard_command_and_combine_arrays_of_values() {
         .block_on(cmd.query_async::<_, Vec<String>>(&mut connection))
         .unwrap();
     assert_eq!(result, vec!["foo-6382", "bar-6380", "baz-6380"]);
+}
+
+#[test]
+fn test_cluster_handle_asking_error_in_split_multi_shard_command() {
+    let name = "test_cluster_handle_asking_error_in_split_multi_shard_command";
+    let mut cmd = cmd("MGET");
+    cmd.arg("foo").arg("bar").arg("baz");
+    let asking_called = Arc::new(AtomicU16::new(0));
+    let asking_called_cloned = asking_called.clone();
+    let MockEnv {
+        runtime,
+        async_connection: mut connection,
+        handler: _handler,
+        ..
+    } = MockEnv::with_client_builder(
+        ClusterClient::builder(vec![&*format!("redis://{name}")]).read_from_replicas(),
+        name,
+        move |received_cmd: &[u8], port| {
+            respond_startup_with_replica_using_config(name, received_cmd, None)?;
+            let cmd_str = std::str::from_utf8(received_cmd).unwrap();
+            if cmd_str.contains("ASKING") && port == 6382 {
+                asking_called_cloned.fetch_add(1, Ordering::Relaxed);
+            }
+            if port == 6380 && cmd_str.contains("baz") {
+                return Err(parse_redis_value(
+                    format!("-ASK 14000 {name}:6382\r\n").as_bytes(),
+                ));
+            }
+            let results = ["foo", "bar", "baz"]
+                .iter()
+                .filter_map(|expected_key| {
+                    if cmd_str.contains(expected_key) {
+                        Some(Value::Data(format!("{expected_key}-{port}").into_bytes()))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            Err(Ok(Value::Bulk(results)))
+        },
+    );
+
+    let result = runtime
+        .block_on(cmd.query_async::<_, Vec<String>>(&mut connection))
+        .unwrap();
+    assert_eq!(result, vec!["foo-6382", "bar-6380", "baz-6382"]);
+    assert_eq!(asking_called.load(Ordering::Relaxed), 1);
 }
 
 #[test]


### PR DESCRIPTION
rebased over https://github.com/redis-rs/redis-rs/pull/899 .

This means multi node operations now get error handling, and can trigger
MOVED, etc.

Additionally, func was removed from CmdArg::Cmd/Pipeline. This removes
the need to allocate a box on every request, and slightly reduces code
complexity.