### PR TITLE
Rustls: Remove usage of deprecated method.

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -65,7 +65,7 @@ tokio-native-tls = { version = "0.3", optional = true }
 async-native-tls = { version = "0.4", optional = true }
 
 # Only needed for rustls
-rustls = { version = "0.21.0", optional = true }
+rustls = { version = "0.21.6", optional = true }
 webpki-roots = { version = "0.23.0", optional = true }
 rustls-native-certs = { version = "0.6.2", optional = true }
 tokio-rustls = { version = "0.24.0", optional = true }

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -720,7 +720,7 @@ impl ActualConnection {
 pub(crate) fn create_rustls_config(insecure: bool) -> RedisResult<rustls::ClientConfig> {
     let mut root_store = RootCertStore::empty();
     #[cfg(feature = "tls-rustls-webpki-roots")]
-    root_store.add_server_trust_anchors(TLS_SERVER_ROOTS.0.iter().map(|ta| {
+    root_store.add_trust_anchors(TLS_SERVER_ROOTS.0.iter().map(|ta| {
         OwnedTrustAnchor::from_subject_spki_name_constraints(
             ta.subject,
             ta.spki,


### PR DESCRIPTION
https://github.com/rustls/rustls/pull/1383

Fixes this linter error:
https://github.com/redis-rs/redis-rs/actions/runs/5737543101/job/15699563878?pr=918