### PR TITLE
feat(redis): set TCP_NODELAY to reduce latency

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -103,6 +103,7 @@ streams = []
 cluster-async = ["cluster", "futures", "futures-util", "log"]
 keep-alive = ["socket2"]
 sentinel = ["rand"]
+tcp_nodelay = []
 
 # Deprecated features
 tls = ["tls-native-tls"] # use "tls-native-tls" instead

--- a/redis/src/aio/async_std.rs
+++ b/redis/src/aio/async_std.rs
@@ -31,6 +31,7 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 #[inline(always)]
 async fn connect_tcp(addr: &SocketAddr) -> io::Result<TcpStream> {
     let socket = TcpStream::connect(addr).await?;
+    socket.set_nodelay(true)?;
     #[cfg(feature = "keep-alive")]
     {
         //For now rely on system defaults

--- a/redis/src/aio/async_std.rs
+++ b/redis/src/aio/async_std.rs
@@ -31,6 +31,7 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 #[inline(always)]
 async fn connect_tcp(addr: &SocketAddr) -> io::Result<TcpStream> {
     let socket = TcpStream::connect(addr).await?;
+    #[cfg(feature = "tcp_nodelay")]
     socket.set_nodelay(true)?;
     #[cfg(feature = "keep-alive")]
     {

--- a/redis/src/aio/tokio.rs
+++ b/redis/src/aio/tokio.rs
@@ -32,6 +32,7 @@ use super::Path;
 #[inline(always)]
 async fn connect_tcp(addr: &SocketAddr) -> io::Result<TcpStreamTokio> {
     let socket = TcpStreamTokio::connect(addr).await?;
+    #[cfg(feature = "tcp_nodelay")]
     socket.set_nodelay(true)?;
     #[cfg(feature = "keep-alive")]
     {
@@ -93,30 +94,6 @@ impl AsyncWrite for Tokio {
             Tokio::TcpTls(r) => Pin::new(r).poll_shutdown(cx),
             #[cfg(unix)]
             Tokio::Unix(r) => Pin::new(r).poll_shutdown(cx),
-        }
-    }
-
-    fn poll_write_vectored(
-        mut self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
-        bufs: &[io::IoSlice<'_>],
-    ) -> Poll<Result<usize, io::Error>> {
-        match &mut *self {
-            Tokio::Tcp(r) => Pin::new(r).poll_write_vectored(cx, bufs),
-            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
-            Tokio::TcpTls(r) => Pin::new(r).poll_write_vectored(cx, bufs),
-            #[cfg(unix)]
-            Tokio::Unix(r) => Pin::new(r).poll_write_vectored(cx, bufs),
-        }
-    }
-
-    fn is_write_vectored(&self) -> bool {
-        match self {
-            Tokio::Tcp(r) => r.is_write_vectored(),
-            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
-            Tokio::TcpTls(r) => r.is_write_vectored(),
-            #[cfg(unix)]
-            Tokio::Unix(r) => r.is_write_vectored(),
         }
     }
 }

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -39,6 +39,7 @@ static DEFAULT_PORT: u16 = 6379;
 #[inline(always)]
 fn connect_tcp(addr: (&str, u16)) -> io::Result<TcpStream> {
     let socket = TcpStream::connect(addr)?;
+    socket.set_nodelay(true)?;
     #[cfg(feature = "keep-alive")]
     {
         //For now rely on system defaults
@@ -57,6 +58,7 @@ fn connect_tcp(addr: (&str, u16)) -> io::Result<TcpStream> {
 #[inline(always)]
 fn connect_tcp_timeout(addr: &SocketAddr, timeout: Duration) -> io::Result<TcpStream> {
     let socket = TcpStream::connect_timeout(addr, timeout)?;
+    socket.set_nodelay(true)?;
     #[cfg(feature = "keep-alive")]
     {
         //For now rely on system defaults

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -39,6 +39,7 @@ static DEFAULT_PORT: u16 = 6379;
 #[inline(always)]
 fn connect_tcp(addr: (&str, u16)) -> io::Result<TcpStream> {
     let socket = TcpStream::connect(addr)?;
+    #[cfg(feature = "tcp_nodelay")]
     socket.set_nodelay(true)?;
     #[cfg(feature = "keep-alive")]
     {
@@ -58,6 +59,7 @@ fn connect_tcp(addr: (&str, u16)) -> io::Result<TcpStream> {
 #[inline(always)]
 fn connect_tcp_timeout(addr: &SocketAddr, timeout: Duration) -> io::Result<TcpStream> {
     let socket = TcpStream::connect_timeout(addr, timeout)?;
+    #[cfg(feature = "tcp_nodelay")]
     socket.set_nodelay(true)?;
     #[cfg(feature = "keep-alive")]
     {


### PR DESCRIPTION
`TCP_NODELAY` is quite important for redis client because this greatly affects latency.
This PR adds this option by default.
This PR also implements writev for tokio tcp connection (maybe for future optimization).
Fixes #354 .