### PR TITLE
Fix parser infinite loop

### DIFF
--- a/redis/src/parser.rs
+++ b/redis/src/parser.rs
@@ -154,13 +154,23 @@ where
                     })
                 };
 
+                let unknown = || {
+                    line().map(|line| {
+                        RedisError::from((
+                            ErrorKind::ResponseError,
+                            "Unknown response",
+                            format!("Unknown line: {}", line),
+                        ))
+                    })
+                };
+
                 combine::dispatch!(b;
                     b'+' => status().map(Ok),
                     b':' => int().map(|i| Ok(Value::Int(i))),
                     b'$' => data().map(Ok),
                     b'*' => bulk(),
                     b'-' => error().map(Err),
-                    b => combine::unexpected_any(combine::error::Token(b))
+                    _ => unknown().map(Err)
                 )
             })
     ))

--- a/redis/src/parser.rs
+++ b/redis/src/parser.rs
@@ -344,6 +344,8 @@ pub fn parse_redis_value(bytes: &[u8]) -> RedisResult<Value> {
 
 #[cfg(test)]
 mod tests {
+    use bytes::BytesMut;
+    use tokio_util::codec::Decoder;
 
     use super::*;
 
@@ -369,5 +371,19 @@ mod tests {
             Ok(_) => panic!("Expected Err"),
             Err(e) => assert!(matches!(e.kind(), ErrorKind::ResponseError)),
         }
+    }
+
+    #[test]
+    fn test_handle_unknown() {
+        let mut bytes = BytesMut::from(&b"/test\r\n*1\r\n"[..]);
+
+        let mut codec = ValueCodec::default();
+
+        match codec.decode(&mut bytes) {
+            Ok(Some(Err(e))) => assert!(matches!(e.kind(), ErrorKind::ResponseError)),
+            _ => panic!("Expected Err"),
+        }
+
+        assert!(codec.decode(&mut bytes).is_ok())
     }
 }

--- a/redis/src/parser.rs
+++ b/redis/src/parser.rs
@@ -344,9 +344,6 @@ pub fn parse_redis_value(bytes: &[u8]) -> RedisResult<Value> {
 
 #[cfg(test)]
 mod tests {
-    use bytes::BytesMut;
-    use tokio_util::codec::Decoder;
-
     use super::*;
 
     #[cfg(feature = "aio")]
@@ -373,8 +370,12 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "aio")]
     #[test]
     fn test_handle_unknown() {
+        use bytes::BytesMut;
+        use tokio_util::codec::Decoder;
+
         let mut bytes = BytesMut::from(&b"/test\r\n*1\r\n"[..]);
 
         let mut codec = ValueCodec::default();


### PR DESCRIPTION
- Issue: #487
- Problem
  - If the ValueCodec parses an invalid line, it will not consume the line and continuously parse the same invalid line in an infinite loop, in some cases consuming the resources of the thread
- Fix
  - Consume the invalid line and return an error
  - Issue referenced avoided by: #633 