### PR TITLE
Remove redis version from redis-test.

### DIFF
--- a/redis-test/Cargo.toml
+++ b/redis-test/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.63"
 bench = false
 
 [dependencies]
-redis = { version = "0.23.3", path = "../redis" }
+redis = { path = "../redis" }
 
 bytes = { version = "1", optional = true }
 futures = { version = "0.3", optional = true }
@@ -22,5 +22,5 @@ futures = { version = "0.3", optional = true }
 aio = ["futures", "redis/aio"]
 
 [dev-dependencies]
-redis = { version = "0.23.3", path = "../redis", features = ["aio", "tokio-comp"] }
+redis = { path = "../redis", features = ["aio", "tokio-comp"] }
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }


### PR DESCRIPTION
Since `redis` is found by path, there's only a single version to choose.