### PR TITLE
Call CLIENT SETINFO on new connections.

### DIFF
--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "async-std-comp")]
 use super::async_std;
 use super::ConnectionLike;
-use super::{authenticate, AsyncStream, RedisRuntime};
+use super::{setup_connection, AsyncStream, RedisRuntime};
 use crate::cmd::{cmd, Cmd};
 use crate::connection::{ConnectionAddr, ConnectionInfo, Msg, RedisConnectionInfo};
 #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
@@ -78,7 +78,7 @@ where
             db: connection_info.db,
             pubsub: false,
         };
-        authenticate(connection_info, &mut rv).await?;
+        setup_connection(connection_info, &mut rv).await?;
         Ok(rv)
     }
 

--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -127,6 +127,12 @@ where
         }
     }
 
+    // result is ignored, as per the command's instructions.
+    // https://redis.io/commands/client-setinfo/
+    let _: RedisResult<()> = crate::connection::client_set_info_pipeline()
+        .query_async(con)
+        .await;
+
     Ok(())
 }
 

--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -72,7 +72,8 @@ pub trait ConnectionLike {
     fn get_db(&self) -> i64;
 }
 
-async fn authenticate<C>(connection_info: &RedisConnectionInfo, con: &mut C) -> RedisResult<()>
+// Initial setup for every connection.
+async fn setup_connection<C>(connection_info: &RedisConnectionInfo, con: &mut C) -> RedisResult<()>
 where
     C: ConnectionLike,
 {

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -1,5 +1,5 @@
 use super::ConnectionLike;
-use crate::aio::authenticate;
+use crate::aio::setup_connection;
 use crate::cmd::Cmd;
 use crate::connection::RedisConnectionInfo;
 #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
@@ -349,7 +349,7 @@ impl MultiplexedConnection {
             db: connection_info.db,
         };
         let driver = {
-            let auth = authenticate(connection_info, &mut con);
+            let auth = setup_connection(connection_info, &mut con);
             futures_util::pin_mut!(auth);
 
             match futures_util::future::select(auth, driver).await {

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -806,6 +806,23 @@ pub fn connect(
     setup_connection(con, &connection_info.redis)
 }
 
+pub(crate) fn client_set_info_pipeline() -> Pipeline {
+    let mut pipeline = crate::pipe();
+    pipeline
+        .cmd("CLIENT")
+        .arg("SETINFO")
+        .arg("LIB-NAME")
+        .arg("redis-rs")
+        .ignore();
+    pipeline
+        .cmd("CLIENT")
+        .arg("SETINFO")
+        .arg("LIB-VER")
+        .arg(env!("CARGO_PKG_VERSION"))
+        .ignore();
+    pipeline
+}
+
 fn setup_connection(
     con: ActualConnection,
     connection_info: &RedisConnectionInfo,
@@ -833,6 +850,10 @@ fn setup_connection(
             )),
         }
     }
+
+    // result is ignored, as per the command's instructions.
+    // https://redis.io/commands/client-setinfo/
+    let _: RedisResult<()> = client_set_info_pipeline().query(&mut rv);
 
     Ok(rv)
 }


### PR DESCRIPTION
CLIENT SETINFO is a new command to Redis 7.2.0.