### PR TITLE
feat: optimize make_pipeline_results by pre-allocate memory

### DIFF
--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -305,7 +305,7 @@ macro_rules! implement_pipeline_commands {
             }
 
             fn make_pipeline_results(&self, resp: Vec<Value>) -> Value {
-                let mut rv = vec![];
+                let mut rv = Vec::with_capacity(resp.len() - self.ignored_commands.len());
                 for (idx, result) in resp.into_iter().enumerate() {
                     if !self.ignored_commands.contains(&idx) {
                         rv.push(result);


### PR DESCRIPTION
This pr optimize the `make_pipeline_results` method by pre-allocating memory for rv.