### PR TITLE
Sorted set blocking commands

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -612,9 +612,21 @@ implement_commands! {
         cmd("ZLEXCOUNT").arg(key).arg(min).arg(max)
     }
 
+    /// Removes and returns the member with the highest score in a sorted set.
+    /// Blocks until a member is available otherwise.
+    fn bzpopmax<K: ToRedisArgs>(key: K, timeout: isize) {
+        cmd("BZPOPMAX").arg(key).arg(timeout)
+    }
+
     /// Removes and returns up to count members with the highest scores in a sorted set
     fn zpopmax<K: ToRedisArgs>(key: K, count: isize) {
         cmd("ZPOPMAX").arg(key).arg(count)
+    }
+
+    /// Removes and returns the member with the lowest score in a sorted set.
+    /// Blocks until a member is available otherwise.
+    fn bzpopmin<K: ToRedisArgs>(key: K, timeout: isize) {
+        cmd("BZPOPMIN").arg(key).arg(timeout)
     }
 
     /// Removes and returns up to count members with the lowest scores in a sorted set
@@ -624,8 +636,22 @@ implement_commands! {
 
     /// Removes and returns up to count members with the highest scores,
     /// from the first non-empty sorted set in the provided list of key names.
+    /// Blocks until a member is available otherwise.
+    fn bzmpop_max<K: ToRedisArgs>(timeout: isize, keys: &'a [K], count: isize) {
+        cmd("BZMPOP").arg(timeout).arg(keys.len()).arg(keys).arg("MAX").arg("COUNT").arg(count)
+    }
+
+    /// Removes and returns up to count members with the highest scores,
+    /// from the first non-empty sorted set in the provided list of key names.
     fn zmpop_max<K: ToRedisArgs>(keys: &'a [K], count: isize) {
         cmd("ZMPOP").arg(keys.len()).arg(keys).arg("MAX").arg("COUNT").arg(count)
+    }
+
+    /// Removes and returns up to count members with the lowest scores,
+    /// from the first non-empty sorted set in the provided list of key names.
+    /// Blocks until a member is available otherwise.
+    fn bzmpop_min<K: ToRedisArgs>(timeout: isize, keys: &'a [K], count: isize) {
+        cmd("BZMPOP").arg(timeout).arg(keys.len()).arg(keys).arg("MIN").arg("COUNT").arg(count)
     }
 
     /// Removes and returns up to count members with the lowest scores,

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -1290,22 +1290,22 @@ fn test_blocking_sorted_set_api() {
     assert_eq!(con.zadd("b", "2b", 2), Ok(()));
     assert_eq!(con.zadd("c", "3c", 3), Ok(()));
     assert_eq!(con.zadd("d", "4d", 4), Ok(()));
-    assert_eq!(con.zadd("a", "5a", 1), Ok(()));
-    assert_eq!(con.zadd("b", "6b", 2), Ok(()));
-    assert_eq!(con.zadd("c", "7c", 3), Ok(()));
-    assert_eq!(con.zadd("d", "8d", 4), Ok(()));
+    assert_eq!(con.zadd("a", "5a", 5), Ok(()));
+    assert_eq!(con.zadd("b", "6b", 6), Ok(()));
+    assert_eq!(con.zadd("c", "7c", 7), Ok(()));
+    assert_eq!(con.zadd("d", "8d", 8), Ok(()));
 
     let result_multiple_min = con
         .bzmpop_min::<&str, (String, Vec<Vec<(String, String)>>)>(0, vec!["a", "b", "c", "d"].as_slice(), 1);
     let result_multiple_max  = con
-        .bzmpop_min::<&str, (String, Vec<Vec<(String, String)>>)>(0, vec!["a", "b", "c", "d"].as_slice(), 1);
+        .bzmpop_max::<&str, (String, Vec<Vec<(String, String)>>)>(0, vec!["a", "b", "c", "d"].as_slice(), 1);
 
     let result_min = con.bzpopmin::<&str, (String, String, String)>("b", 0);
-    let result_max = con.bzpopmin::<&str, (String, String, String)>("b", 0);
+    let result_max = con.bzpopmax::<&str, (String, String, String)>("b", 0);
 
     assert_eq!(result_multiple_min.unwrap().1[0][0], (String::from("1a"), String::from("1")));
-    assert_eq!(result_multiple_max.unwrap().1[0][0], (String::from("5a"), String::from("1")));
+    assert_eq!(result_multiple_max.unwrap().1[0][0], (String::from("5a"), String::from("5")));
 
     assert_eq!(result_min.unwrap(), (String::from("b"), String::from("2b"), String::from("2")));
-    assert_eq!(result_max.unwrap(), (String::from("b"), String::from("6b"), String::from("2")));
+    assert_eq!(result_max.unwrap(), (String::from("b"), String::from("6b"), String::from("6")));
 }

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -1314,7 +1314,7 @@ fn test_blocking_sorted_set_api() {
         (String::from("b"), String::from("6b"), String::from("6"))
     );
 
-    if redis_version.0 > 7 {
+    if redis_version.0 >= 7 {
         let min = con.bzmpop_min::<&str, (String, Vec<Vec<(String, String)>>)>(
             0,
             vec!["a", "b", "c", "d"].as_slice(),

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -1286,6 +1286,13 @@ fn test_blocking_sorted_set_api() {
     let ctx = TestContext::new();
     let mut con = ctx.connection();
 
+    // setup version & input data followed by assertions that take into account Redis version
+    // BZPOPMIN & BZPOPMAX are available from Redis version 5.0.0
+    // BZMPOP is available from Redis version 7.0.0
+
+    let redis_version = ctx.get_version();
+    assert!(redis_version.0 >= 5);
+
     assert_eq!(con.zadd("a", "1a", 1), Ok(()));
     assert_eq!(con.zadd("b", "2b", 2), Ok(()));
     assert_eq!(con.zadd("c", "3c", 3), Ok(()));
@@ -1295,17 +1302,37 @@ fn test_blocking_sorted_set_api() {
     assert_eq!(con.zadd("c", "7c", 7), Ok(()));
     assert_eq!(con.zadd("d", "8d", 8), Ok(()));
 
-    let result_multiple_min = con
-        .bzmpop_min::<&str, (String, Vec<Vec<(String, String)>>)>(0, vec!["a", "b", "c", "d"].as_slice(), 1);
-    let result_multiple_max  = con
-        .bzmpop_max::<&str, (String, Vec<Vec<(String, String)>>)>(0, vec!["a", "b", "c", "d"].as_slice(), 1);
+    let min = con.bzpopmin::<&str, (String, String, String)>("b", 0);
+    let max = con.bzpopmax::<&str, (String, String, String)>("b", 0);
 
-    let result_min = con.bzpopmin::<&str, (String, String, String)>("b", 0);
-    let result_max = con.bzpopmax::<&str, (String, String, String)>("b", 0);
+    assert_eq!(
+        min.unwrap(),
+        (String::from("b"), String::from("2b"), String::from("2"))
+    );
+    assert_eq!(
+        max.unwrap(),
+        (String::from("b"), String::from("6b"), String::from("6"))
+    );
 
-    assert_eq!(result_multiple_min.unwrap().1[0][0], (String::from("1a"), String::from("1")));
-    assert_eq!(result_multiple_max.unwrap().1[0][0], (String::from("5a"), String::from("5")));
+    if redis_version.0 > 7 {
+        let min = con.bzmpop_min::<&str, (String, Vec<Vec<(String, String)>>)>(
+            0,
+            vec!["a", "b", "c", "d"].as_slice(),
+            1,
+        );
+        let max = con.bzmpop_max::<&str, (String, Vec<Vec<(String, String)>>)>(
+            0,
+            vec!["a", "b", "c", "d"].as_slice(),
+            1,
+        );
 
-    assert_eq!(result_min.unwrap(), (String::from("b"), String::from("2b"), String::from("2")));
-    assert_eq!(result_max.unwrap(), (String::from("b"), String::from("6b"), String::from("6")));
+        assert_eq!(
+            min.unwrap().1[0][0],
+            (String::from("1a"), String::from("1"))
+        );
+        assert_eq!(
+            max.unwrap().1[0][0],
+            (String::from("5a"), String::from("5"))
+        );
+    }
 }


### PR DESCRIPTION
Hello,

The feature has been requested in #944 & #476.

The commands implemented are:
https://redis.io/commands/bzpopmin
https://redis.io/commands/bzpopmax
https://redis.io/commands/bzmpop

Tests were added for all 3 of them.