### PR TITLE
Cluster: fix read from replica & missing slots.

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -224,7 +224,7 @@ where
     ) -> RedisResult<Self> {
         let connection = Self {
             connections: RefCell::new(HashMap::new()),
-            slots: RefCell::new(SlotMap::new()),
+            slots: RefCell::new(SlotMap::new(cluster_params.read_from_replicas)),
             auto_reconnect: RefCell::new(true),
             read_timeout: RefCell::new(None),
             write_timeout: RefCell::new(None),
@@ -375,10 +375,7 @@ where
         for conn in samples.iter_mut() {
             let value = conn.req_command(&slot_cmd())?;
             if let Ok(slots_data) = parse_slots(value, self.cluster_params.tls) {
-                new_slots = Some(SlotMap::from_slots(
-                    &slots_data,
-                    self.cluster_params.read_from_replicas,
-                ));
+                new_slots = Some(SlotMap::from_slots(slots_data, self.cluster_params.read_from_replicas));
                 break;
             }
         }

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -36,6 +36,7 @@
 //!     .query(&mut connection).unwrap();
 //! ```
 use std::cell::RefCell;
+use std::collections::HashSet;
 use std::iter::Iterator;
 use std::str::FromStr;
 use std::thread;
@@ -375,7 +376,10 @@ where
         for conn in samples.iter_mut() {
             let value = conn.req_command(&slot_cmd())?;
             if let Ok(slots_data) = parse_slots(value, self.cluster_params.tls) {
-                new_slots = Some(SlotMap::from_slots(slots_data, self.cluster_params.read_from_replicas));
+                new_slots = Some(SlotMap::from_slots(
+                    slots_data,
+                    self.cluster_params.read_from_replicas,
+                ));
                 break;
             }
         }
@@ -481,6 +485,80 @@ where
         Ok(result)
     }
 
+    fn exectue_on_all<'a>(
+        &'a self,
+        input: Input,
+        addresses: HashSet<&'a str>,
+        connections: &'a mut HashMap<String, C>,
+    ) -> Vec<RedisResult<(&'a str, Value)>> {
+        addresses
+            .into_iter()
+            .map(|addr| {
+                let connection = self.get_connection_by_addr(connections, addr)?;
+                match input {
+                    Input::Slice { cmd, routable: _ } => connection.req_packed_command(cmd),
+                    Input::Cmd(cmd) => connection.req_command(cmd),
+                    Input::Commands {
+                        cmd: _,
+                        route: _,
+                        offset: _,
+                        count: _,
+                    } => Err((
+                        ErrorKind::ClientError,
+                        "req_packed_commands isn't supported with multiple nodes",
+                    )
+                        .into()),
+                }
+                .map(|res| (addr, res))
+            })
+            .collect()
+    }
+
+    fn exectue_on_all_nodes<'a>(
+        &'a self,
+        input: Input,
+        slots: &'a mut SlotMap,
+        connections: &'a mut HashMap<String, C>,
+    ) -> Vec<RedisResult<(&'a str, Value)>> {
+        self.exectue_on_all(input, slots.addresses_for_all_nodes(), connections)
+    }
+
+    fn exectue_on_all_primaries<'a>(
+        &'a self,
+        input: Input,
+        slots: &'a mut SlotMap,
+        connections: &'a mut HashMap<String, C>,
+    ) -> Vec<RedisResult<(&'a str, Value)>> {
+        self.exectue_on_all(input, slots.addresses_for_all_primaries(), connections)
+    }
+
+    fn exectue_multi_slot<'a, 'b>(
+        &'a self,
+        input: Input,
+        slots: &'a mut SlotMap,
+        connections: &'a mut HashMap<String, C>,
+        routes: &'b [(Route, Vec<usize>)],
+    ) -> Vec<RedisResult<(&'a str, Value)>>
+    where
+        'b: 'a,
+    {
+        slots
+            .addresses_for_multi_slot(routes)
+            .enumerate()
+            .map(|(index, addr)| {
+                let addr = addr.ok_or(RedisError::from((
+                    ErrorKind::IoError,
+                    "Couldn't find connection",
+                )))?;
+                let connection = self.get_connection_by_addr(connections, addr)?;
+                let (_, indices) = routes.get(index).unwrap();
+                let cmd =
+                    crate::cluster_routing::command_for_multi_slot_indices(&input, indices.iter());
+                connection.req_command(&cmd).map(|res| (addr, res))
+            })
+            .collect()
+    }
+
     fn execute_on_multiple_nodes(
         &self,
         input: Input,
@@ -488,45 +566,20 @@ where
         response_policy: Option<ResponsePolicy>,
     ) -> RedisResult<Value> {
         let mut connections = self.connections.borrow_mut();
-        let slots = self.slots.borrow_mut();
-        let addresses = slots.addresses_for_multi_routing(&routing);
+        let mut slots = self.slots.borrow_mut();
 
-        // TODO: reconnect and shit
-        let results = addresses.iter().enumerate().map(|(index, addr)| {
-            if let Some(connection) = connections.get_mut(*addr) {
-                match &routing {
-                    MultipleNodeRoutingInfo::MultiSlot(vec) => {
-                        let (_, indices) = vec.get(index).unwrap();
-                        let cmd = crate::cluster_routing::command_for_multi_slot_indices(
-                            &input,
-                            indices.iter(),
-                        );
-                        connection.req_command(&cmd)
-                    }
-                    _ => match input {
-                        Input::Slice { cmd, routable: _ } => connection.req_packed_command(cmd),
-                        Input::Cmd(cmd) => connection.req_command(cmd),
-                        Input::Commands {
-                            cmd: _,
-                            route: _,
-                            offset: _,
-                            count: _,
-                        } => Err((
-                            ErrorKind::ClientError,
-                            "req_packed_commands isn't supported with multiple nodes",
-                        )
-                            .into()),
-                    },
-                }
-            } else {
-                Err((
-                    ErrorKind::IoError,
-                    "connection error",
-                    format!("Disconnected from {addr}"),
-                )
-                    .into())
+        let results = match &routing {
+            MultipleNodeRoutingInfo::MultiSlot(routes) => {
+                self.exectue_multi_slot(input, &mut slots, &mut connections, routes)
             }
-        });
+            MultipleNodeRoutingInfo::AllMasters => {
+                self.exectue_on_all_primaries(input, &mut slots, &mut connections)
+            }
+            MultipleNodeRoutingInfo::AllNodes => {
+                self.exectue_on_all_nodes(input, &mut slots, &mut connections)
+            }
+        };
+
         match response_policy {
             Some(ResponsePolicy::AllSucceeded) => {
                 for result in results {
@@ -540,7 +593,7 @@ where
 
                 for result in results {
                     match result {
-                        Ok(val) => return Ok(val),
+                        Ok((_, val)) => return Ok(val),
                         Err(err) => last_failure = Some(err),
                     }
                 }
@@ -552,7 +605,7 @@ where
                 let mut last_failure = None;
 
                 for result in results {
-                    match result {
+                    match result.map(|(_, res)| res) {
                         Ok(Value::Nil) => continue,
                         Ok(val) => return Ok(val),
                         Err(err) => last_failure = Some(err),
@@ -562,15 +615,24 @@ where
                     .unwrap_or_else(|| (ErrorKind::IoError, "Couldn't find a connection").into()))
             }
             Some(ResponsePolicy::Aggregate(op)) => {
-                let results = results.collect::<RedisResult<Vec<_>>>()?;
+                let results = results
+                    .into_iter()
+                    .map(|res| res.map(|(_, val)| val))
+                    .collect::<RedisResult<Vec<_>>>()?;
                 crate::cluster_routing::aggregate(results, op)
             }
             Some(ResponsePolicy::AggregateLogical(op)) => {
-                let results = results.collect::<RedisResult<Vec<_>>>()?;
+                let results = results
+                    .into_iter()
+                    .map(|res| res.map(|(_, val)| val))
+                    .collect::<RedisResult<Vec<_>>>()?;
                 crate::cluster_routing::logical_aggregate(results, op)
             }
             Some(ResponsePolicy::CombineArrays) => {
-                let results = results.collect::<RedisResult<Vec<_>>>()?;
+                let results = results
+                    .into_iter()
+                    .map(|res| res.map(|(_, val)| val))
+                    .collect::<RedisResult<Vec<_>>>()?;
                 match routing {
                     MultipleNodeRoutingInfo::MultiSlot(vec) => {
                         crate::cluster_routing::combine_and_sort_array_results(
@@ -586,10 +648,9 @@ where
                 // TODO - once RESP3 is merged, return a map value here.
                 // TODO - once Value::Error is merged, we can use join_all and report separate errors and also pass successes.
                 let results = results
-                    .enumerate()
-                    .map(|(index, result)| {
-                        let addr = addresses[index];
-                        result.map(|val| {
+                    .into_iter()
+                    .map(|result| {
+                        result.map(|(addr, val)| {
                             Value::Bulk(vec![Value::Data(addr.as_bytes().to_vec()), val])
                         })
                     })

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -485,7 +485,7 @@ where
         Ok(result)
     }
 
-    fn exectue_on_all<'a>(
+    fn execute_on_all<'a>(
         &'a self,
         input: Input,
         addresses: HashSet<&'a str>,
@@ -514,25 +514,25 @@ where
             .collect()
     }
 
-    fn exectue_on_all_nodes<'a>(
+    fn execute_on_all_nodes<'a>(
         &'a self,
         input: Input,
         slots: &'a mut SlotMap,
         connections: &'a mut HashMap<String, C>,
     ) -> Vec<RedisResult<(&'a str, Value)>> {
-        self.exectue_on_all(input, slots.addresses_for_all_nodes(), connections)
+        self.execute_on_all(input, slots.addresses_for_all_nodes(), connections)
     }
 
-    fn exectue_on_all_primaries<'a>(
+    fn execute_on_all_primaries<'a>(
         &'a self,
         input: Input,
         slots: &'a mut SlotMap,
         connections: &'a mut HashMap<String, C>,
     ) -> Vec<RedisResult<(&'a str, Value)>> {
-        self.exectue_on_all(input, slots.addresses_for_all_primaries(), connections)
+        self.execute_on_all(input, slots.addresses_for_all_primaries(), connections)
     }
 
-    fn exectue_multi_slot<'a, 'b>(
+    fn execute_multi_slot<'a, 'b>(
         &'a self,
         input: Input,
         slots: &'a mut SlotMap,
@@ -570,13 +570,13 @@ where
 
         let results = match &routing {
             MultipleNodeRoutingInfo::MultiSlot(routes) => {
-                self.exectue_multi_slot(input, &mut slots, &mut connections, routes)
+                self.execute_multi_slot(input, &mut slots, &mut connections, routes)
             }
             MultipleNodeRoutingInfo::AllMasters => {
-                self.exectue_on_all_primaries(input, &mut slots, &mut connections)
+                self.execute_on_all_primaries(input, &mut slots, &mut connections)
             }
             MultipleNodeRoutingInfo::AllNodes => {
-                self.exectue_on_all_nodes(input, &mut slots, &mut connections)
+                self.execute_on_all_nodes(input, &mut slots, &mut connections)
             }
         };
 

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -853,6 +853,41 @@ fn test_cluster_route_correctly_on_packed_transaction_with_single_node_requests2
     assert_eq!(result, expected_result);
 }
 
+#[test]
+fn test_cluster_can_be_created_with_partial_slot_coverage() {
+    let name = "test_cluster_can_be_created_with_partial_slot_coverage";
+    let slots_config = Some(vec![
+        MockSlotRange {
+            primary_port: 6379,
+            replica_ports: vec![],
+            slot_range: (0..8000),
+        },
+        MockSlotRange {
+            primary_port: 6381,
+            replica_ports: vec![],
+            slot_range: (8201..16380),
+        },
+    ]);
+
+    let MockEnv {
+        mut connection,
+        handler: _handler,
+        ..
+    } = MockEnv::with_client_builder(
+        ClusterClient::builder(vec![&*format!("redis://{name}")])
+            .retries(0)
+            .read_from_replicas(),
+        name,
+        move |received_cmd: &[u8], _| {
+            respond_startup_with_replica_using_config(name, received_cmd, slots_config.clone())?;
+            Err(Ok(Value::Status("PONG".into())))
+        },
+    );
+
+    let res = connection.req_command(&redis::cmd("PING"));
+    assert!(res.is_ok());
+}
+
 #[cfg(feature = "tls-rustls")]
 mod mtls_test {
     use super::*;


### PR DESCRIPTION
This PR refactors the cluster `SlotMap` to account for 4 existing issues:
1. ATM clusters can't be created with partial slot coverage. This is erroneous, because given the right configuration the Redis cluster can work in such a situation, so we shouldn't fail it.
This was fixed by removing the asserts enforcing this from the cluster connections, and adding to the SlotMap the start slot of each range, so that it could return `None` when trying to get the address for a missing slot.

2. Since SlotAddrs saves at most 1 replica (or none, if
`read_from_replica` is false), it means that when there are 2 or more
replicas in the cluster, `AllNodes` commands aren't actually sent to
all nodes.
This was fixed by saving a Vec of addresses in SlotAddrs instead of a single replica.

3. `SlotAddr::Replica` carries 2 separate semantic meanings - it could
mean that the command is a readonly command, or that the user asked to
route the command to a replica.
The first case should be affected by the `read_from_replica` client
flag, but the second case shouldn't - if the user requested that this
specific command be routed to the replica, the specific request should
override the prior configuration.
This was fixed by separating `SlotAddr::Replica` to `SlotAddr::ReplicaOptional` and `SlotAddr::ReplicaRequired`.

4. MultiSlot commands were some routes are to missing slots. In this case we silently ignore the missing slots, in order to allow the rest of the commands to be sent.