### PR TITLE
Bump aHash to v0.8.6

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -76,7 +76,7 @@ serde = { version = "1.0.82", optional = true }
 serde_json = { version = "1.0.82", optional = true }
 
 # Optional aHash support
-ahash = { version = "0.8.3", optional = true }
+ahash = { version = "0.8.6", optional = true }
 
 log = { version = "0.4", optional = true }
 

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -76,7 +76,7 @@ serde = { version = "1.0.82", optional = true }
 serde_json = { version = "1.0.82", optional = true }
 
 # Optional aHash support
-ahash = { version = "0.7.6", optional = true }
+ahash = { version = "0.8.3", optional = true }
 
 log = { version = "0.4", optional = true }
 

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1365,10 +1365,8 @@ impl<K: FromRedisValue + Eq + Hash, V: FromRedisValue, S: BuildHasher + Default>
 }
 
 #[cfg(feature = "ahash")]
-impl<K: FromRedisValue + Eq + Hash, V: FromRedisValue, S: BuildHasher + Default> FromRedisValue
-    for ahash::AHashMap<K, V, S>
-{
-    fn from_redis_value(v: &Value) -> RedisResult<ahash::AHashMap<K, V, S>> {
+impl<K: FromRedisValue + Eq + Hash, V: FromRedisValue> FromRedisValue for ahash::AHashMap<K, V> {
+    fn from_redis_value(v: &Value) -> RedisResult<ahash::AHashMap<K, V>> {
         match *v {
             Value::Nil => Ok(ahash::AHashMap::with_hasher(Default::default())),
             _ => v
@@ -1406,10 +1404,8 @@ impl<T: FromRedisValue + Eq + Hash, S: BuildHasher + Default> FromRedisValue
 }
 
 #[cfg(feature = "ahash")]
-impl<T: FromRedisValue + Eq + Hash, S: BuildHasher + Default> FromRedisValue
-    for ahash::AHashSet<T, S>
-{
-    fn from_redis_value(v: &Value) -> RedisResult<ahash::AHashSet<T, S>> {
+impl<T: FromRedisValue + Eq + Hash> FromRedisValue for ahash::AHashSet<T> {
+    fn from_redis_value(v: &Value) -> RedisResult<ahash::AHashSet<T>> {
         let items = v
             .as_sequence()
             .ok_or_else(|| invalid_type_error_inner!(v, "Response type not hashset compatible"))?;


### PR DESCRIPTION
This is a breaking change, bumping the `ahash` dependency in a semver-incompatible way