### PR TITLE
Fix HashMap conversion (#977)

### DIFF
--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -219,7 +219,13 @@ impl Value {
     /// Returns an iterator of `(&Value, &Value)` if `self` is compatible with a map type
     pub fn as_map_iter(&self) -> Option<MapIter<'_>> {
         match self {
-            Value::Bulk(items) => Some(MapIter(items.iter())),
+            Value::Bulk(items) => {
+                if items.len() % 2 == 0 {
+                    Some(MapIter(items.iter()))
+                } else {
+                    None
+                }
+            }
             _ => None,
         }
     }

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -126,7 +126,7 @@ fn test_tuple() {
 #[test]
 fn test_hashmap() {
     use fnv::FnvHasher;
-    use redis::{FromRedisValue, Value};
+    use redis::{ErrorKind, FromRedisValue, Value};
     use std::collections::HashMap;
     use std::hash::BuildHasherDefault;
 
@@ -163,6 +163,10 @@ fn test_hashmap() {
     e.insert("b".into(), 2);
     e.insert("c".into(), 3);
     assert_eq!(v, Ok(e));
+
+    let v: Result<Hm, _> =
+        FromRedisValue::from_redis_value(&Value::Bulk(vec![Value::Data("a".into())]));
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
 }
 
 #[test]


### PR DESCRIPTION
When the list in a bulk value contains an odd number of elements, the last element would be silently discarded by MapIter. The list is now checked to be of even lenth during initialization.