### PR TITLE
Bump ahash dependency version

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -76,7 +76,7 @@ serde = { version = "1.0.82", optional = true }
 serde_json = { version = "1.0.82", optional = true }
 
 # Optional aHash support
-ahash = { version = "0.7.6", optional = true }
+ahash = { version = "0.8.5", optional = true }
 
 log = { version = "0.4", optional = true }
 


### PR DESCRIPTION
The previous version had a bug, and was yanked.