### PR TITLE
Disable JSON module tests for redis 6.2.4.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,7 +73,7 @@ jobs:
       run: make test
 
     - name: Checkout RedisJSON
-      if: steps.cache-redisjson.outputs.cache-hit != 'true'
+      if: steps.cache-redisjson.outputs.cache-hit != 'true' && matrix.redis != '6.2.4'
       uses: actions/checkout@v4
       with:
         repository: "RedisJSON/RedisJSON"
@@ -94,7 +94,7 @@ jobs:
       # This shouldn't cause issues in the future so long as no profiles or patches
       # are applied to the workspace Cargo.toml file
     - name: Compile RedisJSON
-      if: steps.cache-redisjson.outputs.cache-hit != 'true'
+      if: steps.cache-redisjson.outputs.cache-hit != 'true' && matrix.redis != '6.2.4'
       run: |
         cp ./Cargo.toml ./Cargo.toml.actual
         echo $'\nexclude = [\"./__ci/redis-json\"]' >> Cargo.toml
@@ -104,6 +104,7 @@ jobs:
         rm -rf ./__ci/redis-json
 
     - name: Run module-specific tests
+      if: matrix.redis != '6.2.4'
       run: make test-module
 
     - name: Check features


### PR DESCRIPTION
This happens due to a consistent crash -
https://github.com/RedisJSON/RedisJSON/issues/1124