### PR TITLE
Prefer routing to primary in a transaction.

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -38,7 +38,7 @@ use crate::{
     cluster_client::{ClusterParams, RetryParams},
     cluster_routing::{
         MultipleNodeRoutingInfo, Redirect, ResponsePolicy, Route, RoutingInfo,
-        SingleNodeRoutingInfo, Slot, SlotMap,
+        SingleNodeRoutingInfo, Slot, SlotAddr, SlotMap,
     },
     Cmd, ConnectionInfo, ErrorKind, IntoConnectionInfo, RedisError, RedisFuture, RedisResult,
     Value,
@@ -228,8 +228,21 @@ fn route_for_pipeline(pipeline: &crate::Pipeline) -> Option<Route> {
     pipeline
         .cmd_iter()
         .map(route_for_command)
-        .find(|route| route.is_some())
-        .flatten()
+        .fold(None, |chosen_route, next_cmd_route| {
+            match (chosen_route, next_cmd_route) {
+                (None, _) => next_cmd_route,
+                (Some(route), None) => Some(route),
+                (Some(chosen_route), Some(next_cmd_route)) => {
+                    if chosen_route.slot() == next_cmd_route.slot()
+                        && chosen_route.slot_addr() == &SlotAddr::Replica
+                    {
+                        Some(next_cmd_route)
+                    } else {
+                        Some(chosen_route)
+                    }
+                }
+            }
+        })
 }
 enum Response {
     Single(Value),
@@ -1310,6 +1323,22 @@ mod pipeline_routing_tests {
         assert_eq!(
             route_for_pipeline(&pipeline),
             Some(Route::new(12182, SlotAddr::Replica))
+        );
+    }
+
+    #[test]
+    fn test_prefer_primary_route_over_replica() {
+        let mut pipeline = crate::Pipeline::new();
+
+        pipeline
+            .get("foo") // route to replica of slot 12182
+            .add_command(cmd("FLUSHALL")) // route to all masters
+            .add_command(cmd("EVAL"))// route randomly
+            .set("foo", "bar"); // route to primary of slot 12182
+
+        assert_eq!(
+            route_for_pipeline(&pipeline),
+            Some(Route::new(12182, SlotAddr::Master))
         );
     }
 

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -211,7 +211,7 @@ enum CmdArg<C> {
     },
 }
 
-fn route_pipeline(pipeline: &crate::Pipeline) -> Option<Route> {
+fn route_for_pipeline(pipeline: &crate::Pipeline) -> Option<Route> {
     fn route_for_command(cmd: &Cmd) -> Option<Route> {
         match RoutingInfo::for_routable(cmd) {
             Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)) => None,
@@ -1207,7 +1207,7 @@ where
         offset: usize,
         count: usize,
     ) -> RedisFuture<'a, Vec<Value>> {
-        let route = route_pipeline(pipeline).into();
+        let route = route_for_pipeline(pipeline).into();
         self.route_pipeline(pipeline, offset, count, route).boxed()
     }
 
@@ -1292,7 +1292,7 @@ where
 
 #[cfg(test)]
 mod pipeline_routing_tests {
-    use super::route_pipeline;
+    use super::route_for_pipeline;
     use crate::{
         cluster_routing::{Route, SlotAddr},
         cmd,
@@ -1308,7 +1308,7 @@ mod pipeline_routing_tests {
             .add_command(cmd("EVAL")); // route randomly
 
         assert_eq!(
-            route_pipeline(&pipeline),
+            route_for_pipeline(&pipeline),
             Some(Route::new(12182, SlotAddr::Replica))
         );
     }
@@ -1323,7 +1323,7 @@ mod pipeline_routing_tests {
             .get("foo"); // route to slot 12182
 
         assert_eq!(
-            route_pipeline(&pipeline),
+            route_for_pipeline(&pipeline),
             Some(Route::new(4813, SlotAddr::Master))
         );
     }


### PR DESCRIPTION
This change will cause transactions with commands that are routed to replicas and primaries to prefer the primary routing over the replica.