### PR TITLE
Accept iterator at `ClusterClient` initialization

### DIFF
--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -104,7 +104,9 @@ impl ClusterClientBuilder {
     /// Creates a new `ClusterClientBuilder` with the provided initial_nodes.
     ///
     /// This is the same as `ClusterClient::builder(initial_nodes)`.
-    pub fn new<T: IntoConnectionInfo>(initial_nodes: Vec<T>) -> ClusterClientBuilder {
+    pub fn new<T: IntoConnectionInfo>(
+        initial_nodes: impl IntoIterator<Item = T>,
+    ) -> ClusterClientBuilder {
         ClusterClientBuilder {
             initial_nodes: initial_nodes
                 .into_iter()
@@ -322,12 +324,16 @@ impl ClusterClient {
     ///
     /// Upon failure to parse initial nodes or if the initial nodes have different passwords or
     /// usernames, an error is returned.
-    pub fn new<T: IntoConnectionInfo>(initial_nodes: Vec<T>) -> RedisResult<ClusterClient> {
+    pub fn new<T: IntoConnectionInfo>(
+        initial_nodes: impl IntoIterator<Item = T>,
+    ) -> RedisResult<ClusterClient> {
         Self::builder(initial_nodes).build()
     }
 
     /// Creates a [`ClusterClientBuilder`] with the provided initial_nodes.
-    pub fn builder<T: IntoConnectionInfo>(initial_nodes: Vec<T>) -> ClusterClientBuilder {
+    pub fn builder<T: IntoConnectionInfo>(
+        initial_nodes: impl IntoIterator<Item = T>,
+    ) -> ClusterClientBuilder {
         ClusterClientBuilder::new(initial_nodes)
     }
 


### PR DESCRIPTION
## Problem

So, here's the deal – right now, when you want to initialize a `ClusterClient`, you're kinda stuck with using a `Vec` data type. This works fine for a lot of situations, but this restricts users options and fails to provide the flexibility they desire. It. This limitation can force you into making extra allocations or unneeded conversions, and nobody wants that.

## Solution

But hey, good news! Here's a solution for it. This PR changes the `ClusterClientBuilder::new`, `ClusterClient::new`, and `ClusterClient::builder` signatures. The trick is – they can now accept any data type that's got the `IntoIterator` trait going for it. 

It means you can initialize a `ClusterClient` with a bunch of different data types. This gives you the freedom to keep things flexible and make your life easier.

This update simplifies how we initialize a `ClusterClient`, cuts down on unnecessary conversions, and just generally makes these methods more flexible and user-friendly.