### PR TITLE
Changing timeouts from usize and isize to f64

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -333,29 +333,29 @@ implement_commands! {
 
     /// Pop an element from a list, push it to another list
     /// and return it; or block until one is available
-    fn blmove<S: ToRedisArgs, D: ToRedisArgs>(srckey: S, dstkey: D, src_dir: Direction, dst_dir: Direction, timeout: usize) {
+    fn blmove<S: ToRedisArgs, D: ToRedisArgs>(srckey: S, dstkey: D, src_dir: Direction, dst_dir: Direction, timeout: f64) {
         cmd("BLMOVE").arg(srckey).arg(dstkey).arg(src_dir).arg(dst_dir).arg(timeout)
     }
 
     /// Pops `count` elements from the first non-empty list key from the list of
     /// provided key names; or blocks until one is available.
-    fn blmpop<K: ToRedisArgs>(timeout: usize, numkeys: usize, key: K, dir: Direction, count: usize){
+    fn blmpop<K: ToRedisArgs>(timeout: f64, numkeys: usize, key: K, dir: Direction, count: usize){
         cmd("BLMPOP").arg(timeout).arg(numkeys).arg(key).arg(dir).arg("COUNT").arg(count)
     }
 
     /// Remove and get the first element in a list, or block until one is available.
-    fn blpop<K: ToRedisArgs>(key: K, timeout: usize) {
+    fn blpop<K: ToRedisArgs>(key: K, timeout: f64) {
         cmd("BLPOP").arg(key).arg(timeout)
     }
 
     /// Remove and get the last element in a list, or block until one is available.
-    fn brpop<K: ToRedisArgs>(key: K, timeout: usize) {
+    fn brpop<K: ToRedisArgs>(key: K, timeout: f64) {
         cmd("BRPOP").arg(key).arg(timeout)
     }
 
     /// Pop a value from a list, push it to another list and return it;
     /// or block until one is available.
-    fn brpoplpush<S: ToRedisArgs, D: ToRedisArgs>(srckey: S, dstkey: D, timeout: usize) {
+    fn brpoplpush<S: ToRedisArgs, D: ToRedisArgs>(srckey: S, dstkey: D, timeout: f64) {
         cmd("BRPOPLPUSH").arg(srckey).arg(dstkey).arg(timeout)
     }
 
@@ -614,7 +614,7 @@ implement_commands! {
 
     /// Removes and returns the member with the highest score in a sorted set.
     /// Blocks until a member is available otherwise.
-    fn bzpopmax<K: ToRedisArgs>(key: K, timeout: isize) {
+    fn bzpopmax<K: ToRedisArgs>(key: K, timeout: f64) {
         cmd("BZPOPMAX").arg(key).arg(timeout)
     }
 
@@ -625,7 +625,7 @@ implement_commands! {
 
     /// Removes and returns the member with the lowest score in a sorted set.
     /// Blocks until a member is available otherwise.
-    fn bzpopmin<K: ToRedisArgs>(key: K, timeout: isize) {
+    fn bzpopmin<K: ToRedisArgs>(key: K, timeout: f64) {
         cmd("BZPOPMIN").arg(key).arg(timeout)
     }
 
@@ -637,7 +637,7 @@ implement_commands! {
     /// Removes and returns up to count members with the highest scores,
     /// from the first non-empty sorted set in the provided list of key names.
     /// Blocks until a member is available otherwise.
-    fn bzmpop_max<K: ToRedisArgs>(timeout: isize, keys: &'a [K], count: isize) {
+    fn bzmpop_max<K: ToRedisArgs>(timeout: f64, keys: &'a [K], count: isize) {
         cmd("BZMPOP").arg(timeout).arg(keys.len()).arg(keys).arg("MAX").arg("COUNT").arg(count)
     }
 
@@ -650,7 +650,7 @@ implement_commands! {
     /// Removes and returns up to count members with the lowest scores,
     /// from the first non-empty sorted set in the provided list of key names.
     /// Blocks until a member is available otherwise.
-    fn bzmpop_min<K: ToRedisArgs>(timeout: isize, keys: &'a [K], count: isize) {
+    fn bzmpop_min<K: ToRedisArgs>(timeout: f64, keys: &'a [K], count: isize) {
         cmd("BZMPOP").arg(timeout).arg(keys.len()).arg(keys).arg("MIN").arg("COUNT").arg(count)
     }
 

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -1302,8 +1302,8 @@ fn test_blocking_sorted_set_api() {
     assert_eq!(con.zadd("c", "7c", 7), Ok(()));
     assert_eq!(con.zadd("d", "8d", 8), Ok(()));
 
-    let min = con.bzpopmin::<&str, (String, String, String)>("b", 0);
-    let max = con.bzpopmax::<&str, (String, String, String)>("b", 0);
+    let min = con.bzpopmin::<&str, (String, String, String)>("b", 0.0);
+    let max = con.bzpopmax::<&str, (String, String, String)>("b", 0.0);
 
     assert_eq!(
         min.unwrap(),
@@ -1316,12 +1316,12 @@ fn test_blocking_sorted_set_api() {
 
     if redis_version.0 >= 7 {
         let min = con.bzmpop_min::<&str, (String, Vec<Vec<(String, String)>>)>(
-            0,
+            0.0,
             vec!["a", "b", "c", "d"].as_slice(),
             1,
         );
         let max = con.bzmpop_max::<&str, (String, Vec<Vec<(String, String)>>)>(
-            0,
+            0.0,
             vec!["a", "b", "c", "d"].as_slice(),
             1,
         );


### PR DESCRIPTION
Changing timeout values of functions:
- blmove
- blmpop
- blpop
- brpop
- brpoplpush
- bzpopmax
- bzpopmin
- bzmpop_max
- bzmpop_min

The reason behind it is that the timeout is in seconds and being limited to a minimum of one second is challenging.

The timeout value of all of these functions is a double value in redis versions greater than 6.0.0.