### PR TITLE
feat: add SMISMEMBER command

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -497,6 +497,11 @@ implement_commands! {
         cmd("SISMEMBER").arg(key).arg(member)
     }
 
+    /// Determine if given values are members of a set.
+    fn smismember<K: ToRedisArgs, M: ToRedisArgs>(key: K, members: M) {
+        cmd("SMISMEMBER").arg(key).arg(members)
+    }
+
     /// Get all the members in a set.
     fn smembers<K: ToRedisArgs>(key: K) {
         cmd("SMEMBERS").arg(key)

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -1211,6 +1211,21 @@ fn test_zrandmember() {
     assert_eq!(results.len(), 10);
 }
 
+#[test]
+fn test_sismember() {
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+
+    let setname = "myset";
+    assert_eq!(con.sadd(setname, &["a"]), Ok(1));
+
+    let result: bool = con.sismember(setname, &["a"]).unwrap();
+    assert!(result);
+
+    let result: bool = con.sismember(setname, &["b"]).unwrap();
+    assert!(!result);
+}
+
 // Requires redis-server >= 6.2.0.
 // Not supported with the current appveyor/windows binary deployed.
 #[cfg(not(target_os = "windows"))]

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -1211,6 +1211,20 @@ fn test_zrandmember() {
     assert_eq!(results.len(), 10);
 }
 
+// Requires redis-server >= 6.2.0.
+// Not supported with the current appveyor/windows binary deployed.
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn test_smismember() {
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+
+    let setname = "myset";
+    assert_eq!(con.sadd(setname, &["a", "b", "c"]), Ok(3));
+    let results: Vec<bool> = con.smismember(setname, &["0", "a", "b", "c", "x"]).unwrap();
+    assert_eq!(results, vec![false, true, true, true, false]);
+}
+
 #[test]
 fn test_object_commands() {
     let ctx = TestContext::new();


### PR DESCRIPTION
Hello

I have just found that the command SMISMEMBERS is missing from the lib.

I think it can be great for checking presence of multiple members with one network connection.

As I didn't found a Contributing section, I'm naively proposing this change.

Please do not hesitate to tell me what changes are needed along with my initial commit.

Please note that SMISMEMBERS appears at redis version 6.2.0