### PR TITLE
Fix the problem that AsyncIter may be blocked

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -149,6 +149,10 @@ required-features = ["json", "serde/derive"]
 name = "test_cluster_async"
 required-features = ["cluster-async"]
 
+[[test]]
+name = "test_iter_async"
+required-features = ["tokio-comp"]
+
 [[bench]]
 name = "bench_basic"
 harness = false

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -118,7 +118,9 @@ impl<'a, T: FromRedisValue + 'a> AsyncIterInner<'a, T> {
                 return None
             );
             let (cur, batch): (u64, Vec<T>) = unwrap_or!(from_redis_value(&rv).ok(), return None);
-
+            if batch.is_empty() {
+                return None;
+            }
             self.cmd.cursor = Some(cur);
             self.batch = batch.into_iter();
         }
@@ -494,7 +496,7 @@ impl Cmd {
         } else {
             (0, from_redis_value(&rv)?)
         };
-        if cursor == 0 {
+        if cursor == 0 || batch.is_empty() {
             self.cursor = None;
         } else {
             self.cursor = Some(cursor);

--- a/redis/tests/test_iter_async.rs
+++ b/redis/tests/test_iter_async.rs
@@ -1,0 +1,57 @@
+use std::time::Duration;
+use futures::{prelude::*};
+use tokio::time::timeout;
+
+use redis::{
+    AsyncCommands,
+};
+
+use crate::support::*;
+
+mod support;
+
+#[test]
+fn iter_async_hscan_match() {
+    let ctx = TestContext::new();
+    let connect = ctx.multiplexed_async_connection();
+
+    block_on_all(connect.and_then(|mut con| async move {
+        let max = 100_000;
+        for i in 0..max {
+            con.hset::<_, _, _, i32>("map1", format!("k_{}", i), i).await.unwrap();
+        }
+
+        let now = std::time::Instant::now();
+        let mut iter = con.hscan_match::<_, _, (String, i32)>("map1", "kk*").await.unwrap();
+        while let Ok(Some((_, _v))) = timeout( Duration::from_millis(500), iter.next_item()).await {
+        }
+        println!("cost time: {:?}", now.elapsed());
+        assert!(now.elapsed().as_millis() < 500);
+
+        Ok(())
+    })).unwrap();
+}
+
+
+#[test]
+fn iter_async_sscan_match() {
+    let ctx = TestContext::new();
+    let connect = ctx.multiplexed_async_connection();
+
+    block_on_all(connect.and_then(|mut con| async move {
+        let max = 100_000;
+        for i in 0..max {
+            con.sadd::<_, String, usize>("set1", format!("k_{}", i)).await.unwrap();
+        }
+
+        let now = std::time::Instant::now();
+        let mut iter = con.sscan_match::<_, _, String>("set1", "kk*").await.unwrap();
+        while let Ok(Some(_v)) = timeout( Duration::from_millis(500), iter.next_item()).await {
+
+        }
+        println!("cost time: {:?}", now.elapsed());
+        assert!(now.elapsed().as_millis() < 500);
+
+        Ok(())
+    })).unwrap();
+}


### PR DESCRIPTION
When executing: 
```
  async_conn.hscan_match::<_, _, Vec<u8>>(name, prefix.as_slice()).await?
```
or
```
  cmd("HSCAN")
        .arg(name).cursor_arg(0).arg("match").arg(prefix).clone()
        .iter_async::<Vec<u8>>(&mut async_conn)
        .await?;
```

When no data with prefix is found, it will be blocked.

Viewing the source code is due to the blockage caused by the cursor not being 0 but the return result set being empty, which will always attempt to obtain more data.

The following is the result of directly executing the Redis command in Redis cli:
```
127.0.0.1:6379> hscan "map001" 0 match "10206*" count 10
1) "1572864"
2) (empty array)
```













