### PR TITLE
Use enum instead of boolean for RESP version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test:
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features and RESP3"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=tcp RESP3=true cargo test -p redis --all-features -- --nocapture --test-threads=1 --skip test_module
+	@REDISRS_SERVER_TYPE=tcp PROTOCOL=RESP3 cargo test -p redis --all-features -- --nocapture --test-threads=1 --skip test_module
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features and Rustls support"

--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -1,7 +1,7 @@
 //! Adds async IO support to redis.
 use crate::cmd::{cmd, Cmd};
 use crate::connection::{get_resp3_hello_command_error, RedisConnectionInfo};
-use crate::types::{ErrorKind, RedisFuture, RedisResult, Value};
+use crate::types::{ErrorKind, ProtocolVersion, RedisFuture, RedisResult, Value};
 #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
 use ::async_std::net::ToSocketAddrs;
 use ::tokio::io::{AsyncRead, AsyncWrite};
@@ -78,7 +78,7 @@ async fn authenticate<C>(connection_info: &RedisConnectionInfo, con: &mut C) -> 
 where
     C: ConnectionLike,
 {
-    if connection_info.use_resp3 {
+    if connection_info.protocol != ProtocolVersion::RESP2 {
         let hello_cmd = resp3_hello(connection_info);
         let val: RedisResult<Value> = hello_cmd.query_async(con).await;
         if let Err(err) = val {

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -402,7 +402,8 @@ pub use crate::types::{
     // low level values
     Value,
     PushKind,
-    VerbatimFormat
+    VerbatimFormat,
+    ProtocolVersion
 };
 
 #[cfg(feature = "aio")]

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1739,3 +1739,14 @@ impl FromRedisValue for bytes::Bytes {
 pub fn from_redis_value<T: FromRedisValue>(v: &Value) -> RedisResult<T> {
     FromRedisValue::from_redis_value(v)
 }
+
+/// Enum representing the communication protocol with the server. This enum represents the types
+/// of data that the server can send to the client, and the capabilities that the client can use.
+#[derive(Clone, Eq, PartialEq, Default, Debug, Copy)]
+pub enum ProtocolVersion {
+    /// <https://github.com/redis/redis-specifications/blob/master/protocol/RESP2.md>
+    #[default]
+    RESP2,
+    /// <https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md>
+    RESP3,
+}

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -12,11 +12,12 @@ use redis::aio::ConnectionLike;
 #[cfg(feature = "cluster-async")]
 use redis::cluster_async::Connect;
 use redis::ConnectionInfo;
+use redis::ProtocolVersion;
 use tempfile::TempDir;
 
 use crate::support::build_keys_and_certs_for_tls;
 
-use super::use_resp3;
+use super::use_protocol;
 use super::Module;
 use super::RedisServer;
 
@@ -247,7 +248,7 @@ impl Drop for RedisCluster {
 pub struct TestClusterContext {
     pub cluster: RedisCluster,
     pub client: redis::cluster::ClusterClient,
-    pub use_resp3: bool,
+    pub protocol: ProtocolVersion,
 }
 
 impl TestClusterContext {
@@ -269,14 +270,14 @@ impl TestClusterContext {
             .map(RedisServer::connection_info)
             .collect();
         let mut builder = redis::cluster::ClusterClientBuilder::new(initial_nodes);
-        builder = builder.use_resp3(use_resp3());
+        builder = builder.use_protocol(use_protocol());
         builder = initializer(builder);
 
         let client = builder.build().unwrap();
         TestClusterContext {
             cluster,
             client,
-            use_resp3: use_resp3(),
+            protocol: use_protocol(),
         }
     }
 

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::let_unit_value)]
 
-use redis::{cmd, PushInfo};
+use redis::{cmd, ProtocolVersion, PushInfo};
 use redis::{
     Commands, ConnectionInfo, ConnectionLike, ControlFlow, ErrorKind, Expiry, PubSubCommands,
     PushKind, RedisResult, Value,
@@ -1112,6 +1112,8 @@ fn test_zrembylex() {
 #[cfg(not(target_os = "windows"))]
 #[test]
 fn test_zrandmember() {
+    use redis::ProtocolVersion;
+
     let ctx = TestContext::new();
     let mut con = ctx.connection();
 
@@ -1143,7 +1145,7 @@ fn test_zrandmember() {
     let results: Vec<String> = con.zrandmember(setname, Some(-5)).unwrap();
     assert_eq!(results.len(), 5);
 
-    if !ctx.use_resp3 {
+    if ctx.protocol == ProtocolVersion::RESP2 {
         let results: Vec<String> = con.zrandmember_withscores(setname, 5).unwrap();
         assert_eq!(results.len(), 10);
 
@@ -1239,7 +1241,7 @@ fn test_multi_generics() {
 #[test]
 fn test_push_manager() {
     let ctx = TestContext::new();
-    if !ctx.use_resp3 {
+    if ctx.protocol == ProtocolVersion::RESP2 {
         return;
     }
     let mut con = ctx.connection();
@@ -1290,7 +1292,7 @@ fn test_push_manager() {
 #[test]
 fn test_push_manager_disconnection() {
     let ctx = TestContext::new();
-    if !ctx.use_resp3 {
+    if ctx.protocol == ProtocolVersion::RESP2 {
         return;
     }
     let mut con = ctx.connection();

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -8,7 +8,7 @@ use std::sync::{
 use crate::support::*;
 use redis::{
     cluster::{cluster_pipe, ClusterClient},
-    cmd, parse_redis_value, Commands, ErrorKind, RedisError, Value,
+    cmd, parse_redis_value, Commands, ErrorKind, ProtocolVersion, RedisError, Value,
 };
 
 #[test]
@@ -111,7 +111,7 @@ fn test_cluster_eval() {
 
 #[test]
 fn test_cluster_resp3() {
-    if !use_resp3() {
+    if use_protocol() == ProtocolVersion::RESP2 {
         return;
     }
     let cluster = TestClusterContext::new(3, 0);

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -14,7 +14,7 @@ use redis::{
     cluster::ClusterClient,
     cluster_async::Connect,
     cmd, parse_redis_value, AsyncCommands, Cmd, ErrorKind, InfoDict, IntoConnectionInfo,
-    RedisError, RedisFuture, RedisResult, Script, Value,
+    ProtocolVersion, RedisError, RedisFuture, RedisResult, Script, Value,
 };
 
 use crate::support::*;
@@ -82,7 +82,7 @@ fn test_async_cluster_basic_script() {
 
 #[test]
 fn test_cluster_resp3() {
-    if !use_resp3() {
+    if use_protocol() == ProtocolVersion::RESP2 {
         return;
     }
     block_on_all(async move {

--- a/redis/tests/test_module_json.rs
+++ b/redis/tests/test_module_json.rs
@@ -3,7 +3,7 @@
 use std::assert_eq;
 use std::collections::HashMap;
 
-use redis::JsonCommands;
+use redis::{JsonCommands, ProtocolVersion};
 
 use redis::{
     ErrorKind, RedisError, RedisResult,
@@ -346,7 +346,7 @@ fn test_module_json_num_incr_by() {
     assert_eq!(set_initial, Ok(true));
 
     let redis_ver = std::env::var("REDIS_VERSION").unwrap_or_default();
-    if ctx.use_resp3 && redis_ver.starts_with("7.") {
+    if ctx.protocol != ProtocolVersion::RESP2 && redis_ver.starts_with("7.") {
         // cannot increment a string
         let json_numincrby_a: RedisResult<Vec<Value>> = con.json_num_incr_by(TEST_KEY, "$.a", 2);
         assert_eq!(json_numincrby_a, Ok(vec![Nil]));
@@ -499,7 +499,7 @@ fn test_module_json_type() {
     let json_type_c: RedisResult<Value> = con.json_type(TEST_KEY, "$..dummy");
 
     let redis_ver = std::env::var("REDIS_VERSION").unwrap_or_default();
-    if ctx.use_resp3 && redis_ver.starts_with("7.") {
+    if ctx.protocol != ProtocolVersion::RESP2 && redis_ver.starts_with("7.") {
         // In RESP3 current RedisJSON always gives response in an array.
         assert_eq!(
             json_type_a,


### PR DESCRIPTION
Since there's a discussion starting about what might become RESP4 (https://github.com/redis/redis/issues/12873), this
PR will make it easier to add more RESP versions in the future.