### PR TITLE
Fix warnings that appear only with native-TLS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,54 +6,54 @@ test:
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP without features"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo test -p redis --no-default-features -- --nocapture --test-threads=1
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo test -p redis --no-default-features -- --nocapture --test-threads=1
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo test -p redis --all-features -- --nocapture --test-threads=1 --skip test_module
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo test -p redis --all-features -- --nocapture --test-threads=1 --skip test_module
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features and Rustls support"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo test -p redis --all-features -- --nocapture --test-threads=1 --skip test_module
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo test -p redis --all-features -- --nocapture --test-threads=1 --skip test_module
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features and native-TLS support"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo test -p redis --features=json,tokio-native-tls-comp,connection-manager,cluster-async -- --nocapture --test-threads=1 --skip test_module
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo test -p redis --features=json,tokio-native-tls-comp,connection-manager,cluster-async -- --nocapture --test-threads=1 --skip test_module
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type UNIX"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo test -p redis --test parser --test test_basic --test test_types --all-features -- --test-threads=1 --skip test_module
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo test -p redis --test parser --test test_basic --test test_types --all-features -- --test-threads=1 --skip test_module
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type UNIX SOCKETS"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo test -p redis --all-features -- --test-threads=1 --skip test_cluster --skip test_async_cluster --skip test_module
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo test -p redis --all-features -- --test-threads=1 --skip test_cluster --skip test_async_cluster --skip test_module
 
 	@echo "===================================================================="
 	@echo "Testing async-std with Rustls"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo test -p redis --features=async-std-rustls-comp,cluster-async -- --nocapture --test-threads=1
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo test -p redis --features=async-std-rustls-comp,cluster-async -- --nocapture --test-threads=1
 
 	@echo "===================================================================="
 	@echo "Testing async-std with native-TLS"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo test -p redis --features=async-std-native-tls-comp,cluster-async -- --nocapture --test-threads=1
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo test -p redis --features=async-std-native-tls-comp,cluster-async -- --nocapture --test-threads=1
 
 	@echo "===================================================================="
 	@echo "Testing redis-test"
 	@echo "===================================================================="
-	@RUST_BACKTRACE=1 cargo test -p redis-test 
+	@RUSTFLAGS="-D warnings" RUST_BACKTRACE=1 cargo test -p redis-test 
 
 
 test-module:
 	@echo "===================================================================="
 	@echo "Testing with module support enabled (currently only RedisJSON)"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo test --all-features test_module -- --test-threads=1
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo test --all-features test_module -- --test-threads=1
 
 test-single: test
 
@@ -61,7 +61,7 @@ bench:
 	cargo bench --all-features
 
 docs:
-	@RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps
+	@RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps
 
 upload-docs: docs
 	@./upload-docs.sh

--- a/redis/src/aio/async_std.rs
+++ b/redis/src/aio/async_std.rs
@@ -205,7 +205,7 @@ impl RedisRuntime for AsyncStd {
         hostname: &str,
         socket_addr: SocketAddr,
         insecure: bool,
-        tls_params: &Option<TlsConnParams>,
+        _tls_params: &Option<TlsConnParams>,
     ) -> RedisResult<Self> {
         let tcp_stream = connect_tcp(&socket_addr).await?;
         let tls_connector = if insecure {

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -45,9 +45,6 @@ use crate::{
     Value,
 };
 
-#[cfg(not(feature = "tls-rustls"))]
-use crate::connection::TlsConnParams;
-
 #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
 use crate::aio::{async_std::AsyncStd, RedisRuntime};
 use futures::{

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -263,9 +263,9 @@ impl RedisCluster {
         cluster
     }
 
-    // parameter `mtls_enabled` can only be used if `feature = tls-rustls` is active
+    // parameter `_mtls_enabled` can only be used if `feature = tls-rustls` is active
     #[allow(dead_code)]
-    fn wait_for_replicas(&self, replicas: u16, mtls_enabled: bool) {
+    fn wait_for_replicas(&self, replicas: u16, _mtls_enabled: bool) {
         'server: for server in &self.servers {
             let conn_info = server.connection_info();
             eprintln!(
@@ -275,7 +275,7 @@ impl RedisCluster {
 
             #[cfg(feature = "tls-rustls")]
             let client =
-                build_single_client(server.connection_info(), &self.tls_paths, mtls_enabled)
+                build_single_client(server.connection_info(), &self.tls_paths, _mtls_enabled)
                     .unwrap();
             #[cfg(not(feature = "tls-rustls"))]
             let client = redis::Client::open(server.connection_info()).unwrap();

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -11,6 +11,7 @@ use std::{
     io::{BufReader, Read},
 };
 
+#[cfg(feature = "aio")]
 use futures::Future;
 use redis::{ConnectionAddr, InfoDict, Value};
 

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -106,6 +106,7 @@ mod mock_cluster;
 mod util;
 
 #[cfg(any(feature = "cluster", feature = "cluster-async"))]
+#[allow(unused_imports)]
 pub use self::cluster::*;
 
 #[cfg(any(feature = "cluster", feature = "cluster-async"))]

--- a/redis/tests/test_bignum.rs
+++ b/redis/tests/test_bignum.rs
@@ -1,3 +1,8 @@
+#![cfg(any(
+    feature = "rust_decimal",
+    feature = "bigdecimal",
+    feature = "num-bigint"
+))]
 use redis::{ErrorKind, FromRedisValue, RedisResult, ToRedisArgs, Value};
 use std::str::FromStr;
 

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -241,9 +241,9 @@ async fn do_failover(redis: &mut redis::aio::MultiplexedConnection) -> Result<()
     Ok(())
 }
 
-// parameter `mtls_enabled` can only be used if `feature = tls-rustls` is active
+// parameter `_mtls_enabled` can only be used if `feature = tls-rustls` is active
 #[allow(dead_code)]
-async fn test_failover(env: &TestClusterContext, requests: i32, value: i32, mtls_enabled: bool) {
+async fn test_failover(env: &TestClusterContext, requests: i32, value: i32, _mtls_enabled: bool) {
     let completed = Arc::new(AtomicI32::new(0));
 
     let connection = env.async_connection().await;
@@ -257,7 +257,7 @@ async fn test_failover(env: &TestClusterContext, requests: i32, value: i32, mtls
 
                 #[cfg(feature = "tls-rustls")]
                 let client =
-                    build_single_client(server.connection_info(), &server.tls_paths, mtls_enabled)
+                    build_single_client(server.connection_info(), &server.tls_paths, _mtls_enabled)
                         .unwrap_or_else(|e| panic!("Failed to connect to '{addr}': {e}"));
 
                 #[cfg(not(feature = "tls-rustls"))]


### PR DESCRIPTION
Added `RUSTFLAGS="-D warnings" ` to all CI flows, to ensure that warnings won't appear when only some features are used, since our lint flow checks for all features at once.