### PR TITLE
Hide the `req_packed_commands` from docs.

### DIFF
--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -65,6 +65,11 @@ pub trait ConnectionLike {
     /// Sends multiple already encoded (packed) command into the TCP socket
     /// and reads `count` responses from it.  This is used to implement
     /// pipelining.
+    /// Important - this function is meant for internal usage, since it's
+    /// easy to pass incorrect `offset` & `count` parameters, which might
+    /// cause the connection to enter an erroneous state. Users shouldn't
+    /// call it, instead using the Pipeline::query_async function.
+    #[doc(hidden)]
     fn req_packed_commands<'a>(
         &'a mut self,
         cmd: &'a crate::Pipeline,

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -1000,6 +1000,11 @@ pub trait ConnectionLike {
     /// Sends multiple already encoded (packed) command into the TCP socket
     /// and reads `count` responses from it.  This is used to implement
     /// pipelining.
+    /// Important - this function is meant for internal usage, since it's
+    /// easy to pass incorrect `offset` & `count` parameters, which might
+    /// cause the connection to enter an erroneous state. Users shouldn't
+    /// call it, instead using the Pipeline::query function.
+    #[doc(hidden)]
     fn req_packed_commands(
         &mut self,
         cmd: &[u8],


### PR DESCRIPTION
`req_packed_commands` is meant for internal usage by the `Pipeline` object, and is an easy to misuse footgun.
See https://github.com/redis-rs/redis-rs/issues/1017#issuecomment-1878158571