### PR TITLE
Fix documentaion error

### DIFF
--- a/redis/src/commands/json.rs
+++ b/redis/src/commands/json.rs
@@ -93,7 +93,7 @@ macro_rules! implement_json_commands {
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
         /// let mut con = client.get_async_connection().await?;
         /// redis::cmd("JSON.SET").arg("my_key").arg("$").arg(&json!({"item": 42i32}).to_string()).query_async(&mut con).await?;
-        /// assert_eq!(redis::cmd("GET").arg("my_key").arg("$").query_async(&mut con).await, Ok(String::from(r#"[{"item":42}]"#)));
+        /// assert_eq!(redis::cmd("JSON.GET").arg("my_key").arg("$").query_async(&mut con).await, Ok(String::from(r#"[{"item":42}]"#)));
         /// # Ok(()) }
         /// ```
         ///


### PR DESCRIPTION
docs have 
assert_eq!(redis::cmd("GET").arg("my_key").arg("$").query_async(&mut con).await, Ok(String::from(r#"[{"item":42}]"#)));

should be 

assert_eq!(redis::cmd("JSON.GET").arg("my_key").arg("$").query_async(&mut con).await, Ok(String::from(r#"[{"item":42}]"#)));