### PR TITLE
Add Support for UUIDs

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -88,6 +88,9 @@ ahash = { version = "0.8.6", optional = true }
 log = { version = "0.4", optional = true }
 futures-time = { version = "3.0.0", optional = true }
 
+# Optional uuid support
+uuid = { version = "1.6.1", optional = true }
+
 [features]
 default = ["acl", "streams", "geospatial", "script", "keep-alive"]
 acl = []
@@ -115,6 +118,7 @@ tcp_nodelay = []
 rust_decimal = ["dep:rust_decimal"]
 bigdecimal = ["dep:bigdecimal"]
 num-bigint = ["dep:num-bigint"]
+uuid = ["dep:uuid"]
 
 # Deprecated features
 tls = ["tls-native-tls"] # use "tls-native-tls" instead

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -355,6 +355,20 @@ impl From<rustls_pki_types::InvalidDnsNameError> for RedisError {
     }
 }
 
+#[cfg(feature = "uuid")]
+impl From<uuid::Error> for RedisError {
+    fn from(err: uuid::Error) -> RedisError {
+        RedisError {
+            repr: ErrorRepr::WithDescriptionAndDetail(
+                ErrorKind::TypeError,
+                "Value is not a valid UUID",
+                err.to_string(),
+            ),
+        }
+    }
+
+}
+
 impl From<FromUtf8Error> for RedisError {
     fn from(_: FromUtf8Error) -> RedisError {
         RedisError {
@@ -1613,6 +1627,26 @@ impl FromRedisValue for bytes::Bytes {
             Value::Data(bytes_vec) => Ok(bytes::Bytes::copy_from_slice(bytes_vec.as_ref())),
             _ => invalid_type_error!(v, "Not binary data"),
         }
+    }
+}
+
+#[cfg(feature = "uuid")]
+impl FromRedisValue for uuid::Uuid {
+    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+        match *v {
+            Value::Data(ref bytes) => Ok(uuid::Uuid::from_slice(bytes)?),
+            _ => invalid_type_error!(v, "Response type not uuid compatible."),
+        }
+    }
+}
+
+#[cfg(feature = "uuid")]
+impl ToRedisArgs for uuid::Uuid {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite 
+    {
+        out.write_arg(self.as_bytes());
     }
 }
 

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -307,6 +307,37 @@ fn test_bytes() {
     assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
 }
 
+#[cfg(feature = "uuid")]
+#[test]
+fn test_uuid() {
+    use std::str::FromStr;
+
+    use redis::{ErrorKind, FromRedisValue, RedisResult, Value};
+    use uuid::Uuid;
+
+    let uuid = Uuid::from_str("abab64b7-e265-4052-a41b-23e1e28674bf").unwrap();
+    let bytes = uuid.as_bytes().to_vec();
+
+    let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Data(bytes));
+    assert_eq!(v, Ok(uuid));
+
+    let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Status("garbage".into()));
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+    let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Okay);
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+    let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Nil);
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+    let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Int(0));
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+    let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Int(42));
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+}
+
+
 #[test]
 fn test_cstring() {
     use redis::{ErrorKind, FromRedisValue, RedisResult, Value};


### PR DESCRIPTION
This allows for UUID's to be used directly as an optional feature flag. Aside from the added ease of use this also skips the added cast to a string if we where to read the UUID as string then parse it.

In short `FromRedisValue` and `ToRedisArgs` implementations for the Uuid type from the [uuid](https://docs.rs/uuid/latest/uuid/) crate