### PR TITLE
Add `FromRedisValue::from_owned_redis_value` to reduce copies while parsing responses

### DIFF
--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -9,7 +9,7 @@ use crate::connection::{ConnectionAddr, ConnectionInfo, Msg, RedisConnectionInfo
 #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
 use crate::parser::ValueCodec;
 use crate::types::{ErrorKind, FromRedisValue, RedisError, RedisFuture, RedisResult, Value};
-use crate::{from_redis_value, ToRedisArgs};
+use crate::{from_owned_redis_value, ToRedisArgs};
 #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
 use ::async_std::net::ToSocketAddrs;
 use ::tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
@@ -147,7 +147,7 @@ where
         let mut received_unsub = false;
         let mut received_punsub = false;
         loop {
-            let res: (Vec<u8>, (), isize) = from_redis_value(&self.read_response().await?)?;
+            let res: (Vec<u8>, (), isize) = from_owned_redis_value(self.read_response().await?)?;
 
             match res.0.first() {
                 Some(&b'u') => received_unsub = true,
@@ -352,7 +352,7 @@ where
         ValueCodec::default()
             .framed(&mut self.0.con)
             .filter_map(|value| {
-                Box::pin(async move { T::from_redis_value(&value.ok()?.ok()?).ok() })
+                Box::pin(async move { T::from_owned_redis_value(value.ok()?.ok()?).ok() })
             })
     }
 
@@ -361,7 +361,7 @@ where
         ValueCodec::default()
             .framed(self.0.con)
             .filter_map(|value| {
-                Box::pin(async move { T::from_redis_value(&value.ok()?.ok()?).ok() })
+                Box::pin(async move { T::from_owned_redis_value(value.ok()?.ok()?).ok() })
             })
     }
 }

--- a/redis/src/cluster_pipeline.rs
+++ b/redis/src/cluster_pipeline.rs
@@ -1,7 +1,7 @@
 use crate::cluster::ClusterConnection;
 use crate::cmd::{cmd, Cmd};
 use crate::types::{
-    from_redis_value, ErrorKind, FromRedisValue, HashSet, RedisResult, ToRedisArgs, Value,
+    from_owned_redis_value, ErrorKind, FromRedisValue, HashSet, RedisResult, ToRedisArgs, Value,
 };
 
 pub(crate) const UNROUTABLE_ERROR: (ErrorKind, &str) = (
@@ -118,13 +118,11 @@ impl ClusterPipeline {
             }
         }
 
-        from_redis_value(
-            &(if self.commands.is_empty() {
-                Value::Bulk(vec![])
-            } else {
-                self.make_pipeline_results(con.execute_pipeline(self)?)
-            }),
-        )
+        from_owned_redis_value(if self.commands.is_empty() {
+            Value::Bulk(vec![])
+        } else {
+            self.make_pipeline_results(con.execute_pipeline(self)?)
+        })
     }
 
     /// This is a shortcut to `query()` that does not return a value and

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -11,7 +11,8 @@ use crate::cmd::{cmd, pipe, Cmd};
 use crate::parser::Parser;
 use crate::pipeline::Pipeline;
 use crate::types::{
-    from_redis_value, ErrorKind, FromRedisValue, RedisError, RedisResult, ToRedisArgs, Value,
+    from_owned_redis_value, from_redis_value, ErrorKind, FromRedisValue, RedisError, RedisResult,
+    ToRedisArgs, Value,
 };
 
 #[cfg(unix)]
@@ -1136,7 +1137,7 @@ impl Connection {
         let mut received_unsub = false;
         let mut received_punsub = false;
         loop {
-            let res: (Vec<u8>, (), isize) = from_redis_value(&self.recv_response()?)?;
+            let res: (Vec<u8>, (), isize) = from_owned_redis_value(self.recv_response()?)?;
 
             match res.0.first() {
                 Some(&b'u') => received_unsub = true,
@@ -1409,7 +1410,7 @@ impl Msg {
     pub fn from_value(value: &Value) -> Option<Self> {
         let raw_msg: Vec<Value> = from_redis_value(value).ok()?;
         let mut iter = raw_msg.into_iter();
-        let msg_type: String = from_redis_value(&iter.next()?).ok()?;
+        let msg_type: String = from_owned_redis_value(iter.next()?).ok()?;
         let mut pattern = None;
         let payload;
         let channel;

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -383,6 +383,7 @@ pub use crate::script::{Script, ScriptInvocation};
 pub use crate::types::{
     // utility functions
     from_redis_value,
+    from_owned_redis_value,
 
     // error kinds
     ErrorKind,

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -219,7 +219,7 @@ impl Value {
         }
     }
 
-    /// Returns an `Vec<Value>` if `self` is compatible with a sequence type,
+    /// Returns a `Vec<Value>` if `self` is compatible with a sequence type,
     /// otherwise returns `Err(self)`.
     pub fn into_sequence(self) -> Result<Vec<Value>, Value> {
         match self {

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -285,7 +285,7 @@ impl RedisCluster {
             // retry 500 times
             for _ in 1..500 {
                 let value = redis::cmd("CLUSTER").arg("SLOTS").query(&mut con).unwrap();
-                let slots: Vec<Vec<redis::Value>> = redis::from_redis_value(&value).unwrap();
+                let slots: Vec<Vec<redis::Value>> = redis::from_owned_redis_value(value).unwrap();
 
                 // all slots should have following items:
                 // [start slot range, end slot range, master's IP, replica1's IP, replica2's IP,... ]

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -257,7 +257,7 @@ impl redis::ConnectionLike for MockConnection {
                     Err((
                         ErrorKind::ResponseError,
                         "non-array response",
-                        String::from_redis_value(&res).unwrap(),
+                        String::from_owned_redis_value(res).unwrap(),
                     )
                         .into())
                 }


### PR DESCRIPTION
This PR adds new methods, `from_owned_redis_value` and `from_owned_redis_values` to complement the existing `from_redis_value` and `from_redis_values`.

A typical call to `FromRedisValue::from_redis_value()` looked like:

```rs
let res: (Vec<u8>, (), isize) = from_redis_value(&self.read_response().await?)?;
```
This call-site is typical, in that we produce a temporary (`self.read_response().await?`) and then pass a reference to that temporary.

This means that even if we want to just "take" the data stored in the `redis::Value`, we are forced to clone it, including any reallocations. For example, if I want to get out a `Vec<u8>`, but the value is a `redis::Value::Data(Vec<u8>)`, I have to copy the slice into a new vector instead of just returning it as-is.

---

Slightly abbreviated, the change to `FromRedisValue` looks like:

```rs
pub trait FromRedisValue: Sized {
    fn from_redis_value(v: &Value) -> RedisResult<Self>;
+   fn from_owned_redis_value(v: Value) -> RedisResult<Self> {
+       // By default, fall back to `from_redis_value`.
+       // This function only needs to be implemented if it can benefit
+       // from taking `v` by value.
+       Self::from_redis_value(&v)
+   }
    fn from_redis_values(items: &[Value]) -> RedisResult<Vec<Self>> {
        items.iter().map(FromRedisValue::from_redis_value).collect()
    }
+   fn from_owned_redis_values(items: Vec<Value>) -> RedisResult<Vec<Self>> {
+       items
+           .into_iter()
+           .map(FromRedisValue::from_owned_redis_value)
+           .collect()
+   }
    fn from_byte_vec(_vec: &[u8]) -> Option<Vec<Self>> {
        Self::from_owned_redis_value(Value::Data(_vec.into()))
            .map(|rv| vec![rv])
            .ok()
    }
+   fn from_byte_vec(_vec: Vec<u8>) -> Option<Vec<Self>> {
+       Self::from_owned_redis_value(Value::Data(_vec))
+           .map(|rv| vec![rv])
+           .ok()
+   }
}
```
---

I replaced the existing calls of `from_redis_value` with calls to `from_owned_redis_value` where the argument was a reference to a temporary.

I also updated most of the existing implementations of `FromRedisValue` to have a more-efficient `from_owned_redis_value` function when it makes sense. 

---

To test the change, I updated the tests in `test_types.rs`. A demonstrative example:


<table>
<tr>
<td>Before</td><td>After</td>
</tr>
<tr>
<td>

```rs
#[test]
fn test_i32() {
    use redis::{ErrorKind, FromRedisValue, Value};

    let i = FromRedisValue::from_redis_value(&Value::Status("42".into()));
    assert_eq!(i, Ok(42i32));

    let i = FromRedisValue::from_redis_value(&Value::Int(42));
    assert_eq!(i, Ok(42i32));

    let i = FromRedisValue::from_redis_value(&Value::Data("42".into()));
    assert_eq!(i, Ok(42i32));

    let bad_i: Result<i32, _> = FromRedisValue::from_redis_value(&Value::Status("42x".into()));
    assert_eq!(bad_i.unwrap_err().kind(), ErrorKind::TypeError);
}
```

</td>
<td>

```rs
#[test]
fn test_i32() {
    use redis::{ErrorKind, Value};

    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
        let i = parse_mode.parse_redis_value(&Value::Status("42".into()));
        assert_eq!(i, Ok(42i32));

        let i = parse_mode.parse_redis_value(&Value::Int(42));
        assert_eq!(i, Ok(42i32));

        let i = parse_mode.parse_redis_value(&Value::Data("42".into()));
        assert_eq!(i, Ok(42i32));

        let bad_i: Result<i32, _> = parse_mode.parse_redis_value(&Value::Status("42x".into()));
        assert_eq!(bad_i.unwrap_err().kind(), ErrorKind::TypeError);
    }
}
```

</td>
</tr>
</table>

Each test loops over the two parse modes, `RedisParseMode::Owned` and `RedisParseMode::Ref`. The latter calls `from_redis_value(v)` while the former calls `from_owned_redis_value(v.clone())`, thus ensuring both methods get coverage.