### PR TITLE
Don't disconnect on timeout errors.

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -405,11 +405,20 @@ where
                         });
                         self.poll(cx)
                     }
-                    ErrorKind::IoError => Next::Reconnect {
-                        request: this.request.take().unwrap(),
-                        target: address,
+                    ErrorKind::IoError => {
+                        if err.is_timeout() {
+                            Next::Retry {
+                                request: this.request.take().unwrap(),
+                            }
+                            .into()
+                        } else {
+                            Next::Reconnect {
+                                request: this.request.take().unwrap(),
+                                target: address,
+                            }
+                            .into()
+                        }
                     }
-                    .into(),
                     _ => {
                         if err.is_retryable() {
                             Next::Retry {


### PR DESCRIPTION
timeouts can be transitory, and continually disconnecting & reconnecting from a server that already times out is harmful. It will increase the pressure on it, especially if the server uses TLS, and thus might lead to connection storms.