### PR TITLE
Update dependency versions and limit `half` package version.

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -42,7 +42,7 @@ futures-util = { version = "0.3.15", default-features = false, optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 tokio-util = { version = "0.7", optional = true }
 tokio = { version = "1", features = ["rt", "net", "time"], optional = true }
-socket2 = { version = "0.4", default-features = false, optional = true }
+socket2 = { version = "0.5", default-features = false, optional = true }
 
 # Only needed for the connection manager
 arc-swap = { version = "1.1.0", optional = true }
@@ -126,17 +126,19 @@ async-std-tls-comp = ["async-std-native-tls-comp"] # use "async-std-native-tls-c
 
 [dev-dependencies]
 rand = "0.8"
-socket2 = "0.4"
+socket2 = "0.5"
 assert_approx_eq = "1.0"
 fnv = "1.0.5"
 futures = "0.3"
-criterion = "0.4"
+criterion = "0.5"
 partial-io = { version = "0.5", features = ["tokio", "quickcheck1"] }
 quickcheck = "1.0.3"
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "time"] }
-tempfile = "=3.6.0"
+tempfile = "=3.9.0"
 once_cell = "1"
 anyhow = "1"
+# This isn't a direct dependency. It's just added to request a version that is compatible with Rust 1.65
+half = { version = "=2.2" } 
 
 [[test]]
 name = "test_async"


### PR DESCRIPTION
Limit the `half` indirect dependency to a version compatible with our CI.