### PR TITLE
docs: add "connection-manager" cfg attr

### DIFF
--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -156,6 +156,7 @@ pub use multiplexed_connection::*;
 #[cfg(feature = "connection-manager")]
 mod connection_manager;
 #[cfg(feature = "connection-manager")]
+#[cfg_attr(docsrs, doc(cfg(feature = "connection-manager")))]
 pub use connection_manager::*;
 mod runtime;
 pub(super) use runtime::*;


### PR DESCRIPTION
This ensures that generated rustdoc for `ConnectionManager` will mention that the `connection-manager` feature is required to expose it.

This was done previously in #475, but seems to have been lost in refactor in #821.