### PR TITLE
Remove the usage of aio::Connection in tests.

### DIFF
--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -489,15 +489,20 @@ impl TestContext {
     }
 
     #[cfg(feature = "aio")]
-    #[allow(deprecated)]
-    pub async fn async_connection(&self) -> redis::RedisResult<redis::aio::Connection> {
-        self.client.get_async_connection().await
+    pub async fn async_connection(&self) -> redis::RedisResult<redis::aio::MultiplexedConnection> {
+        self.client.get_multiplexed_async_connection().await
+    }
+
+    #[cfg(feature = "aio")]
+    pub async fn async_pubsub(&self) -> redis::RedisResult<redis::aio::PubSub> {
+        self.client.get_async_pubsub().await
     }
 
     #[cfg(feature = "async-std-comp")]
-    #[allow(deprecated)]
-    pub async fn async_connection_async_std(&self) -> redis::RedisResult<redis::aio::Connection> {
-        self.client.get_async_std_connection().await
+    pub async fn async_connection_async_std(
+        &self,
+    ) -> redis::RedisResult<redis::aio::MultiplexedConnection> {
+        self.client.get_multiplexed_async_std_connection().await
     }
 
     pub fn stop_server(&mut self) {
@@ -505,25 +510,24 @@ impl TestContext {
     }
 
     #[cfg(feature = "tokio-comp")]
-    pub fn multiplexed_async_connection(
+    pub async fn multiplexed_async_connection(
         &self,
-    ) -> impl Future<Output = redis::RedisResult<redis::aio::MultiplexedConnection>> {
-        self.multiplexed_async_connection_tokio()
+    ) -> redis::RedisResult<redis::aio::MultiplexedConnection> {
+        self.multiplexed_async_connection_tokio().await
     }
 
     #[cfg(feature = "tokio-comp")]
-    pub fn multiplexed_async_connection_tokio(
+    pub async fn multiplexed_async_connection_tokio(
         &self,
-    ) -> impl Future<Output = redis::RedisResult<redis::aio::MultiplexedConnection>> {
-        let client = self.client.clone();
-        async move { client.get_multiplexed_tokio_connection().await }
+    ) -> redis::RedisResult<redis::aio::MultiplexedConnection> {
+        self.client.get_multiplexed_tokio_connection().await
     }
+
     #[cfg(feature = "async-std-comp")]
-    pub fn multiplexed_async_connection_async_std(
+    pub async fn multiplexed_async_connection_async_std(
         &self,
-    ) -> impl Future<Output = redis::RedisResult<redis::aio::MultiplexedConnection>> {
-        let client = self.client.clone();
-        async move { client.get_multiplexed_async_std_connection().await }
+    ) -> redis::RedisResult<redis::aio::MultiplexedConnection> {
+        self.client.get_multiplexed_async_std_connection().await
     }
 
     pub fn get_version(&self) -> Version {

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -36,7 +36,8 @@ fn test_args() {
 #[test]
 fn dont_panic_on_closed_multiplexed_connection() {
     let ctx = TestContext::new();
-    let connect = ctx.multiplexed_async_connection();
+    let client = ctx.client.clone();
+    let connect = client.get_multiplexed_async_connection();
     drop(ctx);
 
     block_on_all(async move {
@@ -535,7 +536,7 @@ mod pub_sub {
 
         let ctx = TestContext::new();
         block_on_all(async move {
-            let mut pubsub_conn = ctx.async_connection().await?.into_pubsub();
+            let mut pubsub_conn = ctx.async_pubsub().await?;
             pubsub_conn.subscribe("phonewave").await?;
             let mut pubsub_stream = pubsub_conn.on_message();
             let mut publish_conn = ctx.async_connection().await?;
@@ -557,7 +558,7 @@ mod pub_sub {
 
         let ctx = TestContext::new();
         block_on_all(async move {
-            let mut pubsub_conn = ctx.async_connection().await?.into_pubsub();
+            let mut pubsub_conn = ctx.async_pubsub().await?;
             pubsub_conn.subscribe(SUBSCRIPTION_KEY).await?;
             pubsub_conn.unsubscribe(SUBSCRIPTION_KEY).await?;
 
@@ -583,7 +584,7 @@ mod pub_sub {
 
         let ctx = TestContext::new();
         block_on_all(async move {
-            let mut pubsub_conn = ctx.async_connection().await?.into_pubsub();
+            let mut pubsub_conn = ctx.async_pubsub().await?;
             pubsub_conn.subscribe(SUBSCRIPTION_KEY).await?;
             drop(pubsub_conn);
 
@@ -616,7 +617,7 @@ mod pub_sub {
 
         let ctx = TestContext::new();
         block_on_all(async move {
-            let mut pubsub_conn = ctx.async_connection().await?.into_pubsub();
+            let mut pubsub_conn = ctx.async_pubsub().await?;
             pubsub_conn.subscribe("phonewave").await?;
             pubsub_conn.psubscribe("*").await?;
 

--- a/redis/tests/test_async_async_std.rs
+++ b/redis/tests/test_async_async_std.rs
@@ -59,7 +59,8 @@ fn test_args_async_std() {
 #[test]
 fn dont_panic_on_closed_multiplexed_connection() {
     let ctx = TestContext::new();
-    let connect = ctx.multiplexed_async_connection_async_std();
+    let client = ctx.client.clone();
+    let connect = client.get_multiplexed_async_std_connection();
     drop(ctx);
 
     block_on_all_using_async_std(async move {


### PR DESCRIPTION
`aio::Connection` is deprecated, we should test `aio::MultiplexedConnection` instead.