### PR TITLE
Reconnect on parsing errors.

### DIFF
--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -69,7 +69,7 @@ type SharedRedisFuture<T> = Shared<BoxFuture<'static, CloneableRedisResult<T>>>;
 macro_rules! reconnect_if_dropped {
     ($self:expr, $result:expr, $current:expr) => {
         if let Err(ref e) = $result {
-            if e.is_connection_dropped() {
+            if e.is_unrecoverable_error() {
                 $self.reconnect($current);
             }
         }

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -721,13 +721,13 @@ where
                     }
                     retries += 1;
 
-                    match err.kind() {
-                        ErrorKind::Ask => {
+                    match err.retry_method() {
+                        crate::types::RetryMethod::AskRedirect => {
                             redirected = err
                                 .redirect_node()
                                 .map(|(node, _slot)| Redirect::Ask(node.to_string()));
                         }
-                        ErrorKind::Moved => {
+                        crate::types::RetryMethod::MovedRedirect => {
                             // Refresh slots.
                             self.refresh_slots()?;
                             // Request again.
@@ -735,7 +735,7 @@ where
                                 .redirect_node()
                                 .map(|(node, _slot)| Redirect::Moved(node.to_string()));
                         }
-                        ErrorKind::TryAgain | ErrorKind::ClusterDown => {
+                        crate::types::RetryMethod::WaitAndRetry => {
                             // Sleep and retry.
                             let sleep_time = self
                                 .cluster_params
@@ -743,7 +743,7 @@ where
                                 .wait_time_for_retry(retries);
                             thread::sleep(sleep_time);
                         }
-                        ErrorKind::IoError => {
+                        crate::types::RetryMethod::Reconnect => {
                             if *self.auto_reconnect.borrow() {
                                 if let Ok(mut conn) = self.connect(&addr) {
                                     if conn.check_connection() {
@@ -752,11 +752,10 @@ where
                                 }
                             }
                         }
-                        _ => {
-                            if !err.is_retryable() {
-                                return Err(err);
-                            }
+                        crate::types::RetryMethod::NoRetry => {
+                            return Err(err);
                         }
+                        crate::types::RetryMethod::RetryImmediately => {}
                     }
                 }
             }

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -704,7 +704,7 @@ impl ActualConnection {
                 let res = connection.reader.write_all(bytes).map_err(RedisError::from);
                 match res {
                     Err(e) => {
-                        if e.is_connection_dropped() {
+                        if e.is_unrecoverable_error() {
                             connection.open = false;
                         }
                         Err(e)
@@ -717,7 +717,7 @@ impl ActualConnection {
                 let res = connection.reader.write_all(bytes).map_err(RedisError::from);
                 match res {
                     Err(e) => {
-                        if e.is_connection_dropped() {
+                        if e.is_unrecoverable_error() {
                             connection.open = false;
                         }
                         Err(e)
@@ -730,7 +730,7 @@ impl ActualConnection {
                 let res = connection.reader.write_all(bytes).map_err(RedisError::from);
                 match res {
                     Err(e) => {
-                        if e.is_connection_dropped() {
+                        if e.is_unrecoverable_error() {
                             connection.open = false;
                         }
                         Err(e)
@@ -743,7 +743,7 @@ impl ActualConnection {
                 let result = connection.sock.write_all(bytes).map_err(RedisError::from);
                 match result {
                     Err(e) => {
-                        if e.is_connection_dropped() {
+                        if e.is_unrecoverable_error() {
                             connection.open = false;
                         }
                         Err(e)

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -382,7 +382,7 @@ async fn async_try_single_sentinel<T: FromRedisValue>(
     let result = cmd.query_async(cached_connection.as_mut().unwrap()).await;
 
     if let Err(err) = result {
-        if err.is_connection_dropped() || err.is_io_error() {
+        if err.is_unrecoverable_error() || err.is_io_error() {
             async_reconnect(cached_connection, connection_info).await?;
             cmd.query_async(cached_connection.as_mut().unwrap()).await
         } else {
@@ -415,7 +415,7 @@ fn try_single_sentinel<T: FromRedisValue>(
     let result = cmd.query(cached_connection.as_mut().unwrap());
 
     if let Err(err) = result {
-        if err.is_connection_dropped() || err.is_io_error() {
+        if err.is_unrecoverable_error() || err.is_io_error() {
             reconnect(cached_connection, connection_info)?;
             cmd.query(cached_connection.as_mut().unwrap())
         } else {

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -486,6 +486,15 @@ impl fmt::Debug for RedisError {
     }
 }
 
+pub(crate) enum RetryMethod {
+    Reconnect,
+    NoRetry,
+    RetryImmediately,
+    WaitAndRetry,
+    AskRedirect,
+    MovedRedirect,
+}
+
 /// Indicates a general failure in the library.
 impl RedisError {
     /// Returns the kind of the error.
@@ -625,6 +634,19 @@ impl RedisError {
         }
     }
 
+    /// Returns true if the error is likely to not be recoverable, and the connection must be replaced.
+    pub fn is_unrecoverable_error(&self) -> bool {
+        match self.retry_method() {
+            RetryMethod::Reconnect => true,
+
+            RetryMethod::NoRetry => false,
+            RetryMethod::RetryImmediately => false,
+            RetryMethod::WaitAndRetry => false,
+            RetryMethod::AskRedirect => false,
+            RetryMethod::MovedRedirect => false,
+        }
+    }
+
     /// Returns the node the error refers to.
     ///
     /// This returns `(addr, slot_id)`.
@@ -677,37 +699,52 @@ impl RedisError {
         Self { repr }
     }
 
-    // TODO: In addition to/instead of returning a bool here, consider a method
-    // that returns an enum with more detail about _how_ to retry errors, e.g.,
-    // `RetryImmediately`, `WaitAndRetry`, etc.
-    #[cfg(feature = "cluster")] // Used to avoid "unused method" warning
-    pub(crate) fn is_retryable(&self) -> bool {
+    pub(crate) fn retry_method(&self) -> RetryMethod {
         match self.kind() {
-            ErrorKind::BusyLoadingError => true,
-            ErrorKind::Moved => true,
-            ErrorKind::Ask => true,
-            ErrorKind::TryAgain => true,
-            ErrorKind::MasterDown => true,
-            ErrorKind::IoError => true,
-            ErrorKind::ReadOnly => true,
-            ErrorKind::ClusterDown => true,
-            ErrorKind::MasterNameNotFoundBySentinel => true,
-            ErrorKind::NoValidReplicasFoundBySentinel => true,
-            ErrorKind::ClusterConnectionNotFound => true,
+            ErrorKind::Moved => RetryMethod::MovedRedirect,
+            ErrorKind::Ask => RetryMethod::AskRedirect,
 
-            ErrorKind::ExtensionError => false,
-            ErrorKind::ExecAbortError => false,
-            ErrorKind::ResponseError => false,
-            ErrorKind::AuthenticationFailed => false,
-            ErrorKind::TypeError => false,
-            ErrorKind::NoScriptError => false,
-            ErrorKind::InvalidClientConfig => false,
-            ErrorKind::CrossSlot => false,
-            ErrorKind::ClientError => false,
-            ErrorKind::EmptySentinelList => false,
-            ErrorKind::NotBusy => false,
+            ErrorKind::TryAgain => RetryMethod::WaitAndRetry,
+            ErrorKind::MasterDown => RetryMethod::WaitAndRetry,
+            ErrorKind::ClusterDown => RetryMethod::WaitAndRetry,
+            ErrorKind::BusyLoadingError => RetryMethod::WaitAndRetry,
+            ErrorKind::MasterNameNotFoundBySentinel => RetryMethod::WaitAndRetry,
+            ErrorKind::NoValidReplicasFoundBySentinel => RetryMethod::WaitAndRetry,
+
+            ErrorKind::ReadOnly => RetryMethod::NoRetry,
+            ErrorKind::ExtensionError => RetryMethod::NoRetry,
+            ErrorKind::ExecAbortError => RetryMethod::NoRetry,
+            ErrorKind::TypeError => RetryMethod::NoRetry,
+            ErrorKind::NoScriptError => RetryMethod::NoRetry,
+            ErrorKind::InvalidClientConfig => RetryMethod::NoRetry,
+            ErrorKind::CrossSlot => RetryMethod::NoRetry,
+            ErrorKind::ClientError => RetryMethod::NoRetry,
+            ErrorKind::EmptySentinelList => RetryMethod::NoRetry,
+            ErrorKind::NotBusy => RetryMethod::NoRetry,
             #[cfg(feature = "json")]
-            ErrorKind::Serialize => false,
+            ErrorKind::Serialize => RetryMethod::NoRetry,
+
+            ErrorKind::AuthenticationFailed => RetryMethod::Reconnect,
+            ErrorKind::ResponseError => RetryMethod::Reconnect,
+            ErrorKind::ClusterConnectionNotFound => todo!(),
+
+            ErrorKind::IoError => match &self.repr {
+                ErrorRepr::IoError(err) => match err.kind() {
+                    io::ErrorKind::ConnectionRefused => RetryMethod::Reconnect,
+                    io::ErrorKind::NotFound => RetryMethod::Reconnect,
+                    io::ErrorKind::ConnectionReset => RetryMethod::Reconnect,
+                    io::ErrorKind::ConnectionAborted => RetryMethod::Reconnect,
+                    io::ErrorKind::NotConnected => RetryMethod::Reconnect,
+                    io::ErrorKind::BrokenPipe => RetryMethod::Reconnect,
+                    io::ErrorKind::UnexpectedEof => RetryMethod::Reconnect,
+
+                    io::ErrorKind::PermissionDenied => RetryMethod::NoRetry,
+                    io::ErrorKind::Unsupported => RetryMethod::NoRetry,
+
+                    _ => RetryMethod::RetryImmediately,
+                },
+                _ => RetryMethod::RetryImmediately,
+            },
         }
     }
 }


### PR DESCRIPTION
Parsing errors mean that the connection received a response it doesn't know how to handle. This means that it cannot make sense of the next values sent over the connection, and the connection must be replaced.

related:
https://github.com/redis-rs/redis-rs/issues/984#issuecomment-1930956524