### PR TITLE
Fix new clippy lints.

### DIFF
--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -528,7 +528,7 @@ impl Cmd {
     }
 
     /// Returns an iterator over the arguments in this command (including the command name itself)
-    pub fn args_iter(&self) -> impl Iterator<Item = Arg<&[u8]>> + Clone + ExactSizeIterator {
+    pub fn args_iter(&self) -> impl Clone + ExactSizeIterator<Item = Arg<&[u8]>> {
         let mut prev = 0;
         self.args.iter().map(move |arg| match *arg {
             Arg::Simple(i) => {

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -210,7 +210,7 @@ fn random_replica_index(max: NonZeroUsize) -> usize {
 }
 
 fn try_connect_to_first_replica(
-    addresses: &Vec<ConnectionInfo>,
+    addresses: &[ConnectionInfo],
     start_index: Option<usize>,
 ) -> Result<Client, crate::RedisError> {
     if addresses.is_empty() {

--- a/redis/tests/support/sentinel.rs
+++ b/redis/tests/support/sentinel.rs
@@ -191,7 +191,7 @@ fn wait_for_replica(mut get_client_fn: impl FnMut() -> RedisResult<Client>) -> R
     Err(())
 }
 
-fn wait_for_replicas_to_sync(servers: &Vec<RedisServer>, masters: u16) {
+fn wait_for_replicas_to_sync(servers: &[RedisServer], masters: u16) {
     let cluster_size = servers.len() / (masters as usize);
     let clusters = servers.len() / cluster_size;
     let replicas = cluster_size - 1;


### PR DESCRIPTION
Replace Vec reference with a slice, and remove iterator trait when using ExactSizeIterator, since it encompasses it.