### PR TITLE
Handle server errors in array response 2.

### DIFF
--- a/redis/tests/parser.rs
+++ b/redis/tests/parser.rs
@@ -43,6 +43,7 @@ impl ::quickcheck::Arbitrary for ArbitraryValue {
             Value::Status(ref status) => {
                 Box::new(status.shrink().map(Value::Status).map(ArbitraryValue))
             }
+            Value::ServerError(_) => Box::new(Some(self.0.clone()).into_iter().map(ArbitraryValue)),
         }
     }
 }

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -554,6 +554,7 @@ where
         }
         Value::Okay => write!(writer, "+OK\r\n"),
         Value::Status(ref s) => write!(writer, "+{s}\r\n"),
+        Value::ServerError(ref err) => write!(writer, "-{err}\r\n"),
     }
 }
 

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -664,6 +664,53 @@ mod pub_sub {
     }
 }
 
+#[test]
+fn test_async_basic_pipe_with_parsing_error() {
+    let ctx = TestContext::new();
+
+    block_on_all(async move {
+        let mut conn = ctx.multiplexed_async_connection().await?;
+
+        // Tests a specific case involving FCALL errors in transactions.
+        let redis_fn = "#!lua name=testable
+redis.register_function('echo_error', function(keys, args)
+return redis.error_reply('error')
+end)";
+        redis::cmd("FUNCTION")
+            .arg("LOAD")
+            .arg("REPLACE")
+            .arg(redis_fn)
+            .query_async::<_, ()>(&mut conn)
+            .await
+            .unwrap();
+
+        redis::pipe()
+            .atomic()
+            .cmd("FCALL")
+            .arg("echo_error")
+            .arg(0)
+            .cmd("FCALL")
+            .arg("echo_error")
+            .arg(0)
+            .query_async::<_, ((), ())>(&mut conn)
+            .await
+            .expect_err("echo_error should return an error");
+
+        assert!(
+            // Arbitrary Redis command that should not return an error.
+            redis::cmd("SMEMBERS")
+                .arg("nonexistent_key")
+                .query_async::<_, Vec<String>>(&mut conn)
+                .await
+                .is_ok(),
+            "Failed transaction should not interfere with future calls."
+        );
+
+        Ok::<_, redis::RedisError>(())
+    })
+    .unwrap()
+}
+
 #[cfg(feature = "connection-manager")]
 async fn wait_for_server_to_become_ready(client: redis::Client) {
     let millisecond = std::time::Duration::from_millis(1);


### PR DESCRIPTION
Currently server errors stop the parser and return a RedisError. This caused errors that are returned inside an array, such as transaction errors, to cause the rest of the array to not be parsed. This is solved by adding a `ServerError` variant to `Value` that contains the server errors, so when parsing to the server message, the array will finish parsing, and then extracting the error.

Pros:
- Gives the user/contributor a separation between errors returned from the server and connection / logic errors.
- Gives us the ability to return the actual array of responses on pipe operations, which allows further improvements down the line. For example, the `setup_connection` functions could be made faster by using a pipeline.

Cons:
- not backwards compatible - users who `match` on Value will need to handle the extra variant. This will be less painful if we ship this in the same version with the RESP3 update.