### PR TITLE
Small disambiguity in examples

### DIFF
--- a/redis/examples/async-multiplexed.rs
+++ b/redis/examples/async-multiplexed.rs
@@ -9,7 +9,7 @@ async fn test_cmd(con: &MultiplexedConnection, i: i32) -> RedisResult<()> {
     let value = format!("foo{i}");
 
     redis::cmd("SET")
-        .arg(&key[..])
+        .arg(&key)
         .arg(&value)
         .query_async(&mut con)
         .await?;


### PR DESCRIPTION
When I first saw it, I thought it could only accept the `&str` type. After tried & read more documents, I found that `String` and `&String` are also acceptable. So I hope this ambiguity can be cleared up.