### PR TITLE
Avoid library dependency on futures-time

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -86,7 +86,6 @@ num-bigint = { version = "0.4.4", optional = true }
 ahash = { version = "0.8.6", optional = true }
 
 log = { version = "0.4", optional = true }
-futures-time = { version = "3.0.0", optional = true }
 
 # Optional uuid support
 uuid = { version = "1.6.1", optional = true }
@@ -94,7 +93,7 @@ uuid = { version = "1.6.1", optional = true }
 [features]
 default = ["acl", "streams", "geospatial", "script", "keep-alive"]
 acl = []
-aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/alloc", "futures-util/sink", "tokio/io-util", "tokio-util", "tokio-util/codec", "tokio/sync", "combine/tokio", "async-trait", "futures-time"]
+aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/alloc", "futures-util/sink", "tokio/io-util", "tokio-util", "tokio-util/codec", "tokio/sync", "combine/tokio", "async-trait"]
 geospatial = []
 json = ["serde", "serde/derive", "serde_json"]
 cluster = ["crc16", "rand"]
@@ -131,6 +130,7 @@ socket2 = "0.4"
 assert_approx_eq = "1.0"
 fnv = "1.0.5"
 futures = "0.3"
+futures-time = "3"
 criterion = "0.4"
 partial-io = { version = "0.5", features = ["tokio", "quickcheck1"] }
 quickcheck = "1.0.3"

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -56,7 +56,7 @@ pub struct ConnectionManager {
     retry_strategy: ExponentialBackoff,
     number_of_retries: usize,
     response_timeout: std::time::Duration,
-    connection_timeout: futures_time::time::Duration,
+    connection_timeout: std::time::Duration,
 }
 
 /// A `RedisResult` that can be cloned because `RedisError` is behind an `Arc`.
@@ -161,7 +161,7 @@ impl ConnectionManager {
             retry_strategy.clone(),
             number_of_retries,
             response_timeout,
-            connection_timeout.into(),
+            connection_timeout,
         )
         .await?;
 
@@ -175,7 +175,7 @@ impl ConnectionManager {
             number_of_retries,
             retry_strategy,
             response_timeout,
-            connection_timeout: connection_timeout.into(),
+            connection_timeout,
         })
     }
 
@@ -184,13 +184,13 @@ impl ConnectionManager {
         exponential_backoff: ExponentialBackoff,
         number_of_retries: usize,
         response_timeout: std::time::Duration,
-        connection_timeout: futures_time::time::Duration,
+        connection_timeout: std::time::Duration,
     ) -> RedisResult<MultiplexedConnection> {
         let retry_strategy = exponential_backoff.map(jitter).take(number_of_retries);
         Retry::spawn(retry_strategy, || {
             client.get_multiplexed_async_connection_with_timeouts(
                 response_timeout,
-                connection_timeout.into(),
+                connection_timeout,
             )
         })
         .await


### PR DESCRIPTION
The futures-time crate brings in a bunch of extra dependencies from the async-std ecosystem even when this crate is configured to use `tokio-comp`. Additionally, it hasn't had a release in 2 years, so it depends on older versions of its transitive dependencies (for example, rustix). It is relatively straightforward to replace it with some direct calls to the runtime.