### PR TITLE
MultiplexedConnection: Separate response handling for pipeline.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ main, 0.21.x ]
+    branches: [ main, 0.*.x ]
   pull_request:
-    branches: [ main, 0.21.x ]
+    branches: [ main, 0.*.x ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "ahash 0.8.7",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The crate is called `redis` and you can depend on it via cargo:
 
 ```ini
 [dependencies]
-redis = "0.25.1"
+redis = "0.25.2"
 ```
 
 Documentation on the library can be found at
@@ -59,10 +59,10 @@ To enable asynchronous clients, enable the relevant feature in your Cargo.toml,
 
 ```
 # if you use tokio
-redis = { version = "0.25.1", features = ["tokio-comp"] }
+redis = { version = "0.25.2", features = ["tokio-comp"] }
 
 # if you use async-std
-redis = { version = "0.25.1", features = ["async-std-comp"] }
+redis = { version = "0.25.2", features = ["async-std-comp"] }
 ```
 
 ## TLS Support
@@ -73,25 +73,25 @@ Currently, `native-tls` and `rustls` are supported.
 To use `native-tls`:
 
 ```
-redis = { version = "0.25.1", features = ["tls-native-tls"] }
+redis = { version = "0.25.2", features = ["tls-native-tls"] }
 
 # if you use tokio
-redis = { version = "0.25.1", features = ["tokio-native-tls-comp"] }
+redis = { version = "0.25.2", features = ["tokio-native-tls-comp"] }
 
 # if you use async-std
-redis = { version = "0.25.1", features = ["async-std-native-tls-comp"] }
+redis = { version = "0.25.2", features = ["async-std-native-tls-comp"] }
 ```
 
 To use `rustls`:
 
 ```
-redis = { version = "0.25.1", features = ["tls-rustls"] }
+redis = { version = "0.25.2", features = ["tls-rustls"] }
 
 # if you use tokio
-redis = { version = "0.25.1", features = ["tokio-rustls-comp"] }
+redis = { version = "0.25.2", features = ["tokio-rustls-comp"] }
 
 # if you use async-std
-redis = { version = "0.25.1", features = ["async-std-rustls-comp"] }
+redis = { version = "0.25.2", features = ["async-std-rustls-comp"] }
 ```
 
 With `rustls`, you can add the following feature flags on top of other feature flags to enable additional features:
@@ -117,7 +117,7 @@ let client = redis::Client::open("rediss://127.0.0.1/#insecure")?;
 
 Support for Redis Cluster can be enabled by enabling the `cluster` feature in your Cargo.toml:
 
-`redis = { version = "0.25.1", features = [ "cluster"] }`
+`redis = { version = "0.25.2", features = [ "cluster"] }`
 
 Then you can simply use the `ClusterClient`, which accepts a list of available nodes. Note
 that only one node in the cluster needs to be specified when instantiating the client, though
@@ -140,7 +140,7 @@ fn fetch_an_integer() -> String {
 Async Redis Cluster support can be enabled by enabling the `cluster-async` feature, along
 with your preferred async runtime, e.g.:
 
-`redis = { version = "0.25.1", features = [ "cluster-async", "tokio-std-comp" ] }`
+`redis = { version = "0.25.2", features = [ "cluster-async", "tokio-std-comp" ] }`
 
 ```rust
 use redis::cluster::ClusterClient;
@@ -160,7 +160,7 @@ async fn fetch_an_integer() -> String {
 
 Support for the RedisJSON Module can be enabled by specifying "json" as a feature in your Cargo.toml.
 
-`redis = { version = "0.25.1", features = ["json"] }`
+`redis = { version = "0.25.2", features = ["json"] }`
 
 Then you can simply import the `JsonCommands` trait which will add the `json` commands to all Redis Connections (not to be confused with just `Commands` which only adds the default commands)
 

--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.25.2 (2024-03-15)
+
+* MultiplexedConnection: Separate response handling for pipeline. ([#1078](https://github.com/redis-rs/redis-rs/pull/1078))
+
 ### 0.25.1 (2024-03-12)
 
 * Fix small disambiguity in examples ([#1072](https://github.com/redis-rs/redis-rs/pull/1072) @sunhuachuang)

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis"
-version = "0.25.1"
+version = "0.25.2"
 keywords = ["redis", "database"]
 description = "Redis driver for Rust."
 homepage = "https://github.com/redis-rs/redis-rs"
@@ -56,7 +56,7 @@ r2d2 = { version = "0.8.8", optional = true }
 crc16 = { version = "0.4", optional = true }
 rand = { version = "0.8", optional = true }
 # Only needed for async_std support
-async-std = { version = "1.8.0", optional = true}
+async-std = { version = "1.8.0", optional = true }
 async-trait = { version = "0.1.24", optional = true }
 
 # Only needed for native tls

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -29,31 +29,41 @@ use tokio_util::codec::Decoder;
 // Senders which the result of a single request are sent through
 type PipelineOutput = oneshot::Sender<RedisResult<Value>>;
 
-struct InFlight {
-    output: PipelineOutput,
-    expected_response_count: usize,
-    current_response_count: usize,
-    buffer: Option<Value>,
-    first_err: Option<RedisError>,
+enum ResponseAggregate {
+    SingleCommand,
+    Pipeline {
+        expected_response_count: usize,
+        current_response_count: usize,
+        buffer: Vec<Value>,
+        first_err: Option<RedisError>,
+    },
 }
 
-impl InFlight {
-    fn new(output: PipelineOutput, expected_response_count: usize) -> Self {
-        Self {
-            output,
-            expected_response_count,
-            current_response_count: 0,
-            buffer: None,
-            first_err: None,
+impl ResponseAggregate {
+    fn new(pipeline_response_count: Option<usize>) -> Self {
+        match pipeline_response_count {
+            Some(response_count) => ResponseAggregate::Pipeline {
+                expected_response_count: response_count,
+                current_response_count: 0,
+                buffer: Vec::new(),
+                first_err: None,
+            },
+            None => ResponseAggregate::SingleCommand,
         }
     }
+}
+
+struct InFlight {
+    output: PipelineOutput,
+    response_aggregate: ResponseAggregate,
 }
 
 // A single message sent through the pipeline
 struct PipelineMessage<S> {
     input: S,
     output: PipelineOutput,
-    response_count: usize,
+    // If `None`, this is a single request, not a pipeline of multiple requests.
+    pipeline_response_count: Option<usize>,
 }
 
 /// Wrapper around a `Stream + Sink` where each item sent through the `Sink` results in one or more
@@ -122,51 +132,51 @@ where
         let self_ = self.project();
 
         {
-            let entry = match self_.in_flight.front_mut() {
+            let mut entry = match self_.in_flight.pop_front() {
                 Some(entry) => entry,
                 None => return,
             };
 
-            match result {
-                Ok(item) => {
-                    entry.buffer = Some(match entry.buffer.take() {
-                        Some(Value::Bulk(mut values)) if entry.current_response_count > 1 => {
-                            values.push(item);
-                            Value::Bulk(values)
-                        }
-                        Some(value) => {
-                            let mut vec = Vec::with_capacity(entry.expected_response_count);
-                            vec.push(value);
-                            vec.push(item);
-                            Value::Bulk(vec)
-                        }
-                        None => item,
-                    });
+            match &mut entry.response_aggregate {
+                ResponseAggregate::SingleCommand => {
+                    entry.output.send(result).ok();
                 }
-                Err(err) => {
-                    if entry.first_err.is_none() {
-                        entry.first_err = Some(err);
+                ResponseAggregate::Pipeline {
+                    expected_response_count,
+                    current_response_count,
+                    buffer,
+                    first_err,
+                } => {
+                    match result {
+                        Ok(item) => {
+                            buffer.push(item);
+                        }
+                        Err(err) => {
+                            if first_err.is_none() {
+                                *first_err = Some(err);
+                            }
+                        }
                     }
-                }
-            }
 
-            entry.current_response_count += 1;
-            if entry.current_response_count < entry.expected_response_count {
-                // Need to gather more response values
-                return;
+                    *current_response_count += 1;
+                    if current_response_count < expected_response_count {
+                        // Need to gather more response values
+                        self_.in_flight.push_front(entry);
+                        return;
+                    }
+
+                    let response = match first_err.take() {
+                        Some(err) => Err(err),
+                        None => Ok(Value::Bulk(std::mem::take(buffer))),
+                    };
+
+                    // `Err` means that the receiver was dropped in which case it does not
+                    // care about the output and we can continue by just dropping the value
+                    // and sender
+                    entry.output.send(response).ok();
+                }
             }
         }
-
-        let entry = self_.in_flight.pop_front().unwrap();
-        let response = match entry.first_err {
-            Some(err) => Err(err),
-            None => Ok(entry.buffer.unwrap_or(Value::Bulk(vec![]))),
-        };
-
-        // `Err` means that the receiver was dropped in which case it does not
-        // care about the output and we can continue by just dropping the value
-        // and sender
-        entry.output.send(response).ok();
     }
 }
 
@@ -195,7 +205,7 @@ where
         PipelineMessage {
             input,
             output,
-            response_count,
+            pipeline_response_count,
         }: PipelineMessage<SinkItem>,
     ) -> Result<(), Self::Error> {
         // If there is nothing to receive our output we do not need to send the message as it is
@@ -214,9 +224,13 @@ where
 
         match self_.sink_stream.start_send(input) {
             Ok(()) => {
-                self_
-                    .in_flight
-                    .push_back(InFlight::new(output, response_count));
+                let response_aggregate = ResponseAggregate::new(pipeline_response_count);
+                let entry = InFlight {
+                    output,
+                    response_aggregate,
+                };
+
+                self_.in_flight.push_back(entry);
                 Ok(())
             }
             Err(err) => {
@@ -284,13 +298,14 @@ where
         item: SinkItem,
         timeout: Duration,
     ) -> Result<Value, Option<RedisError>> {
-        self.send_recv(item, 1, timeout).await
+        self.send_recv(item, None, timeout).await
     }
 
     async fn send_recv(
         &mut self,
         input: SinkItem,
-        count: usize,
+        // If `None`, this is a single request, not a pipeline of multiple requests.
+        pipeline_response_count: Option<usize>,
         timeout: Duration,
     ) -> Result<Value, Option<RedisError>> {
         let (sender, receiver) = oneshot::channel();
@@ -298,7 +313,7 @@ where
         self.0
             .send(PipelineMessage {
                 input,
-                response_count: count,
+                pipeline_response_count,
                 output: sender,
             })
             .await
@@ -424,7 +439,7 @@ impl MultiplexedConnection {
             .pipeline
             .send_recv(
                 cmd.get_packed_pipeline(),
-                offset + count,
+                Some(offset + count),
                 self.response_timeout,
             )
             .await

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use futures::{prelude::*, StreamExt};
 use redis::{
     aio::{ConnectionLike, MultiplexedConnection},
@@ -5,7 +7,6 @@ use redis::{
 };
 
 use crate::support::*;
-
 mod support;
 
 #[test]
@@ -30,6 +31,61 @@ fn test_args() {
         assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
         result
     }))
+    .unwrap();
+}
+
+#[test]
+fn test_nice_hash_api() {
+    let ctx = TestContext::new();
+
+    block_on_all(async move {
+        let mut connection = ctx.async_connection().await.unwrap();
+
+        assert_eq!(
+            connection
+                .hset_multiple("my_hash", &[("f1", 1), ("f2", 2), ("f3", 4), ("f4", 8)])
+                .await,
+            Ok(())
+        );
+
+        let hm: HashMap<String, isize> = connection.hgetall("my_hash").await.unwrap();
+        assert_eq!(hm.len(), 4);
+        assert_eq!(hm.get("f1"), Some(&1));
+        assert_eq!(hm.get("f2"), Some(&2));
+        assert_eq!(hm.get("f3"), Some(&4));
+        assert_eq!(hm.get("f4"), Some(&8));
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn test_nice_hash_api_in_pipe() {
+    let ctx = TestContext::new();
+
+    block_on_all(async move {
+        let mut connection = ctx.async_connection().await.unwrap();
+
+        assert_eq!(
+            connection
+                .hset_multiple("my_hash", &[("f1", 1), ("f2", 2), ("f3", 4), ("f4", 8)])
+                .await,
+            Ok(())
+        );
+
+        let mut pipe = redis::pipe();
+        pipe.cmd("HGETALL").arg("my_hash");
+        let mut vec: Vec<HashMap<String, isize>> = pipe.query_async(&mut connection).await.unwrap();
+        assert_eq!(vec.len(), 1);
+        let hash = vec.pop().unwrap();
+        assert_eq!(hash.len(), 4);
+        assert_eq!(hash.get("f1"), Some(&1));
+        assert_eq!(hash.get("f2"), Some(&2));
+        assert_eq!(hash.get("f3"), Some(&4));
+        assert_eq!(hash.get("f4"), Some(&8));
+
+        Ok(())
+    })
     .unwrap();
 }
 
@@ -542,7 +598,6 @@ async fn test_issue_async_commands_scan_broken() {
 }
 
 mod pub_sub {
-    use std::collections::HashMap;
     use std::time::Duration;
 
     use super::*;


### PR DESCRIPTION
https://github.com/redis-rs/redis-rs/issues/1078
This fixes a bug where pipeline responses for a single request that return a `Vec` as that single value aren't wrapped in another `Vec`.
Since this is the second bug introduced by https://github.com/redis-rs/redis-rs/commit/70dfb95713fbcfe944a9262189c2adf23c12977c,
while we still want to maintain the performance improvement for single requests introduced by same, the fix is to separate the logic of single responses from pipeline responses.