### PR TITLE
Deprecate function that erroneously use tokio in its name.

### DIFF
--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -416,7 +416,7 @@ impl Client {
         factor: u64,
         number_of_retries: usize,
     ) -> RedisResult<crate::aio::ConnectionManager> {
-        self.get_tokio_connection_manager_with_backoff_and_timeouts(
+        self.get_connection_manager_with_backoff_and_timeouts(
             exponent_base,
             factor,
             number_of_retries,
@@ -445,7 +445,46 @@ impl Client {
     /// [multiplexed-connection]: aio/struct.MultiplexedConnection.html
     #[cfg(feature = "connection-manager")]
     #[cfg_attr(docsrs, doc(cfg(feature = "connection-manager")))]
+    #[deprecated(note = "use get_connection_manager_with_backoff_and_timeouts instead")]
     pub async fn get_tokio_connection_manager_with_backoff_and_timeouts(
+        &self,
+        exponent_base: u64,
+        factor: u64,
+        number_of_retries: usize,
+        response_timeout: std::time::Duration,
+        connection_timeout: std::time::Duration,
+    ) -> RedisResult<crate::aio::ConnectionManager> {
+        crate::aio::ConnectionManager::new_with_backoff_and_timeouts(
+            self.clone(),
+            exponent_base,
+            factor,
+            number_of_retries,
+            response_timeout,
+            connection_timeout,
+        )
+        .await
+    }
+
+    /// Returns an async [`ConnectionManager`][connection-manager] from the client.
+    ///
+    /// The connection manager wraps a
+    /// [`MultiplexedConnection`][multiplexed-connection]. If a command to that
+    /// connection fails with a connection error, then a new connection is
+    /// established in the background and the error is returned to the caller.
+    ///
+    /// This means that on connection loss at least one command will fail, but
+    /// the connection will be re-established automatically if possible. Please
+    /// refer to the [`ConnectionManager`][connection-manager] docs for
+    /// detailed reconnecting behavior.
+    ///
+    /// A connection manager can be cloned, allowing requests to be be sent concurrently
+    /// on the same underlying connection (tcp/unix socket).
+    ///
+    /// [connection-manager]: aio/struct.ConnectionManager.html
+    /// [multiplexed-connection]: aio/struct.MultiplexedConnection.html
+    #[cfg(feature = "connection-manager")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "connection-manager")))]
+    pub async fn get_connection_manager_with_backoff_and_timeouts(
         &self,
         exponent_base: u64,
         factor: u64,


### PR DESCRIPTION
continuing https://github.com/redis-rs/redis-rs/pull/913