### PR TITLE
feat: add implementation of `ToRedisArgs`,`FromRedisValue` traits for `Arc<T>`,`Box<T>`,`Rc<T>`

### DIFF
--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1976,81 +1976,70 @@ macro_rules! forwarded_impl {
 forwarded_impl!((T), Box<T>, Box::new);
 forwarded_impl!((T), std::sync::Arc<T>, std::sync::Arc::new);
 
-/// Implement `FromRedisValue` for `$Type` (which should use the generic parameter `$T`).
-///
-/// The implementation parses the value into a vec, and then passes the value through `$convert`.
-/// If `$convert` is ommited, it defaults to `Into::into`.
-macro_rules! from_vec_from_redis_value {
-    (<$T:ident> $Type:ty) => {
-        from_vec_from_redis_value!(<$T> $Type; Into::into);
-    };
-
-    (<$T:ident> $Type:ty; $convert:expr) => {
-        impl<$T: FromRedisValue> FromRedisValue for $Type {
-            fn from_redis_value(v: &Value) -> RedisResult<$Type> {
-                match v {
-                    // All binary data except u8 will try to parse into a single element vector.
-                    // u8 has its own implementation of from_byte_vec.
-                    Value::BulkString(bytes) => match FromRedisValue::from_byte_vec(bytes) {
-                        Some(x) => Ok($convert(x)),
-                        None => invalid_type_error!(
-                            v,
-                            format!("Conversion to {} failed.", std::any::type_name::<$Type>())
-                        ),
-                    },
-                    Value::Array(items) => FromRedisValue::from_redis_values(items).map($convert),
-                    Value::Set(ref items) => FromRedisValue::from_redis_values(items).map($convert),
-                    Value::Map(ref items) => {
-                        let mut n: Vec<T> = vec![];
-                        for item in items {
-                            match FromRedisValue::from_redis_value(&Value::Map(vec![item.clone()])) {
-                                Ok(v) => {
-                                    n.push(v);
-                                }
-                                Err(e) => {
-                                    return Err(e);
-                                }
-                            }
+impl<T: FromRedisValue> FromRedisValue for Vec<T> {
+    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+        match v {
+            // All binary data except u8 will try to parse into a single element vector.
+            // u8 has its own implementation of from_byte_vec.
+            Value::BulkString(bytes) => match FromRedisValue::from_byte_vec(bytes) {
+                Some(x) => Ok(x),
+                None => invalid_type_error!(
+                    v,
+                    format!("Conversion to {} failed.", std::any::type_name::<Self>())
+                ),
+            },
+            Value::Array(items) => FromRedisValue::from_redis_values(items),
+            Value::Set(ref items) => FromRedisValue::from_redis_values(items),
+            Value::Map(ref items) => {
+                let mut n: Vec<T> = vec![];
+                for item in items {
+                    match FromRedisValue::from_redis_value(&Value::Map(vec![item.clone()])) {
+                        Ok(v) => {
+                            n.push(v);
                         }
-                        Ok($convert(n))
-                    }
-                    Value::Nil => Ok($convert(Vec::new())),
-                    _ => invalid_type_error!(v, "Response type not vector compatible."),
-                }
-            }
-            fn from_owned_redis_value(v: Value) -> RedisResult<$Type> {
-                match v {
-                    // Binary data is parsed into a single-element vector, except
-                    // for the element type `u8`, which directly consumes the entire
-                    // array of bytes.
-                    Value::BulkString(bytes) => FromRedisValue::from_owned_byte_vec(bytes).map($convert),
-                    Value::Array(items) => FromRedisValue::from_owned_redis_values(items).map($convert),
-                    Value::Set(items) => FromRedisValue::from_owned_redis_values(items).map($convert),
-                    Value::Map(items) => {
-                        let mut n: Vec<T> = vec![];
-                        for item in items {
-                            match FromRedisValue::from_owned_redis_value(Value::Map(vec![item])) {
-                                Ok(v) => {
-                                    n.push(v);
-                                }
-                                Err(e) => {
-                                    return Err(e);
-                                }
-                            }
+                        Err(e) => {
+                            return Err(e);
                         }
-                        Ok($convert(n))
                     }
-                    Value::Nil => Ok($convert(Vec::new())),
-                    _ => invalid_type_error!(v, "Response type not vector compatible."),
                 }
+                Ok(n)
             }
+            Value::Nil => Ok(Vec::new()),
+            _ => invalid_type_error!(v, "Response type not vector compatible."),
         }
-    };
+    }
+    fn from_owned_redis_value(v: Value) -> RedisResult<Self> {
+        match v {
+            // Binary data is parsed into a single-element vector, except
+            // for the element type `u8`, which directly consumes the entire
+            // array of bytes.
+            Value::BulkString(bytes) => FromRedisValue::from_owned_byte_vec(bytes),
+            Value::Array(items) => FromRedisValue::from_owned_redis_values(items),
+            Value::Set(items) => FromRedisValue::from_owned_redis_values(items),
+            Value::Map(items) => {
+                let mut n: Vec<T> = vec![];
+                for item in items {
+                    match FromRedisValue::from_owned_redis_value(Value::Map(vec![item])) {
+                        Ok(v) => {
+                            n.push(v);
+                        }
+                        Err(e) => {
+                            return Err(e);
+                        }
+                    }
+                }
+                Ok(n)
+            }
+            Value::Nil => Ok(Self::new()),
+            _ => invalid_type_error!(v, "Response type not vector compatible."),
+        }
+    }
 }
 
-from_vec_from_redis_value!(<T> Vec<T>);
-from_vec_from_redis_value!(<T> std::sync::Arc<[T]>);
-from_vec_from_redis_value!(<T> Box<[T]>; Vec::into_boxed_slice);
+forwarded_impl!((T), Box<[T]>, Vec::into_boxed_slice);
+forwarded_impl! {
+    (T), std::sync::Arc<[T]>, |v: Vec<T>| std::sync::Arc::from(v)
+}
 
 impl<K: FromRedisValue + Eq + Hash, V: FromRedisValue, S: BuildHasher + Default> FromRedisValue
     for std::collections::HashMap<K, V, S>

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1502,6 +1502,10 @@ deref_to_write_redis_args_impl! {
     <T: ?Sized> ToRedisArgs for std::sync::Arc<T> where T: ToRedisArgs
 }
 
+deref_to_write_redis_args_impl! {
+    <T: ?Sized> ToRedisArgs for std::rc::Rc<T> where T: ToRedisArgs
+}
+
 /// @note: Redis cannot store empty sets so the application has to
 /// check whether the set is empty and if so, not attempt to use that
 /// result
@@ -1975,6 +1979,7 @@ macro_rules! pointer_from_redis_value_impl {
 
 pointer_from_redis_value_impl!(T, Box<T>, Box::new);
 pointer_from_redis_value_impl!(T, std::sync::Arc<T>, std::sync::Arc::new);
+pointer_from_redis_value_impl!(T, std::rc::Rc<T>, std::rc::Rc::new);
 
 /// Implement `FromRedisValue` for `$Type` (which should use the generic parameter `$T`).
 ///

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1460,7 +1460,7 @@ impl<T: ToRedisArgs> ToRedisArgs for Option<T> {
     }
 }
 
-macro_rules! deref_impl {
+macro_rules! deref_to_write_redis_args_impl {
     (
         $(#[$attr:meta])*
         <$($desc:tt)+
@@ -1486,19 +1486,19 @@ macro_rules! deref_impl {
     };
 }
 
-deref_impl! {
+deref_to_write_redis_args_impl! {
     <'a, T: ?Sized> ToRedisArgs for &'a T where T: ToRedisArgs
 }
 
-deref_impl! {
+deref_to_write_redis_args_impl! {
     <'a, T: ?Sized> ToRedisArgs for &'a mut T where T: ToRedisArgs
 }
 
-deref_impl! {
+deref_to_write_redis_args_impl! {
     <T: ?Sized> ToRedisArgs for Box<T> where T: ToRedisArgs
 }
 
-deref_impl! {
+deref_to_write_redis_args_impl! {
     <T: ?Sized> ToRedisArgs for std::sync::Arc<T> where T: ToRedisArgs
 }
 
@@ -1954,10 +1954,10 @@ impl FromRedisValue for String {
     }
 }
 
-macro_rules! forwarded_impl {
+macro_rules! pointer_from_redis_value_impl {
     (
         $(#[$attr:meta])*
-        ($id:ident), $ty:ty, $func:expr
+        $id:ident, $ty:ty, $func:expr
     ) => {
         $(#[$attr])*
         impl<$id: ?Sized + FromRedisValue> FromRedisValue for $ty {
@@ -1973,8 +1973,8 @@ macro_rules! forwarded_impl {
     }
 }
 
-forwarded_impl!((T), Box<T>, Box::new);
-forwarded_impl!((T), std::sync::Arc<T>, std::sync::Arc::new);
+pointer_from_redis_value_impl!(T, Box<T>, Box::new);
+pointer_from_redis_value_impl!(T, std::sync::Arc<T>, std::sync::Arc::new);
 
 /// Implement `FromRedisValue` for `$Type` (which should use the generic parameter `$T`).
 ///

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -1,606 +1,656 @@
+use std::sync::Arc;
+
+use redis::{FromRedisValue, ToRedisArgs, Value};
 mod support;
 
-#[cfg(test)]
-mod types {
-    use redis::{FromRedisValue, ToRedisArgs, Value};
-    #[test]
-    fn test_is_single_arg() {
-        let sslice: &[_] = &["foo"][..];
-        let nestslice: &[_] = &[sslice][..];
-        let nestvec = vec![nestslice];
-        let bytes = b"Hello World!";
-        let twobytesslice: &[_] = &[bytes, bytes][..];
-        let twobytesvec = vec![bytes, bytes];
+#[test]
+fn test_is_single_arg() {
+    let sslice: &[_] = &["foo"][..];
+    let nestslice: &[_] = &[sslice][..];
+    let nestvec = vec![nestslice];
+    let bytes = b"Hello World!";
+    let twobytesslice: &[_] = &[bytes, bytes][..];
+    let twobytesvec = vec![bytes, bytes];
 
-        assert!("foo".is_single_arg());
-        assert!(sslice.is_single_arg());
-        assert!(nestslice.is_single_arg());
-        assert!(nestvec.is_single_arg());
-        assert!(bytes.is_single_arg());
+    assert!("foo".is_single_arg());
+    assert!(sslice.is_single_arg());
+    assert!(nestslice.is_single_arg());
+    assert!(nestvec.is_single_arg());
+    assert!(bytes.is_single_arg());
+    assert!(Arc::new(sslice).is_single_arg());
 
-        assert!(!twobytesslice.is_single_arg());
-        assert!(!twobytesvec.is_single_arg());
-    }
+    assert!(!twobytesslice.is_single_arg());
+    assert!(!twobytesvec.is_single_arg());
+    assert!(!Arc::new(twobytesslice).is_single_arg());
+}
 
-    /// The `FromRedisValue` trait provides two methods for parsing:
-    /// - `fn from_redis_value(&Value) -> Result<T, RedisError>`
-    /// - `fn from_owned_redis_value(Value) -> Result<T, RedisError>`
-    /// The `RedisParseMode` below allows choosing between the two
-    /// so that test logic does not need to be duplicated for each.
-    enum RedisParseMode {
-        Owned,
-        Ref,
-    }
+/// The `FromRedisValue` trait provides two methods for parsing:
+/// - `fn from_redis_value(&Value) -> Result<T, RedisError>`
+/// - `fn from_owned_redis_value(Value) -> Result<T, RedisError>`
+/// The `RedisParseMode` below allows choosing between the two
+/// so that test logic does not need to be duplicated for each.
+enum RedisParseMode {
+    Owned,
+    Ref,
+}
 
-    impl RedisParseMode {
-        /// Calls either `FromRedisValue::from_owned_redis_value` or
-        /// `FromRedisValue::from_redis_value`.
-        fn parse_redis_value<T: redis::FromRedisValue>(
-            &self,
-            value: redis::Value,
-        ) -> Result<T, redis::RedisError> {
-            match self {
-                Self::Owned => redis::FromRedisValue::from_owned_redis_value(value),
-                Self::Ref => redis::FromRedisValue::from_redis_value(&value),
-            }
+impl RedisParseMode {
+    /// Calls either `FromRedisValue::from_owned_redis_value` or
+    /// `FromRedisValue::from_redis_value`.
+    fn parse_redis_value<T: redis::FromRedisValue>(
+        &self,
+        value: redis::Value,
+    ) -> Result<T, redis::RedisError> {
+        match self {
+            Self::Owned => redis::FromRedisValue::from_owned_redis_value(value),
+            Self::Ref => redis::FromRedisValue::from_redis_value(&value),
         }
     }
+}
 
-    #[test]
-    fn test_info_dict() {
-        use redis::{InfoDict, Value};
+#[test]
+fn test_info_dict() {
+    use redis::{InfoDict, Value};
 
-        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-            let d: InfoDict = parse_mode
-                .parse_redis_value(Value::SimpleString(
-                    "# this is a comment\nkey1:foo\nkey2:42\n".into(),
-                ))
-                .unwrap();
+    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+        let d: InfoDict = parse_mode
+            .parse_redis_value(Value::SimpleString(
+                "# this is a comment\nkey1:foo\nkey2:42\n".into(),
+            ))
+            .unwrap();
 
-            assert_eq!(d.get("key1"), Some("foo".to_string()));
-            assert_eq!(d.get("key2"), Some(42i64));
-            assert_eq!(d.get::<String>("key3"), None);
-        }
+        assert_eq!(d.get("key1"), Some("foo".to_string()));
+        assert_eq!(d.get("key2"), Some(42i64));
+        assert_eq!(d.get::<String>("key3"), None);
     }
+}
 
-    #[test]
-    fn test_i32() {
-        use redis::{ErrorKind, Value};
+#[test]
+fn test_i32() {
+    use redis::{ErrorKind, Value};
 
-        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-            let i = parse_mode.parse_redis_value(Value::SimpleString("42".into()));
-            assert_eq!(i, Ok(42i32));
+    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+        let i = parse_mode.parse_redis_value(Value::SimpleString("42".into()));
+        assert_eq!(i, Ok(42i32));
 
-            let i = parse_mode.parse_redis_value(Value::Int(42));
-            assert_eq!(i, Ok(42i32));
+        let i = parse_mode.parse_redis_value(Value::Int(42));
+        assert_eq!(i, Ok(42i32));
 
-            let i = parse_mode.parse_redis_value(Value::BulkString("42".into()));
-            assert_eq!(i, Ok(42i32));
+        let i = parse_mode.parse_redis_value(Value::BulkString("42".into()));
+        assert_eq!(i, Ok(42i32));
 
-            let bad_i: Result<i32, _> =
-                parse_mode.parse_redis_value(Value::SimpleString("42x".into()));
-            assert_eq!(bad_i.unwrap_err().kind(), ErrorKind::TypeError);
-        }
+        let bad_i: Result<i32, _> = parse_mode.parse_redis_value(Value::SimpleString("42x".into()));
+        assert_eq!(bad_i.unwrap_err().kind(), ErrorKind::TypeError);
+
+        let bad_i_deref: Result<Box<i32>, _> =
+            parse_mode.parse_redis_value(Value::SimpleString("42x".into()));
+        assert_eq!(bad_i_deref.unwrap_err().kind(), ErrorKind::TypeError);
     }
+}
 
-    #[test]
-    fn test_u32() {
-        use redis::{ErrorKind, Value};
+#[test]
+fn test_u32() {
+    use redis::{ErrorKind, Value};
 
-        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-            let i = parse_mode.parse_redis_value(Value::SimpleString("42".into()));
-            assert_eq!(i, Ok(42u32));
+    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+        let i = parse_mode.parse_redis_value(Value::SimpleString("42".into()));
+        assert_eq!(i, Ok(42u32));
 
-            let bad_i: Result<u32, _> =
-                parse_mode.parse_redis_value(Value::SimpleString("-1".into()));
-            assert_eq!(bad_i.unwrap_err().kind(), ErrorKind::TypeError);
-        }
+        let bad_i: Result<u32, _> = parse_mode.parse_redis_value(Value::SimpleString("-1".into()));
+        assert_eq!(bad_i.unwrap_err().kind(), ErrorKind::TypeError);
     }
+}
 
-    #[test]
-    fn test_vec() {
-        use redis::Value;
+#[test]
+fn test_parse_boxed() {
+    use redis::Value;
 
-        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-            let v = parse_mode.parse_redis_value(Value::Array(vec![
-                Value::BulkString("1".into()),
-                Value::BulkString("2".into()),
-                Value::BulkString("3".into()),
-            ]));
-            assert_eq!(v, Ok(vec![1i32, 2, 3]));
-
-            let content: &[u8] = b"\x01\x02\x03\x04";
-            let content_vec: Vec<u8> = Vec::from(content);
-            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
-            assert_eq!(v, Ok(content_vec));
-
-            let content: &[u8] = b"1";
-            let content_vec: Vec<u8> = Vec::from(content);
-            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
-            assert_eq!(v, Ok(vec![b'1']));
-            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec));
-            assert_eq!(v, Ok(vec![1_u16]));
-        }
+    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+        let simple_string_exp = "Simple string".to_string();
+        let v = parse_mode.parse_redis_value(Value::SimpleString(simple_string_exp.clone()));
+        assert_eq!(v, Ok(Box::new(simple_string_exp.clone())));
     }
+}
 
-    #[test]
-    fn test_box_slice() {
-        use redis::{FromRedisValue, Value};
-        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-            let v = parse_mode.parse_redis_value(Value::Array(vec![
-                Value::BulkString("1".into()),
-                Value::BulkString("2".into()),
-                Value::BulkString("3".into()),
-            ]));
-            assert_eq!(v, Ok(vec![1i32, 2, 3].into_boxed_slice()));
+#[test]
+fn test_parse_arc() {
+    use redis::Value;
+    use std::sync::Arc;
 
-            let content: &[u8] = b"\x01\x02\x03\x04";
-            let content_vec: Vec<u8> = Vec::from(content);
-            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
-            assert_eq!(v, Ok(content_vec.into_boxed_slice()));
+    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+        let simple_string_exp = "Simple string".to_string();
+        let v = parse_mode.parse_redis_value(Value::SimpleString(simple_string_exp.clone()));
+        assert_eq!(v, Ok(Arc::new(simple_string_exp.clone())));
 
-            let content: &[u8] = b"1";
-            let content_vec: Vec<u8> = Vec::from(content);
-            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
-            assert_eq!(v, Ok(vec![b'1'].into_boxed_slice()));
-            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec));
-            assert_eq!(v, Ok(vec![1_u16].into_boxed_slice()));
+        // works with optional
+        let v = parse_mode.parse_redis_value(Value::SimpleString(simple_string_exp.clone()));
+        assert_eq!(v, Ok(Arc::new(Some(simple_string_exp))));
+    }
+}
 
-            assert_eq!(
+#[test]
+fn test_vec() {
+    use redis::Value;
+
+    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+        let v = parse_mode.parse_redis_value(Value::Array(vec![
+            Value::BulkString("1".into()),
+            Value::BulkString("2".into()),
+            Value::BulkString("3".into()),
+        ]));
+        assert_eq!(v, Ok(vec![1i32, 2, 3]));
+
+        let content: &[u8] = b"\x01\x02\x03\x04";
+        let content_vec: Vec<u8> = Vec::from(content);
+        let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
+        assert_eq!(v, Ok(content_vec));
+
+        let content: &[u8] = b"1";
+        let content_vec: Vec<u8> = Vec::from(content);
+        let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
+        assert_eq!(v, Ok(vec![b'1']));
+        let v = parse_mode.parse_redis_value(Value::BulkString(content_vec));
+        assert_eq!(v, Ok(vec![1_u16]));
+    }
+}
+
+#[test]
+fn test_box_slice() {
+    use redis::{FromRedisValue, Value};
+    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+        let v = parse_mode.parse_redis_value(Value::Array(vec![
+            Value::BulkString("1".into()),
+            Value::BulkString("2".into()),
+            Value::BulkString("3".into()),
+        ]));
+        assert_eq!(v, Ok(vec![1i32, 2, 3].into_boxed_slice()));
+
+        let content: &[u8] = b"\x01\x02\x03\x04";
+        let content_vec: Vec<u8> = Vec::from(content);
+        let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
+        assert_eq!(v, Ok(content_vec.into_boxed_slice()));
+
+        let content: &[u8] = b"1";
+        let content_vec: Vec<u8> = Vec::from(content);
+        let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
+        assert_eq!(v, Ok(vec![b'1'].into_boxed_slice()));
+        let v = parse_mode.parse_redis_value(Value::BulkString(content_vec));
+        assert_eq!(v, Ok(vec![1_u16].into_boxed_slice()));
+
+        assert_eq!(
         Box::<[i32]>::from_redis_value(
             &Value::BulkString("just a string".into())
         ).unwrap_err().to_string(),
         "Response was of incompatible type - TypeError: \"Conversion to alloc::boxed::Box<[i32]> failed.\" (response was bulk-string('\"just a string\"'))",
     );
-        }
+    }
+}
+
+#[test]
+fn test_arc_slice() {
+    use redis::{FromRedisValue, Value};
+    use std::sync::Arc;
+
+    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+        let v = parse_mode.parse_redis_value(Value::Array(vec![
+            Value::BulkString("1".into()),
+            Value::BulkString("2".into()),
+            Value::BulkString("3".into()),
+        ]));
+        assert_eq!(v, Ok(Arc::new(vec![1i32, 2, 3])));
+
+        let content: &[u8] = b"\x01\x02\x03\x04";
+        let content_vec: Vec<u8> = Vec::from(content);
+        let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
+        assert_eq!(v, Ok(Arc::new(content_vec)));
+
+        let content: &[u8] = b"1";
+        let content_vec: Vec<u8> = Vec::from(content);
+        let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
+        assert_eq!(v, Ok(Arc::new(vec![b'1'])));
+        let v = parse_mode.parse_redis_value(Value::BulkString(content_vec));
+        assert_eq!(v, Ok(Arc::new(vec![1_u16])));
+
+        assert_eq!(
+            Arc::<[i32]>::from_redis_value(
+                &Value::BulkString("just a string".into())
+            ).unwrap_err().to_string(),
+            "Response was of incompatible type - TypeError: \"Conversion to alloc::sync::Arc<[i32]> failed.\" (response was bulk-string('\"just a string\"'))",
+        );
+    }
+}
+
+#[test]
+fn test_single_bool_vec() {
+    use redis::Value;
+
+    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+        let v = parse_mode.parse_redis_value(Value::BulkString("1".into()));
+
+        assert_eq!(v, Ok(vec![true]));
+    }
+}
+
+#[test]
+fn test_single_i32_vec() {
+    use redis::Value;
+
+    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+        let v = parse_mode.parse_redis_value(Value::BulkString("1".into()));
+
+        assert_eq!(v, Ok(vec![1i32]));
+    }
+}
+
+#[test]
+fn test_single_u32_vec() {
+    use redis::Value;
+
+    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+        let v = parse_mode.parse_redis_value(Value::BulkString("42".into()));
+
+        assert_eq!(v, Ok(vec![42u32]));
+    }
+}
+
+#[test]
+fn test_single_string_vec() {
+    use redis::Value;
+
+    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+        let v = parse_mode.parse_redis_value(Value::BulkString("1".into()));
+        assert_eq!(v, Ok(vec!["1".to_string()]));
+    }
+}
+
+#[test]
+fn test_tuple() {
+    use redis::Value;
+
+    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+        let v = parse_mode.parse_redis_value(Value::Array(vec![Value::Array(vec![
+            Value::BulkString("1".into()),
+            Value::BulkString("2".into()),
+            Value::BulkString("3".into()),
+        ])]));
+
+        assert_eq!(v, Ok(((1i32, 2, 3,),)));
+    }
+}
+
+#[test]
+fn test_hashmap() {
+    use fnv::FnvHasher;
+    use redis::{ErrorKind, Value};
+    use std::collections::HashMap;
+    use std::hash::BuildHasherDefault;
+
+    type Hm = HashMap<String, i32>;
+
+    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+        let v: Result<Hm, _> = parse_mode.parse_redis_value(Value::Array(vec![
+            Value::BulkString("a".into()),
+            Value::BulkString("1".into()),
+            Value::BulkString("b".into()),
+            Value::BulkString("2".into()),
+            Value::BulkString("c".into()),
+            Value::BulkString("3".into()),
+        ]));
+        let mut e: Hm = HashMap::new();
+        e.insert("a".into(), 1);
+        e.insert("b".into(), 2);
+        e.insert("c".into(), 3);
+        assert_eq!(v, Ok(e));
+
+        type Hasher = BuildHasherDefault<FnvHasher>;
+        type HmHasher = HashMap<String, i32, Hasher>;
+        let v: Result<HmHasher, _> = parse_mode.parse_redis_value(Value::Array(vec![
+            Value::BulkString("a".into()),
+            Value::BulkString("1".into()),
+            Value::BulkString("b".into()),
+            Value::BulkString("2".into()),
+            Value::BulkString("c".into()),
+            Value::BulkString("3".into()),
+        ]));
+
+        let fnv = Hasher::default();
+        let mut e: HmHasher = HashMap::with_hasher(fnv);
+        e.insert("a".into(), 1);
+        e.insert("b".into(), 2);
+        e.insert("c".into(), 3);
+        assert_eq!(v, Ok(e));
+
+        let v: Result<Hm, _> =
+            parse_mode.parse_redis_value(Value::Array(vec![Value::BulkString("a".into())]));
+        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+    }
+}
+
+#[test]
+fn test_bool() {
+    use redis::{ErrorKind, Value};
+
+    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+        let v = parse_mode.parse_redis_value(Value::BulkString("1".into()));
+        assert_eq!(v, Ok(true));
+
+        let v = parse_mode.parse_redis_value(Value::BulkString("0".into()));
+        assert_eq!(v, Ok(false));
+
+        let v: Result<bool, _> = parse_mode.parse_redis_value(Value::BulkString("garbage".into()));
+        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+        let v = parse_mode.parse_redis_value(Value::SimpleString("1".into()));
+        assert_eq!(v, Ok(true));
+
+        let v = parse_mode.parse_redis_value(Value::SimpleString("0".into()));
+        assert_eq!(v, Ok(false));
+
+        let v: Result<bool, _> =
+            parse_mode.parse_redis_value(Value::SimpleString("garbage".into()));
+        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+        let v = parse_mode.parse_redis_value(Value::Okay);
+        assert_eq!(v, Ok(true));
+
+        let v = parse_mode.parse_redis_value(Value::Nil);
+        assert_eq!(v, Ok(false));
+
+        let v = parse_mode.parse_redis_value(Value::Int(0));
+        assert_eq!(v, Ok(false));
+
+        let v = parse_mode.parse_redis_value(Value::Int(42));
+        assert_eq!(v, Ok(true));
+    }
+}
+
+#[cfg(feature = "bytes")]
+#[test]
+fn test_bytes() {
+    use bytes::Bytes;
+    use redis::{ErrorKind, RedisResult, Value};
+
+    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+        let content: &[u8] = b"\x01\x02\x03\x04";
+        let content_vec: Vec<u8> = Vec::from(content);
+        let content_bytes = Bytes::from_static(content);
+
+        let v: RedisResult<Bytes> = parse_mode.parse_redis_value(Value::BulkString(content_vec));
+        assert_eq!(v, Ok(content_bytes));
+
+        let v: RedisResult<Bytes> =
+            parse_mode.parse_redis_value(Value::SimpleString("garbage".into()));
+        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+        let v: RedisResult<Bytes> = parse_mode.parse_redis_value(Value::Okay);
+        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+        let v: RedisResult<Bytes> = parse_mode.parse_redis_value(Value::Nil);
+        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+        let v: RedisResult<Bytes> = parse_mode.parse_redis_value(Value::Int(0));
+        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+        let v: RedisResult<Bytes> = parse_mode.parse_redis_value(Value::Int(42));
+        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+    }
+}
+
+#[cfg(feature = "uuid")]
+#[test]
+fn test_uuid() {
+    use std::str::FromStr;
+
+    use redis::{ErrorKind, FromRedisValue, RedisResult, Value};
+    use uuid::Uuid;
+
+    let uuid = Uuid::from_str("abab64b7-e265-4052-a41b-23e1e28674bf").unwrap();
+    let bytes = uuid.as_bytes().to_vec();
+
+    let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::BulkString(bytes));
+    assert_eq!(v, Ok(uuid));
+
+    let v: RedisResult<Uuid> =
+        FromRedisValue::from_redis_value(&Value::SimpleString("garbage".into()));
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+    let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Okay);
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+    let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Nil);
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+    let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Int(0));
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+    let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Int(42));
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+}
+
+#[test]
+fn test_cstring() {
+    use redis::{ErrorKind, RedisResult, Value};
+    use std::ffi::CString;
+
+    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+        let content: &[u8] = b"\x01\x02\x03\x04";
+        let content_vec: Vec<u8> = Vec::from(content);
+
+        let v: RedisResult<CString> = parse_mode.parse_redis_value(Value::BulkString(content_vec));
+        assert_eq!(v, Ok(CString::new(content).unwrap()));
+
+        let v: RedisResult<CString> =
+            parse_mode.parse_redis_value(Value::SimpleString("garbage".into()));
+        assert_eq!(v, Ok(CString::new("garbage").unwrap()));
+
+        let v: RedisResult<CString> = parse_mode.parse_redis_value(Value::Okay);
+        assert_eq!(v, Ok(CString::new("OK").unwrap()));
+
+        let v: RedisResult<CString> =
+            parse_mode.parse_redis_value(Value::SimpleString("gar\0bage".into()));
+        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+        let v: RedisResult<CString> = parse_mode.parse_redis_value(Value::Nil);
+        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+        let v: RedisResult<CString> = parse_mode.parse_redis_value(Value::Int(0));
+        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+        let v: RedisResult<CString> = parse_mode.parse_redis_value(Value::Int(42));
+        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+    }
+}
+
+#[test]
+fn test_std_types_to_redis_args() {
+    use redis::ToRedisArgs;
+    use std::collections::BTreeMap;
+    use std::collections::BTreeSet;
+    use std::collections::HashMap;
+    use std::collections::HashSet;
+
+    assert!(!5i32.to_redis_args().is_empty());
+    assert!(!"abc".to_redis_args().is_empty());
+    assert!(!"abc".to_redis_args().is_empty());
+    assert!(!String::from("x").to_redis_args().is_empty());
+
+    assert!(![5, 4]
+        .iter()
+        .cloned()
+        .collect::<HashSet<_>>()
+        .to_redis_args()
+        .is_empty());
+
+    assert!(![5, 4]
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .to_redis_args()
+        .is_empty());
+
+    // this can be used on something HMSET
+    assert!(![("a", 5), ("b", 6), ("C", 7)]
+        .iter()
+        .cloned()
+        .collect::<BTreeMap<_, _>>()
+        .to_redis_args()
+        .is_empty());
+
+    // this can also be used on something HMSET
+    assert!(![("d", 8), ("e", 9), ("f", 10)]
+        .iter()
+        .cloned()
+        .collect::<HashMap<_, _>>()
+        .to_redis_args()
+        .is_empty());
+}
+
+#[test]
+#[allow(unused_allocation)]
+fn test_deref_types_to_redis_args() {
+    use redis::ToRedisArgs;
+    use std::collections::BTreeMap;
+
+    let number = 456i64;
+    let expected_result = number.to_redis_args();
+    assert_eq!(Arc::new(number).to_redis_args(), expected_result);
+    assert_eq!(Arc::new(&number).to_redis_args(), expected_result);
+    assert_eq!(Box::new(number).to_redis_args(), expected_result);
+
+    let array = vec![1, 2, 3];
+    let expected_array = array.to_redis_args();
+    assert_eq!(Arc::new(array.clone()).to_redis_args(), expected_array);
+    assert_eq!(Arc::new(&array).to_redis_args(), expected_array);
+    assert_eq!(Box::new(array.clone()).to_redis_args(), expected_array);
+
+    let map = [("k1", "v1"), ("k2", "v2")]
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+    let expected_map = map.to_redis_args();
+    assert_eq!(Arc::new(map.clone()).to_redis_args(), expected_map);
+    assert_eq!(Box::new(map.clone()).to_redis_args(), expected_map);
+}
+
+#[test]
+fn test_large_usize_array_to_redis_args_and_back() {
+    use crate::support::encode_value;
+    use redis::ToRedisArgs;
+
+    let mut array = [0; 1000];
+    for (i, item) in array.iter_mut().enumerate() {
+        *item = i;
     }
 
-    #[test]
-    fn test_arc_slice() {
-        use redis::{FromRedisValue, Value};
-        use std::sync::Arc;
+    let vec = (&array).to_redis_args();
+    assert_eq!(array.len(), vec.len());
 
-        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-            let v = parse_mode.parse_redis_value(Value::Array(vec![
-                Value::BulkString("1".into()),
-                Value::BulkString("2".into()),
-                Value::BulkString("3".into()),
-            ]));
-            assert_eq!(v, Ok(Arc::from(vec![1i32, 2, 3])));
-
-            let content: &[u8] = b"\x01\x02\x03\x04";
-            let content_vec: Vec<u8> = Vec::from(content);
-            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
-            assert_eq!(v, Ok(Arc::from(content_vec)));
-
-            let content: &[u8] = b"1";
-            let content_vec: Vec<u8> = Vec::from(content);
-            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
-            assert_eq!(v, Ok(Arc::from(vec![b'1'])));
-            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec));
-            assert_eq!(v, Ok(Arc::from(vec![1_u16])));
-
-            assert_eq!(
-        Arc::<[i32]>::from_redis_value(
-            &Value::BulkString("just a string".into())
-        ).unwrap_err().to_string(),
-        "Response was of incompatible type - TypeError: \"Conversion to alloc::sync::Arc<[i32]> failed.\" (response was bulk-string('\"just a string\"'))",
+    let value = Value::Array(
+        vec.iter()
+            .map(|val| Value::BulkString(val.clone()))
+            .collect(),
     );
-        }
+    let mut encoded_input = Vec::new();
+    encode_value(&value, &mut encoded_input).unwrap();
+
+    let new_array: [usize; 1000] = FromRedisValue::from_redis_value(&value).unwrap();
+    assert_eq!(new_array, array);
+}
+
+#[test]
+fn test_large_u8_array_to_redis_args_and_back() {
+    use crate::support::encode_value;
+    use redis::ToRedisArgs;
+
+    let mut array: [u8; 1000] = [0; 1000];
+    for (i, item) in array.iter_mut().enumerate() {
+        *item = (i % 256) as u8;
     }
 
-    #[test]
-    fn test_single_bool_vec() {
-        use redis::Value;
+    let vec = (&array).to_redis_args();
+    assert_eq!(vec.len(), 1);
+    assert_eq!(array.len(), vec[0].len());
 
-        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-            let v = parse_mode.parse_redis_value(Value::BulkString("1".into()));
+    let value = Value::Array(vec[0].iter().map(|val| Value::Int(*val as i64)).collect());
+    let mut encoded_input = Vec::new();
+    encode_value(&value, &mut encoded_input).unwrap();
 
-            assert_eq!(v, Ok(vec![true]));
-        }
+    let new_array: [u8; 1000] = FromRedisValue::from_redis_value(&value).unwrap();
+    assert_eq!(new_array, array);
+}
+
+#[test]
+fn test_large_string_array_to_redis_args_and_back() {
+    use crate::support::encode_value;
+    use redis::ToRedisArgs;
+
+    let mut array: [String; 1000] = [(); 1000].map(|_| String::new());
+    for (i, item) in array.iter_mut().enumerate() {
+        *item = format!("{i}");
     }
 
-    #[test]
-    fn test_single_i32_vec() {
-        use redis::Value;
+    let vec = (&array).to_redis_args();
+    assert_eq!(array.len(), vec.len());
 
-        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-            let v = parse_mode.parse_redis_value(Value::BulkString("1".into()));
+    let value = Value::Array(
+        vec.iter()
+            .map(|val| Value::BulkString(val.clone()))
+            .collect(),
+    );
+    let mut encoded_input = Vec::new();
+    encode_value(&value, &mut encoded_input).unwrap();
 
-            assert_eq!(v, Ok(vec![1i32]));
-        }
+    let new_array: [String; 1000] = FromRedisValue::from_redis_value(&value).unwrap();
+    assert_eq!(new_array, array);
+}
+
+#[test]
+fn test_0_length_usize_array_to_redis_args_and_back() {
+    use crate::support::encode_value;
+    use redis::ToRedisArgs;
+
+    let array: [usize; 0] = [0; 0];
+
+    let vec = (&array).to_redis_args();
+    assert_eq!(array.len(), vec.len());
+
+    let value = Value::Array(
+        vec.iter()
+            .map(|val| Value::BulkString(val.clone()))
+            .collect(),
+    );
+    let mut encoded_input = Vec::new();
+    encode_value(&value, &mut encoded_input).unwrap();
+
+    let new_array: [usize; 0] = FromRedisValue::from_redis_value(&value).unwrap();
+    assert_eq!(new_array, array);
+
+    let new_array: [usize; 0] = FromRedisValue::from_redis_value(&Value::Nil).unwrap();
+    assert_eq!(new_array, array);
+}
+
+#[test]
+fn test_attributes() {
+    use redis::{parse_redis_value, FromRedisValue, Value};
+    let bytes: &[u8] = b"*3\r\n:1\r\n:2\r\n|1\r\n+ttl\r\n:3600\r\n:3\r\n";
+    let val = parse_redis_value(bytes).unwrap();
+    {
+        // The case user doesn't expect attributes from server
+        let x: Vec<i32> = redis::FromRedisValue::from_redis_value(&val).unwrap();
+        assert_eq!(x, vec![1, 2, 3]);
     }
-
-    #[test]
-    fn test_single_u32_vec() {
-        use redis::Value;
-
-        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-            let v = parse_mode.parse_redis_value(Value::BulkString("42".into()));
-
-            assert_eq!(v, Ok(vec![42u32]));
-        }
-    }
-
-    #[test]
-    fn test_single_string_vec() {
-        use redis::Value;
-
-        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-            let v = parse_mode.parse_redis_value(Value::BulkString("1".into()));
-            assert_eq!(v, Ok(vec!["1".to_string()]));
-        }
-    }
-
-    #[test]
-    fn test_tuple() {
-        use redis::Value;
-
-        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-            let v = parse_mode.parse_redis_value(Value::Array(vec![Value::Array(vec![
-                Value::BulkString("1".into()),
-                Value::BulkString("2".into()),
-                Value::BulkString("3".into()),
-            ])]));
-
-            assert_eq!(v, Ok(((1i32, 2, 3,),)));
-        }
-    }
-
-    #[test]
-    fn test_hashmap() {
-        use fnv::FnvHasher;
-        use redis::{ErrorKind, Value};
-        use std::collections::HashMap;
-        use std::hash::BuildHasherDefault;
-
-        type Hm = HashMap<String, i32>;
-
-        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-            let v: Result<Hm, _> = parse_mode.parse_redis_value(Value::Array(vec![
-                Value::BulkString("a".into()),
-                Value::BulkString("1".into()),
-                Value::BulkString("b".into()),
-                Value::BulkString("2".into()),
-                Value::BulkString("c".into()),
-                Value::BulkString("3".into()),
-            ]));
-            let mut e: Hm = HashMap::new();
-            e.insert("a".into(), 1);
-            e.insert("b".into(), 2);
-            e.insert("c".into(), 3);
-            assert_eq!(v, Ok(e));
-
-            type Hasher = BuildHasherDefault<FnvHasher>;
-            type HmHasher = HashMap<String, i32, Hasher>;
-            let v: Result<HmHasher, _> = parse_mode.parse_redis_value(Value::Array(vec![
-                Value::BulkString("a".into()),
-                Value::BulkString("1".into()),
-                Value::BulkString("b".into()),
-                Value::BulkString("2".into()),
-                Value::BulkString("c".into()),
-                Value::BulkString("3".into()),
-            ]));
-
-            let fnv = Hasher::default();
-            let mut e: HmHasher = HashMap::with_hasher(fnv);
-            e.insert("a".into(), 1);
-            e.insert("b".into(), 2);
-            e.insert("c".into(), 3);
-            assert_eq!(v, Ok(e));
-
-            let v: Result<Hm, _> =
-                parse_mode.parse_redis_value(Value::Array(vec![Value::BulkString("a".into())]));
-            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-        }
-    }
-
-    #[test]
-    fn test_bool() {
-        use redis::{ErrorKind, Value};
-
-        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-            let v = parse_mode.parse_redis_value(Value::BulkString("1".into()));
-            assert_eq!(v, Ok(true));
-
-            let v = parse_mode.parse_redis_value(Value::BulkString("0".into()));
-            assert_eq!(v, Ok(false));
-
-            let v: Result<bool, _> =
-                parse_mode.parse_redis_value(Value::BulkString("garbage".into()));
-            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-
-            let v = parse_mode.parse_redis_value(Value::SimpleString("1".into()));
-            assert_eq!(v, Ok(true));
-
-            let v = parse_mode.parse_redis_value(Value::SimpleString("0".into()));
-            assert_eq!(v, Ok(false));
-
-            let v: Result<bool, _> =
-                parse_mode.parse_redis_value(Value::SimpleString("garbage".into()));
-            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-
-            let v = parse_mode.parse_redis_value(Value::Okay);
-            assert_eq!(v, Ok(true));
-
-            let v = parse_mode.parse_redis_value(Value::Nil);
-            assert_eq!(v, Ok(false));
-
-            let v = parse_mode.parse_redis_value(Value::Int(0));
-            assert_eq!(v, Ok(false));
-
-            let v = parse_mode.parse_redis_value(Value::Int(42));
-            assert_eq!(v, Ok(true));
-        }
-    }
-
-    #[cfg(feature = "bytes")]
-    #[test]
-    fn test_bytes() {
-        use bytes::Bytes;
-        use redis::{ErrorKind, RedisResult, Value};
-
-        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-            let content: &[u8] = b"\x01\x02\x03\x04";
-            let content_vec: Vec<u8> = Vec::from(content);
-            let content_bytes = Bytes::from_static(content);
-
-            let v: RedisResult<Bytes> =
-                parse_mode.parse_redis_value(Value::BulkString(content_vec));
-            assert_eq!(v, Ok(content_bytes));
-
-            let v: RedisResult<Bytes> =
-                parse_mode.parse_redis_value(Value::SimpleString("garbage".into()));
-            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-
-            let v: RedisResult<Bytes> = parse_mode.parse_redis_value(Value::Okay);
-            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-
-            let v: RedisResult<Bytes> = parse_mode.parse_redis_value(Value::Nil);
-            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-
-            let v: RedisResult<Bytes> = parse_mode.parse_redis_value(Value::Int(0));
-            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-
-            let v: RedisResult<Bytes> = parse_mode.parse_redis_value(Value::Int(42));
-            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-        }
-    }
-
-    #[cfg(feature = "uuid")]
-    #[test]
-    fn test_uuid() {
-        use std::str::FromStr;
-
-        use redis::{ErrorKind, FromRedisValue, RedisResult, Value};
-        use uuid::Uuid;
-
-        let uuid = Uuid::from_str("abab64b7-e265-4052-a41b-23e1e28674bf").unwrap();
-        let bytes = uuid.as_bytes().to_vec();
-
-        let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::BulkString(bytes));
-        assert_eq!(v, Ok(uuid));
-
-        let v: RedisResult<Uuid> =
-            FromRedisValue::from_redis_value(&Value::SimpleString("garbage".into()));
-        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-
-        let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Okay);
-        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-
-        let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Nil);
-        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-
-        let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Int(0));
-        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-
-        let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Int(42));
-        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-    }
-
-    #[test]
-    fn test_cstring() {
-        use redis::{ErrorKind, RedisResult, Value};
-        use std::ffi::CString;
-
-        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-            let content: &[u8] = b"\x01\x02\x03\x04";
-            let content_vec: Vec<u8> = Vec::from(content);
-
-            let v: RedisResult<CString> =
-                parse_mode.parse_redis_value(Value::BulkString(content_vec));
-            assert_eq!(v, Ok(CString::new(content).unwrap()));
-
-            let v: RedisResult<CString> =
-                parse_mode.parse_redis_value(Value::SimpleString("garbage".into()));
-            assert_eq!(v, Ok(CString::new("garbage").unwrap()));
-
-            let v: RedisResult<CString> = parse_mode.parse_redis_value(Value::Okay);
-            assert_eq!(v, Ok(CString::new("OK").unwrap()));
-
-            let v: RedisResult<CString> =
-                parse_mode.parse_redis_value(Value::SimpleString("gar\0bage".into()));
-            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-
-            let v: RedisResult<CString> = parse_mode.parse_redis_value(Value::Nil);
-            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-
-            let v: RedisResult<CString> = parse_mode.parse_redis_value(Value::Int(0));
-            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-
-            let v: RedisResult<CString> = parse_mode.parse_redis_value(Value::Int(42));
-            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-        }
-    }
-
-    #[test]
-    fn test_types_to_redis_args() {
-        use redis::ToRedisArgs;
-        use std::collections::BTreeMap;
-        use std::collections::BTreeSet;
-        use std::collections::HashMap;
-        use std::collections::HashSet;
-
-        assert!(!5i32.to_redis_args().is_empty());
-        assert!(!"abc".to_redis_args().is_empty());
-        assert!(!"abc".to_redis_args().is_empty());
-        assert!(!String::from("x").to_redis_args().is_empty());
-
-        assert!(![5, 4]
-            .iter()
-            .cloned()
-            .collect::<HashSet<_>>()
-            .to_redis_args()
-            .is_empty());
-
-        assert!(![5, 4]
-            .iter()
-            .cloned()
-            .collect::<BTreeSet<_>>()
-            .to_redis_args()
-            .is_empty());
-
-        // this can be used on something HMSET
-        assert!(![("a", 5), ("b", 6), ("C", 7)]
-            .iter()
-            .cloned()
-            .collect::<BTreeMap<_, _>>()
-            .to_redis_args()
-            .is_empty());
-
-        // this can also be used on something HMSET
-        assert!(![("d", 8), ("e", 9), ("f", 10)]
-            .iter()
-            .cloned()
-            .collect::<HashMap<_, _>>()
-            .to_redis_args()
-            .is_empty());
-    }
-
-    #[test]
-    fn test_large_usize_array_to_redis_args_and_back() {
-        use crate::support::encode_value;
-        use redis::ToRedisArgs;
-
-        let mut array = [0; 1000];
-        for (i, item) in array.iter_mut().enumerate() {
-            *item = i;
-        }
-
-        let vec = (&array).to_redis_args();
-        assert_eq!(array.len(), vec.len());
-
-        let value = Value::Array(
-            vec.iter()
-                .map(|val| Value::BulkString(val.clone()))
-                .collect(),
-        );
-        let mut encoded_input = Vec::new();
-        encode_value(&value, &mut encoded_input).unwrap();
-
-        let new_array: [usize; 1000] = FromRedisValue::from_redis_value(&value).unwrap();
-        assert_eq!(new_array, array);
-    }
-
-    #[test]
-    fn test_large_u8_array_to_redis_args_and_back() {
-        use crate::support::encode_value;
-        use redis::ToRedisArgs;
-
-        let mut array: [u8; 1000] = [0; 1000];
-        for (i, item) in array.iter_mut().enumerate() {
-            *item = (i % 256) as u8;
-        }
-
-        let vec = (&array).to_redis_args();
-        assert_eq!(vec.len(), 1);
-        assert_eq!(array.len(), vec[0].len());
-
-        let value = Value::Array(vec[0].iter().map(|val| Value::Int(*val as i64)).collect());
-        let mut encoded_input = Vec::new();
-        encode_value(&value, &mut encoded_input).unwrap();
-
-        let new_array: [u8; 1000] = FromRedisValue::from_redis_value(&value).unwrap();
-        assert_eq!(new_array, array);
-    }
-
-    #[test]
-    fn test_large_string_array_to_redis_args_and_back() {
-        use crate::support::encode_value;
-        use redis::ToRedisArgs;
-
-        let mut array: [String; 1000] = [(); 1000].map(|_| String::new());
-        for (i, item) in array.iter_mut().enumerate() {
-            *item = format!("{i}");
-        }
-
-        let vec = (&array).to_redis_args();
-        assert_eq!(array.len(), vec.len());
-
-        let value = Value::Array(
-            vec.iter()
-                .map(|val| Value::BulkString(val.clone()))
-                .collect(),
-        );
-        let mut encoded_input = Vec::new();
-        encode_value(&value, &mut encoded_input).unwrap();
-
-        let new_array: [String; 1000] = FromRedisValue::from_redis_value(&value).unwrap();
-        assert_eq!(new_array, array);
-    }
-
-    #[test]
-    fn test_0_length_usize_array_to_redis_args_and_back() {
-        use crate::support::encode_value;
-        use redis::ToRedisArgs;
-
-        let array: [usize; 0] = [0; 0];
-
-        let vec = (&array).to_redis_args();
-        assert_eq!(array.len(), vec.len());
-
-        let value = Value::Array(
-            vec.iter()
-                .map(|val| Value::BulkString(val.clone()))
-                .collect(),
-        );
-        let mut encoded_input = Vec::new();
-        encode_value(&value, &mut encoded_input).unwrap();
-
-        let new_array: [usize; 0] = FromRedisValue::from_redis_value(&value).unwrap();
-        assert_eq!(new_array, array);
-
-        let new_array: [usize; 0] = FromRedisValue::from_redis_value(&Value::Nil).unwrap();
-        assert_eq!(new_array, array);
-    }
-
-    #[test]
-    fn test_attributes() {
-        use redis::{parse_redis_value, FromRedisValue, Value};
-        let bytes: &[u8] = b"*3\r\n:1\r\n:2\r\n|1\r\n+ttl\r\n:3600\r\n:3\r\n";
-        let val = parse_redis_value(bytes).unwrap();
-        {
-            // The case user doesn't expect attributes from server
-            let x: Vec<i32> = redis::FromRedisValue::from_redis_value(&val).unwrap();
-            assert_eq!(x, vec![1, 2, 3]);
-        }
-        {
-            // The case user wants raw value from server
-            let x: Value = FromRedisValue::from_redis_value(&val).unwrap();
-            assert_eq!(
-                x,
-                Value::Array(vec![
-                    Value::Int(1),
-                    Value::Int(2),
-                    Value::Attribute {
-                        data: Box::new(Value::Int(3)),
-                        attributes: vec![(
-                            Value::SimpleString("ttl".to_string()),
-                            Value::Int(3600)
-                        )]
-                    }
-                ])
-            )
-        }
+    {
+        // The case user wants raw value from server
+        let x: Value = FromRedisValue::from_redis_value(&val).unwrap();
+        assert_eq!(
+            x,
+            Value::Array(vec![
+                Value::Int(1),
+                Value::Int(2),
+                Value::Attribute {
+                    data: Box::new(Value::Int(3)),
+                    attributes: vec![(Value::SimpleString("ttl".to_string()), Value::Int(3600))]
+                }
+            ])
+        )
     }
 }

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -519,7 +519,7 @@ fn test_deref_types_to_redis_args() {
     let expected_map = map.to_redis_args();
     assert_eq!(Arc::new(map.clone()).to_redis_args(), expected_map);
     assert_eq!(Box::new(map.clone()).to_redis_args(), expected_map);
-    assert_eq!(Rc::new(&number).to_redis_args(), expected_map);
+    assert_eq!(Rc::new(map).to_redis_args(), expected_map);
 }
 
 #[test]

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -182,24 +182,25 @@ fn test_box_slice() {
 #[test]
 fn test_arc_slice() {
     for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-        let v = parse_mode.parse_redis_value(Value::Array(vec![
+        let v = parse_mode.parse_redis_value::<Arc<[_]>>(Value::Array(vec![
             Value::BulkString("1".into()),
             Value::BulkString("2".into()),
             Value::BulkString("3".into()),
         ]));
-        assert_eq!(v, Ok(Arc::new(vec![1i32, 2, 3])));
+        assert_eq!(v, Ok(Arc::from(vec![1i32, 2, 3])));
 
         let content: &[u8] = b"\x01\x02\x03\x04";
         let content_vec: Vec<u8> = Vec::from(content);
-        let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
-        assert_eq!(v, Ok(Arc::new(content_vec)));
+        let v = parse_mode.parse_redis_value::<Arc<[_]>>(Value::BulkString(content_vec.clone()));
+        assert_eq!(v, Ok(Arc::from(content_vec)));
 
         let content: &[u8] = b"1";
         let content_vec: Vec<u8> = Vec::from(content);
-        let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
-        assert_eq!(v, Ok(Arc::new(vec![b'1'])));
-        let v = parse_mode.parse_redis_value(Value::BulkString(content_vec));
-        assert_eq!(v, Ok(Arc::new(vec![1_u16])));
+        let v: Result<Arc<[u8]>, _> =
+            parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
+        assert_eq!(v, Ok(Arc::from(vec![b'1'])));
+        let v = parse_mode.parse_redis_value::<Arc<[_]>>(Value::BulkString(content_vec));
+        assert_eq!(v, Ok(Arc::from(vec![1_u16])));
 
         assert_eq!(
             Arc::<[i32]>::from_redis_value(

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -1,643 +1,655 @@
-use std::{rc::Rc, sync::Arc};
-
-use redis::{ErrorKind, FromRedisValue, RedisResult, ToRedisArgs, Value};
 mod support;
 
-#[test]
-fn test_is_single_arg() {
-    let sslice: &[_] = &["foo"][..];
-    let nestslice: &[_] = &[sslice][..];
-    let nestvec = vec![nestslice];
-    let bytes = b"Hello World!";
-    let twobytesslice: &[_] = &[bytes, bytes][..];
-    let twobytesvec = vec![bytes, bytes];
+mod types {
+    use std::{rc::Rc, sync::Arc};
 
-    assert!("foo".is_single_arg());
-    assert!(sslice.is_single_arg());
-    assert!(nestslice.is_single_arg());
-    assert!(nestvec.is_single_arg());
-    assert!(bytes.is_single_arg());
-    assert!(Arc::new(sslice).is_single_arg());
-    assert!(Rc::new(nestslice).is_single_arg());
+    use redis::{ErrorKind, FromRedisValue, RedisResult, ToRedisArgs, Value};
 
-    assert!(!twobytesslice.is_single_arg());
-    assert!(!twobytesvec.is_single_arg());
-    assert!(!Arc::new(twobytesslice).is_single_arg());
-    assert!(!Rc::new(twobytesslice).is_single_arg());
-}
+    #[test]
+    fn test_is_single_arg() {
+        let sslice: &[_] = &["foo"][..];
+        let nestslice: &[_] = &[sslice][..];
+        let nestvec = vec![nestslice];
+        let bytes = b"Hello World!";
+        let twobytesslice: &[_] = &[bytes, bytes][..];
+        let twobytesvec = vec![bytes, bytes];
 
-/// The `FromRedisValue` trait provides two methods for parsing:
-/// - `fn from_redis_value(&Value) -> Result<T, RedisError>`
-/// - `fn from_owned_redis_value(Value) -> Result<T, RedisError>`
-/// The `RedisParseMode` below allows choosing between the two
-/// so that test logic does not need to be duplicated for each.
-enum RedisParseMode {
-    Owned,
-    Ref,
-}
+        assert!("foo".is_single_arg());
+        assert!(sslice.is_single_arg());
+        assert!(nestslice.is_single_arg());
+        assert!(nestvec.is_single_arg());
+        assert!(bytes.is_single_arg());
+        assert!(Arc::new(sslice).is_single_arg());
+        assert!(Rc::new(nestslice).is_single_arg());
 
-impl RedisParseMode {
-    /// Calls either `FromRedisValue::from_owned_redis_value` or
-    /// `FromRedisValue::from_redis_value`.
-    fn parse_redis_value<T: redis::FromRedisValue>(
-        &self,
-        value: redis::Value,
-    ) -> Result<T, redis::RedisError> {
-        match self {
-            Self::Owned => redis::FromRedisValue::from_owned_redis_value(value),
-            Self::Ref => redis::FromRedisValue::from_redis_value(&value),
+        assert!(!twobytesslice.is_single_arg());
+        assert!(!twobytesvec.is_single_arg());
+        assert!(!Arc::new(twobytesslice).is_single_arg());
+        assert!(!Rc::new(twobytesslice).is_single_arg());
+    }
+
+    /// The `FromRedisValue` trait provides two methods for parsing:
+    /// - `fn from_redis_value(&Value) -> Result<T, RedisError>`
+    /// - `fn from_owned_redis_value(Value) -> Result<T, RedisError>`
+    /// The `RedisParseMode` below allows choosing between the two
+    /// so that test logic does not need to be duplicated for each.
+    enum RedisParseMode {
+        Owned,
+        Ref,
+    }
+
+    impl RedisParseMode {
+        /// Calls either `FromRedisValue::from_owned_redis_value` or
+        /// `FromRedisValue::from_redis_value`.
+        fn parse_redis_value<T: redis::FromRedisValue>(
+            &self,
+            value: redis::Value,
+        ) -> Result<T, redis::RedisError> {
+            match self {
+                Self::Owned => redis::FromRedisValue::from_owned_redis_value(value),
+                Self::Ref => redis::FromRedisValue::from_redis_value(&value),
+            }
         }
     }
-}
 
-#[test]
-fn test_info_dict() {
-    use redis::InfoDict;
+    #[test]
+    fn test_info_dict() {
+        use redis::InfoDict;
 
-    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-        let d: InfoDict = parse_mode
-            .parse_redis_value(Value::SimpleString(
-                "# this is a comment\nkey1:foo\nkey2:42\n".into(),
-            ))
-            .unwrap();
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            let d: InfoDict = parse_mode
+                .parse_redis_value(Value::SimpleString(
+                    "# this is a comment\nkey1:foo\nkey2:42\n".into(),
+                ))
+                .unwrap();
 
-        assert_eq!(d.get("key1"), Some("foo".to_string()));
-        assert_eq!(d.get("key2"), Some(42i64));
-        assert_eq!(d.get::<String>("key3"), None);
+            assert_eq!(d.get("key1"), Some("foo".to_string()));
+            assert_eq!(d.get("key2"), Some(42i64));
+            assert_eq!(d.get::<String>("key3"), None);
+        }
     }
-}
 
-#[test]
-fn test_i32() {
-    // from hte book hitchhiker's guide to the galaxy
-    let everything_num = 42i32;
-    let everything_str_x = "42x";
+    #[test]
+    fn test_i32() {
+        // from hte book hitchhiker's guide to the galaxy
+        let everything_num = 42i32;
+        let everything_str_x = "42x";
 
-    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-        let i = parse_mode.parse_redis_value(Value::SimpleString(everything_num.to_string()));
-        assert_eq!(i, Ok(everything_num));
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            let i = parse_mode.parse_redis_value(Value::SimpleString(everything_num.to_string()));
+            assert_eq!(i, Ok(everything_num));
 
-        let i = parse_mode.parse_redis_value(Value::Int(everything_num.into()));
-        assert_eq!(i, Ok(everything_num));
+            let i = parse_mode.parse_redis_value(Value::Int(everything_num.into()));
+            assert_eq!(i, Ok(everything_num));
 
-        let i = parse_mode.parse_redis_value(Value::BulkString(everything_num.to_string().into()));
-        assert_eq!(i, Ok(everything_num));
+            let i =
+                parse_mode.parse_redis_value(Value::BulkString(everything_num.to_string().into()));
+            assert_eq!(i, Ok(everything_num));
 
-        let bad_i: Result<i32, _> =
-            parse_mode.parse_redis_value(Value::SimpleString(everything_str_x.into()));
-        assert_eq!(bad_i.unwrap_err().kind(), ErrorKind::TypeError);
+            let bad_i: Result<i32, _> =
+                parse_mode.parse_redis_value(Value::SimpleString(everything_str_x.into()));
+            assert_eq!(bad_i.unwrap_err().kind(), ErrorKind::TypeError);
 
-        let bad_i_deref: Result<Box<i32>, _> =
-            parse_mode.parse_redis_value(Value::SimpleString(everything_str_x.into()));
-        assert_eq!(bad_i_deref.unwrap_err().kind(), ErrorKind::TypeError);
+            let bad_i_deref: Result<Box<i32>, _> =
+                parse_mode.parse_redis_value(Value::SimpleString(everything_str_x.into()));
+            assert_eq!(bad_i_deref.unwrap_err().kind(), ErrorKind::TypeError);
+        }
     }
-}
 
-#[test]
-fn test_u32() {
-    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-        let i = parse_mode.parse_redis_value(Value::SimpleString("42".into()));
-        assert_eq!(i, Ok(42u32));
+    #[test]
+    fn test_u32() {
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            let i = parse_mode.parse_redis_value(Value::SimpleString("42".into()));
+            assert_eq!(i, Ok(42u32));
 
-        let bad_i: Result<u32, _> = parse_mode.parse_redis_value(Value::SimpleString("-1".into()));
-        assert_eq!(bad_i.unwrap_err().kind(), ErrorKind::TypeError);
+            let bad_i: Result<u32, _> =
+                parse_mode.parse_redis_value(Value::SimpleString("-1".into()));
+            assert_eq!(bad_i.unwrap_err().kind(), ErrorKind::TypeError);
+        }
     }
-}
 
-#[test]
-fn test_parse_boxed() {
-    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-        let simple_string_exp = "Simple string".to_string();
-        let v = parse_mode.parse_redis_value(Value::SimpleString(simple_string_exp.clone()));
-        assert_eq!(v, Ok(Box::new(simple_string_exp.clone())));
+    #[test]
+    fn test_parse_boxed() {
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            let simple_string_exp = "Simple string".to_string();
+            let v = parse_mode.parse_redis_value(Value::SimpleString(simple_string_exp.clone()));
+            assert_eq!(v, Ok(Box::new(simple_string_exp.clone())));
+        }
     }
-}
 
-#[test]
-fn test_parse_arc() {
-    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-        let simple_string_exp = "Simple string".to_string();
-        let v = parse_mode.parse_redis_value(Value::SimpleString(simple_string_exp.clone()));
-        assert_eq!(v, Ok(Arc::new(simple_string_exp.clone())));
+    #[test]
+    fn test_parse_arc() {
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            let simple_string_exp = "Simple string".to_string();
+            let v = parse_mode.parse_redis_value(Value::SimpleString(simple_string_exp.clone()));
+            assert_eq!(v, Ok(Arc::new(simple_string_exp.clone())));
 
-        // works with optional
-        let v = parse_mode.parse_redis_value(Value::SimpleString(simple_string_exp.clone()));
-        assert_eq!(v, Ok(Arc::new(Some(simple_string_exp))));
+            // works with optional
+            let v = parse_mode.parse_redis_value(Value::SimpleString(simple_string_exp.clone()));
+            assert_eq!(v, Ok(Arc::new(Some(simple_string_exp))));
+        }
     }
-}
 
-#[test]
-fn test_parse_rc() {
-    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-        let simple_string_exp = "Simple string".to_string();
-        let v = parse_mode.parse_redis_value(Value::SimpleString(simple_string_exp.clone()));
-        assert_eq!(v, Ok(Rc::new(simple_string_exp.clone())));
+    #[test]
+    fn test_parse_rc() {
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            let simple_string_exp = "Simple string".to_string();
+            let v = parse_mode.parse_redis_value(Value::SimpleString(simple_string_exp.clone()));
+            assert_eq!(v, Ok(Rc::new(simple_string_exp.clone())));
 
-        // works with optional
-        let v = parse_mode.parse_redis_value(Value::SimpleString(simple_string_exp.clone()));
-        assert_eq!(v, Ok(Rc::new(Some(simple_string_exp))));
+            // works with optional
+            let v = parse_mode.parse_redis_value(Value::SimpleString(simple_string_exp.clone()));
+            assert_eq!(v, Ok(Rc::new(Some(simple_string_exp))));
+        }
     }
-}
 
-#[test]
-fn test_vec() {
-    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-        let v = parse_mode.parse_redis_value(Value::Array(vec![
-            Value::BulkString("1".into()),
-            Value::BulkString("2".into()),
-            Value::BulkString("3".into()),
-        ]));
-        assert_eq!(v, Ok(vec![1i32, 2, 3]));
+    #[test]
+    fn test_vec() {
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            let v = parse_mode.parse_redis_value(Value::Array(vec![
+                Value::BulkString("1".into()),
+                Value::BulkString("2".into()),
+                Value::BulkString("3".into()),
+            ]));
+            assert_eq!(v, Ok(vec![1i32, 2, 3]));
 
-        let content: &[u8] = b"\x01\x02\x03\x04";
-        let content_vec: Vec<u8> = Vec::from(content);
-        let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
-        assert_eq!(v, Ok(content_vec));
+            let content: &[u8] = b"\x01\x02\x03\x04";
+            let content_vec: Vec<u8> = Vec::from(content);
+            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
+            assert_eq!(v, Ok(content_vec));
 
-        let content: &[u8] = b"1";
-        let content_vec: Vec<u8> = Vec::from(content);
-        let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
-        assert_eq!(v, Ok(vec![b'1']));
-        let v = parse_mode.parse_redis_value(Value::BulkString(content_vec));
-        assert_eq!(v, Ok(vec![1_u16]));
+            let content: &[u8] = b"1";
+            let content_vec: Vec<u8> = Vec::from(content);
+            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
+            assert_eq!(v, Ok(vec![b'1']));
+            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec));
+            assert_eq!(v, Ok(vec![1_u16]));
+        }
     }
-}
 
-#[test]
-fn test_box_slice() {
-    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-        let v = parse_mode.parse_redis_value(Value::Array(vec![
-            Value::BulkString("1".into()),
-            Value::BulkString("2".into()),
-            Value::BulkString("3".into()),
-        ]));
-        assert_eq!(v, Ok(vec![1i32, 2, 3].into_boxed_slice()));
+    #[test]
+    fn test_box_slice() {
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            let v = parse_mode.parse_redis_value(Value::Array(vec![
+                Value::BulkString("1".into()),
+                Value::BulkString("2".into()),
+                Value::BulkString("3".into()),
+            ]));
+            assert_eq!(v, Ok(vec![1i32, 2, 3].into_boxed_slice()));
 
-        let content: &[u8] = b"\x01\x02\x03\x04";
-        let content_vec: Vec<u8> = Vec::from(content);
-        let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
-        assert_eq!(v, Ok(content_vec.into_boxed_slice()));
+            let content: &[u8] = b"\x01\x02\x03\x04";
+            let content_vec: Vec<u8> = Vec::from(content);
+            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
+            assert_eq!(v, Ok(content_vec.into_boxed_slice()));
 
-        let content: &[u8] = b"1";
-        let content_vec: Vec<u8> = Vec::from(content);
-        let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
-        assert_eq!(v, Ok(vec![b'1'].into_boxed_slice()));
-        let v = parse_mode.parse_redis_value(Value::BulkString(content_vec));
-        assert_eq!(v, Ok(vec![1_u16].into_boxed_slice()));
+            let content: &[u8] = b"1";
+            let content_vec: Vec<u8> = Vec::from(content);
+            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
+            assert_eq!(v, Ok(vec![b'1'].into_boxed_slice()));
+            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec));
+            assert_eq!(v, Ok(vec![1_u16].into_boxed_slice()));
 
-        assert_eq!(
+            assert_eq!(
         Box::<[i32]>::from_redis_value(
             &Value::BulkString("just a string".into())
         ).unwrap_err().to_string(),
         "Response was of incompatible type - TypeError: \"Conversion to alloc::boxed::Box<[i32]> failed.\" (response was bulk-string('\"just a string\"'))",
     );
+        }
     }
-}
 
-#[test]
-fn test_arc_slice() {
-    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-        let v = parse_mode.parse_redis_value::<Arc<[_]>>(Value::Array(vec![
-            Value::BulkString("1".into()),
-            Value::BulkString("2".into()),
-            Value::BulkString("3".into()),
-        ]));
-        assert_eq!(v, Ok(Arc::from(vec![1i32, 2, 3])));
+    #[test]
+    fn test_arc_slice() {
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            let v = parse_mode.parse_redis_value::<Arc<[_]>>(Value::Array(vec![
+                Value::BulkString("1".into()),
+                Value::BulkString("2".into()),
+                Value::BulkString("3".into()),
+            ]));
+            assert_eq!(v, Ok(Arc::from(vec![1i32, 2, 3])));
 
-        let content: &[u8] = b"\x01\x02\x03\x04";
-        let content_vec: Vec<u8> = Vec::from(content);
-        let v = parse_mode.parse_redis_value::<Arc<[_]>>(Value::BulkString(content_vec.clone()));
-        assert_eq!(v, Ok(Arc::from(content_vec)));
+            let content: &[u8] = b"\x01\x02\x03\x04";
+            let content_vec: Vec<u8> = Vec::from(content);
+            let v =
+                parse_mode.parse_redis_value::<Arc<[_]>>(Value::BulkString(content_vec.clone()));
+            assert_eq!(v, Ok(Arc::from(content_vec)));
 
-        let content: &[u8] = b"1";
-        let content_vec: Vec<u8> = Vec::from(content);
-        let v: Result<Arc<[u8]>, _> =
-            parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
-        assert_eq!(v, Ok(Arc::from(vec![b'1'])));
-        let v = parse_mode.parse_redis_value::<Arc<[_]>>(Value::BulkString(content_vec));
-        assert_eq!(v, Ok(Arc::from(vec![1_u16])));
+            let content: &[u8] = b"1";
+            let content_vec: Vec<u8> = Vec::from(content);
+            let v: Result<Arc<[u8]>, _> =
+                parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
+            assert_eq!(v, Ok(Arc::from(vec![b'1'])));
+            let v = parse_mode.parse_redis_value::<Arc<[_]>>(Value::BulkString(content_vec));
+            assert_eq!(v, Ok(Arc::from(vec![1_u16])));
 
-        assert_eq!(
+            assert_eq!(
             Arc::<[i32]>::from_redis_value(
                 &Value::BulkString("just a string".into())
             ).unwrap_err().to_string(),
             "Response was of incompatible type - TypeError: \"Conversion to alloc::sync::Arc<[i32]> failed.\" (response was bulk-string('\"just a string\"'))",
         );
+        }
     }
-}
 
-#[test]
-fn test_single_bool_vec() {
-    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-        let v = parse_mode.parse_redis_value(Value::BulkString("1".into()));
+    #[test]
+    fn test_single_bool_vec() {
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            let v = parse_mode.parse_redis_value(Value::BulkString("1".into()));
 
-        assert_eq!(v, Ok(vec![true]));
+            assert_eq!(v, Ok(vec![true]));
+        }
     }
-}
 
-#[test]
-fn test_single_i32_vec() {
-    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-        let v = parse_mode.parse_redis_value(Value::BulkString("1".into()));
+    #[test]
+    fn test_single_i32_vec() {
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            let v = parse_mode.parse_redis_value(Value::BulkString("1".into()));
 
-        assert_eq!(v, Ok(vec![1i32]));
+            assert_eq!(v, Ok(vec![1i32]));
+        }
     }
-}
 
-#[test]
-fn test_single_u32_vec() {
-    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-        let v = parse_mode.parse_redis_value(Value::BulkString("42".into()));
+    #[test]
+    fn test_single_u32_vec() {
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            let v = parse_mode.parse_redis_value(Value::BulkString("42".into()));
 
-        assert_eq!(v, Ok(vec![42u32]));
+            assert_eq!(v, Ok(vec![42u32]));
+        }
     }
-}
 
-#[test]
-fn test_single_string_vec() {
-    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-        let v = parse_mode.parse_redis_value(Value::BulkString("1".into()));
-        assert_eq!(v, Ok(vec!["1".to_string()]));
+    #[test]
+    fn test_single_string_vec() {
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            let v = parse_mode.parse_redis_value(Value::BulkString("1".into()));
+            assert_eq!(v, Ok(vec!["1".to_string()]));
+        }
     }
-}
 
-#[test]
-fn test_tuple() {
-    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-        let v = parse_mode.parse_redis_value(Value::Array(vec![Value::Array(vec![
-            Value::BulkString("1".into()),
-            Value::BulkString("2".into()),
-            Value::BulkString("3".into()),
-        ])]));
+    #[test]
+    fn test_tuple() {
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            let v = parse_mode.parse_redis_value(Value::Array(vec![Value::Array(vec![
+                Value::BulkString("1".into()),
+                Value::BulkString("2".into()),
+                Value::BulkString("3".into()),
+            ])]));
 
-        assert_eq!(v, Ok(((1i32, 2, 3,),)));
+            assert_eq!(v, Ok(((1i32, 2, 3,),)));
+        }
     }
-}
 
-#[test]
-fn test_hashmap() {
-    use fnv::FnvHasher;
-    use std::collections::HashMap;
-    use std::hash::BuildHasherDefault;
+    #[test]
+    fn test_hashmap() {
+        use fnv::FnvHasher;
+        use std::collections::HashMap;
+        use std::hash::BuildHasherDefault;
 
-    type Hm = HashMap<String, i32>;
+        type Hm = HashMap<String, i32>;
 
-    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-        let v: Result<Hm, _> = parse_mode.parse_redis_value(Value::Array(vec![
-            Value::BulkString("a".into()),
-            Value::BulkString("1".into()),
-            Value::BulkString("b".into()),
-            Value::BulkString("2".into()),
-            Value::BulkString("c".into()),
-            Value::BulkString("3".into()),
-        ]));
-        let mut e: Hm = HashMap::new();
-        e.insert("a".into(), 1);
-        e.insert("b".into(), 2);
-        e.insert("c".into(), 3);
-        assert_eq!(v, Ok(e));
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            let v: Result<Hm, _> = parse_mode.parse_redis_value(Value::Array(vec![
+                Value::BulkString("a".into()),
+                Value::BulkString("1".into()),
+                Value::BulkString("b".into()),
+                Value::BulkString("2".into()),
+                Value::BulkString("c".into()),
+                Value::BulkString("3".into()),
+            ]));
+            let mut e: Hm = HashMap::new();
+            e.insert("a".into(), 1);
+            e.insert("b".into(), 2);
+            e.insert("c".into(), 3);
+            assert_eq!(v, Ok(e));
 
-        type Hasher = BuildHasherDefault<FnvHasher>;
-        type HmHasher = HashMap<String, i32, Hasher>;
-        let v: Result<HmHasher, _> = parse_mode.parse_redis_value(Value::Array(vec![
-            Value::BulkString("a".into()),
-            Value::BulkString("1".into()),
-            Value::BulkString("b".into()),
-            Value::BulkString("2".into()),
-            Value::BulkString("c".into()),
-            Value::BulkString("3".into()),
-        ]));
+            type Hasher = BuildHasherDefault<FnvHasher>;
+            type HmHasher = HashMap<String, i32, Hasher>;
+            let v: Result<HmHasher, _> = parse_mode.parse_redis_value(Value::Array(vec![
+                Value::BulkString("a".into()),
+                Value::BulkString("1".into()),
+                Value::BulkString("b".into()),
+                Value::BulkString("2".into()),
+                Value::BulkString("c".into()),
+                Value::BulkString("3".into()),
+            ]));
 
-        let fnv = Hasher::default();
-        let mut e: HmHasher = HashMap::with_hasher(fnv);
-        e.insert("a".into(), 1);
-        e.insert("b".into(), 2);
-        e.insert("c".into(), 3);
-        assert_eq!(v, Ok(e));
+            let fnv = Hasher::default();
+            let mut e: HmHasher = HashMap::with_hasher(fnv);
+            e.insert("a".into(), 1);
+            e.insert("b".into(), 2);
+            e.insert("c".into(), 3);
+            assert_eq!(v, Ok(e));
 
-        let v: Result<Hm, _> =
-            parse_mode.parse_redis_value(Value::Array(vec![Value::BulkString("a".into())]));
-        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+            let v: Result<Hm, _> =
+                parse_mode.parse_redis_value(Value::Array(vec![Value::BulkString("a".into())]));
+            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+        }
     }
-}
 
-#[test]
-fn test_bool() {
-    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-        let v = parse_mode.parse_redis_value(Value::BulkString("1".into()));
-        assert_eq!(v, Ok(true));
+    #[test]
+    fn test_bool() {
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            let v = parse_mode.parse_redis_value(Value::BulkString("1".into()));
+            assert_eq!(v, Ok(true));
 
-        let v = parse_mode.parse_redis_value(Value::BulkString("0".into()));
-        assert_eq!(v, Ok(false));
+            let v = parse_mode.parse_redis_value(Value::BulkString("0".into()));
+            assert_eq!(v, Ok(false));
 
-        let v: Result<bool, _> = parse_mode.parse_redis_value(Value::BulkString("garbage".into()));
-        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+            let v: Result<bool, _> =
+                parse_mode.parse_redis_value(Value::BulkString("garbage".into()));
+            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
 
-        let v = parse_mode.parse_redis_value(Value::SimpleString("1".into()));
-        assert_eq!(v, Ok(true));
+            let v = parse_mode.parse_redis_value(Value::SimpleString("1".into()));
+            assert_eq!(v, Ok(true));
 
-        let v = parse_mode.parse_redis_value(Value::SimpleString("0".into()));
-        assert_eq!(v, Ok(false));
+            let v = parse_mode.parse_redis_value(Value::SimpleString("0".into()));
+            assert_eq!(v, Ok(false));
 
-        let v: Result<bool, _> =
-            parse_mode.parse_redis_value(Value::SimpleString("garbage".into()));
-        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+            let v: Result<bool, _> =
+                parse_mode.parse_redis_value(Value::SimpleString("garbage".into()));
+            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
 
-        let v = parse_mode.parse_redis_value(Value::Okay);
-        assert_eq!(v, Ok(true));
+            let v = parse_mode.parse_redis_value(Value::Okay);
+            assert_eq!(v, Ok(true));
 
-        let v = parse_mode.parse_redis_value(Value::Nil);
-        assert_eq!(v, Ok(false));
+            let v = parse_mode.parse_redis_value(Value::Nil);
+            assert_eq!(v, Ok(false));
 
-        let v = parse_mode.parse_redis_value(Value::Int(0));
-        assert_eq!(v, Ok(false));
+            let v = parse_mode.parse_redis_value(Value::Int(0));
+            assert_eq!(v, Ok(false));
 
-        let v = parse_mode.parse_redis_value(Value::Int(42));
-        assert_eq!(v, Ok(true));
+            let v = parse_mode.parse_redis_value(Value::Int(42));
+            assert_eq!(v, Ok(true));
+        }
     }
-}
 
-#[cfg(feature = "bytes")]
-#[test]
-fn test_bytes() {
-    use bytes::Bytes;
+    #[cfg(feature = "bytes")]
+    #[test]
+    fn test_bytes() {
+        use bytes::Bytes;
 
-    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-        let content: &[u8] = b"\x01\x02\x03\x04";
-        let content_vec: Vec<u8> = Vec::from(content);
-        let content_bytes = Bytes::from_static(content);
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            let content: &[u8] = b"\x01\x02\x03\x04";
+            let content_vec: Vec<u8> = Vec::from(content);
+            let content_bytes = Bytes::from_static(content);
 
-        let v: RedisResult<Bytes> = parse_mode.parse_redis_value(Value::BulkString(content_vec));
-        assert_eq!(v, Ok(content_bytes));
+            let v: RedisResult<Bytes> =
+                parse_mode.parse_redis_value(Value::BulkString(content_vec));
+            assert_eq!(v, Ok(content_bytes));
 
-        let v: RedisResult<Bytes> =
-            parse_mode.parse_redis_value(Value::SimpleString("garbage".into()));
-        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+            let v: RedisResult<Bytes> =
+                parse_mode.parse_redis_value(Value::SimpleString("garbage".into()));
+            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
 
-        let v: RedisResult<Bytes> = parse_mode.parse_redis_value(Value::Okay);
-        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+            let v: RedisResult<Bytes> = parse_mode.parse_redis_value(Value::Okay);
+            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
 
-        let v: RedisResult<Bytes> = parse_mode.parse_redis_value(Value::Nil);
-        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+            let v: RedisResult<Bytes> = parse_mode.parse_redis_value(Value::Nil);
+            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
 
-        let v: RedisResult<Bytes> = parse_mode.parse_redis_value(Value::Int(0));
-        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+            let v: RedisResult<Bytes> = parse_mode.parse_redis_value(Value::Int(0));
+            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
 
-        let v: RedisResult<Bytes> = parse_mode.parse_redis_value(Value::Int(42));
-        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+            let v: RedisResult<Bytes> = parse_mode.parse_redis_value(Value::Int(42));
+            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+        }
     }
-}
 
-#[cfg(feature = "uuid")]
-#[test]
-fn test_uuid() {
-    use std::str::FromStr;
+    #[cfg(feature = "uuid")]
+    #[test]
+    fn test_uuid() {
+        use std::str::FromStr;
 
-    use uuid::Uuid;
+        use uuid::Uuid;
 
-    let uuid = Uuid::from_str("abab64b7-e265-4052-a41b-23e1e28674bf").unwrap();
-    let bytes = uuid.as_bytes().to_vec();
+        let uuid = Uuid::from_str("abab64b7-e265-4052-a41b-23e1e28674bf").unwrap();
+        let bytes = uuid.as_bytes().to_vec();
 
-    let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::BulkString(bytes));
-    assert_eq!(v, Ok(uuid));
+        let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::BulkString(bytes));
+        assert_eq!(v, Ok(uuid));
 
-    let v: RedisResult<Uuid> =
-        FromRedisValue::from_redis_value(&Value::SimpleString("garbage".into()));
-    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-
-    let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Okay);
-    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-
-    let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Nil);
-    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-
-    let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Int(0));
-    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-
-    let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Int(42));
-    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
-}
-
-#[test]
-fn test_cstring() {
-    use std::ffi::CString;
-
-    for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
-        let content: &[u8] = b"\x01\x02\x03\x04";
-        let content_vec: Vec<u8> = Vec::from(content);
-
-        let v: RedisResult<CString> = parse_mode.parse_redis_value(Value::BulkString(content_vec));
-        assert_eq!(v, Ok(CString::new(content).unwrap()));
-
-        let v: RedisResult<CString> =
-            parse_mode.parse_redis_value(Value::SimpleString("garbage".into()));
-        assert_eq!(v, Ok(CString::new("garbage").unwrap()));
-
-        let v: RedisResult<CString> = parse_mode.parse_redis_value(Value::Okay);
-        assert_eq!(v, Ok(CString::new("OK").unwrap()));
-
-        let v: RedisResult<CString> =
-            parse_mode.parse_redis_value(Value::SimpleString("gar\0bage".into()));
+        let v: RedisResult<Uuid> =
+            FromRedisValue::from_redis_value(&Value::SimpleString("garbage".into()));
         assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
 
-        let v: RedisResult<CString> = parse_mode.parse_redis_value(Value::Nil);
+        let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Okay);
         assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
 
-        let v: RedisResult<CString> = parse_mode.parse_redis_value(Value::Int(0));
+        let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Nil);
         assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
 
-        let v: RedisResult<CString> = parse_mode.parse_redis_value(Value::Int(42));
+        let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Int(0));
+        assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+        let v: RedisResult<Uuid> = FromRedisValue::from_redis_value(&Value::Int(42));
         assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
     }
-}
 
-#[test]
-fn test_std_types_to_redis_args() {
-    use std::collections::BTreeMap;
-    use std::collections::BTreeSet;
-    use std::collections::HashMap;
-    use std::collections::HashSet;
+    #[test]
+    fn test_cstring() {
+        use std::ffi::CString;
 
-    assert!(!5i32.to_redis_args().is_empty());
-    assert!(!"abc".to_redis_args().is_empty());
-    assert!(!"abc".to_redis_args().is_empty());
-    assert!(!String::from("x").to_redis_args().is_empty());
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            let content: &[u8] = b"\x01\x02\x03\x04";
+            let content_vec: Vec<u8> = Vec::from(content);
 
-    assert!(![5, 4]
-        .iter()
-        .cloned()
-        .collect::<HashSet<_>>()
-        .to_redis_args()
-        .is_empty());
+            let v: RedisResult<CString> =
+                parse_mode.parse_redis_value(Value::BulkString(content_vec));
+            assert_eq!(v, Ok(CString::new(content).unwrap()));
 
-    assert!(![5, 4]
-        .iter()
-        .cloned()
-        .collect::<BTreeSet<_>>()
-        .to_redis_args()
-        .is_empty());
+            let v: RedisResult<CString> =
+                parse_mode.parse_redis_value(Value::SimpleString("garbage".into()));
+            assert_eq!(v, Ok(CString::new("garbage").unwrap()));
 
-    // this can be used on something HMSET
-    assert!(![("a", 5), ("b", 6), ("C", 7)]
-        .iter()
-        .cloned()
-        .collect::<BTreeMap<_, _>>()
-        .to_redis_args()
-        .is_empty());
+            let v: RedisResult<CString> = parse_mode.parse_redis_value(Value::Okay);
+            assert_eq!(v, Ok(CString::new("OK").unwrap()));
 
-    // this can also be used on something HMSET
-    assert!(![("d", 8), ("e", 9), ("f", 10)]
-        .iter()
-        .cloned()
-        .collect::<HashMap<_, _>>()
-        .to_redis_args()
-        .is_empty());
-}
+            let v: RedisResult<CString> =
+                parse_mode.parse_redis_value(Value::SimpleString("gar\0bage".into()));
+            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
 
-#[test]
-#[allow(unused_allocation)]
-fn test_deref_types_to_redis_args() {
-    use std::collections::BTreeMap;
+            let v: RedisResult<CString> = parse_mode.parse_redis_value(Value::Nil);
+            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
 
-    let number = 456i64;
-    let expected_result = number.to_redis_args();
-    assert_eq!(Arc::new(number).to_redis_args(), expected_result);
-    assert_eq!(Arc::new(&number).to_redis_args(), expected_result);
-    assert_eq!(Box::new(number).to_redis_args(), expected_result);
-    assert_eq!(Rc::new(&number).to_redis_args(), expected_result);
+            let v: RedisResult<CString> = parse_mode.parse_redis_value(Value::Int(0));
+            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
 
-    let array = vec![1, 2, 3];
-    let expected_array = array.to_redis_args();
-    assert_eq!(Arc::new(array.clone()).to_redis_args(), expected_array);
-    assert_eq!(Arc::new(&array).to_redis_args(), expected_array);
-    assert_eq!(Box::new(array.clone()).to_redis_args(), expected_array);
-    assert_eq!(Rc::new(array.clone()).to_redis_args(), expected_array);
-
-    let map = [("k1", "v1"), ("k2", "v2")]
-        .into_iter()
-        .collect::<BTreeMap<_, _>>();
-    let expected_map = map.to_redis_args();
-    assert_eq!(Arc::new(map.clone()).to_redis_args(), expected_map);
-    assert_eq!(Box::new(map.clone()).to_redis_args(), expected_map);
-    assert_eq!(Rc::new(map).to_redis_args(), expected_map);
-}
-
-#[test]
-fn test_large_usize_array_to_redis_args_and_back() {
-    use crate::support::encode_value;
-
-    let mut array = [0; 1000];
-    for (i, item) in array.iter_mut().enumerate() {
-        *item = i;
+            let v: RedisResult<CString> = parse_mode.parse_redis_value(Value::Int(42));
+            assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+        }
     }
 
-    let vec = (&array).to_redis_args();
-    assert_eq!(array.len(), vec.len());
+    #[test]
+    fn test_std_types_to_redis_args() {
+        use std::collections::BTreeMap;
+        use std::collections::BTreeSet;
+        use std::collections::HashMap;
+        use std::collections::HashSet;
 
-    let value = Value::Array(
-        vec.iter()
-            .map(|val| Value::BulkString(val.clone()))
-            .collect(),
-    );
-    let mut encoded_input = Vec::new();
-    encode_value(&value, &mut encoded_input).unwrap();
+        assert!(!5i32.to_redis_args().is_empty());
+        assert!(!"abc".to_redis_args().is_empty());
+        assert!(!"abc".to_redis_args().is_empty());
+        assert!(!String::from("x").to_redis_args().is_empty());
 
-    let new_array: [usize; 1000] = FromRedisValue::from_redis_value(&value).unwrap();
-    assert_eq!(new_array, array);
-}
+        assert!(![5, 4]
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>()
+            .to_redis_args()
+            .is_empty());
 
-#[test]
-fn test_large_u8_array_to_redis_args_and_back() {
-    use crate::support::encode_value;
+        assert!(![5, 4]
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>()
+            .to_redis_args()
+            .is_empty());
 
-    let mut array: [u8; 1000] = [0; 1000];
-    for (i, item) in array.iter_mut().enumerate() {
-        *item = (i % 256) as u8;
+        // this can be used on something HMSET
+        assert!(![("a", 5), ("b", 6), ("C", 7)]
+            .iter()
+            .cloned()
+            .collect::<BTreeMap<_, _>>()
+            .to_redis_args()
+            .is_empty());
+
+        // this can also be used on something HMSET
+        assert!(![("d", 8), ("e", 9), ("f", 10)]
+            .iter()
+            .cloned()
+            .collect::<HashMap<_, _>>()
+            .to_redis_args()
+            .is_empty());
     }
 
-    let vec = (&array).to_redis_args();
-    assert_eq!(vec.len(), 1);
-    assert_eq!(array.len(), vec[0].len());
+    #[test]
+    #[allow(unused_allocation)]
+    fn test_deref_types_to_redis_args() {
+        use std::collections::BTreeMap;
 
-    let value = Value::Array(vec[0].iter().map(|val| Value::Int(*val as i64)).collect());
-    let mut encoded_input = Vec::new();
-    encode_value(&value, &mut encoded_input).unwrap();
+        let number = 456i64;
+        let expected_result = number.to_redis_args();
+        assert_eq!(Arc::new(number).to_redis_args(), expected_result);
+        assert_eq!(Arc::new(&number).to_redis_args(), expected_result);
+        assert_eq!(Box::new(number).to_redis_args(), expected_result);
+        assert_eq!(Rc::new(&number).to_redis_args(), expected_result);
 
-    let new_array: [u8; 1000] = FromRedisValue::from_redis_value(&value).unwrap();
-    assert_eq!(new_array, array);
-}
+        let array = vec![1, 2, 3];
+        let expected_array = array.to_redis_args();
+        assert_eq!(Arc::new(array.clone()).to_redis_args(), expected_array);
+        assert_eq!(Arc::new(&array).to_redis_args(), expected_array);
+        assert_eq!(Box::new(array.clone()).to_redis_args(), expected_array);
+        assert_eq!(Rc::new(array.clone()).to_redis_args(), expected_array);
 
-#[test]
-fn test_large_string_array_to_redis_args_and_back() {
-    use crate::support::encode_value;
-
-    let mut array: [String; 1000] = [(); 1000].map(|_| String::new());
-    for (i, item) in array.iter_mut().enumerate() {
-        *item = format!("{i}");
+        let map = [("k1", "v1"), ("k2", "v2")]
+            .into_iter()
+            .collect::<BTreeMap<_, _>>();
+        let expected_map = map.to_redis_args();
+        assert_eq!(Arc::new(map.clone()).to_redis_args(), expected_map);
+        assert_eq!(Box::new(map.clone()).to_redis_args(), expected_map);
+        assert_eq!(Rc::new(map).to_redis_args(), expected_map);
     }
 
-    let vec = (&array).to_redis_args();
-    assert_eq!(array.len(), vec.len());
+    #[test]
+    fn test_large_usize_array_to_redis_args_and_back() {
+        use crate::support::encode_value;
 
-    let value = Value::Array(
-        vec.iter()
-            .map(|val| Value::BulkString(val.clone()))
-            .collect(),
-    );
-    let mut encoded_input = Vec::new();
-    encode_value(&value, &mut encoded_input).unwrap();
+        let mut array = [0; 1000];
+        for (i, item) in array.iter_mut().enumerate() {
+            *item = i;
+        }
 
-    let new_array: [String; 1000] = FromRedisValue::from_redis_value(&value).unwrap();
-    assert_eq!(new_array, array);
-}
+        let vec = (&array).to_redis_args();
+        assert_eq!(array.len(), vec.len());
 
-#[test]
-fn test_0_length_usize_array_to_redis_args_and_back() {
-    use crate::support::encode_value;
+        let value = Value::Array(
+            vec.iter()
+                .map(|val| Value::BulkString(val.clone()))
+                .collect(),
+        );
+        let mut encoded_input = Vec::new();
+        encode_value(&value, &mut encoded_input).unwrap();
 
-    let array: [usize; 0] = [0; 0];
-
-    let vec = (&array).to_redis_args();
-    assert_eq!(array.len(), vec.len());
-
-    let value = Value::Array(
-        vec.iter()
-            .map(|val| Value::BulkString(val.clone()))
-            .collect(),
-    );
-    let mut encoded_input = Vec::new();
-    encode_value(&value, &mut encoded_input).unwrap();
-
-    let new_array: [usize; 0] = FromRedisValue::from_redis_value(&value).unwrap();
-    assert_eq!(new_array, array);
-
-    let new_array: [usize; 0] = FromRedisValue::from_redis_value(&Value::Nil).unwrap();
-    assert_eq!(new_array, array);
-}
-
-#[test]
-fn test_attributes() {
-    use redis::parse_redis_value;
-    let bytes: &[u8] = b"*3\r\n:1\r\n:2\r\n|1\r\n+ttl\r\n:3600\r\n:3\r\n";
-    let val = parse_redis_value(bytes).unwrap();
-    {
-        // The case user doesn't expect attributes from server
-        let x: Vec<i32> = redis::FromRedisValue::from_redis_value(&val).unwrap();
-        assert_eq!(x, vec![1, 2, 3]);
+        let new_array: [usize; 1000] = FromRedisValue::from_redis_value(&value).unwrap();
+        assert_eq!(new_array, array);
     }
-    {
-        // The case user wants raw value from server
-        let x: Value = FromRedisValue::from_redis_value(&val).unwrap();
-        assert_eq!(
-            x,
-            Value::Array(vec![
-                Value::Int(1),
-                Value::Int(2),
-                Value::Attribute {
-                    data: Box::new(Value::Int(3)),
-                    attributes: vec![(Value::SimpleString("ttl".to_string()), Value::Int(3600))]
-                }
-            ])
-        )
+
+    #[test]
+    fn test_large_u8_array_to_redis_args_and_back() {
+        use crate::support::encode_value;
+
+        let mut array: [u8; 1000] = [0; 1000];
+        for (i, item) in array.iter_mut().enumerate() {
+            *item = (i % 256) as u8;
+        }
+
+        let vec = (&array).to_redis_args();
+        assert_eq!(vec.len(), 1);
+        assert_eq!(array.len(), vec[0].len());
+
+        let value = Value::Array(vec[0].iter().map(|val| Value::Int(*val as i64)).collect());
+        let mut encoded_input = Vec::new();
+        encode_value(&value, &mut encoded_input).unwrap();
+
+        let new_array: [u8; 1000] = FromRedisValue::from_redis_value(&value).unwrap();
+        assert_eq!(new_array, array);
+    }
+
+    #[test]
+    fn test_large_string_array_to_redis_args_and_back() {
+        use crate::support::encode_value;
+
+        let mut array: [String; 1000] = [(); 1000].map(|_| String::new());
+        for (i, item) in array.iter_mut().enumerate() {
+            *item = format!("{i}");
+        }
+
+        let vec = (&array).to_redis_args();
+        assert_eq!(array.len(), vec.len());
+
+        let value = Value::Array(
+            vec.iter()
+                .map(|val| Value::BulkString(val.clone()))
+                .collect(),
+        );
+        let mut encoded_input = Vec::new();
+        encode_value(&value, &mut encoded_input).unwrap();
+
+        let new_array: [String; 1000] = FromRedisValue::from_redis_value(&value).unwrap();
+        assert_eq!(new_array, array);
+    }
+
+    #[test]
+    fn test_0_length_usize_array_to_redis_args_and_back() {
+        use crate::support::encode_value;
+
+        let array: [usize; 0] = [0; 0];
+
+        let vec = (&array).to_redis_args();
+        assert_eq!(array.len(), vec.len());
+
+        let value = Value::Array(
+            vec.iter()
+                .map(|val| Value::BulkString(val.clone()))
+                .collect(),
+        );
+        let mut encoded_input = Vec::new();
+        encode_value(&value, &mut encoded_input).unwrap();
+
+        let new_array: [usize; 0] = FromRedisValue::from_redis_value(&value).unwrap();
+        assert_eq!(new_array, array);
+
+        let new_array: [usize; 0] = FromRedisValue::from_redis_value(&Value::Nil).unwrap();
+        assert_eq!(new_array, array);
+    }
+
+    #[test]
+    fn test_attributes() {
+        use redis::parse_redis_value;
+        let bytes: &[u8] = b"*3\r\n:1\r\n:2\r\n|1\r\n+ttl\r\n:3600\r\n:3\r\n";
+        let val = parse_redis_value(bytes).unwrap();
+        {
+            // The case user doesn't expect attributes from server
+            let x: Vec<i32> = redis::FromRedisValue::from_redis_value(&val).unwrap();
+            assert_eq!(x, vec![1, 2, 3]);
+        }
+        {
+            // The case user wants raw value from server
+            let x: Value = FromRedisValue::from_redis_value(&val).unwrap();
+            assert_eq!(
+                x,
+                Value::Array(vec![
+                    Value::Int(1),
+                    Value::Int(2),
+                    Value::Attribute {
+                        data: Box::new(Value::Int(3)),
+                        attributes: vec![(
+                            Value::SimpleString("ttl".to_string()),
+                            Value::Int(3600)
+                        )]
+                    }
+                ])
+            )
+        }
     }
 }


### PR DESCRIPTION
With these macros(kudos to serde crate) it will be very easy to add other std types like `Mutex`,`Rc`,`ArcWeak` 

I think this PR might contains breaking changes for some users because from now you need to specify output type. See `test_vec` function.  