### PR TITLE
Expose Errors in `Value`

### DIFF
--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -372,7 +372,7 @@ where
     pub fn on_message(&mut self) -> impl Stream<Item = Msg> + '_ {
         ValueCodec::default()
             .framed(&mut self.0.con)
-            .filter_map(|msg| Box::pin(async move { Msg::from_owned_value(msg.ok()?.ok()?) }))
+            .filter_map(|msg| Box::pin(async move { Msg::from_owned_value(msg.ok()?) }))
     }
 
     /// Returns [`Stream`] of [`Msg`]s from this [`PubSub`]s subscriptions consuming it.
@@ -384,7 +384,7 @@ where
     pub fn into_on_message(self) -> impl Stream<Item = Msg> {
         ValueCodec::default()
             .framed(self.0.con)
-            .filter_map(|msg| Box::pin(async move { Msg::from_owned_value(msg.ok()?.ok()?) }))
+            .filter_map(|msg| Box::pin(async move { Msg::from_owned_value(msg.ok()?) }))
     }
 
     /// Exits from `PubSub` mode and converts [`PubSub`] into [`Connection`].
@@ -415,7 +415,7 @@ where
         ValueCodec::default()
             .framed(&mut self.0.con)
             .filter_map(|value| {
-                Box::pin(async move { T::from_owned_redis_value(value.ok()?.ok()?).ok() })
+                Box::pin(async move { T::from_owned_redis_value(value.ok()?).ok() })
             })
     }
 
@@ -424,7 +424,7 @@ where
         ValueCodec::default()
             .framed(self.0.con)
             .filter_map(|value| {
-                Box::pin(async move { T::from_owned_redis_value(value.ok()?.ok()?).ok() })
+                Box::pin(async move { T::from_owned_redis_value(value.ok()?).ok() })
             })
     }
 }

--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -258,10 +258,18 @@ where
 
             for _ in 0..offset {
                 let response = self.read_response().await;
-                if let Err(err) = response {
-                    if first_err.is_none() {
-                        first_err = Some(err);
+                match response {
+                    Ok(Value::ServerError(err)) => {
+                        if first_err.is_none() {
+                            first_err = Some(err.into());
+                        }
                     }
+                    Err(err) => {
+                        if first_err.is_none() {
+                            first_err = Some(err);
+                        }
+                    }
+                    _ => {}
                 }
             }
 

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -15,7 +15,7 @@ use futures_util::{
     future::{Future, FutureExt},
     ready,
     sink::Sink,
-    stream::{self, Stream, StreamExt, TryStreamExt as _},
+    stream::{self, Stream, StreamExt},
 };
 use pin_project_lite::pin_project;
 use std::collections::VecDeque;
@@ -465,9 +465,7 @@ impl MultiplexedConnection {
         compile_error!("tokio-comp or async-std-comp features required for aio feature");
 
         let redis_connection_info = &connection_info.redis;
-        let codec = ValueCodec::default()
-            .framed(stream)
-            .and_then(|msg| async move { msg });
+        let codec = ValueCodec::default().framed(stream);
         let (mut pipeline, driver) = Pipeline::new(codec);
         let driver = boxed(driver);
         let pm = PushManager::default();

--- a/redis/src/cluster_pipeline.rs
+++ b/redis/src/cluster_pipeline.rs
@@ -121,7 +121,7 @@ impl ClusterPipeline {
         from_owned_redis_value(if self.commands.is_empty() {
             Value::Array(vec![])
         } else {
-            self.make_pipeline_results(con.execute_pipeline(self)?)
+            self.make_pipeline_results(con.execute_pipeline(self)?)?
         })
     }
 

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -423,7 +423,7 @@ impl Cmd {
     #[inline]
     pub fn query<T: FromRedisValue>(&self, con: &mut dyn ConnectionLike) -> RedisResult<T> {
         match con.req_command(self) {
-            Ok(val) => from_owned_redis_value(val),
+            Ok(val) => from_owned_redis_value(val.extract_error()?),
             Err(e) => Err(e),
         }
     }
@@ -436,7 +436,7 @@ impl Cmd {
         C: crate::aio::ConnectionLike,
     {
         let val = con.req_packed_command(self).await?;
-        from_owned_redis_value(val)
+        from_owned_redis_value(val.extract_error()?)
     }
 
     /// Similar to `query()` but returns an iterator over the items of the

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -1351,6 +1351,15 @@ impl ConnectionLike for Connection {
             // See: https://github.com/redis-rs/redis-rs/issues/436
             let response = self.read_response();
             match response {
+                Ok(Value::ServerError(err)) => {
+                    if idx < offset {
+                        if first_err.is_none() {
+                            first_err = Some(err.into());
+                        }
+                    } else {
+                        rv.push(Value::ServerError(err));
+                    }
+                }
                 Ok(item) => {
                     // RESP3 can insert push data between command replies
                     if let Value::Push {

--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -81,11 +81,11 @@ impl Pipeline {
     }
 
     fn execute_pipelined(&self, con: &mut dyn ConnectionLike) -> RedisResult<Value> {
-        Ok(self.make_pipeline_results(con.req_packed_commands(
+        self.make_pipeline_results(con.req_packed_commands(
             &encode_pipeline(&self.commands, false),
             0,
             self.commands.len(),
-        )?))
+        )?)
     }
 
     fn execute_transaction(&self, con: &mut dyn ConnectionLike) -> RedisResult<Value> {
@@ -94,9 +94,10 @@ impl Pipeline {
             self.commands.len() + 1,
             1,
         )?;
+
         match resp.pop() {
             Some(Value::Nil) => Ok(Value::Nil),
-            Some(Value::Array(items)) => Ok(self.make_pipeline_results(items)),
+            Some(Value::Array(items)) => self.make_pipeline_results(items),
             _ => fail!((
                 ErrorKind::ResponseError,
                 "Invalid response when parsing multi response"
@@ -129,13 +130,15 @@ impl Pipeline {
                 "This connection does not support pipelining."
             ));
         }
-        from_owned_redis_value(if self.commands.is_empty() {
+        let value = if self.commands.is_empty() {
             Value::Array(vec![])
         } else if self.transaction_mode {
             self.execute_transaction(con)?
         } else {
             self.execute_pipelined(con)?
-        })
+        };
+
+        from_owned_redis_value(value.extract_error()?)
     }
 
     #[cfg(feature = "aio")]
@@ -146,7 +149,7 @@ impl Pipeline {
         let value = con
             .req_packed_commands(self, 0, self.commands.len())
             .await?;
-        Ok(self.make_pipeline_results(value))
+        self.make_pipeline_results(value)
     }
 
     #[cfg(feature = "aio")]
@@ -159,7 +162,7 @@ impl Pipeline {
             .await?;
         match resp.pop() {
             Some(Value::Nil) => Ok(Value::Nil),
-            Some(Value::Array(items)) => Ok(self.make_pipeline_results(items)),
+            Some(Value::Array(items)) => self.make_pipeline_results(items),
             _ => Err((
                 ErrorKind::ResponseError,
                 "Invalid response when parsing multi response",
@@ -175,14 +178,14 @@ impl Pipeline {
     where
         C: crate::aio::ConnectionLike,
     {
-        let v = if self.commands.is_empty() {
+        let value = if self.commands.is_empty() {
             return from_owned_redis_value(Value::Array(vec![]));
         } else if self.transaction_mode {
             self.execute_transaction_async(con).await?
         } else {
             self.execute_pipelined_async(con).await?
         };
-        from_owned_redis_value(v)
+        from_owned_redis_value(value.extract_error()?)
     }
 
     /// This is a shortcut to `query()` that does not return a value and
@@ -302,14 +305,16 @@ macro_rules! implement_pipeline_commands {
                 &mut self.commands[idx]
             }
 
-            fn make_pipeline_results(&self, resp: Vec<Value>) -> Value {
+            fn make_pipeline_results(&self, resp: Vec<Value>) -> RedisResult<Value> {
+                let resp = Value::extract_error_vec(resp)?;
+
                 let mut rv = Vec::with_capacity(resp.len() - self.ignored_commands.len());
                 for (idx, result) in resp.into_iter().enumerate() {
                     if !self.ignored_commands.contains(&idx) {
                         rv.push(result);
                     }
                 }
-                Value::Array(rv)
+                Ok(Value::Array(rv))
             }
         }
 

--- a/redis/tests/parser.rs
+++ b/redis/tests/parser.rs
@@ -84,6 +84,9 @@ impl ::quickcheck::Arbitrary for ArbitraryValue {
                 })]
                 .into_iter(),
             ),
+            Value::ServerError(ref i) => {
+                Box::new(vec![ArbitraryValue(Value::ServerError(i.clone()))].into_iter())
+            }
         }
     }
 }

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -627,6 +627,10 @@ where
             }
             Ok(())
         }
+        Value::ServerError(ref err) => match err.details() {
+            Some(details) => write!(writer, "-{} {details}\r\n", err.code()),
+            None => write!(writer, "-{}\r\n", err.code()),
+        },
     }
 }
 

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -7,7 +7,7 @@ mod basic_async {
     use futures::{prelude::*, StreamExt};
     use redis::{
         aio::{ConnectionLike, MultiplexedConnection},
-        cmd, pipe, AsyncCommands, ConnectionInfo, ErrorKind, PushInfo, PushKind,
+        cmd, pipe, AsyncCommands, ConnectionInfo, ErrorKind, ProtocolVersion, PushInfo, PushKind,
         RedisConnectionInfo, RedisResult, ScanOptions, Value,
     };
     use tokio::{sync::mpsc::error::TryRecvError, time::timeout};
@@ -673,8 +673,6 @@ mod basic_async {
     mod pub_sub {
         use std::time::Duration;
 
-        use redis::ProtocolVersion;
-
         use super::*;
 
         #[test]
@@ -1051,8 +1049,6 @@ mod basic_async {
     #[test]
     #[cfg(feature = "connection-manager")]
     fn test_push_manager_cm() {
-        use redis::ProtocolVersion;
-
         let ctx = TestContext::new();
         let mut connection_info = ctx.server.connection_info();
         connection_info.redis.protocol = ProtocolVersion::RESP3;

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -485,7 +485,7 @@ mod basic {
             .ignore()
             .get("y")
             .query::<()>(&mut con);
-        assert!(res.is_err() && res.unwrap_err().kind() == ErrorKind::ReadOnly);
+        assert_eq!(res.unwrap_err().kind(), ErrorKind::ReadOnly);
 
         // Make sure we don't get leftover responses from the pipeline ("y-value"). See #436.
         let res = redis::cmd("GET")


### PR DESCRIPTION
1. Remove `InternalValue` and add the `ServerError` variant to `Value`.
2. Don't convert `ServerError`s in the parser to `RedisError`. In order to maintain the behavior of the high level APIs (query/_async), they now call `extract_error`.
3. Used the internal error in order to pipeline connection setup requests - this can remove some back-and-forth with the server, and thus reduce connection setup time.