### PR TITLE
Route unkeyed commands to a random node.

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -1491,6 +1491,7 @@ mod pipeline_routing_tests {
             .get("foo") // route to replica of slot 12182
             .add_command(cmd("FLUSHALL")) // route to all masters
             .add_command(cmd("EVAL"))// route randomly
+            .cmd("CONFIG").arg("GET").arg("timeout") // unkeyed command
             .set("foo", "bar"); // route to primary of slot 12182
 
         assert_eq!(
@@ -1511,6 +1512,23 @@ mod pipeline_routing_tests {
         assert_eq!(
             route_for_pipeline(&pipeline).unwrap_err().kind(),
             crate::ErrorKind::CrossSlot
+        );
+    }
+
+    #[test]
+    fn unkeyed_commands_dont_affect_route() {
+        let mut pipeline = crate::Pipeline::new();
+
+        pipeline
+            .set("{foo}bar", "baz") // route to primary of slot 12182
+            .cmd("CONFIG").arg("GET").arg("timeout") // unkeyed command
+            .set("foo", "bar") // route to primary of slot 12182
+            .cmd("DEBUG").arg("PAUSE").arg("100") // unkeyed command
+            .cmd("ECHO").arg("hello world"); // unkeyed command
+
+        assert_eq!(
+            route_for_pipeline(&pipeline),
+            Ok(Some(Route::new(12182, SlotAddr::Master)))
         );
     }
 }


### PR DESCRIPTION
Commands which have more arguments that aren't keys (such as `CONFIG SET timeout`) shouldn't be routed according to the hash of the additional arguments - so they must be marked explicitly as routed randomly, otherwise the check in `route_for_pipeline` might erroneously mark it as a cross-slot pipeline.