### PR TITLE
MultiplexedConnection: Report disconnects without polling.

### DIFF
--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -13,6 +13,8 @@ use std::{
 
 #[cfg(feature = "aio")]
 use futures::Future;
+#[cfg(feature = "aio")]
+use redis::{aio, cmd, RedisResult};
 use redis::{ConnectionAddr, InfoDict, Pipeline, ProtocolVersion, RedisConnectionInfo, Value};
 
 #[cfg(feature = "tls-rustls")]
@@ -43,7 +45,7 @@ pub fn current_thread_runtime() -> tokio::runtime::Runtime {
 #[cfg(feature = "aio")]
 pub fn block_on_all<F, V>(f: F) -> F::Output
 where
-    F: Future<Output = redis::RedisResult<V>>,
+    F: Future<Output = RedisResult<V>>,
 {
     use std::panic;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -508,19 +510,19 @@ impl TestContext {
     }
 
     #[cfg(feature = "aio")]
-    pub async fn async_connection(&self) -> redis::RedisResult<redis::aio::MultiplexedConnection> {
+    pub async fn async_connection(&self) -> RedisResult<redis::aio::MultiplexedConnection> {
         self.client.get_multiplexed_async_connection().await
     }
 
     #[cfg(feature = "aio")]
-    pub async fn async_pubsub(&self) -> redis::RedisResult<redis::aio::PubSub> {
+    pub async fn async_pubsub(&self) -> RedisResult<redis::aio::PubSub> {
         self.client.get_async_pubsub().await
     }
 
     #[cfg(feature = "async-std-comp")]
     pub async fn async_connection_async_std(
         &self,
-    ) -> redis::RedisResult<redis::aio::MultiplexedConnection> {
+    ) -> RedisResult<redis::aio::MultiplexedConnection> {
         self.client.get_multiplexed_async_std_connection().await
     }
 
@@ -531,21 +533,21 @@ impl TestContext {
     #[cfg(feature = "tokio-comp")]
     pub async fn multiplexed_async_connection(
         &self,
-    ) -> redis::RedisResult<redis::aio::MultiplexedConnection> {
+    ) -> RedisResult<redis::aio::MultiplexedConnection> {
         self.multiplexed_async_connection_tokio().await
     }
 
     #[cfg(feature = "tokio-comp")]
     pub async fn multiplexed_async_connection_tokio(
         &self,
-    ) -> redis::RedisResult<redis::aio::MultiplexedConnection> {
+    ) -> RedisResult<redis::aio::MultiplexedConnection> {
         self.client.get_multiplexed_tokio_connection().await
     }
 
     #[cfg(feature = "async-std-comp")]
     pub async fn multiplexed_async_connection_async_std(
         &self,
-    ) -> redis::RedisResult<redis::aio::MultiplexedConnection> {
+    ) -> RedisResult<redis::aio::MultiplexedConnection> {
         self.client.get_multiplexed_async_std_connection().await
     }
 
@@ -802,7 +804,7 @@ pub(crate) fn build_single_client<T: redis::IntoConnectionInfo>(
     connection_info: T,
     tls_file_params: &Option<TlsFilePaths>,
     mtls_enabled: bool,
-) -> redis::RedisResult<redis::Client> {
+) -> RedisResult<redis::Client> {
     if mtls_enabled && tls_file_params.is_some() {
         redis::Client::build_with_tls(
             connection_info,

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -821,11 +821,12 @@ mod basic_async {
             use redis::RedisError;
 
             let ctx = TestContext::new();
-            if ctx.protocol == ProtocolVersion::RESP2 {
-                return;
-            }
+            let mut connection_info = ctx.server.connection_info();
+            connection_info.redis.protocol = ProtocolVersion::RESP3;
+            let client = redis::Client::open(connection_info).unwrap();
+
             block_on_all(async move {
-                let mut conn = ctx.multiplexed_async_connection().await?;
+                let mut conn = client.get_multiplexed_async_connection().await?;
                 let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
                 let pub_count = 10;
                 let channel_name = "phonewave".to_string();
@@ -872,11 +873,12 @@ mod basic_async {
             use redis::RedisError;
 
             let ctx = TestContext::new();
-            if ctx.protocol == ProtocolVersion::RESP2 {
-                return;
-            }
+            let mut connection_info = ctx.server.connection_info();
+            connection_info.redis.protocol = ProtocolVersion::RESP3;
+            let client = redis::Client::open(connection_info).unwrap();
+
             block_on_all(async move {
-                let mut conn = ctx.multiplexed_async_connection().await?;
+                let mut conn = client.get_multiplexed_async_connection().await?;
                 let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
                 conn.get_push_manager().replace_sender(tx.clone());
 
@@ -1077,14 +1079,12 @@ mod basic_async {
         use redis::ProtocolVersion;
 
         let ctx = TestContext::new();
-        if ctx.protocol == ProtocolVersion::RESP2 {
-            return;
-        }
+        let mut connection_info = ctx.server.connection_info();
+        connection_info.redis.protocol = ProtocolVersion::RESP3;
+        let client = redis::Client::open(connection_info).unwrap();
 
         block_on_all(async move {
-            let mut manager = redis::aio::ConnectionManager::new(ctx.client.clone())
-                .await
-                .unwrap();
+            let mut manager = redis::aio::ConnectionManager::new(client).await.unwrap();
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
             manager.get_push_manager().replace_sender(tx.clone());
             manager

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -569,37 +569,7 @@ mod basic_async {
         let ctx = TestContext::new();
 
         let mut conn_to_kill = ctx.async_connection().await.unwrap();
-        cmd("CLIENT")
-            .arg("SETNAME")
-            .arg("to-kill")
-            .query_async::<_, ()>(&mut conn_to_kill)
-            .await
-            .unwrap();
-
-        let client_list: String = cmd("CLIENT")
-            .arg("LIST")
-            .query_async(&mut conn_to_kill)
-            .await
-            .unwrap();
-
-        eprintln!("{client_list}");
-        let client_to_kill = client_list
-            .split('\n')
-            .find(|line| line.contains("to-kill"))
-            .expect("line")
-            .split(' ')
-            .nth(0)
-            .expect("id")
-            .split('=')
-            .nth(1)
-            .expect("id value");
-
-        let mut killer_conn = ctx.async_connection().await.unwrap();
-        let () = cmd("CLIENT")
-            .arg("KILL")
-            .arg("ID")
-            .arg(client_to_kill)
-            .query_async(&mut killer_conn)
+        kill_client_async(&mut conn_to_kill, &ctx.client)
             .await
             .unwrap();
         let mut killed_client = conn_to_kill;
@@ -611,7 +581,7 @@ mod basic_async {
                 Err(err) => break err,
             }
         };
-        assert_eq!(err.kind(), ErrorKind::IoError); // Shouldn't this be IoError?
+        assert_eq!(err.kind(), ErrorKind::IoError);
     }
 
     #[tokio::test]

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -1553,10 +1553,11 @@ mod basic {
     #[test]
     fn test_push_manager() {
         let ctx = TestContext::new();
-        if ctx.protocol == ProtocolVersion::RESP2 {
-            return;
-        }
-        let mut con = ctx.connection();
+        let mut connection_info = ctx.server.connection_info();
+        connection_info.redis.protocol = ProtocolVersion::RESP3;
+        let client = redis::Client::open(connection_info).unwrap();
+
+        let mut con = client.get_connection().unwrap();
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         con.get_push_manager().replace_sender(tx);
         let _ = cmd("CLIENT")
@@ -1608,10 +1609,11 @@ mod basic {
     #[test]
     fn test_push_manager_disconnection() {
         let ctx = TestContext::new();
-        if ctx.protocol == ProtocolVersion::RESP2 {
-            return;
-        }
-        let mut con = ctx.connection();
+        let mut connection_info = ctx.server.connection_info();
+        connection_info.redis.protocol = ProtocolVersion::RESP3;
+        let client = redis::Client::open(connection_info).unwrap();
+
+        let mut con = client.get_connection().unwrap();
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         con.get_push_manager().replace_sender(tx.clone());
 


### PR DESCRIPTION
Fixes https://github.com/redis-rs/redis-rs/issues/1091 for `MultiplexedConnection`.

based over https://github.com/redis-rs/redis-rs/pull/1084