### PR TITLE
Add `invoke_script` to commands to allow for pipelining of scripts

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -165,6 +165,10 @@ required-features = ["cluster-async"]
 [[test]]
 name = "test_bignum"
 
+[[test]]
+name = "test_script"
+required-features = ["script"]
+
 [[bench]]
 name = "bench_basic"
 harness = false

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -1862,7 +1862,6 @@ implement_commands! {
             .arg(count)
     }
 
-
     /// Trim a stream `key` to a MAXLEN count.
     ///
     /// ```text
@@ -1875,6 +1874,36 @@ implement_commands! {
         maxlen: streams::StreamMaxlen
     ) {
         cmd("XTRIM").arg(key).arg(maxlen)
+    }
+
+    // script commands
+
+    /// Adds a prepared script command to the pipeline.
+    #[cfg_attr(feature = "script", doc = r##"
+
+# Examples:
+
+```rust,no_run
+# fn do_something() -> redis::RedisResult<()> {
+# let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+# let mut con = client.get_connection().unwrap();
+let script = redis::Script::new(r"
+    return tonumber(ARGV[1]) + tonumber(ARGV[2]);
+");
+let (a, b): (isize, isize) = redis::pipe()
+    .invoke_script(script.arg(1).arg(2))
+    .invoke_script(script.arg(2).arg(3))
+    .query(&mut con)?;
+
+assert_eq!(a, 3);
+assert_eq!(b, 5);
+# Ok(()) }
+```
+"##)]
+    #[cfg(feature = "script")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "script")))]
+    fn invoke_script<>(invocation: &'a crate::ScriptInvocation<'a>) {
+        &mut invocation.eval_cmd()
     }
 }
 

--- a/redis/src/script.rs
+++ b/redis/src/script.rs
@@ -206,6 +206,7 @@ impl<'a> ScriptInvocation<'a> {
         Ok(hash)
     }
 
+    /// Returns a command to load the script.
     fn load_cmd(&self) -> Cmd {
         let mut cmd = cmd("SCRIPT");
         cmd.arg("LOAD").arg(self.script.code.as_bytes());
@@ -223,7 +224,8 @@ impl<'a> ScriptInvocation<'a> {
             + 4 /* Slots reserved for the length of keys. */
     }
 
-    fn eval_cmd(&self) -> Cmd {
+    /// Returns a command to evalute the command.
+    pub(crate) fn eval_cmd(&self) -> Cmd {
         let args_len = 3 + self.keys.len() + self.args.len();
         let mut cmd = Cmd::with_capacity(args_len, self.estimate_buflen());
         cmd.arg("EVALSHA")

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -914,41 +914,6 @@ mod basic {
     }
 
     #[test]
-    #[cfg(feature = "script")]
-    fn test_script() {
-        let ctx = TestContext::new();
-        let mut con = ctx.connection();
-
-        let script = redis::Script::new(
-            r"
-       return {redis.call('GET', KEYS[1]), ARGV[1]}
-    ",
-        );
-
-        let _: () = redis::cmd("SET")
-            .arg("my_key")
-            .arg("foo")
-            .query(&mut con)
-            .unwrap();
-        let response = script.key("my_key").arg(42).invoke(&mut con);
-
-        assert_eq!(response, Ok(("foo".to_string(), 42)));
-    }
-
-    #[test]
-    #[cfg(feature = "script")]
-    fn test_script_load() {
-        let ctx = TestContext::new();
-        let mut con = ctx.connection();
-
-        let script = redis::Script::new("return 'Hello World'");
-
-        let hash = script.prepare_invoke().load(&mut con);
-
-        assert_eq!(hash, Ok(script.get_hash().to_string()));
-    }
-
-    #[test]
     fn test_tuple_args() {
         let ctx = TestContext::new();
         let mut con = ctx.connection();

--- a/redis/tests/test_script.rs
+++ b/redis/tests/test_script.rs
@@ -1,0 +1,68 @@
+#![cfg(feature = "script")]
+
+mod support;
+
+mod script {
+    use redis::ErrorKind;
+
+    use crate::support::*;
+
+    #[test]
+    fn test_script() {
+        let ctx = TestContext::new();
+        let mut con = ctx.connection();
+
+        let script = redis::Script::new(r"return {redis.call('GET', KEYS[1]), ARGV[1]}");
+
+        let _: () = redis::cmd("SET")
+            .arg("my_key")
+            .arg("foo")
+            .query(&mut con)
+            .unwrap();
+        let response = script.key("my_key").arg(42).invoke(&mut con);
+
+        assert_eq!(response, Ok(("foo".to_string(), 42)));
+    }
+
+    #[test]
+    fn test_script_load() {
+        let ctx = TestContext::new();
+        let mut con = ctx.connection();
+
+        let script = redis::Script::new("return 'Hello World'");
+
+        let hash = script.prepare_invoke().load(&mut con);
+
+        assert_eq!(hash, Ok(script.get_hash().to_string()));
+    }
+
+    #[test]
+    fn test_script_that_is_not_loaded_fails_on_pipeline_invocation() {
+        let ctx = TestContext::new();
+        let mut con = ctx.connection();
+
+        let script = redis::Script::new(r"return tonumber(ARGV[1]) + tonumber(ARGV[2]);");
+        let r: Result<(), _> = redis::pipe()
+            .invoke_script(script.arg(1).arg(2))
+            .query(&mut con);
+        assert_eq!(r.unwrap_err().kind(), ErrorKind::NoScriptError);
+    }
+
+    #[test]
+    fn test_script_pipeline() {
+        let ctx = TestContext::new();
+        let mut con = ctx.connection();
+
+        let script = redis::Script::new(r"return tonumber(ARGV[1]) + tonumber(ARGV[2]);");
+        script.prepare_invoke().load(&mut con).unwrap();
+
+        let (a, b): (isize, isize) = redis::pipe()
+            .invoke_script(script.arg(1).arg(2))
+            .invoke_script(script.arg(2).arg(3))
+            .query(&mut con)
+            .unwrap();
+
+        assert_eq!(a, 3);
+        assert_eq!(b, 5);
+    }
+}


### PR DESCRIPTION
Currently it's not possible to add a script to a pipeline, adds a new method `script` to the pipelines.

I also exposed `eval_cmd` and `load_cmd` in the script invocation.