### PR TITLE
Fix issues that prevented cluster tests from running concurrently.

### DIFF
--- a/redis/benches/bench_cluster.rs
+++ b/redis/benches/bench_cluster.rs
@@ -77,7 +77,8 @@ fn bench_pipeline(c: &mut Criterion, con: &mut redis::cluster::ClusterConnection
 }
 
 fn bench_cluster_setup(c: &mut Criterion) {
-    let cluster = TestClusterContext::new(6, 1);
+    let cluster =
+        TestClusterContext::new_with_config(RedisClusterConfiguration::single_replica_config());
     cluster.wait_for_cluster_up();
 
     let mut con = cluster.connection();
@@ -87,11 +88,9 @@ fn bench_cluster_setup(c: &mut Criterion) {
 
 #[allow(dead_code)]
 fn bench_cluster_read_from_replicas_setup(c: &mut Criterion) {
-    let cluster = TestClusterContext::new_with_cluster_client_builder(
-        6,
-        1,
+    let cluster = TestClusterContext::new_with_config_and_builder(
+        RedisClusterConfiguration::single_replica_config(),
         |builder| builder.read_from_replicas(),
-        false,
     );
     cluster.wait_for_cluster_up();
 

--- a/redis/benches/bench_cluster_async.rs
+++ b/redis/benches/bench_cluster_async.rs
@@ -76,7 +76,8 @@ fn bench_cluster_async(
 }
 
 fn bench_cluster_setup(c: &mut Criterion) {
-    let cluster = TestClusterContext::new(6, 1);
+    let cluster =
+        TestClusterContext::new_with_config(RedisClusterConfiguration::single_replica_config());
     cluster.wait_for_cluster_up();
     let runtime = current_thread_runtime();
     let mut con = runtime.block_on(cluster.async_connection());

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -74,8 +74,8 @@ fn port_in_use(addr: &str) -> bool {
 }
 
 pub struct RedisClusterConfiguration {
-    pub nodes: u16,
-    pub replicas: u16,
+    pub num_nodes: u16,
+    pub num_replicas: u16,
     pub modules: Vec<Module>,
     pub mtls_enabled: bool,
     pub ports: Vec<u16>,
@@ -84,8 +84,8 @@ pub struct RedisClusterConfiguration {
 impl RedisClusterConfiguration {
     pub fn single_replica_config() -> Self {
         Self {
-            nodes: 6,
-            replicas: 1,
+            num_nodes: 6,
+            num_replicas: 1,
             ..Default::default()
         }
     }
@@ -94,8 +94,8 @@ impl RedisClusterConfiguration {
 impl Default for RedisClusterConfiguration {
     fn default() -> Self {
         Self {
-            nodes: 3,
-            replicas: 0,
+            num_nodes: 3,
+            num_replicas: 0,
             modules: vec![],
             mtls_enabled: false,
             ports: vec![],
@@ -120,8 +120,8 @@ impl RedisCluster {
 
     pub fn new(configuration: RedisClusterConfiguration) -> RedisCluster {
         let RedisClusterConfiguration {
-            nodes,
-            replicas,
+            num_nodes: nodes,
+            num_replicas: replicas,
             modules,
             mtls_enabled,
             mut ports,

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -72,6 +72,34 @@ fn port_in_use(addr: &str) -> bool {
     socket.connect(&socket_addr.into()).is_ok()
 }
 
+pub struct RedisClusterConfiguration {
+    pub nodes: u16,
+    pub replicas: u16,
+    pub modules: Vec<Module>,
+    pub mtls_enabled: bool,
+}
+
+impl RedisClusterConfiguration {
+    pub fn single_replica_config() -> Self {
+        Self {
+            nodes: 6,
+            replicas: 1,
+            ..Default::default()
+        }
+    }
+}
+
+impl Default for RedisClusterConfiguration {
+    fn default() -> Self {
+        Self {
+            nodes: 3,
+            replicas: 0,
+            modules: vec![],
+            mtls_enabled: false,
+        }
+    }
+}
+
 pub struct RedisCluster {
     pub servers: Vec<RedisServer>,
     pub folders: Vec<TempDir>,
@@ -87,21 +115,14 @@ impl RedisCluster {
         "world"
     }
 
-    pub fn new(nodes: u16, replicas: u16) -> RedisCluster {
-        RedisCluster::with_modules(nodes, replicas, &[], false)
-    }
+    pub fn new(configuration: RedisClusterConfiguration) -> RedisCluster {
+        let RedisClusterConfiguration {
+            nodes,
+            replicas,
+            modules,
+            mtls_enabled,
+        } = configuration;
 
-    #[cfg(feature = "tls-rustls")]
-    pub fn new_with_mtls(nodes: u16, replicas: u16) -> RedisCluster {
-        RedisCluster::with_modules(nodes, replicas, &[], true)
-    }
-
-    pub fn with_modules(
-        nodes: u16,
-        replicas: u16,
-        modules: &[Module],
-        mtls_enabled: bool,
-    ) -> RedisCluster {
         let mut servers = vec![];
         let mut folders = vec![];
         let mut addrs = vec![];
@@ -132,7 +153,7 @@ impl RedisCluster {
                 None,
                 tls_paths.clone(),
                 mtls_enabled,
-                modules,
+                &modules,
                 |cmd| {
                     let tempdir = tempfile::Builder::new()
                         .prefix("redis")
@@ -345,25 +366,40 @@ pub struct TestClusterContext {
 }
 
 impl TestClusterContext {
-    pub fn new(nodes: u16, replicas: u16) -> TestClusterContext {
-        Self::new_with_cluster_client_builder(nodes, replicas, identity, false)
+    pub fn new() -> TestClusterContext {
+        Self::new_with_config(RedisClusterConfiguration::default())
     }
 
-    #[cfg(feature = "tls-rustls")]
-    pub fn new_with_mtls(nodes: u16, replicas: u16) -> TestClusterContext {
-        Self::new_with_cluster_client_builder(nodes, replicas, identity, true)
+    pub fn new_with_mtls() -> TestClusterContext {
+        Self::new_with_config_and_builder(
+            RedisClusterConfiguration {
+                mtls_enabled: true,
+                ..Default::default()
+            },
+            identity,
+        )
     }
 
-    pub fn new_with_cluster_client_builder<F>(
-        nodes: u16,
-        replicas: u16,
+    pub fn new_with_config(cluster_config: RedisClusterConfiguration) -> TestClusterContext {
+        Self::new_with_config_and_builder(cluster_config, identity)
+    }
+
+    pub fn new_with_cluster_client_builder<F>(initializer: F) -> TestClusterContext
+    where
+        F: FnOnce(redis::cluster::ClusterClientBuilder) -> redis::cluster::ClusterClientBuilder,
+    {
+        Self::new_with_config_and_builder(RedisClusterConfiguration::default(), initializer)
+    }
+
+    pub fn new_with_config_and_builder<F>(
+        cluster_config: RedisClusterConfiguration,
         initializer: F,
-        mtls_enabled: bool,
     ) -> TestClusterContext
     where
         F: FnOnce(redis::cluster::ClusterClientBuilder) -> redis::cluster::ClusterClientBuilder,
     {
-        let cluster = RedisCluster::new(nodes, replicas);
+        let mtls_enabled = cluster_config.mtls_enabled;
+        let cluster = RedisCluster::new(cluster_config);
         let initial_nodes: Vec<ConnectionInfo> = cluster
             .iter_servers()
             .map(RedisServer::connection_info)

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -198,8 +198,10 @@ impl RedisCluster {
 
                         match process.try_wait() {
                             Ok(Some(status)) => {
+                                let stdout = process.stdout;
+                                let stderr = process.stderr;
                                 let err =
-                                    format!("redis server creation failed with status {status:?}");
+                                    format!("redis server creation failed with status {status:?}.\nstdout: `{stdout:?}`.\nstderr: `{stderr:?}`");
                                 if cur_attempts == max_attempts {
                                     panic!("{err}");
                                 }
@@ -207,7 +209,8 @@ impl RedisCluster {
                                 cur_attempts += 1;
                             }
                             Ok(None) => {
-                                let max_attempts = 20;
+                                // wait for 10 seconds for the server to be available.
+                                let max_attempts = 200;
                                 let mut cur_attempts = 0;
                                 loop {
                                     if cur_attempts == max_attempts {

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -447,7 +447,7 @@ mod cluster {
 
     #[test]
     fn test_cluster_ask_redirect() {
-        let name = "node";
+        let name = "test_cluster_ask_redirect";
         let completed = Arc::new(AtomicI32::new(0));
         let MockEnv {
             mut connection,
@@ -464,7 +464,9 @@ mod cluster {
                     let count = completed.fetch_add(1, Ordering::SeqCst);
                     match port {
                         6379 => match count {
-                            0 => Err(parse_redis_value(b"-ASK 14000 node:6380\r\n")),
+                            0 => Err(parse_redis_value(
+                                b"-ASK 14000 test_cluster_ask_redirect:6380\r\n",
+                            )),
                             _ => panic!("Node should not be called now"),
                         },
                         6380 => match count {
@@ -540,7 +542,7 @@ mod cluster {
 
     #[test]
     fn test_cluster_replica_read() {
-        let name = "node";
+        let name = "test_cluster_replica_read";
 
         // requests should route to replica
         let MockEnv {
@@ -593,7 +595,7 @@ mod cluster {
 
     #[test]
     fn test_cluster_io_error() {
-        let name = "node";
+        let name = "test_cluster_io_error";
         let completed = Arc::new(AtomicI32::new(0));
         let MockEnv {
             mut connection,
@@ -626,7 +628,7 @@ mod cluster {
 
     #[test]
     fn test_cluster_non_retryable_error_should_not_retry() {
-        let name = "node";
+        let name = "test_cluster_non_retryable_error_should_not_retry";
         let completed = Arc::new(AtomicI32::new(0));
         let MockEnv { mut connection, .. } = MockEnv::new(name, {
             let completed = completed.clone();
@@ -652,11 +654,11 @@ mod cluster {
     }
 
     fn test_cluster_fan_out(
+        name: &'static str,
         command: &'static str,
         expected_ports: Vec<u16>,
         slots_config: Option<Vec<MockSlotRange>>,
     ) {
-        let name = "node";
         let found_ports = Arc::new(std::sync::Mutex::new(Vec::new()));
         let ports_clone = found_ports.clone();
         let mut cmd = redis::Cmd::new();
@@ -696,17 +698,28 @@ mod cluster {
 
     #[test]
     fn test_cluster_fan_out_to_all_primaries() {
-        test_cluster_fan_out("FLUSHALL", vec![6379, 6381], None);
+        test_cluster_fan_out(
+            "test_cluster_fan_out_to_all_primaries",
+            "FLUSHALL",
+            vec![6379, 6381],
+            None,
+        );
     }
 
     #[test]
     fn test_cluster_fan_out_to_all_nodes() {
-        test_cluster_fan_out("CONFIG SET", vec![6379, 6380, 6381, 6382], None);
+        test_cluster_fan_out(
+            "test_cluster_fan_out_to_all_nodes",
+            "CONFIG SET",
+            vec![6379, 6380, 6381, 6382],
+            None,
+        );
     }
 
     #[test]
     fn test_cluster_fan_out_out_once_to_each_primary_when_no_replicas_are_available() {
         test_cluster_fan_out(
+            "test_cluster_fan_out_out_once_to_each_primary_when_no_replicas_are_available",
             "CONFIG SET",
             vec![6379, 6381],
             Some(vec![
@@ -727,6 +740,7 @@ mod cluster {
     #[test]
     fn test_cluster_fan_out_out_once_even_if_primary_has_multiple_slot_ranges() {
         test_cluster_fan_out(
+            "test_cluster_fan_out_out_once_even_if_primary_has_multiple_slot_ranges",
             "CONFIG SET",
             vec![6379, 6380, 6381, 6382],
             Some(vec![

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -17,7 +17,7 @@ mod cluster {
 
     #[test]
     fn test_cluster_basics() {
-        let cluster = TestClusterContext::new(3, 0);
+        let cluster = TestClusterContext::new();
         let mut con = cluster.connection();
 
         redis::cmd("SET")
@@ -36,16 +36,11 @@ mod cluster {
 
     #[test]
     fn test_cluster_with_username_and_password() {
-        let cluster = TestClusterContext::new_with_cluster_client_builder(
-            3,
-            0,
-            |builder| {
-                builder
-                    .username(RedisCluster::username().to_string())
-                    .password(RedisCluster::password().to_string())
-            },
-            false,
-        );
+        let cluster = TestClusterContext::new_with_cluster_client_builder(|builder| {
+            builder
+                .username(RedisCluster::username().to_string())
+                .password(RedisCluster::password().to_string())
+        });
         cluster.disable_default_user();
 
         let mut con = cluster.connection();
@@ -66,26 +61,19 @@ mod cluster {
 
     #[test]
     fn test_cluster_with_bad_password() {
-        let cluster = TestClusterContext::new_with_cluster_client_builder(
-            3,
-            0,
-            |builder| {
-                builder
-                    .username(RedisCluster::username().to_string())
-                    .password("not the right password".to_string())
-            },
-            false,
-        );
+        let cluster = TestClusterContext::new_with_cluster_client_builder(|builder| {
+            builder
+                .username(RedisCluster::username().to_string())
+                .password("not the right password".to_string())
+        });
         assert!(cluster.client.get_connection().is_err());
     }
 
     #[test]
     fn test_cluster_read_from_replicas() {
-        let cluster = TestClusterContext::new_with_cluster_client_builder(
-            6,
-            1,
+        let cluster = TestClusterContext::new_with_config_and_builder(
+            RedisClusterConfiguration::single_replica_config(),
             |builder| builder.read_from_replicas(),
-            false,
         );
         let mut con = cluster.connection();
 
@@ -107,7 +95,7 @@ mod cluster {
 
     #[test]
     fn test_cluster_eval() {
-        let cluster = TestClusterContext::new(3, 0);
+        let cluster = TestClusterContext::new();
         let mut con = cluster.connection();
 
         let rv = redis::cmd("EVAL")
@@ -131,7 +119,7 @@ mod cluster {
         if use_protocol() == ProtocolVersion::RESP2 {
             return;
         }
-        let cluster = TestClusterContext::new(3, 0);
+        let cluster = TestClusterContext::new();
 
         let mut connection = cluster.connection();
 
@@ -156,7 +144,7 @@ mod cluster {
 
     #[test]
     fn test_cluster_multi_shard_commands() {
-        let cluster = TestClusterContext::new(3, 0);
+        let cluster = TestClusterContext::new();
 
         let mut connection = cluster.connection();
 
@@ -171,7 +159,7 @@ mod cluster {
     #[test]
     #[cfg(feature = "script")]
     fn test_cluster_script() {
-        let cluster = TestClusterContext::new(3, 0);
+        let cluster = TestClusterContext::new();
         let mut con = cluster.connection();
 
         let script = redis::Script::new(
@@ -188,7 +176,7 @@ mod cluster {
 
     #[test]
     fn test_cluster_pipeline() {
-        let cluster = TestClusterContext::new(3, 0);
+        let cluster = TestClusterContext::new();
         cluster.wait_for_cluster_up();
         let mut con = cluster.connection();
 
@@ -205,7 +193,7 @@ mod cluster {
     #[test]
     fn test_cluster_pipeline_multiple_keys() {
         use redis::FromRedisValue;
-        let cluster = TestClusterContext::new(3, 0);
+        let cluster = TestClusterContext::new();
         cluster.wait_for_cluster_up();
         let mut con = cluster.connection();
 
@@ -241,7 +229,7 @@ mod cluster {
 
     #[test]
     fn test_cluster_pipeline_invalid_command() {
-        let cluster = TestClusterContext::new(3, 0);
+        let cluster = TestClusterContext::new();
         cluster.wait_for_cluster_up();
         let mut con = cluster.connection();
 
@@ -269,7 +257,7 @@ mod cluster {
 
     #[test]
     fn test_cluster_pipeline_command_ordering() {
-        let cluster = TestClusterContext::new(3, 0);
+        let cluster = TestClusterContext::new();
         cluster.wait_for_cluster_up();
         let mut con = cluster.connection();
         let mut pipe = cluster_pipe();
@@ -295,7 +283,7 @@ mod cluster {
     #[test]
     #[ignore] // Flaky
     fn test_cluster_pipeline_ordering_with_improper_command() {
-        let cluster = TestClusterContext::new(3, 0);
+        let cluster = TestClusterContext::new();
         cluster.wait_for_cluster_up();
         let mut con = cluster.connection();
         let mut pipe = cluster_pipe();
@@ -944,7 +932,7 @@ mod cluster {
 
         #[test]
         fn test_cluster_basics_with_mtls() {
-            let cluster = TestClusterContext::new_with_mtls(3, 0);
+            let cluster = TestClusterContext::new_with_mtls();
 
             let client = create_cluster_client_from_cluster(&cluster, true).unwrap();
             let mut con = client.get_connection().unwrap();
@@ -965,7 +953,7 @@ mod cluster {
 
         #[test]
         fn test_cluster_should_not_connect_without_mtls() {
-            let cluster = TestClusterContext::new_with_mtls(3, 0);
+            let cluster = TestClusterContext::new_with_mtls();
 
             let client = create_cluster_client_from_cluster(&cluster, false).unwrap();
             let connection = client.get_connection();

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -163,8 +163,8 @@ mod cluster_async {
     #[test]
     fn test_async_cluster_route_info_to_nodes() {
         let cluster = TestClusterContext::new_with_config(RedisClusterConfiguration {
-            nodes: 12,
-            replicas: 1,
+            num_nodes: 12,
+            num_replicas: 1,
             ..Default::default()
         });
 


### PR DESCRIPTION
1. tests with mocks shared the same handle, so they dropped each other's state.
2. tests with real cluster shared the same ports, so the cluster couldn't run concurrently.