### PR TITLE
Update cluster_async router_command docs

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -84,7 +84,6 @@ where
     }
 
     /// Send a command to the given `routing`, and aggregate the response according to `response_policy`.
-    /// If `routing` is [None], the request will be sent to a random node.
     pub async fn route_command(&mut self, cmd: &Cmd, routing: RoutingInfo) -> RedisResult<Value> {
         trace!("send_packed_command");
         let (sender, receiver) = oneshot::channel();


### PR DESCRIPTION
Since `RoutingInfo` is not an `Option` type, docs should not hint at passing `None` as a parameter