### PR TITLE
Allow splitting async PubSub to Sink &  Stream.

### DIFF
--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -29,6 +29,9 @@ use crate::connection::TlsConnParams;
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio-comp")))]
 pub mod tokio;
 
+mod pubsub;
+pub use pubsub::PubSub;
+
 /// Represents the ability of connecting via TCP or via Unix socket
 #[async_trait]
 pub(crate) trait RedisRuntime: AsyncStream + Send + Sync + Sized + 'static {

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -482,7 +482,6 @@ impl MultiplexedConnection {
             );
         }
         let (pipeline, driver) = Pipeline::new(codec, config.push_sender);
-        let driver = driver.boxed();
         let mut con = MultiplexedConnection {
             pipeline,
             db: connection_info.db,

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -471,12 +471,6 @@ impl MultiplexedConnection {
     where
         C: Unpin + AsyncRead + AsyncWrite + Send + 'static,
     {
-        fn boxed(
-            f: impl Future<Output = ()> + Send + 'static,
-        ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
-            Box::pin(f)
-        }
-
         #[cfg(all(not(feature = "tokio-comp"), not(feature = "async-std-comp")))]
         compile_error!("tokio-comp or async-std-comp features required for aio feature");
 
@@ -488,7 +482,7 @@ impl MultiplexedConnection {
             );
         }
         let (pipeline, driver) = Pipeline::new(codec, config.push_sender);
-        let driver = boxed(driver);
+        let driver = driver.boxed();
         let mut con = MultiplexedConnection {
             pipeline,
             db: connection_info.db,

--- a/redis/src/aio/pubsub.rs
+++ b/redis/src/aio/pubsub.rs
@@ -361,7 +361,6 @@ impl PubSub {
         setup_connection(&mut codec, connection_info).await?;
         let (sender, receiver) = unbounded_channel();
         let (sink, driver) = PubSubSink::new(codec, sender);
-        let driver = driver.boxed();
         let con = PubSub { sink, receiver };
         Ok((con, driver))
     }

--- a/redis/src/aio/pubsub.rs
+++ b/redis/src/aio/pubsub.rs
@@ -4,7 +4,7 @@ use crate::connection::{
 #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
 use crate::parser::ValueCodec;
 use crate::types::{closed_connection_error, RedisError, RedisResult, Value};
-use crate::{cmd, ConnectionInfo, Msg, RedisConnectionInfo};
+use crate::{cmd, ConnectionInfo, Msg, RedisConnectionInfo, ToRedisArgs};
 use ::tokio::{
     io::{AsyncRead, AsyncWrite},
     sync::{mpsc, oneshot},
@@ -260,28 +260,28 @@ impl PubSubSink {
     }
 
     /// Subscribes to a new channel.
-    pub async fn subscribe(&mut self, channel_name: &str) -> RedisResult<()> {
+    pub async fn subscribe(&mut self, channel_name: impl ToRedisArgs) -> RedisResult<()> {
         let mut cmd = cmd("SUBSCRIBE");
         cmd.arg(channel_name);
         self.send_recv(cmd.get_packed_command()).await
     }
 
     /// Unsubscribes from channel.
-    pub async fn unsubscribe(&mut self, channel_name: &str) -> RedisResult<()> {
+    pub async fn unsubscribe(&mut self, channel_name: impl ToRedisArgs) -> RedisResult<()> {
         let mut cmd = cmd("UNSUBSCRIBE");
         cmd.arg(channel_name);
         self.send_recv(cmd.get_packed_command()).await
     }
 
     /// Subscribes to a new channel with pattern.
-    pub async fn psubscribe(&mut self, channel_pattern: &str) -> RedisResult<()> {
+    pub async fn psubscribe(&mut self, channel_pattern: impl ToRedisArgs) -> RedisResult<()> {
         let mut cmd = cmd("PSUBSCRIBE");
         cmd.arg(channel_pattern);
         self.send_recv(cmd.get_packed_command()).await
     }
 
     /// Unsubscribes from channel pattern.
-    pub async fn punsubscribe(&mut self, channel_pattern: &str) -> RedisResult<()> {
+    pub async fn punsubscribe(&mut self, channel_pattern: impl ToRedisArgs) -> RedisResult<()> {
         let mut cmd = cmd("PUNSUBSCRIBE");
         cmd.arg(channel_pattern);
         self.send_recv(cmd.get_packed_command()).await
@@ -376,22 +376,22 @@ impl PubSub {
     }
 
     /// Subscribes to a new channel.
-    pub async fn subscribe(&mut self, channel_name: &str) -> RedisResult<()> {
+    pub async fn subscribe(&mut self, channel_name: impl ToRedisArgs) -> RedisResult<()> {
         self.sink.subscribe(channel_name).await
     }
 
     /// Unsubscribes from channel.
-    pub async fn unsubscribe(&mut self, channel_name: &str) -> RedisResult<()> {
+    pub async fn unsubscribe(&mut self, channel_name: impl ToRedisArgs) -> RedisResult<()> {
         self.sink.unsubscribe(channel_name).await
     }
 
     /// Subscribes to a new channel with pattern.
-    pub async fn psubscribe(&mut self, channel_pattern: &str) -> RedisResult<()> {
+    pub async fn psubscribe(&mut self, channel_pattern: impl ToRedisArgs) -> RedisResult<()> {
         self.sink.psubscribe(channel_pattern).await
     }
 
     /// Unsubscribes from channel pattern.
-    pub async fn punsubscribe(&mut self, channel_pattern: &str) -> RedisResult<()> {
+    pub async fn punsubscribe(&mut self, channel_pattern: impl ToRedisArgs) -> RedisResult<()> {
         self.sink.punsubscribe(channel_pattern).await
     }
 

--- a/redis/src/aio/pubsub.rs
+++ b/redis/src/aio/pubsub.rs
@@ -33,7 +33,7 @@ struct PipelineMessage {
     output: RequestCompletedSignal,
 }
 
-/// A sender to an async task passing the messages to a a `Stream + Sink`.
+/// A sender to an async task passing the messages to a `Stream + Sink`.
 pub struct PubSubSink {
     sender: mpsc::Sender<PipelineMessage>,
 }

--- a/redis/src/aio/runtime.rs
+++ b/redis/src/aio/runtime.rs
@@ -45,7 +45,7 @@ impl Runtime {
     }
 
     #[allow(dead_code)]
-    pub(super) fn spawn(&self, f: impl Future<Output = ()> + Send + 'static) {
+    pub(crate) fn spawn(&self, f: impl Future<Output = ()> + Send + 'static) {
         match self {
             #[cfg(feature = "tokio-comp")]
             Runtime::Tokio => tokio::Tokio::spawn(f),

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -794,7 +794,7 @@ impl Client {
         };
 
         let (connection, driver) =
-            crate::aio::PubSub::new(&self.connection_info, connection).await?;
+            crate::aio::PubSub::new(&self.connection_info.redis, connection).await?;
         rt.spawn(driver);
         Ok(connection)
     }

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -87,6 +87,7 @@ use crate::{
         Slot, SlotMap,
     },
     cluster_topology::parse_slots,
+    types::closed_connection_error,
     Cmd, ConnectionInfo, ErrorKind, IntoConnectionInfo, RedisError, RedisFuture, RedisResult,
     Value,
 };
@@ -186,11 +187,11 @@ where
                 sender,
             })
             .await
-            .map_err(|_| RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe)))?;
+            .map_err(|_| closed_connection_error())?;
 
         receiver
             .await
-            .unwrap_or_else(|_| Err(RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe))))
+            .unwrap_or_else(|_| Err(closed_connection_error()))
             .map(|response| match response {
                 Response::Multiple(values) => values,
                 Response::Single(_) => unreachable!(),

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -281,10 +281,8 @@
 //!
 //! # PubSub
 //!
-//! Pubsub is currently work in progress but provided through the `PubSub`
-//! connection object.  Due to the fact that Rust does not have support
-//! for async IO in libnative yet, the API does not provide a way to
-//! read messages with any form of timeout yet.
+//! Pubsub is provided through the `PubSub` connection object for sync usage, or the `aio::PubSub`
+//! for async usage.
 //!
 //! Example usage:
 //!
@@ -302,6 +300,24 @@
 //!     println!("channel '{}': {}", msg.get_channel_name(), payload);
 //! }
 //! # }
+//! ```
+//! In order to update subscriptions while concurrently waiting for messages, the async PubSub can be split into separate sink & stream components. The sink can be receive subscription requests while the stream is awaited for messages.
+//!
+//! ```rust,no_run
+//! # #[cfg(feature = "aio")]
+//! # use futures_util::StreamExt;
+//! # #[cfg(feature = "aio")]
+//! # async fn do_something() -> redis::RedisResult<()> {
+//! let client = redis::Client::open("redis://127.0.0.1/")?;
+//! let (mut sink, mut stream) = client.get_async_pubsub().await?.split();
+//! sink.subscribe("channel_1").await?;
+//!
+//! loop {
+//!     let msg = stream.next().await.unwrap();
+//!     let payload : String = msg.get_payload().unwrap();
+//!     println!("channel '{}': {}", msg.get_channel_name(), payload);
+//! }
+//! # Ok(()) }
 //! ```
 //!
 //! ## RESP3 async pubsub

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2565,3 +2565,9 @@ pub struct PushInfo {
 pub(crate) type AsyncPushSender = tokio::sync::mpsc::UnboundedSender<PushInfo>;
 
 pub(crate) type SyncPushSender = std::sync::mpsc::Sender<PushInfo>;
+
+// A consistent error value for connections closed without a reason.
+#[cfg(feature = "aio")]
+pub(crate) fn closed_connection_error() -> RedisError {
+    RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe))
+}

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -509,6 +509,12 @@ impl TestContext {
     }
 
     #[cfg(feature = "aio")]
+    #[allow(deprecated)]
+    pub async fn deprecated_async_connection(&self) -> redis::RedisResult<redis::aio::Connection> {
+        self.client.get_async_connection().await
+    }
+
+    #[cfg(feature = "aio")]
     pub async fn async_connection(&self) -> RedisResult<redis::aio::MultiplexedConnection> {
         self.client.get_multiplexed_async_connection().await
     }

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -692,6 +692,30 @@ mod basic_async {
         }
 
         #[test]
+        fn pub_sub_subscription_to_multiple_channels() {
+            use redis::RedisError;
+
+            let ctx = TestContext::new();
+            block_on_all(async move {
+                let mut pubsub_conn = ctx.async_pubsub().await?;
+                let _: () = pubsub_conn.subscribe(&["phonewave", "foo", "bar"]).await?;
+                let mut pubsub_stream = pubsub_conn.on_message();
+                let mut publish_conn = ctx.async_connection().await?;
+                let _: () = publish_conn.publish("phonewave", "banana").await?;
+
+                let msg_payload: String = pubsub_stream.next().await.unwrap().get_payload()?;
+                assert_eq!("banana".to_string(), msg_payload);
+
+                let _: () = publish_conn.publish("foo", "foobar").await?;
+                let msg_payload: String = pubsub_stream.next().await.unwrap().get_payload()?;
+                assert_eq!("foobar".to_string(), msg_payload);
+
+                Ok::<_, RedisError>(())
+            })
+            .unwrap();
+        }
+
+        #[test]
         fn pub_sub_unsubscription() {
             const SUBSCRIPTION_KEY: &str = "phonewave-pub-sub-unsubscription";
 
@@ -723,8 +747,8 @@ mod basic_async {
                 let mut publish_conn = ctx.async_connection().await?;
                 let spawned_read = tokio::spawn(async move { stream.next().await });
 
-                sink.subscribe("phonewave").await?;
-                publish_conn.publish("phonewave", "banana").await?;
+                let _: () = sink.subscribe("phonewave").await?;
+                let _: () = publish_conn.publish("phonewave", "banana").await?;
 
                 let message: String = spawned_read.await.unwrap().unwrap().get_payload().unwrap();
 
@@ -743,9 +767,9 @@ mod basic_async {
                 let mut publish_conn = ctx.async_connection().await?;
                 let spawned_read = tokio::spawn(async move { stream.next().await });
 
-                sink.subscribe("phonewave").await?;
+                let _: () = sink.subscribe("phonewave").await?;
                 drop(sink);
-                publish_conn.publish("phonewave", "banana").await?;
+                let _: () = publish_conn.publish("phonewave", "banana").await?;
 
                 let message: String = spawned_read.await.unwrap().unwrap().get_payload().unwrap();
 
@@ -832,13 +856,11 @@ mod basic_async {
             test_with_all_connection_types(|mut conn| async move {
                 conn.lpush::<&str, &str, ()>("key", "value").await?;
 
-                let res: Result<(String, usize), redis::RedisError> = redis::pipe()
+                redis::pipe()
                 .get("key") // WRONGTYPE
                 .llen("key")
-                .query_async(&mut conn)
-                .await;
-
-                assert!(res.is_err());
+                .exec_async(&mut conn)
+                .await.unwrap_err();
 
                 let list: Vec<String> = conn.lrange("key", 0, -1).await?;
 
@@ -846,6 +868,39 @@ mod basic_async {
 
                 Ok::<_, RedisError>(())
             });
+        }
+
+        #[test]
+        fn multiplexed_pub_sub_subscribe_on_multiple_channels() {
+            let ctx = TestContext::new();
+            if ctx.protocol == ProtocolVersion::RESP2 {
+                return;
+            }
+            block_on_all(async move {
+                let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+                let config = redis::AsyncConnectionConfig::new().set_push_sender(tx);
+                let mut conn = ctx
+                    .client
+                    .get_multiplexed_async_connection_with_config(&config)
+                    .await?;
+                let _: () = conn.subscribe(&["phonewave", "foo", "bar"]).await?;
+                let mut publish_conn = ctx.async_connection().await?;
+
+                let msg_payload = rx.recv().await.unwrap();
+                assert_eq!(msg_payload.kind, PushKind::Subscribe);
+
+                let _: () = publish_conn.publish("foo", "foobar").await?;
+
+                let msg_payload = rx.recv().await.unwrap();
+                assert_eq!(msg_payload.kind, PushKind::Subscribe);
+                let msg_payload = rx.recv().await.unwrap();
+                assert_eq!(msg_payload.kind, PushKind::Subscribe);
+                let msg_payload = rx.recv().await.unwrap();
+                assert_eq!(msg_payload.kind, PushKind::Message);
+
+                Ok(())
+            })
+            .unwrap();
         }
 
         #[test]

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -752,7 +752,7 @@ mod basic_async {
         fn pub_sub_conn_reuse() {
             let ctx = TestContext::new();
             block_on_all(async move {
-                let mut pubsub_conn = ctx.async_pubsub().await?;
+                let mut pubsub_conn = ctx.deprecated_async_connection().await?.into_pubsub();
                 pubsub_conn.subscribe("phonewave").await?;
                 pubsub_conn.psubscribe("*").await?;
 

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -881,6 +881,23 @@ mod basic {
     }
 
     #[test]
+    fn pub_sub_subscription_to_multiple_channels() {
+        let ctx = TestContext::new();
+        let mut conn = ctx.connection();
+        let mut pubsub_conn = conn.as_pubsub();
+        pubsub_conn.subscribe(&["phonewave", "foo", "bar"]).unwrap();
+        let mut publish_conn = ctx.connection();
+
+        let _: () = publish_conn.publish("phonewave", "banana").unwrap();
+        let msg_payload: String = pubsub_conn.get_message().unwrap().get_payload().unwrap();
+        assert_eq!("banana".to_string(), msg_payload);
+
+        let _: () = publish_conn.publish("foo", "foobar").unwrap();
+        let msg_payload: String = pubsub_conn.get_message().unwrap().get_payload().unwrap();
+        assert_eq!("foobar".to_string(), msg_payload);
+    }
+
+    #[test]
     fn test_pubsub_unsubscribe() {
         let ctx = TestContext::new();
         let mut con = ctx.connection();


### PR DESCRIPTION
This PR adds a new implementation for async pubsub, with the main differences - 
1. The new `PubSub` can be split into a `Sink` and `Stream` structs, so that calls to subscribe / unsubscribe won't prevent the user from listening for messages, due to both `on_message` and `un/subscribe` requiring a mutable reference to the connection.
2. Like the MultiplexedConnection (from which a lot of the its code was copied), it spawns a task that reads & writes from the underlying TCP connection, so that reading from the TCP stream doesn't wait for `await` calls on the user-facing APIs. This is important, because it means the the sink and the stream don't affect each other - if the internal polling waited for some external polling, one of these APIs would've had to wait for the user to `await` the other before progressing

For backwards compatibility, the old implementation wasn't removed - it's just no longer available through `Client`.

based over https://github.com/redis-rs/redis-rs/pull/1250.