### PR TITLE
Fix compilation on Windows.

### DIFF
--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -11,13 +11,11 @@ use crate::cmd::{cmd, pipe, Cmd};
 use crate::parser::Parser;
 use crate::pipeline::Pipeline;
 use crate::types::{
-    from_redis_value, ErrorKind, FromRedisValue, PushKind, RedisError, RedisResult, ToRedisArgs,
-    Value,
+    from_redis_value, ErrorKind, FromRedisValue, HashMap, PushKind, RedisError, RedisResult,
+    ToRedisArgs, Value,
 };
 use crate::{from_owned_redis_value, ProtocolVersion};
 
-#[cfg(unix)]
-use crate::types::HashMap;
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
 use std::vec::IntoIter;


### PR DESCRIPTION
Fix compilation error occurs on Windows only. Looks like a mistake IMHO.
```
...
   Compiling redis v0.25.0 (C:\GitHub\redis-rs\redis)
error[E0412]: cannot find type `HashMap` in this scope
   --> C:\GitHub\redis-rs\redis\src\connection.rs:355:16
    |
355 |     let query: HashMap<_, _> = url.query_pairs().collect();
    |                ^^^^^^^ not found in this scope
    |
help: consider importing one of these items
    |
1   + use combine::lib::collections::HashMap;
    |
1   + use crate::types::HashMap;
    |
1   + use std::collections::HashMap;
    |

For more information about this error, try `rustc --explain E0412`.
error: could not compile `redis` (lib) due to previous error
```