### PR TITLE
Add un/subscribe commands to `aio::ConnectionManager`.

### DIFF
--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -168,3 +168,17 @@ pub use connection_manager::*;
 mod runtime;
 use crate::commands::resp3_hello;
 pub(super) use runtime::*;
+
+macro_rules! check_resp3 {
+    ($protocol: expr) => {
+        use crate::types::ProtocolVersion;
+        if $protocol == ProtocolVersion::RESP2 {
+            return Err(RedisError::from((
+                crate::ErrorKind::InvalidClientConfig,
+                "RESP3 is required for this command",
+            )));
+        }
+    };
+}
+
+pub(crate) use check_resp3;

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -1,5 +1,5 @@
 use super::{ConnectionLike, Runtime};
-use crate::aio::setup_connection;
+use crate::aio::{check_resp3, setup_connection};
 use crate::cmd::Cmd;
 #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
 use crate::parser::ValueCodec;
@@ -585,15 +585,11 @@ impl ConnectionLike for MultiplexedConnection {
         self.db
     }
 }
+
 impl MultiplexedConnection {
     /// Subscribes to a new channel.
     pub async fn subscribe(&mut self, channel_name: impl ToRedisArgs) -> RedisResult<()> {
-        if self.protocol == ProtocolVersion::RESP2 {
-            return Err(RedisError::from((
-                crate::ErrorKind::InvalidClientConfig,
-                "RESP3 is required for this command",
-            )));
-        }
+        check_resp3!(self.protocol);
         let mut cmd = cmd("SUBSCRIBE");
         cmd.arg(channel_name);
         cmd.exec_async(self).await?;
@@ -602,12 +598,7 @@ impl MultiplexedConnection {
 
     /// Unsubscribes from channel.
     pub async fn unsubscribe(&mut self, channel_name: impl ToRedisArgs) -> RedisResult<()> {
-        if self.protocol == ProtocolVersion::RESP2 {
-            return Err(RedisError::from((
-                crate::ErrorKind::InvalidClientConfig,
-                "RESP3 is required for this command",
-            )));
-        }
+        check_resp3!(self.protocol);
         let mut cmd = cmd("UNSUBSCRIBE");
         cmd.arg(channel_name);
         cmd.exec_async(self).await?;
@@ -616,12 +607,7 @@ impl MultiplexedConnection {
 
     /// Subscribes to a new channel with pattern.
     pub async fn psubscribe(&mut self, channel_pattern: impl ToRedisArgs) -> RedisResult<()> {
-        if self.protocol == ProtocolVersion::RESP2 {
-            return Err(RedisError::from((
-                crate::ErrorKind::InvalidClientConfig,
-                "RESP3 is required for this command",
-            )));
-        }
+        check_resp3!(self.protocol);
         let mut cmd = cmd("PSUBSCRIBE");
         cmd.arg(channel_pattern);
         cmd.exec_async(self).await?;
@@ -630,12 +616,7 @@ impl MultiplexedConnection {
 
     /// Unsubscribes from channel pattern.
     pub async fn punsubscribe(&mut self, channel_pattern: impl ToRedisArgs) -> RedisResult<()> {
-        if self.protocol == ProtocolVersion::RESP2 {
-            return Err(RedisError::from((
-                crate::ErrorKind::InvalidClientConfig,
-                "RESP3 is required for this command",
-            )));
-        }
+        check_resp3!(self.protocol);
         let mut cmd = cmd("PUNSUBSCRIBE");
         cmd.arg(channel_pattern);
         cmd.exec_async(self).await?;

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -878,6 +878,27 @@ mod basic_async {
         }
 
         #[test]
+        fn pub_sub_requires_resp3() {
+            let ctx = TestContext::new();
+            if ctx.protocol != ProtocolVersion::RESP2 {
+                return;
+            }
+            block_on_all(async move {
+                let mut conn = ctx.multiplexed_async_connection().await?;
+
+                let res = conn.subscribe("foo").await;
+
+                assert_eq!(
+                    res.unwrap_err().kind(),
+                    redis::ErrorKind::InvalidClientConfig
+                );
+
+                Ok(())
+            })
+            .unwrap();
+        }
+
+        #[test]
         fn push_manager_disconnection() {
             use redis::RedisError;
 


### PR DESCRIPTION
The last commit of this PR isn't strictly required for the PR, but it improves our test coverage of the connection manager, which is somewhat related.