### PR TITLE
Cargo "redis-test-utils"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["redis", "redis-test"]
+members = ["redis", "redis-test", "redis/tests"]
 resolver = "2"

--- a/redis/tests/Cargo.toml
+++ b/redis/tests/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "redis-test-utils"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+bench = false
+path = "support/mod.rs"
+
+[dependencies]
+redis = { version = "0.25.3", path = "../../redis" }
+socket2 = "0.5"
+rand = "0.8"
+tempfile = "=3.6.0"
+tokio = "1"


### PR DESCRIPTION
There is a need for a separate crate as mentioned in #1164.
The existing infrastructure can be used by developers of redis modules.

Fixes #1164