### PR TITLE
check tls mode before setting it in the call of certs()

### DIFF
--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -282,7 +282,10 @@ impl ClusterClientBuilder {
     /// If `root_cert` is not provided, then system root certificates are used instead.
     #[cfg(feature = "tls-rustls")]
     pub fn certs(mut self, certificates: TlsCertificates) -> ClusterClientBuilder {
-        self.builder_params.tls = Some(TlsMode::Secure);
+        if self.builder_params.tls.is_none() {
+            self.builder_params.tls = Some(TlsMode::Secure);
+        }
+
         self.builder_params.certs = Some(certificates);
         self
     }


### PR DESCRIPTION
For ClusterClientBuilder, if we call tls(TlsMode::Insecure) first, a following certs() call will set builder_params.tls to Some(TlsMode::Secure) 
In this pr, we will check builder_params.tls  before setting it in fn certs()