### PR TITLE
Timeouts for redis client gotten via sentinel

### DIFF
--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -384,6 +384,7 @@ assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 // public api
+pub use crate::client::AsyncConnectionConfig;
 pub use crate::client::Client;
 pub use crate::cmd::{cmd, pack_command, pipe, Arg, Cmd, Iter};
 pub use crate::commands::{

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -112,6 +112,7 @@ use rand::Rng;
 #[cfg(feature = "aio")]
 use crate::aio::MultiplexedConnection as AsyncConnection;
 
+use crate::client::AsyncConnectionConfig;
 use crate::{
     connection::ConnectionInfo, types::RedisResult, Client, Cmd, Connection, ErrorKind,
     FromRedisValue, IntoConnectionInfo, RedisConnectionInfo, TlsMode, Value,
@@ -766,7 +767,20 @@ impl SentinelClient {
     /// `SentinelClient::get_connection`.
     #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
     pub async fn get_async_connection(&mut self) -> RedisResult<AsyncConnection> {
-        let client = self.async_get_client().await?;
-        client.get_multiplexed_async_connection().await
+        self.get_async_connection_with_config(&AsyncConnectionConfig::new())
+            .await
+    }
+
+    /// Returns an async connection from the client with options, using the same logic from
+    /// `SentinelClient::get_connection`.
+    #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
+    pub async fn get_async_connection_with_config(
+        &mut self,
+        config: &AsyncConnectionConfig,
+    ) -> RedisResult<AsyncConnection> {
+        self.async_get_client()
+            .await?
+            .get_multiplexed_async_connection_with_config(config)
+            .await
     }
 }


### PR DESCRIPTION
Add a redis::sentinel::Sentinel::SentinelClient::get_async_connection_with_config that accepts timeouts

I have added just a happy test for calling with long timeouts. I am not versed enough to add a test for actual timeouts but am not sure it is needed since it just ships the parameters on to redis client.