### PR TITLE
Add xautoclaim command support

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -1317,7 +1317,45 @@ implement_commands! {
             .arg(map)
     }
 
-
+    /// Perform a combined xpending and xclaim flow.
+    ///
+    /// ```no_run
+    /// use redis::{Connection,Commands,RedisResult};
+    /// use redis::streams::{StreamAutoClaimOptions, StreamAutoClaimReply};
+    /// let client = redis::Client::open("redis://127.0.0.1/0").unwrap();
+    /// let mut con = client.get_connection().unwrap();
+    ///
+    /// let opts = StreamAutoClaimOptions::default();
+    /// let results : RedisResult<StreamAutoClaimReply> = con.xautoclaim_options("k1", "g1", "c1", 10, "0-0", opts);
+    /// ```
+    ///
+    /// ```text
+    /// XAUTOCLAIM <key> <group> <consumer> <min-idel-time> <start> [COUNT <count>] [JUSTID]
+    /// ```
+    #[cfg(feature = "streams")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
+    fn xautoclaim_options<
+        K: ToRedisArgs,
+        G: ToRedisArgs,
+        C: ToRedisArgs,
+        MIT: ToRedisArgs,
+        S: ToRedisArgs
+    >(
+        key: K,
+        group: G,
+        consumer: C,
+        min_idle_time: MIT,
+        start: S,
+        options: streams::StreamAutoClaimOptions
+    ) {
+        cmd("XAUTOCLAIM")
+            .arg(key)
+            .arg(group)
+            .arg(consumer)
+            .arg(min_idle_time)
+            .arg(start)
+            .arg(options)
+    }
 
     /// Claim pending, unacked messages, after some period of time,
     /// currently checked out by another consumer.

--- a/redis/tests/test_streams.rs
+++ b/redis/tests/test_streams.rs
@@ -387,6 +387,88 @@ fn test_xread_options_deleted_pel_entry() {
         result_deleted_entry.keys[0].ids[0].id
     );
 }
+
+#[test]
+fn test_xautoclaim() {
+    // Tests the following command....
+    // xautoclaim_options
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+
+    // xautoclaim test basic idea:
+    // 1. we need to test adding messages to a group
+    // 2. then xreadgroup needs to define a consumer and read pending
+    //    messages without acking them
+    // 3. then we need to sleep 5ms and call xautoclaim to claim message
+    //    past the idle time and read them from a different consumer
+
+    // create the group
+    let result: RedisResult<String> = con.xgroup_create_mkstream("k1", "g1", "$");
+    assert!(result.is_ok());
+
+    // add some keys
+    xadd_keyrange(&mut con, "k1", 0, 10);
+
+    // read the pending items for this key & group
+    let reply: StreamReadReply = con
+        .xread_options(
+            &["k1"],
+            &[">"],
+            &StreamReadOptions::default().group("g1", "c1"),
+        )
+        .unwrap();
+    // verify we have 10 ids
+    assert_eq!(reply.keys[0].ids.len(), 10);
+
+    // save this StreamId for later
+    let claim = &reply.keys[0].ids[0];
+    let claim_1 = &reply.keys[0].ids[1];
+
+    // sleep for 5ms
+    sleep(Duration::from_millis(10));
+
+    // grab this id if > 4ms
+    let reply: StreamAutoClaimReply = con
+        .xautoclaim_options(
+            "k1",
+            "g1",
+            "c2",
+            4,
+            claim.id.clone(),
+            StreamAutoClaimOptions::default().count(2),
+        )
+        .unwrap();
+    assert_eq!(reply.claimed.len(), 2);
+    assert_eq!(reply.claimed[0].id, claim.id);
+    assert!(!reply.claimed[0].map.is_empty());
+    assert_eq!(reply.claimed[1].id, claim_1.id);
+    assert!(!reply.claimed[1].map.is_empty());
+
+    // sleep for 5ms
+    sleep(Duration::from_millis(5));
+
+    // let's test some of the xautoclaim_options
+    // call force on the same claim.id
+    let reply: StreamAutoClaimReply = con
+        .xautoclaim_options(
+            "k1",
+            "g1",
+            "c3",
+            4,
+            claim.id.clone(),
+            StreamAutoClaimOptions::default().count(5).with_justid(),
+        )
+        .unwrap();
+
+    // we just claimed the first original 5 ids
+    // and only returned the ids
+    assert_eq!(reply.claimed.len(), 5);
+    assert_eq!(reply.claimed[0].id, claim.id);
+    assert!(reply.claimed[0].map.is_empty());
+    assert_eq!(reply.claimed[1].id, claim_1.id);
+    assert!(reply.claimed[1].map.is_empty());
+}
+
 #[test]
 fn test_xclaim() {
     // Tests the following commands....


### PR DESCRIPTION
This adds a new command for the redis XAUTOCLAIM along with a Reply object to parse the response

This is one of the missing steam commands described in #1153 