### PR TITLE
Correct the document of default feature flags

### DIFF
--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -53,7 +53,7 @@
 //! if so desired.  Some of them are turned on by default.
 //!
 //! * `acl`: enables acl support (enabled by default)
-//! * `aio`: enables async IO support (enabled by default)
+//! * `aio`: enables async IO support (optional)
 //! * `geospatial`: enables geospatial support (enabled by default)
 //! * `script`: enables script support (enabled by default)
 //! * `r2d2`: enables r2d2 connection pool support (optional)
@@ -62,7 +62,7 @@
 //! * `cluster-async`: enables async redis cluster support (optional)
 //! * `tokio-comp`: enables support for tokio (optional)
 //! * `connection-manager`: enables support for automatic reconnection (optional)
-//! * `keep-alive`: enables keep-alive option on socket by means of `socket2` crate (optional)
+//! * `keep-alive`: enables keep-alive option on socket by means of `socket2` crate (enabled by default)
 //!
 //! ## Connection Parameters
 //!


### PR DESCRIPTION
As per `Cargo.toml`, `aio` is not enabled by default, and `keep-alive` is enabled:

https://github.com/redis-rs/redis-rs/blob/523b4ebe4ca052f97ea3db5b7792601092106397/redis/Cargo.toml#L94

However, the documentation for these flags is incorrect. This pull request fixes this error.

https://github.com/redis-rs/redis-rs/blob/523b4ebe4ca052f97ea3db5b7792601092106397/redis/src/lib.rs#L56

https://github.com/redis-rs/redis-rs/blob/523b4ebe4ca052f97ea3db5b7792601092106397/redis/src/lib.rs#L65
