### PR TITLE
Fix explicit IoError not being recognized.

### DIFF
--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -881,7 +881,7 @@ impl RedisError {
 
     /// Indicates that this failure is an IO failure.
     pub fn is_io_error(&self) -> bool {
-        self.as_io_error().is_some()
+        self.kind() == ErrorKind::IoError
     }
 
     pub(crate) fn as_io_error(&self) -> Option<&io::Error> {

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -3,7 +3,16 @@ mod support;
 mod types {
     use std::{rc::Rc, sync::Arc};
 
-    use redis::{ErrorKind, FromRedisValue, RedisResult, ToRedisArgs, Value};
+    use redis::{ErrorKind, FromRedisValue, RedisError, RedisResult, ToRedisArgs, Value};
+
+    #[test]
+    fn test_is_io_error() {
+        let err = RedisError::from((
+            ErrorKind::IoError,
+            "Multiplexed connection driver unexpectedly terminated",
+        ));
+        assert!(err.is_io_error());
+    }
 
     #[test]
     fn test_is_single_arg() {


### PR DESCRIPTION
A RedisError that was created with `ErrorKind::IoError` instead of an actual `io::Error` will now be recognized as an I/O error when checking `is_io_error`. This is required for the correct behavior of `connection_manager`.

https://github.com/redis-rs/redis-rs/issues/1190