### PR TITLE
Add max retry delay for every reconnect

### DIFF
--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -20,7 +20,7 @@ use tokio_retry::Retry;
 
 /// Apply a maximum delay. No retry delay will be longer than this `max_delay`.
 #[derive(Clone, Debug, Default)]
-pub struct ConnectionConfigInfo {
+pub struct ConnectionManagerConfig {
     /// The resulting duration is calculated by taking the base to the `n`-th power,
     /// where `n` denotes the number of past attempts.
     exponent_base: u64,
@@ -38,7 +38,7 @@ pub struct ConnectionConfigInfo {
     connection_timeout: std::time::Duration,
 }
 
-impl ConnectionConfigInfo {
+impl ConnectionManagerConfig {
     const DEFAULT_CONNECTION_RETRY_EXPONENT_BASE: u64 = 2;
     const DEFAULT_CONNECTION_RETRY_FACTOR: u64 = 100;
     const DEFAULT_NUMBER_OF_CONNECTION_RETRIESE: usize = 6;
@@ -58,37 +58,37 @@ impl ConnectionConfigInfo {
     }
 
     /// Sets the factor
-    pub fn factor(mut self, factor: u64) -> ConnectionConfigInfo {
+    pub fn factor(mut self, factor: u64) -> ConnectionManagerConfig {
         self.factor = factor;
         self
     }
 
     /// Sets the max_delay
-    pub fn max_delay(mut self, duration: u64) -> ConnectionConfigInfo {
-        self.max_delay = Some(duration);
+    pub fn max_delay(mut self, time: u64) -> ConnectionManagerConfig {
+        self.max_delay = Some(time);
         self
     }
 
     /// Sets the exponent_base
-    pub fn exponent_base(mut self, duration: u64) -> ConnectionConfigInfo {
-        self.exponent_base = duration;
+    pub fn exponent_base(mut self, base: u64) -> ConnectionManagerConfig {
+        self.exponent_base = base;
         self
     }
 
     /// Sets the number_of_retries
-    pub fn number_of_retries(mut self, amount: usize) -> ConnectionConfigInfo {
+    pub fn number_of_retries(mut self, amount: usize) -> ConnectionManagerConfig {
         self.number_of_retries = amount;
         self
     }
 
     /// Sets the response_timeout
-    pub fn response_timeout(mut self, duration: std::time::Duration) -> ConnectionConfigInfo {
+    pub fn response_timeout(mut self, duration: std::time::Duration) -> ConnectionManagerConfig {
         self.response_timeout = duration;
         self
     }
 
     /// Sets the response_timeout
-    pub fn connection_timeout(mut self, duration: std::time::Duration) -> ConnectionConfigInfo {
+    pub fn connection_timeout(mut self, duration: std::time::Duration) -> ConnectionManagerConfig {
         self.connection_timeout = duration;
         self
     }
@@ -173,15 +173,9 @@ impl ConnectionManager {
     /// This requires the `connection-manager` feature, which will also pull in
     /// the Tokio executor.
     pub async fn new(client: Client) -> RedisResult<Self> {
-        let config = ConnectionConfigInfo::new();
+        let config = ConnectionManagerConfig::new();
 
-        Self::new_with_backoff(
-            client,
-            config.exponent_base,
-            config.factor,
-            config.number_of_retries,
-        )
-        .await
+        Self::new_with_config(client, config).await
     }
 
     /// Connect to the server and store the connection inside the returned `ConnectionManager`.
@@ -228,14 +222,14 @@ impl ConnectionManager {
         response_timeout: std::time::Duration,
         connection_timeout: std::time::Duration,
     ) -> RedisResult<Self> {
-        let config = ConnectionConfigInfo::new()
+        let config = ConnectionManagerConfig::new()
             .exponent_base(exponent_base)
             .factor(factor)
             .number_of_retries(number_of_retries)
             .response_timeout(response_timeout)
             .connection_timeout(connection_timeout);
 
-        Self::new_with_backoff_and_timeouts_new_with_config(client, config).await
+        Self::new_with_config(client, config).await
     }
 
     /// Connect to the server and store the connection inside the returned `ConnectionManager`.
@@ -247,14 +241,13 @@ impl ConnectionManager {
     /// number_of_retries times, with an exponentially increasing delay, calculated as
     /// rand(0 .. factor * (exponent_base ^ current-try)).
     ///
-    /// Apply a maximum delay. No retry delay will be longer than this  ConnectionConfigInfo
-    ///.max_delay` .
+    /// Apply a maximum delay. No retry delay will be longer than this  ConnectionManagerConfig.max_delay` .
     ///
     /// The new connection will timeout operations after `response_timeout` has passed.
     /// Each connection attempt to the server will timeout after `connection_timeout`.
-    pub async fn new_with_backoff_and_timeouts_new_with_config(
+    pub async fn new_with_config(
         client: Client,
-        config: ConnectionConfigInfo,
+        config: ConnectionManagerConfig,
     ) -> RedisResult<Self> {
         // Create a MultiplexedConnection and wait for it to be established
         let push_manager = PushManager::default();

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tokio_retry::Retry;
 
-/// Options for Maximum connection waiting time
+/// Apply a maximum delay. No retry delay will be longer than this `max_delay`.
 #[derive(Clone, Debug, Default)]
 pub struct RetryStrategyInfo {
     /// The resulting duration is calculated by taking the base to the `n`-th power,

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -102,7 +102,6 @@ impl ConnectionManagerConfig {
         self
     }
 }
-
 /// A `ConnectionManager` is a proxy that wraps a [multiplexed
 /// connection][multiplexed-connection] and automatically reconnects to the
 /// server when necessary.

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -20,24 +20,30 @@ use tokio_retry::Retry;
 
 /// Apply a maximum delay. No retry delay will be longer than this `max_delay`.
 #[derive(Clone, Debug, Default)]
-pub struct RetryStrategyInfo {
+pub struct ConnectionConfigInfo {
     /// The resulting duration is calculated by taking the base to the `n`-th power,
     /// where `n` denotes the number of past attempts.
-    pub exponent_base: u64,
+    exponent_base: u64,
     /// A multiplicative factor that will be applied to the retry delay.
     ///
     /// For example, using a factor of `1000` will make each delay in units of seconds.
-    pub factor: u64,
+    factor: u64,
     /// number_of_retries times, with an exponentially increasing delay
-    pub number_of_retries: usize,
+    number_of_retries: usize,
     /// Apply a maximum delay. No retry delay will be longer than this 'duration' milliseconds.
-    pub max_delay: Option<u64>,
+    max_delay: Option<u64>,
+    /// The new connection will timeout operations after `response_timeout` has passed.
+    response_timeout: std::time::Duration,
+    /// Each connection attempt to the server will timeout after `connection_timeout`.
+    connection_timeout: std::time::Duration,
 }
 
-impl RetryStrategyInfo {
+impl ConnectionConfigInfo {
     const DEFAULT_CONNECTION_RETRY_EXPONENT_BASE: u64 = 2;
     const DEFAULT_CONNECTION_RETRY_FACTOR: u64 = 100;
     const DEFAULT_NUMBER_OF_CONNECTION_RETRIESE: usize = 6;
+    const DEFAULT_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::MAX;
+    const DEFAULT_CONNECTION_TIMEOUT: std::time::Duration = std::time::Duration::MAX;
 
     /// Creates a new instance of the options with nothing set
     pub fn new() -> Self {
@@ -46,30 +52,44 @@ impl RetryStrategyInfo {
             factor: Self::DEFAULT_CONNECTION_RETRY_FACTOR,
             number_of_retries: Self::DEFAULT_NUMBER_OF_CONNECTION_RETRIESE,
             max_delay: None,
+            response_timeout: Self::DEFAULT_RESPONSE_TIMEOUT,
+            connection_timeout: Self::DEFAULT_CONNECTION_TIMEOUT,
         }
     }
 
     /// Sets the factor
-    pub fn factor(mut self, factor: u64) -> RetryStrategyInfo {
+    pub fn factor(mut self, factor: u64) -> ConnectionConfigInfo {
         self.factor = factor;
         self
     }
 
     /// Sets the max_delay
-    pub fn max_delay(mut self, duration: u64) -> RetryStrategyInfo {
+    pub fn max_delay(mut self, duration: u64) -> ConnectionConfigInfo {
         self.max_delay = Some(duration);
         self
     }
 
     /// Sets the exponent_base
-    pub fn exponent_base(mut self, duration: u64) -> RetryStrategyInfo {
+    pub fn exponent_base(mut self, duration: u64) -> ConnectionConfigInfo {
         self.exponent_base = duration;
         self
     }
 
     /// Sets the number_of_retries
-    pub fn number_of_retries(mut self, duration: usize) -> RetryStrategyInfo {
-        self.number_of_retries = duration;
+    pub fn number_of_retries(mut self, amount: usize) -> ConnectionConfigInfo {
+        self.number_of_retries = amount;
+        self
+    }
+
+    /// Sets the response_timeout
+    pub fn response_timeout(mut self, duration: std::time::Duration) -> ConnectionConfigInfo {
+        self.response_timeout = duration;
+        self
+    }
+
+    /// Sets the response_timeout
+    pub fn connection_timeout(mut self, duration: std::time::Duration) -> ConnectionConfigInfo {
+        self.connection_timeout = duration;
         self
     }
 }
@@ -153,13 +173,13 @@ impl ConnectionManager {
     /// This requires the `connection-manager` feature, which will also pull in
     /// the Tokio executor.
     pub async fn new(client: Client) -> RedisResult<Self> {
-        let retry_strategy_info = RetryStrategyInfo::new();
+        let config = ConnectionConfigInfo::new();
 
         Self::new_with_backoff(
             client,
-            retry_strategy_info.exponent_base,
-            retry_strategy_info.factor,
-            retry_strategy_info.number_of_retries,
+            config.exponent_base,
+            config.factor,
+            config.number_of_retries,
         )
         .await
     }
@@ -208,17 +228,14 @@ impl ConnectionManager {
         response_timeout: std::time::Duration,
         connection_timeout: std::time::Duration,
     ) -> RedisResult<Self> {
-        let retry_strategy_info = RetryStrategyInfo::new()
+        let config = ConnectionConfigInfo::new()
             .exponent_base(exponent_base)
             .factor(factor)
-            .number_of_retries(number_of_retries);
+            .number_of_retries(number_of_retries)
+            .response_timeout(response_timeout)
+            .connection_timeout(connection_timeout);
 
-        Self::new_with_backoff_and_timeouts_with_max_delay_retry(
-            client,
-            retry_strategy_info,
-            response_timeout,
-            connection_timeout,
-        )
+        Self::new_with_backoff_and_timeouts_new_with_config(client, config).await
     }
 
     /// Connect to the server and store the connection inside the returned `ConnectionManager`.
@@ -230,32 +247,31 @@ impl ConnectionManager {
     /// number_of_retries times, with an exponentially increasing delay, calculated as
     /// rand(0 .. factor * (exponent_base ^ current-try)).
     ///
-    /// Apply a maximum delay. No retry delay will be longer than this `RetryStrategyInfo.max_delay` .
+    /// Apply a maximum delay. No retry delay will be longer than this  ConnectionConfigInfo
+    ///.max_delay` .
     ///
     /// The new connection will timeout operations after `response_timeout` has passed.
     /// Each connection attempt to the server will timeout after `connection_timeout`.
-    pub async fn new_with_backoff_and_timeouts_with_max_delay(
+    pub async fn new_with_backoff_and_timeouts_new_with_config(
         client: Client,
-        retry_strategy_info: RetryStrategyInfo,
-        response_timeout: std::time::Duration,
-        connection_timeout: std::time::Duration,
+        config: ConnectionConfigInfo,
     ) -> RedisResult<Self> {
         // Create a MultiplexedConnection and wait for it to be established
         let push_manager = PushManager::default();
         let runtime = Runtime::locate();
 
-        let mut retry_strategy = ExponentialBackoff::from_millis(retry_strategy_info.exponent_base)
-            .factor(retry_strategy_info.factor);
-        if let Some(max_delay) = retry_strategy_info.max_delay {
+        let mut retry_strategy =
+            ExponentialBackoff::from_millis(config.exponent_base).factor(config.factor);
+        if let Some(max_delay) = config.max_delay {
             retry_strategy = retry_strategy.max_delay(std::time::Duration::from_millis(max_delay));
         }
 
         let mut connection = Self::new_connection(
             client.clone(),
             retry_strategy.clone(),
-            retry_strategy_info.number_of_retries,
-            response_timeout,
-            connection_timeout,
+            config.number_of_retries.clone(),
+            config.response_timeout,
+            config.connection_timeout,
         )
         .await?;
 
@@ -267,10 +283,10 @@ impl ConnectionManager {
                 future::ok(connection).boxed().shared(),
             )),
             runtime,
-            number_of_retries,
+            number_of_retries: config.number_of_retries,
             retry_strategy,
-            response_timeout,
-            connection_timeout,
+            response_timeout: config.response_timeout,
+            connection_timeout: config.connection_timeout,
             push_manager,
         })
     }

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -271,7 +271,7 @@ impl ConnectionManager {
         let mut connection = Self::new_connection(
             client.clone(),
             retry_strategy.clone(),
-            config.number_of_retries.clone(),
+            config.number_of_retries,
             config.response_timeout,
             config.connection_timeout,
         )

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -594,11 +594,11 @@ impl Client {
         connection_timeout: std::time::Duration,
     ) -> RedisResult<crate::aio::ConnectionManager> {
         let config = crate::aio::ConnectionManagerConfig::new()
-            .exponent_base(exponent_base)
-            .factor(factor)
-            .number_of_retries(number_of_retries)
-            .response_timeout(response_timeout)
-            .connection_timeout(connection_timeout);
+            .set_exponent_base(exponent_base)
+            .set_factor(factor)
+            .set_number_of_retries(number_of_retries)
+            .set_response_timeout(response_timeout)
+            .set_connection_timeout(connection_timeout);
 
         crate::aio::ConnectionManager::new_with_config(self.clone(), config).await
     }

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -585,7 +585,7 @@ impl Client {
     /// [multiplexed-connection]: aio/struct.MultiplexedConnection.html
     #[cfg(feature = "connection-manager")]
     #[cfg_attr(docsrs, doc(cfg(feature = "connection-manager")))]
-    pub async fn get_connection_manager_with_backoff_and_timeouts_new_with_config(
+    pub async fn get_connection_manager_with_config(
         &self,
         exponent_base: u64,
         factor: u64,
@@ -593,18 +593,14 @@ impl Client {
         response_timeout: std::time::Duration,
         connection_timeout: std::time::Duration,
     ) -> RedisResult<crate::aio::ConnectionManager> {
-        let config = crate::aio::ConnectionConfigInfo::new()
+        let config = crate::aio::ConnectionManagerConfig::new()
             .exponent_base(exponent_base)
             .factor(factor)
             .number_of_retries(number_of_retries)
             .response_timeout(response_timeout)
             .connection_timeout(connection_timeout);
 
-        crate::aio::ConnectionManager::new_with_backoff_and_timeouts_new_with_config(
-            self.clone(),
-            config,
-        )
-        .await
+        crate::aio::ConnectionManager::new_with_config(self.clone(), config).await
     }
 
     /// Returns an async [`ConnectionManager`][connection-manager] from the client.

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -96,6 +96,12 @@ impl AsyncConnectionConfig {
     }
 }
 
+impl Default for AsyncConnectionConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// To enable async support you need to chose one of the supported runtimes and active its
 /// corresponding feature: `tokio-comp` or `async-std-comp`
 #[cfg(feature = "aio")]

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -587,11 +587,7 @@ impl Client {
     #[cfg_attr(docsrs, doc(cfg(feature = "connection-manager")))]
     pub async fn get_connection_manager_with_config(
         &self,
-        exponent_base: u64,
-        factor: u64,
-        number_of_retries: usize,
-        response_timeout: std::time::Duration,
-        connection_timeout: std::time::Duration,
+        config: crate::aio::ConnectionManagerConfig,
     ) -> RedisResult<crate::aio::ConnectionManager> {
         let config = crate::aio::ConnectionManagerConfig::new()
             .set_exponent_base(exponent_base)

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -96,12 +96,6 @@ impl AsyncConnectionConfig {
     }
 }
 
-impl Default for AsyncConnectionConfig {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// To enable async support you need to chose one of the supported runtimes and active its
 /// corresponding feature: `tokio-comp` or `async-std-comp`
 #[cfg(feature = "aio")]

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -585,6 +585,47 @@ impl Client {
     /// [multiplexed-connection]: aio/struct.MultiplexedConnection.html
     #[cfg(feature = "connection-manager")]
     #[cfg_attr(docsrs, doc(cfg(feature = "connection-manager")))]
+    pub async fn get_connection_manager_with_backoff_and_timeouts_new_with_config(
+        &self,
+        exponent_base: u64,
+        factor: u64,
+        number_of_retries: usize,
+        response_timeout: std::time::Duration,
+        connection_timeout: std::time::Duration,
+    ) -> RedisResult<crate::aio::ConnectionManager> {
+        let config = crate::aio::ConnectionConfigInfo::new()
+            .exponent_base(exponent_base)
+            .factor(factor)
+            .number_of_retries(number_of_retries)
+            .response_timeout(response_timeout)
+            .connection_timeout(connection_timeout);
+
+        crate::aio::ConnectionManager::new_with_backoff_and_timeouts_new_with_config(
+            self.clone(),
+            config,
+        )
+        .await
+    }
+
+    /// Returns an async [`ConnectionManager`][connection-manager] from the client.
+    ///
+    /// The connection manager wraps a
+    /// [`MultiplexedConnection`][multiplexed-connection]. If a command to that
+    /// connection fails with a connection error, then a new connection is
+    /// established in the background and the error is returned to the caller.
+    ///
+    /// This means that on connection loss at least one command will fail, but
+    /// the connection will be re-established automatically if possible. Please
+    /// refer to the [`ConnectionManager`][connection-manager] docs for
+    /// detailed reconnecting behavior.
+    ///
+    /// A connection manager can be cloned, allowing requests to be be sent concurrently
+    /// on the same underlying connection (tcp/unix socket).
+    ///
+    /// [connection-manager]: aio/struct.ConnectionManager.html
+    /// [multiplexed-connection]: aio/struct.MultiplexedConnection.html
+    #[cfg(feature = "connection-manager")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "connection-manager")))]
     pub async fn get_connection_manager_with_backoff(
         &self,
         exponent_base: u64,

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -589,13 +589,6 @@ impl Client {
         &self,
         config: crate::aio::ConnectionManagerConfig,
     ) -> RedisResult<crate::aio::ConnectionManager> {
-        let config = crate::aio::ConnectionManagerConfig::new()
-            .set_exponent_base(exponent_base)
-            .set_factor(factor)
-            .set_number_of_retries(number_of_retries)
-            .set_response_timeout(response_timeout)
-            .set_connection_timeout(connection_timeout);
-
         crate::aio::ConnectionManager::new_with_config(self.clone(), config).await
     }
 

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -960,7 +960,6 @@ mod basic_async {
     fn test_connection_manager_reconnect_after_delay() {
         use redis::ProtocolVersion;
 
-        /// Factor set 10 seconds, but max retry delay set 500 millisecond
         let config = redis::aio::ConnectionManagerConfig::new()
             .set_factor(10000)
             .set_max_delay(500);

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -996,11 +996,11 @@ mod basic_async {
 
     #[test]
     #[cfg(feature = "connection-manager")]
-    fn test_connection_manager_reconnect_after_delay_with_max_delay() {
+    fn test_connection_manager_reconnect_new_with_config() {
         use redis::ProtocolVersion;
 
         /// Factor set 10 seconds, but max retry delay set 500 millisecond
-        let retry_strategy_info = redis::aio::RetryStrategyInfo::new()
+        let config = redis::aio::RetryStrategyInfo::new()
             .factor(10000)
             .max_delay(500);
 
@@ -1013,18 +1013,15 @@ mod basic_async {
         let ctx = TestContext::with_tls(tls_files.clone(), false);
         block_on_all(async move {
             let mut manager =
-                redis::aio::ConnectionManager::new_with_backoff_and_timeouts_with_max_delay(
+                redis::aio::ConnectionManager::new_with_backoff_and_timeouts_new_with_config(
                     ctx.client.clone(),
-                    retry_strategy_info.clone(),
-                    std::time::Duration::MAX,
-                    std::time::Duration::MAX,
+                    config,
                 )
                 .await
                 .unwrap();
             let server = ctx.server;
             let addr = server.client_addr().clone();
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-            manager.get_push_manager().replace_sender(tx.clone());
             drop(server);
 
             let _result: RedisResult<redis::Value> = manager.set("foo", "bar").await; // one call is ignored because it's required to trigger the connection manager's reconnect.

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -960,45 +960,6 @@ mod basic_async {
     fn test_connection_manager_reconnect_after_delay() {
         use redis::ProtocolVersion;
 
-        let tempdir = tempfile::Builder::new()
-            .prefix("redis")
-            .tempdir()
-            .expect("failed to create tempdir");
-        let tls_files = build_keys_and_certs_for_tls(&tempdir);
-
-        let ctx = TestContext::with_tls(tls_files.clone(), false);
-        block_on_all(async move {
-            let mut manager = redis::aio::ConnectionManager::new(ctx.client.clone())
-                .await
-                .unwrap();
-            let server = ctx.server;
-            let addr = server.client_addr().clone();
-            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-            manager.get_push_manager().replace_sender(tx.clone());
-            drop(server);
-
-            let _result: RedisResult<redis::Value> = manager.set("foo", "bar").await; // one call is ignored because it's required to trigger the connection manager's reconnect.
-            if ctx.protocol != ProtocolVersion::RESP2 {
-                assert_eq!(rx.recv().await.unwrap().kind, PushKind::Disconnection);
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-
-            let _new_server = RedisServer::new_with_addr_and_modules(addr.clone(), &[], false);
-            wait_for_server_to_become_ready(ctx.client.clone()).await;
-
-            let result: redis::Value = manager.set("foo", "bar").await.unwrap();
-            assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Empty);
-            assert_eq!(result, redis::Value::Okay);
-            Ok(())
-        })
-        .unwrap();
-    }
-
-    #[test]
-    #[cfg(feature = "connection-manager")]
-    fn test_connection_manager_reconnect_new_with_config() {
-        use redis::ProtocolVersion;
-
         /// Factor set 10 seconds, but max retry delay set 500 millisecond
         let config = redis::aio::ConnectionManagerConfig::new()
             .factor(10000)
@@ -1018,17 +979,21 @@ mod basic_async {
                     .unwrap();
             let server = ctx.server;
             let addr = server.client_addr().clone();
-
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+            manager.get_push_manager().replace_sender(tx.clone());
             drop(server);
 
-            // one call is ignored because it's required to trigger the connection manager's reconnect.
-            let _result: RedisResult<redis::Value> = manager.set("foo", "bar").await;
-
+            let _result: RedisResult<redis::Value> = manager.set("foo", "bar").await; // one call is ignored because it's required to trigger the connection manager's reconnect.
+            if ctx.protocol != ProtocolVersion::RESP2 {
+                assert_eq!(rx.recv().await.unwrap().kind, PushKind::Disconnection);
+            }
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
             let _new_server = RedisServer::new_with_addr_and_modules(addr.clone(), &[], false);
             wait_for_server_to_become_ready(ctx.client.clone()).await;
-            let result: redis::Value = manager.set("foo", "bar").await.unwrap();
 
+            let result: redis::Value = manager.set("foo", "bar").await.unwrap();
+            assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Empty);
             assert_eq!(result, redis::Value::Okay);
             Ok(())
         })

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -962,8 +962,8 @@ mod basic_async {
 
         /// Factor set 10 seconds, but max retry delay set 500 millisecond
         let config = redis::aio::ConnectionManagerConfig::new()
-            .factor(10000)
-            .max_delay(500);
+            .set_factor(10000)
+            .set_max_delay(500);
 
         let tempdir = tempfile::Builder::new()
             .prefix("redis")


### PR DESCRIPTION
Add a redis::aio::ConnectionManager::new_with_backoff_and_timeouts_with_max_delay  Apply a maximum delay. No retry delay will be longer than this `max_delay`.

Todo: I try to add some more cases