### PR TITLE
Log the server / cluster logfile on error.

### DIFF
--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -142,6 +142,7 @@ pub enum Module {
 pub struct RedisServer {
     pub process: process::Child,
     tempdir: tempfile::TempDir,
+    log_file: PathBuf,
     addr: redis::ConnectionAddr,
     pub(crate) tls_paths: Option<TlsFilePaths>,
 }
@@ -172,6 +173,10 @@ impl RedisServer {
     #[cfg(feature = "tls-rustls")]
     pub fn new_with_mtls() -> RedisServer {
         RedisServer::with_modules(&[], true)
+    }
+
+    pub fn log_file_contents(&self) -> String {
+        std::fs::read_to_string(self.log_file.clone()).unwrap()
     }
 
     pub fn get_addr(port: u16) -> ConnectionAddr {
@@ -270,7 +275,8 @@ impl RedisServer {
             .prefix("redis")
             .tempdir()
             .expect("failed to create tempdir");
-        redis_cmd.arg("--logfile").arg(Self::log_file(&tempdir));
+        let log_file = Self::log_file(&tempdir);
+        redis_cmd.arg("--logfile").arg(log_file.clone());
         match addr {
             redis::ConnectionAddr::Tcp(ref bind, server_port) => {
                 redis_cmd
@@ -281,6 +287,7 @@ impl RedisServer {
 
                 RedisServer {
                     process: spawner(&mut redis_cmd),
+                    log_file,
                     tempdir,
                     addr,
                     tls_paths: None,
@@ -320,6 +327,7 @@ impl RedisServer {
 
                 RedisServer {
                     process: spawner(&mut redis_cmd),
+                    log_file,
                     tempdir,
                     addr,
                     tls_paths: Some(tls_paths),
@@ -333,6 +341,7 @@ impl RedisServer {
                     .arg(path);
                 RedisServer {
                     process: spawner(&mut redis_cmd),
+                    log_file,
                     tempdir,
                     addr,
                     tls_paths: None,
@@ -410,15 +419,27 @@ impl TestContext {
     }
 
     pub fn with_tls(tls_files: TlsFilePaths, mtls_enabled: bool) -> TestContext {
+        Self::with_modules_and_tls(&[], mtls_enabled, Some(tls_files))
+    }
+
+    pub fn with_modules(modules: &[Module], mtls_enabled: bool) -> TestContext {
+        Self::with_modules_and_tls(modules, mtls_enabled, None)
+    }
+
+    fn with_modules_and_tls(
+        modules: &[Module],
+        mtls_enabled: bool,
+        tls_files: Option<TlsFilePaths>,
+    ) -> Self {
         let redis_port = get_random_available_port();
         let addr = RedisServer::get_addr(redis_port);
 
         let server = RedisServer::new_with_addr_tls_modules_and_spawner(
             addr,
             None,
-            Some(tls_files),
+            tls_files,
             mtls_enabled,
-            &[],
+            modules,
             |cmd| {
                 cmd.spawn()
                     .unwrap_or_else(|err| panic!("Failed to run {cmd:?}: {err}"))
@@ -442,51 +463,16 @@ impl TestContext {
                         sleep(millisecond);
                         retries += 1;
                         if retries > 100000 {
-                            panic!("Tried to connect too many times, last error: {err}");
+                            panic!(
+                                "Tried to connect too many times, last error: {err}, logfile: {}",
+                                server.log_file_contents()
+                            );
                         }
                     } else {
-                        panic!("Could not connect: {err}");
-                    }
-                }
-                Ok(x) => {
-                    con = x;
-                    break;
-                }
-            }
-        }
-        redis::cmd("FLUSHDB").execute(&mut con);
-
-        TestContext {
-            server,
-            client,
-            protocol: use_protocol(),
-        }
-    }
-
-    pub fn with_modules(modules: &[Module], mtls_enabled: bool) -> TestContext {
-        let server = RedisServer::with_modules(modules, mtls_enabled);
-
-        #[cfg(feature = "tls-rustls")]
-        let client =
-            build_single_client(server.connection_info(), &server.tls_paths, mtls_enabled).unwrap();
-        #[cfg(not(feature = "tls-rustls"))]
-        let client = redis::Client::open(server.connection_info()).unwrap();
-
-        let mut con;
-
-        let millisecond = Duration::from_millis(1);
-        let mut retries = 0;
-        loop {
-            match client.get_connection() {
-                Err(err) => {
-                    if err.is_connection_refusal() {
-                        sleep(millisecond);
-                        retries += 1;
-                        if retries > 100000 {
-                            panic!("Tried to connect too many times, last error: {err}");
-                        }
-                    } else {
-                        panic!("Could not connect: {err}");
+                        panic!(
+                            "Could not connect: {err}, logfile: {}",
+                            server.log_file_contents()
+                        );
                     }
                 }
                 Ok(x) => {

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -383,13 +383,19 @@ impl RedisServer {
 /// process, so this must be used with care (since here we only use it for tests, it's
 /// mostly okay).
 pub fn get_random_available_port() -> u16 {
-    let addr = &"127.0.0.1:0".parse::<SocketAddr>().unwrap().into();
-    let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
-    socket.set_reuse_address(true).unwrap();
-    socket.bind(addr).unwrap();
-    socket.listen(1).unwrap();
-    let listener = TcpListener::from(socket);
-    listener.local_addr().unwrap().port()
+    for _ in 0..10000 {
+        let addr = &"127.0.0.1:0".parse::<SocketAddr>().unwrap().into();
+        let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+        socket.set_reuse_address(true).unwrap();
+        socket.bind(addr).unwrap();
+        socket.listen(1).unwrap();
+        let listener = TcpListener::from(socket);
+        let port = listener.local_addr().unwrap().port();
+        if port < 55535 {
+            return port;
+        }
+    }
+    panic!("Couldn't get a valid port");
 }
 
 impl Drop for RedisServer {


### PR DESCRIPTION
This allows us to find errors that aren't visible
in stdout/stderr.