### PR TITLE
Implement `ToRedisArgs` for `std::borrow::Cow`

### DIFF
--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::default::Default;
 use std::error;
@@ -1406,6 +1407,23 @@ impl<'a> ToRedisArgs for &'a str {
         W: ?Sized + RedisWrite,
     {
         out.write_arg(self.as_bytes())
+    }
+}
+
+impl<'a, T> ToRedisArgs for Cow<'a, T>
+where
+    T: ToOwned + ?Sized,
+    &'a T: ToRedisArgs,
+    for<'b> &'b T::Owned: ToRedisArgs,
+{
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        match self {
+            Cow::Borrowed(inner) => inner.write_redis_args(out),
+            Cow::Owned(inner) => inner.write_redis_args(out),
+        }
     }
 }
 

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -540,6 +540,25 @@ mod types {
     }
 
     #[test]
+    fn test_cow_types_to_redis_args() {
+        use std::borrow::Cow;
+
+        let s = "key".to_string();
+        let expected_string = s.to_redis_args();
+        assert_eq!(Cow::Borrowed(s.as_str()).to_redis_args(), expected_string);
+        assert_eq!(Cow::<str>::Owned(s).to_redis_args(), expected_string);
+
+        let array = vec![0u8, 4, 2, 3, 1];
+        let expected_array = array.to_redis_args();
+
+        assert_eq!(
+            Cow::Borrowed(array.as_slice()).to_redis_args(),
+            expected_array
+        );
+        assert_eq!(Cow::<[u8]>::Owned(array).to_redis_args(), expected_array);
+    }
+
+    #[test]
     fn test_large_usize_array_to_redis_args_and_back() {
         use crate::support::encode_value;
 


### PR DESCRIPTION
In cases where `T: ToOwned, &T: ToRedisArgs, &T::Owned: ToRedisArgs` we can implement `ToRedisArgs` for `Cow<'_, T>` by delegating to the inner implementations. This gives support for `Cow<[u8]>` and `Cow<str>` out of the box, and allows downstream consumers to get `Cow<Newtype>` implementations for free, without needing to `match` in their code.

An alternative implementation would be to always call `Cow::as_ref`, which would relax the bound of `&T::Owned: ToRedisArgs`, but in cases where the implementation of `ToRedisArgs` is specialized for `&T::Owned` this is suboptimal. As an example, see [`String::as_bytes`][1] vs [`String::as_str`][2] followed by [`str::as_bytes`][3]; by using the specialized implementation of `String::to_redis_args`, we save some overhead.

[1]: https://doc.rust-lang.org/std/string/struct.String.html#method.as_bytes
[2]: https://doc.rust-lang.org/std/string/struct.String.html#method.as_str
[3]: https://doc.rust-lang.org/std/primitive.str.html#method.as_bytes