### PR TITLE
Fix flakey test.

### DIFF
--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -960,9 +960,11 @@ mod basic_async {
     fn test_connection_manager_reconnect_after_delay() {
         use redis::ProtocolVersion;
 
+        let max_delay_between_attempts = 50;
+
         let config = redis::aio::ConnectionManagerConfig::new()
             .set_factor(10000)
-            .set_max_delay(500);
+            .set_max_delay(max_delay_between_attempts);
 
         let tempdir = tempfile::Builder::new()
             .prefix("redis")
@@ -982,14 +984,21 @@ mod basic_async {
             manager.get_push_manager().replace_sender(tx.clone());
             drop(server);
 
-            let _result: RedisResult<redis::Value> = manager.set("foo", "bar").await; // one call is ignored because it's required to trigger the connection manager's reconnect.
+            let result: RedisResult<redis::Value> = manager.set("foo", "bar").await;
+            // we expect a connection failure error.
+            assert!(result.unwrap_err().is_unrecoverable_error());
             if ctx.protocol != ProtocolVersion::RESP2 {
                 assert_eq!(rx.recv().await.unwrap().kind, PushKind::Disconnection);
             }
-            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
             let _new_server = RedisServer::new_with_addr_and_modules(addr.clone(), &[], false);
             wait_for_server_to_become_ready(ctx.client.clone()).await;
+
+            // we should perform at least 1 reconnect attempt in this time frame.
+            tokio::time::sleep(std::time::Duration::from_millis(
+                max_delay_between_attempts * 2,
+            ))
+            .await;
 
             let result: redis::Value = manager.set("foo", "bar").await.unwrap();
             assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Empty);


### PR DESCRIPTION
1. reduced the delay time (not required to fix the test, just to make it run faster.
2. wait after restarting the server, in order to give the connection manager time to reconnect before sending another request. I ran this locally for 500 iterations without failing.