### PR TITLE
Cluster connection - Refactor response handling.

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -769,6 +769,16 @@ where
                             return Err(err);
                         }
                         crate::types::RetryMethod::RetryImmediately => {}
+                        crate::types::RetryMethod::ReconnectFromInitialConnections => {
+                            // TODO - implement reconnect from initial connections
+                            if *self.auto_reconnect.borrow() {
+                                if let Ok(mut conn) = self.connect(&addr) {
+                                    if conn.check_connection() {
+                                        self.connections.borrow_mut().insert(addr, conn);
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -50,7 +50,7 @@ use crate::aio::{async_std::AsyncStd, RedisRuntime};
 use futures::{future::BoxFuture, prelude::*, ready};
 use log::{trace, warn};
 use rand::{seq::IteratorRandom, thread_rng};
-use request::{CmdArg, PendingRequest, Request, RequestState};
+use request::{CmdArg, PendingRequest, Request, RequestState, Retry};
 use routing::{route_for_pipeline, InternalRoutingInfo, InternalSingleNodeRouting};
 use tokio::sync::{mpsc, oneshot, RwLock};
 
@@ -180,6 +180,7 @@ fn boxed_sleep(duration: Duration) -> BoxFuture<'static, ()> {
     return Box::pin(async_std::task::sleep(duration));
 }
 
+#[derive(Debug, PartialEq)]
 pub(crate) enum Response {
     Single(Value),
     Multiple(Vec<Value>),
@@ -224,25 +225,6 @@ impl fmt::Debug for ConnectionState {
             }
         )
     }
-}
-
-#[must_use]
-enum Next<C> {
-    Retry {
-        request: PendingRequest<C>,
-    },
-    Reconnect {
-        request: PendingRequest<C>,
-        target: String,
-    },
-    RefreshSlots {
-        request: PendingRequest<C>,
-        sleep_duration: Option<Duration>,
-    },
-    ReconnectToInitialNodes {
-        request: PendingRequest<C>,
-    },
-    Done,
 }
 
 impl<C> ClusterConnInner<C>
@@ -816,13 +798,16 @@ where
         drop(pending_requests_guard);
 
         loop {
-            let result = match Pin::new(&mut self.in_flight_requests).poll_next(cx) {
-                Poll::Ready(Some(result)) => result,
-                Poll::Ready(None) | Poll::Pending => break,
-            };
-            match result {
-                Next::Done => {}
-                Next::Retry { request } => {
+            let (request_handling, next) =
+                match Pin::new(&mut self.in_flight_requests).poll_next(cx) {
+                    Poll::Ready(Some(result)) => result,
+                    Poll::Ready(None) | Poll::Pending => break,
+                };
+            match request_handling {
+                Some(Retry::MoveToPending { request }) => {
+                    self.inner.pending_requests.lock().unwrap().push(request)
+                }
+                Some(Retry::Immediately { request }) => {
                     let future = Self::try_request(request.cmd.clone(), self.inner.clone());
                     self.in_flight_requests.push(Box::pin(Request {
                         retry_params: self.inner.cluster_params.retry_params.clone(),
@@ -832,24 +817,12 @@ where
                         },
                     }));
                 }
-                Next::RefreshSlots {
+                Some(Retry::AfterSleep {
                     request,
                     sleep_duration,
-                } => {
-                    poll_flush_action =
-                        poll_flush_action.change_state(PollFlushAction::RebuildSlots);
-                    let future: RequestState<
-                        Pin<Box<dyn Future<Output = OperationResult> + Send>>,
-                    > = match sleep_duration {
-                        Some(sleep_duration) => RequestState::Sleep {
-                            sleep: boxed_sleep(sleep_duration),
-                        },
-                        None => RequestState::Future {
-                            future: Box::pin(Self::try_request(
-                                request.cmd.clone(),
-                                self.inner.clone(),
-                            )),
-                        },
+                }) => {
+                    let future = RequestState::Sleep {
+                        sleep: boxed_sleep(sleep_duration),
                     };
                     self.in_flight_requests.push(Box::pin(Request {
                         retry_params: self.inner.cluster_params.retry_params.clone(),
@@ -857,19 +830,9 @@ where
                         future,
                     }));
                 }
-                Next::Reconnect {
-                    request, target, ..
-                } => {
-                    poll_flush_action =
-                        poll_flush_action.change_state(PollFlushAction::Reconnect(vec![target]));
-                    self.inner.pending_requests.lock().unwrap().push(request);
-                }
-                Next::ReconnectToInitialNodes { request } => {
-                    poll_flush_action = poll_flush_action
-                        .change_state(PollFlushAction::ReconnectFromInitialConnections);
-                    self.inner.pending_requests.lock().unwrap().push(request);
-                }
-            }
+                None => {}
+            };
+            poll_flush_action = poll_flush_action.change_state(next);
         }
 
         if !matches!(poll_flush_action, PollFlushAction::None) || self.in_flight_requests.is_empty()
@@ -912,6 +875,7 @@ where
     }
 }
 
+#[derive(Debug, PartialEq)]
 enum PollFlushAction {
     None,
     RebuildSlots,

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -15,7 +15,7 @@ fn slot(key: &[u8]) -> u16 {
     crc16::State::<crc16::XMODEM>::calculate(key) % SLOT_SIZE
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 pub(crate) enum Redirect {
     Moved(String),
     Ask(String),

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -780,6 +780,7 @@ pub(crate) enum RetryMethod {
     WaitAndRetry,
     AskRedirect,
     MovedRedirect,
+    ReconnectFromInitialConnections,
 }
 
 /// Indicates a general failure in the library.
@@ -927,6 +928,7 @@ impl RedisError {
     pub fn is_unrecoverable_error(&self) -> bool {
         match self.retry_method() {
             RetryMethod::Reconnect => true,
+            RetryMethod::ReconnectFromInitialConnections => true,
 
             RetryMethod::NoRetry => false,
             RetryMethod::RetryImmediately => false,
@@ -1017,7 +1019,7 @@ impl RedisError {
 
             ErrorKind::ParseError => RetryMethod::Reconnect,
             ErrorKind::AuthenticationFailed => RetryMethod::Reconnect,
-            ErrorKind::ClusterConnectionNotFound => RetryMethod::Reconnect,
+            ErrorKind::ClusterConnectionNotFound => RetryMethod::ReconnectFromInitialConnections,
 
             ErrorKind::IoError => match &self.repr {
                 ErrorRepr::IoError(err) => match err.kind() {


### PR DESCRIPTION
This PR is based over https://github.com/redis-rs/redis-rs/pull/1186

1. Adds a request.rs and routing.rs files to the async cluster connection, in order to move the additional logic outside of the huge mod.rs file.
2. Moves the error handling logic to a seprate function, and add tests for that function.