### PR TITLE
Split `Request` and routing from cluster async to separate files.

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -30,13 +30,14 @@ use std::{
     time::Duration,
 };
 
+mod routing;
 use crate::{
     aio::{ConnectionLike, MultiplexedConnection},
     cluster::{get_connection_info, slot_cmd},
     cluster_client::{ClusterParams, RetryParams},
     cluster_routing::{
-        self, MultipleNodeRoutingInfo, Redirect, ResponsePolicy, Route, RoutingInfo,
-        SingleNodeRoutingInfo, Slot, SlotAddr, SlotMap,
+        MultipleNodeRoutingInfo, Redirect, ResponsePolicy, RoutingInfo, SingleNodeRoutingInfo,
+        Slot, SlotMap,
     },
     cluster_topology::parse_slots,
     Cmd, ConnectionInfo, ErrorKind, IntoConnectionInfo, RedisError, RedisFuture, RedisResult,
@@ -49,6 +50,7 @@ use futures::{future::BoxFuture, prelude::*, ready};
 use log::{trace, warn};
 use pin_project_lite::pin_project;
 use rand::{seq::IteratorRandom, thread_rng};
+use routing::{route_for_pipeline, InternalRoutingInfo, InternalSingleNodeRouting};
 use tokio::sync::{mpsc, oneshot, RwLock};
 
 /// This represents an async Redis Cluster connection. It stores the
@@ -170,66 +172,6 @@ struct ClusterConnInner<C> {
 }
 
 #[derive(Clone)]
-enum InternalRoutingInfo<C> {
-    SingleNode(InternalSingleNodeRouting<C>),
-    MultiNode((MultipleNodeRoutingInfo, Option<ResponsePolicy>)),
-}
-
-impl<C> From<cluster_routing::RoutingInfo> for InternalRoutingInfo<C> {
-    fn from(value: cluster_routing::RoutingInfo) -> Self {
-        match value {
-            cluster_routing::RoutingInfo::SingleNode(route) => {
-                InternalRoutingInfo::SingleNode(route.into())
-            }
-            cluster_routing::RoutingInfo::MultiNode(routes) => {
-                InternalRoutingInfo::MultiNode(routes)
-            }
-        }
-    }
-}
-
-impl<C> From<InternalSingleNodeRouting<C>> for InternalRoutingInfo<C> {
-    fn from(value: InternalSingleNodeRouting<C>) -> Self {
-        InternalRoutingInfo::SingleNode(value)
-    }
-}
-
-#[derive(Clone)]
-enum InternalSingleNodeRouting<C> {
-    Random,
-    SpecificNode(Route),
-    ByAddress(String),
-    Connection {
-        identifier: String,
-        conn: ConnectionFuture<C>,
-    },
-    Redirect {
-        redirect: Redirect,
-        previous_routing: Box<InternalSingleNodeRouting<C>>,
-    },
-}
-
-impl<C> Default for InternalSingleNodeRouting<C> {
-    fn default() -> Self {
-        Self::Random
-    }
-}
-
-impl<C> From<SingleNodeRoutingInfo> for InternalSingleNodeRouting<C> {
-    fn from(value: SingleNodeRoutingInfo) -> Self {
-        match value {
-            SingleNodeRoutingInfo::Random => InternalSingleNodeRouting::Random,
-            SingleNodeRoutingInfo::SpecificNode(route) => {
-                InternalSingleNodeRouting::SpecificNode(route)
-            }
-            SingleNodeRoutingInfo::ByAddress { host, port } => {
-                InternalSingleNodeRouting::ByAddress(format!("{host}:{port}"))
-            }
-        }
-    }
-}
-
-#[derive(Clone)]
 enum CmdArg<C> {
     Cmd {
         cmd: Arc<Cmd>,
@@ -241,41 +183,6 @@ enum CmdArg<C> {
         count: usize,
         route: InternalSingleNodeRouting<C>,
     },
-}
-
-fn route_for_pipeline(pipeline: &crate::Pipeline) -> RedisResult<Option<Route>> {
-    fn route_for_command(cmd: &Cmd) -> Option<Route> {
-        match cluster_routing::RoutingInfo::for_routable(cmd) {
-            Some(cluster_routing::RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)) => None,
-            Some(cluster_routing::RoutingInfo::SingleNode(
-                SingleNodeRoutingInfo::SpecificNode(route),
-            )) => Some(route),
-            Some(cluster_routing::RoutingInfo::MultiNode(_)) => None,
-            Some(cluster_routing::RoutingInfo::SingleNode(SingleNodeRoutingInfo::ByAddress {
-                ..
-            })) => None,
-            None => None,
-        }
-    }
-
-    // Find first specific slot and send to it. There's no need to check If later commands
-    // should be routed to a different slot, since the server will return an error indicating this.
-    pipeline.cmd_iter().map(route_for_command).try_fold(
-        None,
-        |chosen_route, next_cmd_route| match (chosen_route, next_cmd_route) {
-            (None, _) => Ok(next_cmd_route),
-            (_, None) => Ok(chosen_route),
-            (Some(chosen_route), Some(next_cmd_route)) => {
-                if chosen_route.slot() != next_cmd_route.slot() {
-                    Err((ErrorKind::CrossSlot, "Received crossed slots in pipeline").into())
-                } else if chosen_route.slot_addr() != &SlotAddr::Master {
-                    Ok(Some(next_cmd_route))
-                } else {
-                    Ok(Some(chosen_route))
-                }
-            }
-        },
-    )
 }
 
 fn boxed_sleep(duration: Duration) -> BoxFuture<'static, ()> {
@@ -1472,88 +1379,4 @@ where
                 .get(addr)
                 .map(|conn| (addr.clone(), conn.clone()))
         })
-}
-
-#[cfg(test)]
-mod pipeline_routing_tests {
-    use super::route_for_pipeline;
-    use crate::{
-        cluster_routing::{Route, SlotAddr},
-        cmd,
-    };
-
-    #[test]
-    fn test_first_route_is_found() {
-        let mut pipeline = crate::Pipeline::new();
-
-        pipeline
-            .add_command(cmd("FLUSHALL")) // route to all masters
-            .get("foo") // route to slot 12182
-            .add_command(cmd("EVAL")); // route randomly
-
-        assert_eq!(
-            route_for_pipeline(&pipeline),
-            Ok(Some(Route::new(12182, SlotAddr::ReplicaOptional)))
-        );
-    }
-
-    #[test]
-    fn test_return_none_if_no_route_is_found() {
-        let mut pipeline = crate::Pipeline::new();
-
-        pipeline
-            .add_command(cmd("FLUSHALL")) // route to all masters
-            .add_command(cmd("EVAL")); // route randomly
-
-        assert_eq!(route_for_pipeline(&pipeline), Ok(None));
-    }
-
-    #[test]
-    fn test_prefer_primary_route_over_replica() {
-        let mut pipeline = crate::Pipeline::new();
-
-        pipeline
-            .get("foo") // route to replica of slot 12182
-            .add_command(cmd("FLUSHALL")) // route to all masters
-            .add_command(cmd("EVAL"))// route randomly
-            .cmd("CONFIG").arg("GET").arg("timeout") // unkeyed command
-            .set("foo", "bar"); // route to primary of slot 12182
-
-        assert_eq!(
-            route_for_pipeline(&pipeline),
-            Ok(Some(Route::new(12182, SlotAddr::Master)))
-        );
-    }
-
-    #[test]
-    fn test_raise_cross_slot_error_on_conflicting_slots() {
-        let mut pipeline = crate::Pipeline::new();
-
-        pipeline
-            .add_command(cmd("FLUSHALL")) // route to all masters
-            .set("baz", "bar") // route to slot 4813
-            .get("foo"); // route to slot 12182
-
-        assert_eq!(
-            route_for_pipeline(&pipeline).unwrap_err().kind(),
-            crate::ErrorKind::CrossSlot
-        );
-    }
-
-    #[test]
-    fn unkeyed_commands_dont_affect_route() {
-        let mut pipeline = crate::Pipeline::new();
-
-        pipeline
-            .set("{foo}bar", "baz") // route to primary of slot 12182
-            .cmd("CONFIG").arg("GET").arg("timeout") // unkeyed command
-            .set("foo", "bar") // route to primary of slot 12182
-            .cmd("DEBUG").arg("PAUSE").arg("100") // unkeyed command
-            .cmd("ECHO").arg("hello world"); // unkeyed command
-
-        assert_eq!(
-            route_for_pipeline(&pipeline),
-            Ok(Some(Route::new(12182, SlotAddr::Master)))
-        );
-    }
 }

--- a/redis/src/cluster_async/request.rs
+++ b/redis/src/cluster_async/request.rs
@@ -1,0 +1,258 @@
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{self, Poll},
+};
+
+use futures::{future::BoxFuture, ready, Future};
+use log::trace;
+use pin_project_lite::pin_project;
+use tokio::sync::oneshot;
+
+use crate::{
+    cluster_async::{boxed_sleep, OperationTarget},
+    cluster_client::RetryParams,
+    cluster_routing::Redirect,
+    Cmd, ErrorKind, RedisResult,
+};
+
+use super::{
+    routing::{InternalRoutingInfo, InternalSingleNodeRouting},
+    Next, OperationResult, Response,
+};
+
+#[derive(Clone)]
+pub(super) enum CmdArg<C> {
+    Cmd {
+        cmd: Arc<Cmd>,
+        routing: InternalRoutingInfo<C>,
+    },
+    Pipeline {
+        pipeline: Arc<crate::Pipeline>,
+        offset: usize,
+        count: usize,
+        route: InternalSingleNodeRouting<C>,
+    },
+}
+
+#[derive(Clone)]
+pub(super) struct RequestInfo<C> {
+    pub(super) cmd: CmdArg<C>,
+}
+
+impl<C> RequestInfo<C> {
+    fn set_redirect(&mut self, redirect: Option<Redirect>) {
+        if let Some(redirect) = redirect {
+            match &mut self.cmd {
+                CmdArg::Cmd { routing, .. } => match routing {
+                    InternalRoutingInfo::SingleNode(route) => {
+                        let redirect = InternalSingleNodeRouting::Redirect {
+                            redirect,
+                            previous_routing: Box::new(std::mem::take(route)),
+                        }
+                        .into();
+                        *routing = redirect;
+                    }
+                    InternalRoutingInfo::MultiNode(_) => {
+                        panic!("Cannot redirect multinode requests")
+                    }
+                },
+                CmdArg::Pipeline { route, .. } => {
+                    let redirect = InternalSingleNodeRouting::Redirect {
+                        redirect,
+                        previous_routing: Box::new(std::mem::take(route)),
+                    };
+                    *route = redirect;
+                }
+            }
+        }
+    }
+
+    fn reset_routing(&mut self) {
+        let fix_route = |route: &mut InternalSingleNodeRouting<C>| {
+            match route {
+                InternalSingleNodeRouting::Redirect {
+                    previous_routing, ..
+                } => {
+                    let previous_routing = std::mem::take(previous_routing.as_mut());
+                    *route = previous_routing;
+                }
+                // If a specific connection is specified, then reconnecting without resetting the routing
+                // will mean that the request is still routed to the old connection.
+                InternalSingleNodeRouting::Connection { identifier, .. } => {
+                    *route = InternalSingleNodeRouting::ByAddress(std::mem::take(identifier));
+                }
+                _ => {}
+            }
+        };
+        match &mut self.cmd {
+            CmdArg::Cmd { routing, .. } => {
+                if let InternalRoutingInfo::SingleNode(route) = routing {
+                    fix_route(route);
+                }
+            }
+            CmdArg::Pipeline { route, .. } => {
+                fix_route(route);
+            }
+        }
+    }
+}
+
+pin_project! {
+    #[project = RequestStateProj]
+
+pub(super) enum RequestState<F> {
+        None,
+        Future {
+            #[pin]
+            future: F,
+        },
+        Sleep {
+            #[pin]
+            sleep: BoxFuture<'static, ()>,
+        },
+    }
+}
+
+pub(super) struct PendingRequest<C> {
+    pub(super) retry: u32,
+    pub(super) sender: oneshot::Sender<RedisResult<Response>>,
+    pub(super) info: RequestInfo<C>,
+}
+
+pin_project! {
+    pub(super)  struct Request<C> {
+         pub(super)retry_params: RetryParams,
+         pub(super)request: Option<PendingRequest<C>>,
+        #[pin]
+         pub(super)future: RequestState<BoxFuture<'static, OperationResult>>,
+    }
+}
+
+impl<C> Future for Request<C> {
+    type Output = Next<C>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+        let mut this = self.as_mut().project();
+        if this.request.is_none() {
+            return Poll::Ready(Next::Done);
+        }
+        let future = match this.future.as_mut().project() {
+            RequestStateProj::Future { future } => future,
+            RequestStateProj::Sleep { sleep } => {
+                ready!(sleep.poll(cx));
+                return Next::Retry {
+                    request: self.project().request.take().unwrap(),
+                }
+                .into();
+            }
+            _ => panic!("Request future must be Some"),
+        };
+        match ready!(future.poll(cx)) {
+            Ok(item) => {
+                trace!("Ok");
+                self.respond(Ok(item));
+                Next::Done.into()
+            }
+            Err((target, err)) => {
+                trace!("Request error {}", err);
+
+                let request = this.request.as_mut().unwrap();
+                if request.retry >= this.retry_params.number_of_retries {
+                    self.respond(Err(err));
+                    return Next::Done.into();
+                }
+                request.retry = request.retry.saturating_add(1);
+
+                if err.kind() == ErrorKind::ClusterConnectionNotFound {
+                    return Next::ReconnectToInitialNodes {
+                        request: this.request.take().unwrap(),
+                    }
+                    .into();
+                }
+
+                let sleep_duration = this.retry_params.wait_time_for_retry(request.retry);
+
+                let address = match target {
+                    OperationTarget::Node { address } => address,
+                    OperationTarget::FanOut => {
+                        // Fanout operation are retried per internal request, and don't need additional retries.
+                        self.respond(Err(err));
+                        return Next::Done.into();
+                    }
+                    OperationTarget::NotFound => {
+                        // TODO - this is essentially a repeat of the retriable error. probably can remove duplication.
+                        let mut request = this.request.take().unwrap();
+                        request.info.reset_routing();
+                        return Next::RefreshSlots {
+                            request,
+                            sleep_duration: Some(sleep_duration),
+                        }
+                        .into();
+                    }
+                };
+
+                match err.retry_method() {
+                    crate::types::RetryMethod::AskRedirect => {
+                        let mut request = this.request.take().unwrap();
+                        request.info.set_redirect(
+                            err.redirect_node()
+                                .map(|(node, _slot)| Redirect::Ask(node.to_string())),
+                        );
+                        Next::Retry { request }.into()
+                    }
+                    crate::types::RetryMethod::MovedRedirect => {
+                        let mut request = this.request.take().unwrap();
+                        request.info.set_redirect(
+                            err.redirect_node()
+                                .map(|(node, _slot)| Redirect::Moved(node.to_string())),
+                        );
+                        Next::RefreshSlots {
+                            request,
+                            sleep_duration: None,
+                        }
+                        .into()
+                    }
+                    crate::types::RetryMethod::WaitAndRetry => {
+                        // Sleep and retry.
+                        this.future.set(RequestState::Sleep {
+                            sleep: boxed_sleep(sleep_duration),
+                        });
+                        self.poll(cx)
+                    }
+                    crate::types::RetryMethod::Reconnect => {
+                        let mut request = this.request.take().unwrap();
+                        // TODO should we reset the redirect here?
+                        request.info.reset_routing();
+                        Next::Reconnect {
+                            request,
+                            target: address,
+                        }
+                    }
+                    .into(),
+                    crate::types::RetryMethod::RetryImmediately => Next::Retry {
+                        request: this.request.take().unwrap(),
+                    }
+                    .into(),
+                    crate::types::RetryMethod::NoRetry => {
+                        self.respond(Err(err));
+                        Next::Done.into()
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<C> Request<C> {
+    pub(super) fn respond(self: Pin<&mut Self>, msg: RedisResult<Response>) {
+        // If `send` errors the receiver has dropped and thus does not care about the message
+        let _ = self
+            .project()
+            .request
+            .take()
+            .expect("Result should only be sent once")
+            .sender
+            .send(msg);
+    }
+}

--- a/redis/src/cluster_async/request.rs
+++ b/redis/src/cluster_async/request.rs
@@ -97,7 +97,6 @@ pin_project! {
     #[project = RequestStateProj]
 
 pub(super) enum RequestState<F> {
-        None,
         Future {
             #[pin]
             future: F,
@@ -141,7 +140,6 @@ impl<C> Future for Request<C> {
                 }
                 .into();
             }
-            _ => panic!("Request future must be Some"),
         };
         match ready!(future.poll(cx)) {
             Ok(item) => {

--- a/redis/src/cluster_async/routing.rs
+++ b/redis/src/cluster_async/routing.rs
@@ -1,0 +1,188 @@
+use crate::{
+    cluster_routing::{
+        self, MultipleNodeRoutingInfo, Redirect, ResponsePolicy, Route, SingleNodeRoutingInfo,
+        SlotAddr,
+    },
+    Cmd, ErrorKind, RedisResult,
+};
+
+use super::ConnectionFuture;
+
+#[derive(Clone)]
+pub(super) enum InternalRoutingInfo<C> {
+    SingleNode(InternalSingleNodeRouting<C>),
+    MultiNode((MultipleNodeRoutingInfo, Option<ResponsePolicy>)),
+}
+
+impl<C> From<cluster_routing::RoutingInfo> for InternalRoutingInfo<C> {
+    fn from(value: cluster_routing::RoutingInfo) -> Self {
+        match value {
+            cluster_routing::RoutingInfo::SingleNode(route) => {
+                InternalRoutingInfo::SingleNode(route.into())
+            }
+            cluster_routing::RoutingInfo::MultiNode(routes) => {
+                InternalRoutingInfo::MultiNode(routes)
+            }
+        }
+    }
+}
+
+impl<C> From<InternalSingleNodeRouting<C>> for InternalRoutingInfo<C> {
+    fn from(value: InternalSingleNodeRouting<C>) -> Self {
+        InternalRoutingInfo::SingleNode(value)
+    }
+}
+
+#[derive(Clone)]
+pub(super) enum InternalSingleNodeRouting<C> {
+    Random,
+    SpecificNode(Route),
+    ByAddress(String),
+    Connection {
+        identifier: String,
+        conn: ConnectionFuture<C>,
+    },
+    Redirect {
+        redirect: Redirect,
+        previous_routing: Box<InternalSingleNodeRouting<C>>,
+    },
+}
+
+impl<C> Default for InternalSingleNodeRouting<C> {
+    fn default() -> Self {
+        Self::Random
+    }
+}
+
+impl<C> From<SingleNodeRoutingInfo> for InternalSingleNodeRouting<C> {
+    fn from(value: SingleNodeRoutingInfo) -> Self {
+        match value {
+            SingleNodeRoutingInfo::Random => InternalSingleNodeRouting::Random,
+            SingleNodeRoutingInfo::SpecificNode(route) => {
+                InternalSingleNodeRouting::SpecificNode(route)
+            }
+            SingleNodeRoutingInfo::ByAddress { host, port } => {
+                InternalSingleNodeRouting::ByAddress(format!("{host}:{port}"))
+            }
+        }
+    }
+}
+
+pub(super) fn route_for_pipeline(pipeline: &crate::Pipeline) -> RedisResult<Option<Route>> {
+    fn route_for_command(cmd: &Cmd) -> Option<Route> {
+        match cluster_routing::RoutingInfo::for_routable(cmd) {
+            Some(cluster_routing::RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)) => None,
+            Some(cluster_routing::RoutingInfo::SingleNode(
+                SingleNodeRoutingInfo::SpecificNode(route),
+            )) => Some(route),
+            Some(cluster_routing::RoutingInfo::MultiNode(_)) => None,
+            Some(cluster_routing::RoutingInfo::SingleNode(SingleNodeRoutingInfo::ByAddress {
+                ..
+            })) => None,
+            None => None,
+        }
+    }
+
+    // Find first specific slot and send to it. There's no need to check If later commands
+    // should be routed to a different slot, since the server will return an error indicating this.
+    pipeline.cmd_iter().map(route_for_command).try_fold(
+        None,
+        |chosen_route, next_cmd_route| match (chosen_route, next_cmd_route) {
+            (None, _) => Ok(next_cmd_route),
+            (_, None) => Ok(chosen_route),
+            (Some(chosen_route), Some(next_cmd_route)) => {
+                if chosen_route.slot() != next_cmd_route.slot() {
+                    Err((ErrorKind::CrossSlot, "Received crossed slots in pipeline").into())
+                } else if chosen_route.slot_addr() != &SlotAddr::Master {
+                    Ok(Some(next_cmd_route))
+                } else {
+                    Ok(Some(chosen_route))
+                }
+            }
+        },
+    )
+}
+
+#[cfg(test)]
+mod pipeline_routing_tests {
+    use super::route_for_pipeline;
+    use crate::{
+        cluster_routing::{Route, SlotAddr},
+        cmd,
+    };
+
+    #[test]
+    fn test_first_route_is_found() {
+        let mut pipeline = crate::Pipeline::new();
+
+        pipeline
+            .add_command(cmd("FLUSHALL")) // route to all masters
+            .get("foo") // route to slot 12182
+            .add_command(cmd("EVAL")); // route randomly
+
+        assert_eq!(
+            route_for_pipeline(&pipeline),
+            Ok(Some(Route::new(12182, SlotAddr::ReplicaOptional)))
+        );
+    }
+
+    #[test]
+    fn test_return_none_if_no_route_is_found() {
+        let mut pipeline = crate::Pipeline::new();
+
+        pipeline
+            .add_command(cmd("FLUSHALL")) // route to all masters
+            .add_command(cmd("EVAL")); // route randomly
+
+        assert_eq!(route_for_pipeline(&pipeline), Ok(None));
+    }
+
+    #[test]
+    fn test_prefer_primary_route_over_replica() {
+        let mut pipeline = crate::Pipeline::new();
+
+        pipeline
+            .get("foo") // route to replica of slot 12182
+            .add_command(cmd("FLUSHALL")) // route to all masters
+            .add_command(cmd("EVAL"))// route randomly
+            .cmd("CONFIG").arg("GET").arg("timeout") // unkeyed command
+            .set("foo", "bar"); // route to primary of slot 12182
+
+        assert_eq!(
+            route_for_pipeline(&pipeline),
+            Ok(Some(Route::new(12182, SlotAddr::Master)))
+        );
+    }
+
+    #[test]
+    fn test_raise_cross_slot_error_on_conflicting_slots() {
+        let mut pipeline = crate::Pipeline::new();
+
+        pipeline
+            .add_command(cmd("FLUSHALL")) // route to all masters
+            .set("baz", "bar") // route to slot 4813
+            .get("foo"); // route to slot 12182
+
+        assert_eq!(
+            route_for_pipeline(&pipeline).unwrap_err().kind(),
+            crate::ErrorKind::CrossSlot
+        );
+    }
+
+    #[test]
+    fn unkeyed_commands_dont_affect_route() {
+        let mut pipeline = crate::Pipeline::new();
+
+        pipeline
+            .set("{foo}bar", "baz") // route to primary of slot 12182
+            .cmd("CONFIG").arg("GET").arg("timeout") // unkeyed command
+            .set("foo", "bar") // route to primary of slot 12182
+            .cmd("DEBUG").arg("PAUSE").arg("100") // unkeyed command
+            .cmd("ECHO").arg("hello world"); // unkeyed command
+
+        assert_eq!(
+            route_for_pipeline(&pipeline),
+            Ok(Some(Route::new(12182, SlotAddr::Master)))
+        );
+    }
+}


### PR DESCRIPTION
This PR doesn't contain any logic or behavior changes, just a code re-organization. It's in preparation for https://github.com/redis-rs/redis-rs/pull/1222#issuecomment-2174995693