### PR TITLE
Fix nightly compilation warnings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ fn fetch_an_integer() -> redis::RedisResult<isize> {
     let client = redis::Client::open("redis://127.0.0.1/")?;
     let mut con = client.get_connection()?;
     // throw away the result, just make sure it does not fail
-    let _ : () = con.set("my_key", 42)?;
+    let _: () = con.set("my_key", 42)?;
     // read back the key and return it.  Because the return value
     // from the function is a result for integer this will automatically
     // convert into one.

--- a/redis-test/src/lib.rs
+++ b/redis-test/src/lib.rs
@@ -327,7 +327,7 @@ mod tests {
         cmd("SET")
             .arg("foo")
             .arg("42")
-            .query_async::<()>(&mut conn)
+            .exec_async(&mut conn)
             .await
             .unwrap();
         let result: Result<usize, _> = cmd("GET").arg("foo").query_async(&mut conn).await;
@@ -336,7 +336,7 @@ mod tests {
         cmd("SET")
             .arg("bar")
             .arg("foo")
-            .query_async::<()>(&mut conn)
+            .exec_async(&mut conn)
             .await
             .unwrap();
         let result: Result<Vec<u8>, _> = cmd("GET").arg("bar").query_async(&mut conn).await;
@@ -356,7 +356,7 @@ mod tests {
         let err = cmd("SET")
             .arg("bar")
             .arg("foo")
-            .query::<()>(&mut conn)
+            .exec(&mut conn)
             .unwrap_err();
         assert_eq!(err.kind(), ErrorKind::ClientError);
         assert_eq!(err.detail(), Some("unexpected command"));
@@ -374,7 +374,7 @@ mod tests {
         let err = cmd("SET")
             .arg("bar")
             .arg("foo")
-            .query::<()>(&mut conn)
+            .exec(&mut conn)
             .unwrap_err();
         assert_eq!(err.kind(), ErrorKind::ClientError);
         assert!(err.detail().unwrap().contains("unexpected command"));

--- a/redis-test/src/lib.rs
+++ b/redis-test/src/lib.rs
@@ -327,7 +327,7 @@ mod tests {
         cmd("SET")
             .arg("foo")
             .arg("42")
-            .query_async::<_, ()>(&mut conn)
+            .query_async::<()>(&mut conn)
             .await
             .unwrap();
         let result: Result<usize, _> = cmd("GET").arg("foo").query_async(&mut conn).await;
@@ -336,7 +336,7 @@ mod tests {
         cmd("SET")
             .arg("bar")
             .arg("foo")
-            .query_async::<_, ()>(&mut conn)
+            .query_async::<()>(&mut conn)
             .await
             .unwrap();
         let result: Result<Vec<u8>, _> = cmd("GET").arg("bar").query_async(&mut conn).await;

--- a/redis-test/src/lib.rs
+++ b/redis-test/src/lib.rs
@@ -304,10 +304,10 @@ mod tests {
             MockCmd::new(cmd("GET").arg("bar"), Ok("foo")),
         ]);
 
-        cmd("SET").arg("foo").arg(42).execute(&mut conn);
+        cmd("SET").arg("foo").arg(42).exec(&mut conn).unwrap();
         assert_eq!(cmd("GET").arg("foo").query(&mut conn), Ok(42));
 
-        cmd("SET").arg("bar").arg("foo").execute(&mut conn);
+        cmd("SET").arg("bar").arg("foo").exec(&mut conn).unwrap();
         assert_eq!(
             cmd("GET").arg("bar").query(&mut conn),
             Ok(Value::BulkString(b"foo".as_ref().into()))
@@ -350,7 +350,7 @@ mod tests {
             MockCmd::new(cmd("GET").arg("foo"), Ok(42)),
         ]);
 
-        cmd("SET").arg("foo").arg(42).execute(&mut conn);
+        cmd("SET").arg("foo").arg(42).exec(&mut conn).unwrap();
         assert_eq!(cmd("GET").arg("foo").query(&mut conn), Ok(42));
 
         let err = cmd("SET")
@@ -370,7 +370,7 @@ mod tests {
             MockCmd::new(cmd("SET").arg("bar").arg("foo"), Ok("")),
         ]);
 
-        cmd("SET").arg("foo").arg(42).execute(&mut conn);
+        cmd("SET").arg("foo").arg(42).exec(&mut conn).unwrap();
         let err = cmd("SET")
             .arg("bar")
             .arg("foo")

--- a/redis/benches/bench_basic.rs
+++ b/redis/benches/bench_basic.rs
@@ -13,9 +13,9 @@ fn bench_simple_getsetdel(b: &mut Bencher) {
 
     b.iter(|| {
         let key = "test_key";
-        redis::cmd("SET").arg(key).arg(42).execute(&mut con);
+        redis::cmd("SET").arg(key).arg(42).exec(&mut con).unwrap();
         let _: isize = redis::cmd("GET").arg(key).query(&mut con).unwrap();
-        redis::cmd("DEL").arg(key).execute(&mut con);
+        redis::cmd("DEL").arg(key).exec(&mut con).unwrap();
     });
 }
 

--- a/redis/benches/bench_cluster.rs
+++ b/redis/benches/bench_cluster.rs
@@ -68,7 +68,7 @@ fn bench_pipeline(c: &mut Criterion, con: &mut redis::cluster::ClusterConnection
     }
     group.bench_function("query_pipeline", |b| {
         b.iter(|| {
-            pipe.query::<()>(con).unwrap();
+            pipe.exec(con).unwrap();
             black_box(())
         })
     });

--- a/redis/benches/bench_cluster.rs
+++ b/redis/benches/bench_cluster.rs
@@ -17,7 +17,7 @@ fn bench_set_get_and_del(c: &mut Criterion, con: &mut redis::cluster::ClusterCon
 
     group.bench_function("set", |b| {
         b.iter(|| {
-            redis::cmd("SET").arg(key).arg(42).execute(con);
+            redis::cmd("SET").arg(key).arg(42).exec(con).unwrap();
             black_box(())
         })
     });
@@ -27,8 +27,8 @@ fn bench_set_get_and_del(c: &mut Criterion, con: &mut redis::cluster::ClusterCon
     });
 
     let mut set_and_del = || {
-        redis::cmd("SET").arg(key).arg(42).execute(con);
-        redis::cmd("DEL").arg(key).execute(con);
+        redis::cmd("SET").arg(key).arg(42).exec(con).unwrap();
+        redis::cmd("DEL").arg(key).exec(con).unwrap();
     };
     group.bench_function("set_and_del", |b| {
         b.iter(|| {

--- a/redis/benches/bench_cluster_async.rs
+++ b/redis/benches/bench_cluster_async.rs
@@ -21,13 +21,9 @@ fn bench_cluster_async(
             runtime
                 .block_on(async {
                     let key = "test_key";
-                    redis::cmd("SET")
-                        .arg(key)
-                        .arg(42)
-                        .query_async::<()>(con)
-                        .await?;
+                    redis::cmd("SET").arg(key).arg(42).exec_async(con).await?;
                     let _: isize = redis::cmd("GET").arg(key).query_async(con).await?;
-                    redis::cmd("DEL").arg(key).query_async::<()>(con).await?;
+                    redis::cmd("DEL").arg(key).exec_async(con).await?;
 
                     Ok::<_, RedisError>(())
                 })
@@ -49,7 +45,7 @@ fn bench_cluster_async(
                 .block_on(async {
                     cmds.iter()
                         .zip(&mut connections)
-                        .map(|(cmd, con)| cmd.query_async::<()>(con))
+                        .map(|(cmd, con)| cmd.exec_async(con))
                         .collect::<stream::FuturesUnordered<_>>()
                         .try_for_each(|()| async { Ok(()) })
                         .await
@@ -70,7 +66,7 @@ fn bench_cluster_async(
 
         b.iter(|| {
             runtime
-                .block_on(async { pipe.query_async::<()>(con).await })
+                .block_on(async { pipe.exec_async(con).await })
                 .unwrap();
             black_box(())
         });

--- a/redis/benches/bench_cluster_async.rs
+++ b/redis/benches/bench_cluster_async.rs
@@ -21,9 +21,13 @@ fn bench_cluster_async(
             runtime
                 .block_on(async {
                     let key = "test_key";
-                    redis::cmd("SET").arg(key).arg(42).query_async(con).await?;
+                    redis::cmd("SET")
+                        .arg(key)
+                        .arg(42)
+                        .query_async::<()>(con)
+                        .await?;
                     let _: isize = redis::cmd("GET").arg(key).query_async(con).await?;
-                    redis::cmd("DEL").arg(key).query_async(con).await?;
+                    redis::cmd("DEL").arg(key).query_async::<()>(con).await?;
 
                     Ok::<_, RedisError>(())
                 })
@@ -45,7 +49,7 @@ fn bench_cluster_async(
                 .block_on(async {
                     cmds.iter()
                         .zip(&mut connections)
-                        .map(|(cmd, con)| cmd.query_async::<_, ()>(con))
+                        .map(|(cmd, con)| cmd.query_async::<()>(con))
                         .collect::<stream::FuturesUnordered<_>>()
                         .try_for_each(|()| async { Ok(()) })
                         .await
@@ -66,7 +70,7 @@ fn bench_cluster_async(
 
         b.iter(|| {
             runtime
-                .block_on(async { pipe.query_async::<_, ()>(con).await })
+                .block_on(async { pipe.query_async::<()>(con).await })
                 .unwrap();
             black_box(())
         });

--- a/redis/examples/async-await.rs
+++ b/redis/examples/async-await.rs
@@ -9,7 +9,7 @@ async fn main() -> redis::RedisResult<()> {
 
     redis::cmd("SET")
         .arg(&["key2", "bar"])
-        .query_async::<()>(&mut con)
+        .exec_async(&mut con)
         .await?;
 
     let result = redis::cmd("MGET")

--- a/redis/examples/async-await.rs
+++ b/redis/examples/async-await.rs
@@ -5,11 +5,11 @@ async fn main() -> redis::RedisResult<()> {
     let client = redis::Client::open("redis://127.0.0.1/").unwrap();
     let mut con = client.get_multiplexed_async_connection().await?;
 
-    con.set("key1", b"foo").await?;
+    let _: () = con.set("key1", b"foo").await?;
 
     redis::cmd("SET")
         .arg(&["key2", "bar"])
-        .query_async(&mut con)
+        .query_async::<()>(&mut con)
         .await?;
 
     let result = redis::cmd("MGET")

--- a/redis/examples/async-multiplexed.rs
+++ b/redis/examples/async-multiplexed.rs
@@ -11,12 +11,12 @@ async fn test_cmd(con: &MultiplexedConnection, i: i32) -> RedisResult<()> {
     redis::cmd("SET")
         .arg(&key)
         .arg(&value)
-        .query_async::<()>(&mut con)
+        .exec_async(&mut con)
         .await?;
 
     redis::cmd("SET")
         .arg(&[&key2, "bar"])
-        .query_async::<()>(&mut con)
+        .exec_async(&mut con)
         .await?;
 
     redis::cmd("MGET")

--- a/redis/examples/async-multiplexed.rs
+++ b/redis/examples/async-multiplexed.rs
@@ -11,12 +11,12 @@ async fn test_cmd(con: &MultiplexedConnection, i: i32) -> RedisResult<()> {
     redis::cmd("SET")
         .arg(&key)
         .arg(&value)
-        .query_async(&mut con)
+        .query_async::<()>(&mut con)
         .await?;
 
     redis::cmd("SET")
         .arg(&[&key2, "bar"])
-        .query_async(&mut con)
+        .query_async::<()>(&mut con)
         .await?;
 
     redis::cmd("MGET")

--- a/redis/examples/async-pub-sub.rs
+++ b/redis/examples/async-pub-sub.rs
@@ -7,10 +7,10 @@ async fn main() -> redis::RedisResult<()> {
     let mut publish_conn = client.get_multiplexed_async_connection().await?;
     let mut pubsub_conn = client.get_async_pubsub().await?;
 
-    pubsub_conn.subscribe("wavephone").await?;
+    let _: () = pubsub_conn.subscribe("wavephone").await?;
     let mut pubsub_stream = pubsub_conn.on_message();
 
-    publish_conn.publish("wavephone", "banana").await?;
+    let _: () = publish_conn.publish("wavephone", "banana").await?;
 
     let pubsub_msg: String = pubsub_stream.next().await.unwrap().get_payload()?;
     assert_eq!(&pubsub_msg, "banana");

--- a/redis/examples/async-scan.rs
+++ b/redis/examples/async-scan.rs
@@ -6,8 +6,8 @@ async fn main() -> redis::RedisResult<()> {
     let client = redis::Client::open("redis://127.0.0.1/").unwrap();
     let mut con = client.get_multiplexed_async_connection().await?;
 
-    con.set("async-key1", b"foo").await?;
-    con.set("async-key2", b"foo").await?;
+    let _: () = con.set("async-key1", b"foo").await?;
+    let _: () = con.set("async-key2", b"foo").await?;
 
     let iter: AsyncIter<String> = con.scan().await?;
     let mut keys: Vec<_> = iter.collect().await;

--- a/redis/examples/basic.rs
+++ b/redis/examples/basic.rs
@@ -52,7 +52,7 @@ fn do_show_scanning(con: &mut redis::Connection) -> redis::RedisResult<()> {
 
     // since we don't care about the return value of the pipeline we can
     // just cast it into the unit type.
-    pipe.query(con)?;
+    pipe.query::<()>(con)?;
 
     // since rust currently does not track temporaries for us, we need to
     // store it in a local variable.
@@ -75,12 +75,12 @@ fn do_atomic_increment_lowlevel(con: &mut redis::Connection) -> redis::RedisResu
     println!("Run low-level atomic increment:");
 
     // set the initial value so we have something to test with.
-    redis::cmd("SET").arg(key).arg(42).query(con)?;
+    redis::cmd("SET").arg(key).arg(42).query::<()>(con)?;
 
     loop {
         // we need to start watching the key we care about, so that our
         // exec fails if the key changes.
-        redis::cmd("WATCH").arg(key).query(con)?;
+        redis::cmd("WATCH").arg(key).query::<()>(con)?;
 
         // load the old value, so we know what to increment.
         let val: isize = redis::cmd("GET").arg(key).query(con)?;
@@ -118,7 +118,7 @@ fn do_atomic_increment(con: &mut redis::Connection) -> redis::RedisResult<()> {
     println!("Run high-level atomic increment:");
 
     // set the initial value so we have something to test with.
-    con.set(key, 42)?;
+    let _: () = con.set(key, 42)?;
 
     // run the transaction block.
     let (new_val,): (isize,) = transaction(con, &[key], |con, pipe| {

--- a/redis/examples/basic.rs
+++ b/redis/examples/basic.rs
@@ -52,7 +52,7 @@ fn do_show_scanning(con: &mut redis::Connection) -> redis::RedisResult<()> {
 
     // since we don't care about the return value of the pipeline we can
     // just cast it into the unit type.
-    pipe.query::<()>(con)?;
+    pipe.exec(con)?;
 
     // since rust currently does not track temporaries for us, we need to
     // store it in a local variable.
@@ -75,12 +75,12 @@ fn do_atomic_increment_lowlevel(con: &mut redis::Connection) -> redis::RedisResu
     println!("Run low-level atomic increment:");
 
     // set the initial value so we have something to test with.
-    redis::cmd("SET").arg(key).arg(42).query::<()>(con)?;
+    redis::cmd("SET").arg(key).arg(42).exec(con)?;
 
     loop {
         // we need to start watching the key we care about, so that our
         // exec fails if the key changes.
-        redis::cmd("WATCH").arg(key).query::<()>(con)?;
+        redis::cmd("WATCH").arg(key).exec(con)?;
 
         // load the old value, so we know what to increment.
         let val: isize = redis::cmd("GET").arg(key).query(con)?;

--- a/redis/examples/streams.rs
+++ b/redis/examples/streams.rs
@@ -124,7 +124,7 @@ fn add_records(client: &redis::Client) -> RedisResult<()> {
 
     // a stream whose records have two fields
     for _ in 0..thrifty_rand() {
-        con.xadd_maxlen(
+        let _: () = con.xadd_maxlen(
             DOG_STREAM,
             maxlen,
             "*",
@@ -134,7 +134,7 @@ fn add_records(client: &redis::Client) -> RedisResult<()> {
 
     // a streams whose records have three fields
     for _ in 0..thrifty_rand() {
-        con.xadd_maxlen(
+        let _: () = con.xadd_maxlen(
             CAT_STREAM,
             maxlen,
             "*",
@@ -148,7 +148,7 @@ fn add_records(client: &redis::Client) -> RedisResult<()> {
 
     // a streams whose records have four fields
     for _ in 0..thrifty_rand() {
-        con.xadd_maxlen(
+        let _: () = con.xadd_maxlen(
             DUCK_STREAM,
             maxlen,
             "*",

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -596,7 +596,7 @@ impl MultiplexedConnection {
         }
         let mut cmd = cmd("SUBSCRIBE");
         cmd.arg(channel_name);
-        cmd.query_async::<()>(self).await?;
+        cmd.exec_async(self).await?;
         Ok(())
     }
 
@@ -610,7 +610,7 @@ impl MultiplexedConnection {
         }
         let mut cmd = cmd("UNSUBSCRIBE");
         cmd.arg(channel_name);
-        cmd.query_async::<()>(self).await?;
+        cmd.exec_async(self).await?;
         Ok(())
     }
 
@@ -624,7 +624,7 @@ impl MultiplexedConnection {
         }
         let mut cmd = cmd("PSUBSCRIBE");
         cmd.arg(channel_pattern);
-        cmd.query_async::<()>(self).await?;
+        cmd.exec_async(self).await?;
         Ok(())
     }
 
@@ -638,7 +638,7 @@ impl MultiplexedConnection {
         }
         let mut cmd = cmd("PUNSUBSCRIBE");
         cmd.arg(channel_pattern);
-        cmd.query_async::<()>(self).await?;
+        cmd.exec_async(self).await?;
         Ok(())
     }
 

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -596,7 +596,7 @@ impl MultiplexedConnection {
         }
         let mut cmd = cmd("SUBSCRIBE");
         cmd.arg(channel_name);
-        cmd.query_async(self).await?;
+        cmd.query_async::<()>(self).await?;
         Ok(())
     }
 
@@ -610,7 +610,7 @@ impl MultiplexedConnection {
         }
         let mut cmd = cmd("UNSUBSCRIBE");
         cmd.arg(channel_name);
-        cmd.query_async(self).await?;
+        cmd.query_async::<()>(self).await?;
         Ok(())
     }
 
@@ -624,7 +624,7 @@ impl MultiplexedConnection {
         }
         let mut cmd = cmd("PSUBSCRIBE");
         cmd.arg(channel_pattern);
-        cmd.query_async(self).await?;
+        cmd.query_async::<()>(self).await?;
         Ok(())
     }
 
@@ -638,7 +638,7 @@ impl MultiplexedConnection {
         }
         let mut cmd = cmd("PUNSUBSCRIBE");
         cmd.arg(channel_pattern);
-        cmd.query_async(self).await?;
+        cmd.query_async::<()>(self).await?;
         Ok(())
     }
 

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -740,7 +740,7 @@ impl Client {
     ///
     ///     redis::cmd("SET")
     ///         .arg(&["key2", "bar"])
-    ///         .query_async::<()>(&mut con)
+    ///         .exec_async(&mut con)
     ///         .await?;
     ///
     ///     let result = redis::cmd("MGET")

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -740,7 +740,7 @@ impl Client {
     ///
     ///     redis::cmd("SET")
     ///         .arg(&["key2", "bar"])
-    ///         .query_async(&mut con)
+    ///         .query_async::<()>(&mut con)
     ///         .await?;
     ///
     ///     let result = redis::cmd("MGET")

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -407,7 +407,7 @@ where
         let mut conn = C::connect(info, None)?;
         if self.cluster_params.read_from_replicas {
             // If READONLY is sent to primary nodes, it will have no effect
-            cmd("READONLY").query(&mut conn)?;
+            cmd("READONLY").query::<()>(&mut conn)?;
         }
         conn.set_read_timeout(*self.read_timeout.borrow())?;
         conn.set_write_timeout(*self.write_timeout.borrow())?;

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -29,11 +29,11 @@
 //!
 //! let key = "test";
 //!
-//! let _: () = cluster_pipe()
+//! cluster_pipe()
 //!     .rpush(key, "123").ignore()
 //!     .ltrim(key, -10, -1).ignore()
 //!     .expire(key, 60).ignore()
-//!     .query(&mut connection).unwrap();
+//!     .exec(&mut connection).unwrap();
 //! ```
 use std::cell::RefCell;
 use std::collections::HashSet;
@@ -407,7 +407,7 @@ where
         let mut conn = C::connect(info, None)?;
         if self.cluster_params.read_from_replicas {
             // If READONLY is sent to primary nodes, it will have no effect
-            cmd("READONLY").query::<()>(&mut conn)?;
+            cmd("READONLY").exec(&mut conn)?;
         }
         conn.set_read_timeout(*self.read_timeout.borrow())?;
         conn.set_write_timeout(*self.write_timeout.borrow())?;

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -1123,7 +1123,7 @@ where
     check_connection(&mut conn).await?;
     if read_from_replicas {
         // If READONLY is sent to primary nodes, it will have no effect
-        crate::cmd("READONLY").query_async::<()>(&mut conn).await?;
+        crate::cmd("READONLY").exec_async(&mut conn).await?;
     }
     Ok(conn)
 }

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -1123,7 +1123,7 @@ where
     check_connection(&mut conn).await?;
     if read_from_replicas {
         // If READONLY is sent to primary nodes, it will have no effect
-        crate::cmd("READONLY").query_async(&mut conn).await?;
+        crate::cmd("READONLY").query_async::<()>(&mut conn).await?;
     }
     Ok(conn)
 }
@@ -1134,7 +1134,7 @@ where
 {
     let mut cmd = Cmd::new();
     cmd.arg("PING");
-    cmd.query_async::<_, String>(conn).await?;
+    cmd.query_async::<String>(conn).await?;
     Ok(())
 }
 

--- a/redis/src/cluster_pipeline.rs
+++ b/redis/src/cluster_pipeline.rs
@@ -138,11 +138,16 @@ impl ClusterPipeline {
     /// pipe.cmd("SET").arg("key_1").arg(42).ignore().query::<()>(&mut con).unwrap();
     /// ```
     #[inline]
+    #[deprecated(note = "Use Cmd::exec + unwrap, instead")]
     pub fn execute(&self, con: &mut ClusterConnection) {
         self.exec(con).unwrap();
     }
 
-    /// This is a shortcut to `query`, to avoid having to define generic bounds for `()`.
+    /// This is an alternative to `query`` that can be used if you want to be able to handle a
+    /// command's success or failure but don't care about the command's response. For example,
+    /// this is useful for "SET" commands for which the response's content is not important.
+    /// It avoids the need to define generic bounds for ().
+    #[inline]
     pub fn exec(&self, con: &mut ClusterConnection) -> RedisResult<()> {
         self.query::<()>(con)
     }

--- a/redis/src/cluster_pipeline.rs
+++ b/redis/src/cluster_pipeline.rs
@@ -135,11 +135,16 @@ impl ClusterPipeline {
     /// # let client = redis::cluster::ClusterClient::new(nodes).unwrap();
     /// # let mut con = client.get_connection().unwrap();
     /// let mut pipe = redis::cluster::cluster_pipe();
-    /// let _ : () = pipe.cmd("SET").arg("key_1").arg(42).ignore().query(&mut con).unwrap();
+    /// pipe.cmd("SET").arg("key_1").arg(42).ignore().query::<()>(&mut con).unwrap();
     /// ```
     #[inline]
     pub fn execute(&self, con: &mut ClusterConnection) {
-        self.query::<()>(con).unwrap();
+        self.exec(con).unwrap();
+    }
+
+    /// This is a shortcut to `query`, to avoid having to define generic bounds for `()`.
+    pub fn exec(&self, con: &mut ClusterConnection) -> RedisResult<()> {
+        self.query::<()>(con)
     }
 }
 

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -128,8 +128,8 @@ impl<'a, T: FromRedisValue + 'a + Unpin + Send> AsyncIter<'a, T> {
     /// # async fn scan_set() -> redis::RedisResult<()> {
     /// # let client = redis::Client::open("redis://127.0.0.1/")?;
     /// # let mut con = client.get_multiplexed_async_connection().await?;
-    /// con.sadd("my_set", 42i32).await?;
-    /// con.sadd("my_set", 43i32).await?;
+    /// let _ : () = con.sadd("my_set", 42i32).await?;
+    /// let _ : () = con.sadd("my_set", 43i32).await?;
     /// let mut iter: redis::AsyncIter<i32> = con.sscan("my_set").await?;
     /// while let Some(element) = iter.next_item().await {
     ///     assert!(element == 42 || element == 43);
@@ -431,10 +431,10 @@ impl Cmd {
     /// Async version of `query`.
     #[inline]
     #[cfg(feature = "aio")]
-    pub async fn query_async<C, T: FromRedisValue>(&self, con: &mut C) -> RedisResult<T>
-    where
-        C: crate::aio::ConnectionLike,
-    {
+    pub async fn query_async<T: FromRedisValue>(
+        &self,
+        con: &mut impl crate::aio::ConnectionLike,
+    ) -> RedisResult<T> {
         let val = con.req_packed_command(self).await?;
         from_owned_redis_value(val.extract_error()?)
     }

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -527,16 +527,24 @@ impl Cmd {
     /// redis::cmd("PING").query::<()>(&mut con).unwrap();
     /// ```
     #[inline]
+    #[deprecated(note = "Use Cmd::exec + unwrap, instead")]
     pub fn execute(&self, con: &mut dyn ConnectionLike) {
         self.exec(con).unwrap();
     }
 
-    /// This is a shortcut to `query`, to avoid having to define generic bounds for `()`.
+    /// This is an alternative to `query`` that can be used if you want to be able to handle a
+    /// command's success or failure but don't care about the command's response. For example,
+    /// this is useful for "SET" commands for which the response's content is not important.
+    /// It avoids the need to define generic bounds for ().
+    #[inline]
     pub fn exec(&self, con: &mut dyn ConnectionLike) -> RedisResult<()> {
         self.query::<()>(con)
     }
 
-    /// This is a shortcut to `query_async`, to avoid having to define generic bounds for `()`.
+    /// This is an alternative to `query_async` that can be used if you want to be able to handle a
+    /// command's success or failure but don't care about the command's response. For example,
+    /// this is useful for "SET" commands for which the response's content is not important.
+    /// It avoids the need to define generic bounds for ().
     #[cfg(feature = "aio")]
     pub async fn exec_async(&self, con: &mut impl crate::aio::ConnectionLike) -> RedisResult<()> {
         self.query_async::<()>(con).await

--- a/redis/src/commands/json.rs
+++ b/redis/src/commands/json.rs
@@ -33,7 +33,7 @@ macro_rules! implement_json_commands {
         /// # fn do_something() -> redis::RedisResult<()> {
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
         /// let mut con = client.get_connection()?;
-        /// redis::cmd("JSON.SET").arg("my_key").arg("$").arg(&json!({"item": 42i32}).to_string()).execute(&mut con);
+        /// redis::cmd("JSON.SET").arg("my_key").arg("$").arg(&json!({"item": 42i32}).to_string()).exec(&mut con).unwrap();
         /// assert_eq!(redis::cmd("JSON.GET").arg("my_key").arg("$").query(&mut con), Ok(String::from(r#"[{"item":42}]"#)));
         /// # Ok(()) }
         /// ```

--- a/redis/src/commands/json.rs
+++ b/redis/src/commands/json.rs
@@ -46,7 +46,7 @@ macro_rules! implement_json_commands {
         /// # fn do_something() -> redis::RedisResult<()> {
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
         /// let mut con = client.get_connection()?;
-        /// con.json_set("my_key", "$", &json!({"item": 42i32}).to_string())?;
+        /// let _:() = con.json_set("my_key", "$", &json!({"item": 42i32}).to_string())?;
         /// assert_eq!(con.json_get("my_key", "$"), Ok(String::from(r#"[{"item":42}]"#)));
         /// assert_eq!(con.json_get("my_key", "$.item"), Ok(String::from(r#"[42]"#)));
         /// # Ok(()) }
@@ -88,7 +88,7 @@ macro_rules! implement_json_commands {
         /// # async fn do_something() -> redis::RedisResult<()> {
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
         /// let mut con = client.get_multiplexed_async_connection().await?;
-        /// redis::cmd("JSON.SET").arg("my_key").arg("$").arg(&json!({"item": 42i32}).to_string()).query_async(&mut con).await?;
+        /// redis::cmd("JSON.SET").arg("my_key").arg("$").arg(&json!({"item": 42i32}).to_string()).query_async::<()>(&mut con).await?;
         /// assert_eq!(redis::cmd("JSON.GET").arg("my_key").arg("$").query_async(&mut con).await, Ok(String::from(r#"[{"item":42}]"#)));
         /// # Ok(()) }
         /// ```
@@ -102,7 +102,7 @@ macro_rules! implement_json_commands {
         /// use redis::Commands;
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
         /// let mut con = client.get_multiplexed_async_connection().await?;
-        /// con.json_set("my_key", "$", &json!({"item": 42i32}).to_string()).await?;
+        /// let _:() = con.json_set("my_key", "$", &json!({"item": 42i32}).to_string()).await?;
         /// assert_eq!(con.json_get("my_key", "$").await, Ok(String::from(r#"[{"item":42}]"#)));
         /// assert_eq!(con.json_get("my_key", "$.item").await, Ok(String::from(r#"[42]"#)));
         /// # Ok(()) }

--- a/redis/src/commands/json.rs
+++ b/redis/src/commands/json.rs
@@ -46,7 +46,7 @@ macro_rules! implement_json_commands {
         /// # fn do_something() -> redis::RedisResult<()> {
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
         /// let mut con = client.get_connection()?;
-        /// let _:() = con.json_set("my_key", "$", &json!({"item": 42i32}).to_string())?;
+        /// let _: () = con.json_set("my_key", "$", &json!({"item": 42i32}).to_string())?;
         /// assert_eq!(con.json_get("my_key", "$"), Ok(String::from(r#"[{"item":42}]"#)));
         /// assert_eq!(con.json_get("my_key", "$.item"), Ok(String::from(r#"[42]"#)));
         /// # Ok(()) }
@@ -88,7 +88,7 @@ macro_rules! implement_json_commands {
         /// # async fn do_something() -> redis::RedisResult<()> {
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
         /// let mut con = client.get_multiplexed_async_connection().await?;
-        /// redis::cmd("JSON.SET").arg("my_key").arg("$").arg(&json!({"item": 42i32}).to_string()).query_async::<()>(&mut con).await?;
+        /// redis::cmd("JSON.SET").arg("my_key").arg("$").arg(&json!({"item": 42i32}).to_string()).exec_async(&mut con).await?;
         /// assert_eq!(redis::cmd("JSON.GET").arg("my_key").arg("$").query_async(&mut con).await, Ok(String::from(r#"[{"item":42}]"#)));
         /// # Ok(()) }
         /// ```
@@ -102,7 +102,7 @@ macro_rules! implement_json_commands {
         /// use redis::Commands;
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
         /// let mut con = client.get_multiplexed_async_connection().await?;
-        /// let _:() = con.json_set("my_key", "$", &json!({"item": 42i32}).to_string()).await?;
+        /// let _: () = con.json_set("my_key", "$", &json!({"item": 42i32}).to_string()).await?;
         /// assert_eq!(con.json_get("my_key", "$").await, Ok(String::from(r#"[{"item":42}]"#)));
         /// assert_eq!(con.json_get("my_key", "$.item").await, Ok(String::from(r#"[42]"#)));
         /// # Ok(()) }

--- a/redis/src/commands/macros.rs
+++ b/redis/src/commands/macros.rs
@@ -32,7 +32,7 @@ macro_rules! implement_commands {
         /// use redis::Commands;
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
         /// let mut con = client.get_connection()?;
-        /// let _ : () = con.set("my_key", 42)?;
+        /// let _: () = con.set("my_key", 42)?;
         /// assert_eq!(con.get("my_key"), Ok(42));
         /// # Ok(()) }
         /// ```
@@ -144,7 +144,7 @@ macro_rules! implement_commands {
         /// # async fn do_something() -> redis::RedisResult<()> {
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
         /// let mut con = client.get_multiplexed_async_connection().await?;
-        /// redis::cmd("SET").arg("my_key").arg(42i32).query_async::<()>(&mut con).await?;
+        /// redis::cmd("SET").arg("my_key").arg(42i32).exec_async(&mut con).await?;
         /// assert_eq!(redis::cmd("GET").arg("my_key").query_async(&mut con).await, Ok(42i32));
         /// # Ok(()) }
         /// ```
@@ -157,7 +157,7 @@ macro_rules! implement_commands {
         /// use redis::Commands;
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
         /// let mut con = client.get_multiplexed_async_connection().await?;
-        /// let _:() = con.set("my_key", 42i32).await?;
+        /// let _: () = con.set("my_key", 42i32).await?;
         /// assert_eq!(con.get("my_key").await, Ok(42i32));
         /// # Ok(()) }
         /// ```

--- a/redis/src/commands/macros.rs
+++ b/redis/src/commands/macros.rs
@@ -20,7 +20,7 @@ macro_rules! implement_commands {
         /// # fn do_something() -> redis::RedisResult<()> {
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
         /// let mut con = client.get_connection()?;
-        /// redis::cmd("SET").arg("my_key").arg(42).execute(&mut con);
+        /// redis::cmd("SET").arg("my_key").arg(42).exec(&mut con).unwrap();
         /// assert_eq!(redis::cmd("GET").arg("my_key").query(&mut con), Ok(42));
         /// # Ok(()) }
         /// ```

--- a/redis/src/commands/macros.rs
+++ b/redis/src/commands/macros.rs
@@ -32,7 +32,7 @@ macro_rules! implement_commands {
         /// use redis::Commands;
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
         /// let mut con = client.get_connection()?;
-        /// con.set("my_key", 42)?;
+        /// let _ : () = con.set("my_key", 42)?;
         /// assert_eq!(con.get("my_key"), Ok(42));
         /// # Ok(()) }
         /// ```
@@ -144,7 +144,7 @@ macro_rules! implement_commands {
         /// # async fn do_something() -> redis::RedisResult<()> {
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
         /// let mut con = client.get_multiplexed_async_connection().await?;
-        /// redis::cmd("SET").arg("my_key").arg(42i32).query_async(&mut con).await?;
+        /// redis::cmd("SET").arg("my_key").arg(42i32).query_async::<()>(&mut con).await?;
         /// assert_eq!(redis::cmd("GET").arg("my_key").query_async(&mut con).await, Ok(42i32));
         /// # Ok(()) }
         /// ```
@@ -157,7 +157,7 @@ macro_rules! implement_commands {
         /// use redis::Commands;
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
         /// let mut con = client.get_multiplexed_async_connection().await?;
-        /// con.set("my_key", 42i32).await?;
+        /// let _:() = con.set("my_key", 42i32).await?;
         /// assert_eq!(con.get("my_key").await, Ok(42i32));
         /// # Ok(()) }
         /// ```

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -1696,7 +1696,7 @@ pub fn transaction<
 ) -> RedisResult<T> {
     let mut func = func;
     loop {
-        cmd("WATCH").arg(keys).query::<()>(con)?;
+        cmd("WATCH").arg(keys).exec(con)?;
         let mut p = pipe();
         let response: Option<T> = func(con, p.atomic())?;
         match response {
@@ -1706,7 +1706,7 @@ pub fn transaction<
             Some(response) => {
                 // make sure no watch is left in the connection, even if
                 // someone forgot to use the pipeline.
-                cmd("UNWATCH").query::<()>(con)?;
+                cmd("UNWATCH").exec(con)?;
                 return Ok(response);
             }
         }

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -98,7 +98,7 @@
 //!
 //! ```rust,no_run
 //! fn do_something(con: &mut redis::Connection) -> redis::RedisResult<()> {
-//!     redis::cmd("SET").arg("my_key").arg(42).query::<()>(con)?;
+//!     redis::cmd("SET").arg("my_key").arg(42).exec(con)?;
 //!     Ok(())
 //! }
 //! ```
@@ -133,7 +133,7 @@
 //! use redis::Commands;
 //!
 //! fn do_something(con: &mut redis::Connection) -> redis::RedisResult<()> {
-//!     let _ : () = con.set("my_key", 42)?;
+//!     let _: () = con.set("my_key", 42)?;
 //!     Ok(())
 //! }
 //! ```
@@ -366,9 +366,9 @@ use redis::AsyncCommands;
 let client = redis::Client::open("redis://127.0.0.1/").unwrap();
 let mut con = client.get_multiplexed_async_connection().await?;
 
-let _ : () = con.set("key1", b"foo").await?;
+let _: () = con.set("key1", b"foo").await?;
 
-let _ : () = redis::cmd("SET").arg(&["key2", "bar"]).query_async::<()>(&mut con).await?;
+redis::cmd("SET").arg(&["key2", "bar"]).exec_async(&mut con).await?;
 
 let result = redis::cmd("MGET")
  .arg(&["key1", "key2"])

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -98,7 +98,7 @@
 //!
 //! ```rust,no_run
 //! fn do_something(con: &mut redis::Connection) -> redis::RedisResult<()> {
-//!     let _ : () = redis::cmd("SET").arg("my_key").arg(42).query(con)?;
+//!     redis::cmd("SET").arg("my_key").arg(42).query::<()>(con)?;
 //!     Ok(())
 //! }
 //! ```
@@ -114,7 +114,7 @@
 //! fn do_something(con: &mut redis::Connection) -> redis::RedisResult<usize> {
 //!     // This will result in a server error: "unknown command `MEMORY USAGE`"
 //!     // because "USAGE" is technically a sub-command of "MEMORY".
-//!     redis::cmd("MEMORY USAGE").arg("my_key").query(con)?;
+//!     redis::cmd("MEMORY USAGE").arg("my_key").query::<usize>(con)?;
 //!
 //!     // However, this will work as you'd expect
 //!     redis::cmd("MEMORY").arg("USAGE").arg("my_key").query(con)
@@ -366,9 +366,9 @@ use redis::AsyncCommands;
 let client = redis::Client::open("redis://127.0.0.1/").unwrap();
 let mut con = client.get_multiplexed_async_connection().await?;
 
-con.set("key1", b"foo").await?;
+let _ : () = con.set("key1", b"foo").await?;
 
-redis::cmd("SET").arg(&["key2", "bar"]).query_async(&mut con).await?;
+let _ : () = redis::cmd("SET").arg(&["key2", "bar"]).query_async::<()>(&mut con).await?;
 
 let result = redis::cmd("MGET")
  .arg(&["key1", "key2"])

--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -196,7 +196,7 @@ impl Pipeline {
     /// ```rust,no_run
     /// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
     /// # let mut con = client.get_connection().unwrap();
-    /// let _ : () = redis::pipe().cmd("PING").query(&mut con).unwrap();
+    /// redis::pipe().cmd("PING").query::<()>(&mut con).unwrap();
     /// ```
     ///
     /// NOTE: A Pipeline object may be reused after `query()` with all the commands as were inserted
@@ -204,7 +204,18 @@ impl Pipeline {
     ///       it is necessary to call the `clear()` before inserting new commands.
     #[inline]
     pub fn execute(&self, con: &mut dyn ConnectionLike) {
-        self.query::<()>(con).unwrap();
+        self.exec(con).unwrap();
+    }
+
+    /// This is a shortcut to `query`, to avoid having to define generic bounds for `()`.
+    pub fn exec(&self, con: &mut dyn ConnectionLike) -> RedisResult<()> {
+        self.query::<()>(con)
+    }
+
+    /// This is a shortcut to `query_async`, to avoid having to define generic bounds for `()`.
+    #[cfg(feature = "aio")]
+    pub async fn exec_async(&self, con: &mut impl crate::aio::ConnectionLike) -> RedisResult<()> {
+        self.query_async::<()>(con).await
     }
 }
 

--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -203,16 +203,24 @@ impl Pipeline {
     ///       to them. In order to clear a Pipeline object with minimal memory released/allocated,
     ///       it is necessary to call the `clear()` before inserting new commands.
     #[inline]
+    #[deprecated(note = "Use Cmd::exec + unwrap, instead")]
     pub fn execute(&self, con: &mut dyn ConnectionLike) {
         self.exec(con).unwrap();
     }
 
-    /// This is a shortcut to `query`, to avoid having to define generic bounds for `()`.
+    /// This is an alternative to `query`` that can be used if you want to be able to handle a
+    /// command's success or failure but don't care about the command's response. For example,
+    /// this is useful for "SET" commands for which the response's content is not important.
+    /// It avoids the need to define generic bounds for ().
+    #[inline]
     pub fn exec(&self, con: &mut dyn ConnectionLike) -> RedisResult<()> {
         self.query::<()>(con)
     }
 
-    /// This is a shortcut to `query_async`, to avoid having to define generic bounds for `()`.
+    /// This is an alternative to `query_async` that can be used if you want to be able to handle a
+    /// command's success or failure but don't care about the command's response. For example,
+    /// this is useful for "SET" commands for which the response's content is not important.
+    /// It avoids the need to define generic bounds for ().
     #[cfg(feature = "aio")]
     pub async fn exec_async(&self, con: &mut impl crate::aio::ConnectionLike) -> RedisResult<()> {
         self.query_async::<()>(con).await

--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -174,10 +174,10 @@ impl Pipeline {
     /// Async version of `query`.
     #[inline]
     #[cfg(feature = "aio")]
-    pub async fn query_async<C, T: FromRedisValue>(&self, con: &mut C) -> RedisResult<T>
-    where
-        C: crate::aio::ConnectionLike,
-    {
+    pub async fn query_async<T: FromRedisValue>(
+        &self,
+        con: &mut impl crate::aio::ConnectionLike,
+    ) -> RedisResult<T> {
         let value = if self.commands.is_empty() {
             return from_owned_redis_value(Value::Array(vec![]));
         } else if self.transaction_mode {

--- a/redis/src/script.rs
+++ b/redis/src/script.rs
@@ -147,7 +147,7 @@ impl<'a> ScriptInvocation<'a> {
             Ok(val) => Ok(val),
             Err(err) => {
                 if err.kind() == ErrorKind::NoScriptError {
-                    self.load_cmd().query(con)?;
+                    self.load_cmd().query::<()>(con)?;
                     eval_cmd.query(con)
                 } else {
                     Err(err)
@@ -159,11 +159,10 @@ impl<'a> ScriptInvocation<'a> {
     /// Asynchronously invokes the script and returns the result.
     #[inline]
     #[cfg(feature = "aio")]
-    pub async fn invoke_async<C, T>(&self, con: &mut C) -> RedisResult<T>
-    where
-        C: crate::aio::ConnectionLike,
-        T: FromRedisValue,
-    {
+    pub async fn invoke_async<T: FromRedisValue>(
+        &self,
+        con: &mut impl crate::aio::ConnectionLike,
+    ) -> RedisResult<T> {
         let eval_cmd = self.eval_cmd();
         match eval_cmd.query_async(con).await {
             Ok(val) => {
@@ -173,7 +172,7 @@ impl<'a> ScriptInvocation<'a> {
             Err(err) => {
                 // Load the script into Redis if the script hash wasn't there already
                 if err.kind() == ErrorKind::NoScriptError {
-                    self.load_cmd().query_async(con).await?;
+                    self.load_cmd().query_async::<()>(con).await?;
                     eval_cmd.query_async(con).await
                 } else {
                     Err(err)

--- a/redis/src/script.rs
+++ b/redis/src/script.rs
@@ -147,7 +147,7 @@ impl<'a> ScriptInvocation<'a> {
             Ok(val) => Ok(val),
             Err(err) => {
                 if err.kind() == ErrorKind::NoScriptError {
-                    self.load_cmd().query::<()>(con)?;
+                    self.load_cmd().exec(con)?;
                     eval_cmd.query(con)
                 } else {
                     Err(err)
@@ -172,7 +172,7 @@ impl<'a> ScriptInvocation<'a> {
             Err(err) => {
                 // Load the script into Redis if the script hash wasn't there already
                 if err.kind() == ErrorKind::NoScriptError {
-                    self.load_cmd().query_async::<()>(con).await?;
+                    self.load_cmd().exec_async(con).await?;
                     eval_cmd.query_async(con).await
                 } else {
                     Err(err)

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -511,16 +511,16 @@ impl TestClusterContext {
             let client = redis::Client::open(server.connection_info()).unwrap();
 
             let mut con = client.get_connection().unwrap();
-            let _: () = redis::cmd("ACL")
+            redis::cmd("ACL")
                 .arg("SETUSER")
                 .arg("default")
                 .arg("off")
-                .query(&mut con)
+                .exec(&mut con)
                 .unwrap();
 
             // subsequent unauthenticated command should fail:
             if let Ok(mut con) = client.get_connection() {
-                assert!(redis::cmd("PING").query::<()>(&mut con).is_err());
+                assert!(redis::cmd("PING").exec(&mut con).is_err());
             }
         }
     }

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -496,7 +496,7 @@ impl TestContext {
                 }
             }
         }
-        redis::cmd("FLUSHDB").execute(&mut con);
+        redis::cmd("FLUSHDB").exec(&mut con).unwrap();
 
         TestContext {
             server,

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -23,11 +23,11 @@ mod basic_async {
             redis::cmd("SET")
                 .arg("key1")
                 .arg(b"foo")
-                .query_async::<()>(&mut con)
+                .exec_async(&mut con)
                 .await?;
             redis::cmd("SET")
                 .arg(&["key2", "bar"])
-                .query_async::<()>(&mut con)
+                .exec_async(&mut con)
                 .await?;
             let result = redis::cmd("MGET")
                 .arg(&["key1", "key2"])
@@ -248,7 +248,7 @@ mod basic_async {
             redis::cmd("slaveof")
                 .arg("1.1.1.1")
                 .arg("1")
-                .query_async::<()>(&mut con)
+                .exec_async(&mut con)
                 .await
                 .unwrap();
 
@@ -287,11 +287,11 @@ mod basic_async {
             redis::cmd("SET")
                 .arg(&key[..])
                 .arg(foo_val.as_bytes())
-                .query_async::<()>(&mut con)
+                .exec_async(&mut con)
                 .await?;
             redis::cmd("SET")
                 .arg(&[&key2, "bar"])
-                .query_async::<()>(&mut con)
+                .exec_async(&mut con)
                 .await?;
             redis::cmd("MGET")
                 .arg(&[&key_2, &key2_2])
@@ -432,7 +432,7 @@ mod basic_async {
                             redis::cmd("SADD")
                                 .arg("foo")
                                 .arg(x)
-                                .query_async::<()>(&mut con)
+                                .exec_async(&mut con)
                                 .await?;
                             unseen.insert(x);
                         }
@@ -771,7 +771,7 @@ mod basic_async {
                 redis::cmd("SET")
                     .arg("foo")
                     .arg("bar")
-                    .query_async::<()>(&mut conn)
+                    .exec_async(&mut conn)
                     .await?;
 
                 let res: String = redis::cmd("GET").arg("foo").query_async(&mut conn).await?;
@@ -999,7 +999,7 @@ mod basic_async {
                 redis::cmd("SET")
                     .arg("key1")
                     .arg(b"foo")
-                    .query_async::<()>(&mut con)
+                    .exec_async(&mut con)
                     .await?;
                 let result = redis::cmd("GET").arg(&["key1"]).query_async(&mut con).await;
                 assert_eq!(result, Ok("foo".to_string()));
@@ -1020,7 +1020,7 @@ mod basic_async {
                 redis::cmd("SET")
                     .arg("key1")
                     .arg(b"foo")
-                    .query_async::<()>(&mut con)
+                    .exec_async(&mut con)
                     .await?;
                 let result = redis::cmd("GET").arg(&["key1"]).query_async(&mut con).await;
                 assert_eq!(result, Ok("foo".to_string()));

--- a/redis/tests/test_async_async_std.rs
+++ b/redis/tests/test_async_async_std.rs
@@ -15,11 +15,11 @@ fn test_args() {
         redis::cmd("SET")
             .arg("key1")
             .arg(b"foo")
-            .query_async::<()>(&mut con)
+            .exec_async(&mut con)
             .await?;
         redis::cmd("SET")
             .arg(&["key2", "bar"])
-            .query_async::<()>(&mut con)
+            .exec_async(&mut con)
             .await?;
         let result = redis::cmd("MGET")
             .arg(&["key1", "key2"])
@@ -40,11 +40,11 @@ fn test_args_async_std() {
         redis::cmd("SET")
             .arg("key1")
             .arg(b"foo")
-            .query_async::<()>(&mut con)
+            .exec_async(&mut con)
             .await?;
         redis::cmd("SET")
             .arg(&["key2", "bar"])
-            .query_async::<()>(&mut con)
+            .exec_async(&mut con)
             .await?;
         let result = redis::cmd("MGET")
             .arg(&["key1", "key2"])
@@ -137,11 +137,11 @@ fn test_cmd(con: &MultiplexedConnection, i: i32) -> impl Future<Output = RedisRe
         redis::cmd("SET")
             .arg(&key[..])
             .arg(foo_val.as_bytes())
-            .query_async::<()>(&mut con)
+            .exec_async(&mut con)
             .await?;
         redis::cmd("SET")
             .arg(&[&key2, "bar"])
-            .query_async::<()>(&mut con)
+            .exec_async(&mut con)
             .await?;
         redis::cmd("MGET")
             .arg(&[&key_2, &key2_2])

--- a/redis/tests/test_async_async_std.rs
+++ b/redis/tests/test_async_async_std.rs
@@ -15,11 +15,11 @@ fn test_args() {
         redis::cmd("SET")
             .arg("key1")
             .arg(b"foo")
-            .query_async(&mut con)
+            .query_async::<()>(&mut con)
             .await?;
         redis::cmd("SET")
             .arg(&["key2", "bar"])
-            .query_async(&mut con)
+            .query_async::<()>(&mut con)
             .await?;
         let result = redis::cmd("MGET")
             .arg(&["key1", "key2"])
@@ -40,11 +40,11 @@ fn test_args_async_std() {
         redis::cmd("SET")
             .arg("key1")
             .arg(b"foo")
-            .query_async(&mut con)
+            .query_async::<()>(&mut con)
             .await?;
         redis::cmd("SET")
             .arg(&["key2", "bar"])
-            .query_async(&mut con)
+            .query_async::<()>(&mut con)
             .await?;
         let result = redis::cmd("MGET")
             .arg(&["key1", "key2"])
@@ -137,11 +137,11 @@ fn test_cmd(con: &MultiplexedConnection, i: i32) -> impl Future<Output = RedisRe
         redis::cmd("SET")
             .arg(&key[..])
             .arg(foo_val.as_bytes())
-            .query_async(&mut con)
+            .query_async::<()>(&mut con)
             .await?;
         redis::cmd("SET")
             .arg(&[&key2, "bar"])
-            .query_async(&mut con)
+            .query_async::<()>(&mut con)
             .await?;
         redis::cmd("MGET")
             .arg(&[&key_2, &key2_2])
@@ -271,7 +271,7 @@ fn test_script() {
         script1
             .key("key1")
             .arg("foo")
-            .invoke_async(&mut con)
+            .invoke_async::<()>(&mut con)
             .await?;
         let val: String = script2.key("key1").invoke_async(&mut con).await?;
         assert_eq!(val, "foo");
@@ -280,7 +280,7 @@ fn test_script() {
         script1
             .key("key1")
             .arg("bar")
-            .invoke_async(&mut con)
+            .invoke_async::<()>(&mut con)
             .await?;
         let val: String = script2.key("key1").invoke_async(&mut con).await?;
         assert_eq!(val, "bar");

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -36,8 +36,15 @@ mod basic {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
-        redis::cmd("SET").arg("key1").arg(b"foo").execute(&mut con);
-        redis::cmd("SET").arg(&["key2", "bar"]).execute(&mut con);
+        redis::cmd("SET")
+            .arg("key1")
+            .arg(b"foo")
+            .exec(&mut con)
+            .unwrap();
+        redis::cmd("SET")
+            .arg(&["key2", "bar"])
+            .exec(&mut con)
+            .unwrap();
 
         assert_eq!(
             redis::cmd("MGET").arg(&["key1", "key2"]).query(&mut con),
@@ -85,10 +92,14 @@ mod basic {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
-        redis::cmd("SET").arg("foo").arg(42).execute(&mut con);
+        redis::cmd("SET").arg("foo").arg(42).exec(&mut con).unwrap();
         assert_eq!(redis::cmd("GET").arg("foo").query(&mut con), Ok(42));
 
-        redis::cmd("SET").arg("bar").arg("foo").execute(&mut con);
+        redis::cmd("SET")
+            .arg("bar")
+            .arg("foo")
+            .exec(&mut con)
+            .unwrap();
         assert_eq!(
             redis::cmd("GET").arg("bar").query(&mut con),
             Ok(b"foo".to_vec())
@@ -102,7 +113,7 @@ mod basic {
         let mut con = ctx.connection();
 
         //The key is a simple value
-        redis::cmd("SET").arg("foo").arg(42).execute(&mut con);
+        redis::cmd("SET").arg("foo").arg(42).exec(&mut con).unwrap();
         let string_key_type: String = con.key_type("foo").unwrap();
         assert_eq!(string_key_type, "string");
 
@@ -110,7 +121,8 @@ mod basic {
         redis::cmd("LPUSH")
             .arg("list_bar")
             .arg("foo")
-            .execute(&mut con);
+            .exec(&mut con)
+            .unwrap();
         let list_key_type: String = con.key_type("list_bar").unwrap();
         assert_eq!(list_key_type, "list");
 
@@ -118,7 +130,8 @@ mod basic {
         redis::cmd("SADD")
             .arg("set_bar")
             .arg("foo")
-            .execute(&mut con);
+            .exec(&mut con)
+            .unwrap();
         let set_key_type: String = con.key_type("set_bar").unwrap();
         assert_eq!(set_key_type, "set");
 
@@ -127,7 +140,8 @@ mod basic {
             .arg("sorted_set_bar")
             .arg("1")
             .arg("foo")
-            .execute(&mut con);
+            .exec(&mut con)
+            .unwrap();
         let zset_key_type: String = con.key_type("sorted_set_bar").unwrap();
         assert_eq!(zset_key_type, "zset");
 
@@ -136,7 +150,8 @@ mod basic {
             .arg("hset_bar")
             .arg("hset_key_1")
             .arg("foo")
-            .execute(&mut con);
+            .exec(&mut con)
+            .unwrap();
         let hash_key_type: String = con.key_type("hset_bar").unwrap();
         assert_eq!(hash_key_type, "hash");
     }
@@ -183,7 +198,7 @@ mod basic {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
-        redis::cmd("SET").arg("foo").arg(42).execute(&mut con);
+        redis::cmd("SET").arg("foo").arg(42).exec(&mut con).unwrap();
         assert_eq!(redis::cmd("INCR").arg("foo").query(&mut con), Ok(43usize));
     }
 
@@ -192,7 +207,7 @@ mod basic {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
-        redis::cmd("SET").arg("foo").arg(42).execute(&mut con);
+        redis::cmd("SET").arg("foo").arg(42).exec(&mut con).unwrap();
 
         assert_eq!(con.get_del("foo"), Ok(42usize));
 
@@ -207,7 +222,11 @@ mod basic {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
-        redis::cmd("SET").arg("foo").arg(42usize).execute(&mut con);
+        redis::cmd("SET")
+            .arg("foo")
+            .arg(42usize)
+            .exec(&mut con)
+            .unwrap();
 
         // Return of get_ex must match set value
         let ret_value = con.get_ex::<_, usize>("foo", Expiry::EX(1)).unwrap();
@@ -224,7 +243,11 @@ mod basic {
         assert_eq!(after_expire_get, None);
 
         // Persist option test prep
-        redis::cmd("SET").arg("foo").arg(420usize).execute(&mut con);
+        redis::cmd("SET")
+            .arg("foo")
+            .arg(420usize)
+            .exec(&mut con)
+            .unwrap();
 
         // Return of get_ex with persist option must match set value
         let ret_value = con.get_ex::<_, usize>("foo", Expiry::PERSIST).unwrap();
@@ -261,12 +284,14 @@ mod basic {
             .arg("foo")
             .arg("key_1")
             .arg(1)
-            .execute(&mut con);
+            .exec(&mut con)
+            .unwrap();
         redis::cmd("HSET")
             .arg("foo")
             .arg("key_2")
             .arg(2)
-            .execute(&mut con);
+            .exec(&mut con)
+            .unwrap();
 
         let h: HashMap<String, i32> = redis::cmd("HGETALL").arg("foo").query(&mut con).unwrap();
         assert_eq!(h.len(), 2);
@@ -287,12 +312,12 @@ mod basic {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
-        redis::cmd("SET").arg("foo").arg(42).execute(&mut con);
+        redis::cmd("SET").arg("foo").arg(42).exec(&mut con).unwrap();
         assert_eq!(redis::cmd("GET").arg("foo").query(&mut con), Ok(42));
         assert_eq!(con.unlink("foo"), Ok(1));
 
-        redis::cmd("SET").arg("foo").arg(42).execute(&mut con);
-        redis::cmd("SET").arg("bar").arg(42).execute(&mut con);
+        redis::cmd("SET").arg("foo").arg(42).exec(&mut con).unwrap();
+        redis::cmd("SET").arg("bar").arg(42).exec(&mut con).unwrap();
         assert_eq!(con.unlink(&["foo", "bar"]), Ok(2));
     }
 
@@ -344,7 +369,7 @@ mod basic {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
-        redis::cmd("SET").arg("foo").arg(1).execute(&mut con);
+        redis::cmd("SET").arg("foo").arg(1).exec(&mut con).unwrap();
 
         let (a, b): (Option<i32>, Option<i32>) = redis::cmd("MGET")
             .arg("foo")
@@ -368,7 +393,7 @@ mod basic {
         let mut unseen = HashSet::new();
 
         for x in 0..1000 {
-            redis::cmd("SADD").arg("foo").arg(x).execute(&mut con);
+            redis::cmd("SADD").arg("foo").arg(x).exec(&mut con).unwrap();
             unseen.insert(x);
         }
 
@@ -576,7 +601,7 @@ mod basic {
 
         assert_eq!(k1, 42);
 
-        redis::cmd("DEL").arg("pkey_1").execute(&mut con);
+        redis::cmd("DEL").arg("pkey_1").exec(&mut con).unwrap();
 
         // The internal commands vector of the pipeline still contains the previous commands.
         let ((k1,), (k2, k3)): ((i32,), (i32, i32)) = pl
@@ -615,7 +640,7 @@ mod basic {
 
         assert_eq!(k1, 44);
 
-        redis::cmd("DEL").arg("pkey_1").execute(&mut con);
+        redis::cmd("DEL").arg("pkey_1").exec(&mut con).unwrap();
 
         let ((k1, k2),): ((bool, i32),) = pl
             .cmd("SET")
@@ -723,7 +748,11 @@ mod basic {
         });
 
         let _ = barrier.wait();
-        redis::cmd("PUBLISH").arg("foo").arg(42).execute(&mut con);
+        redis::cmd("PUBLISH")
+            .arg("foo")
+            .arg(42)
+            .exec(&mut con)
+            .unwrap();
         // We can also call the command directly
         assert_eq!(con.publish("foo", 23), Ok(1));
 
@@ -957,7 +986,11 @@ mod basic {
         // between channel subscription and blocking for messages.
         sleep(Duration::from_millis(100));
 
-        redis::cmd("PUBLISH").arg("foo").arg(42).execute(&mut con);
+        redis::cmd("PUBLISH")
+            .arg("foo")
+            .arg(42)
+            .exec(&mut con)
+            .unwrap();
         assert_eq!(con.publish("bar", 23), Ok(1));
 
         // Wait for thread
@@ -977,7 +1010,8 @@ mod basic {
         redis::cmd("HMSET")
             .arg("my_key")
             .arg(&[("field_1", 42), ("field_2", 23)])
-            .execute(&mut con);
+            .exec(&mut con)
+            .unwrap();
 
         assert_eq!(
             redis::cmd("HGET")
@@ -1414,7 +1448,8 @@ mod basic {
             .arg("SET")
             .arg(b"maxmemory-policy")
             .arg("allkeys-lfu")
-            .execute(&mut con);
+            .exec(&mut con)
+            .unwrap();
 
         let _: () = con.get("object_key_str").unwrap();
         // since maxmemory-policy changed, freq should reset to 1 since we only called
@@ -1700,15 +1735,20 @@ mod basic {
             redis::cmd("SUBSCRIBE")
                 .arg("foo")
                 .set_no_response(true)
-                .execute(&mut pubsub_con);
+                .exec(&mut pubsub_con)
+                .unwrap();
         }
         // We are using different redis connection to send PubSub message but it's okay to re-use the same connection.
-        redis::cmd("PUBLISH").arg("foo").arg(42).execute(&mut con);
+        redis::cmd("PUBLISH")
+            .arg("foo")
+            .arg(42)
+            .exec(&mut con)
+            .unwrap();
         // We can also call the command directly
         assert_eq!(con.publish("foo", 23), Ok(1));
 
         // In sync connection it can't receive push messages from socket without requesting some command
-        redis::cmd("PING").execute(&mut pubsub_con);
+        redis::cmd("PING").exec(&mut pubsub_con).unwrap();
 
         // We have received verification from Redis that it's subscribed to channel.
         let PushInfo { kind, data } = rx.try_recv().unwrap();

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -463,28 +463,28 @@ mod basic {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
-        let _: () = redis::cmd("SET")
+        redis::cmd("SET")
             .arg("x")
             .arg("x-value")
-            .query(&mut con)
+            .exec(&mut con)
             .unwrap();
-        let _: () = redis::cmd("SET")
+        redis::cmd("SET")
             .arg("y")
             .arg("y-value")
-            .query(&mut con)
+            .exec(&mut con)
             .unwrap();
 
-        let _: () = redis::cmd("SLAVEOF")
+        redis::cmd("SLAVEOF")
             .arg("1.1.1.1")
             .arg("99")
-            .query(&mut con)
+            .exec(&mut con)
             .unwrap();
 
         let res = redis::pipe()
             .set("x", "another-x-value")
             .ignore()
             .get("y")
-            .query::<()>(&mut con);
+            .exec(&mut con);
         assert_eq!(res.unwrap_err().kind(), ErrorKind::ReadOnly);
 
         // Make sure we don't get leftover responses from the pipeline ("y-value"). See #436.
@@ -500,9 +500,9 @@ mod basic {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
-        let _: () = redis::pipe().cmd("PING").ignore().query(&mut con).unwrap();
+        redis::pipe().cmd("PING").ignore().exec(&mut con).unwrap();
 
-        let _: () = redis::pipe().query(&mut con).unwrap();
+        redis::pipe().exec(&mut con).unwrap();
     }
 
     #[test]
@@ -537,10 +537,10 @@ mod basic {
         let _: () = con.set("x", 42).unwrap();
 
         // Make Redis a replica of a nonexistent master, thereby making it read-only.
-        let _: () = redis::cmd("slaveof")
+        redis::cmd("slaveof")
             .arg("1.1.1.1")
             .arg("1")
-            .query(&mut con)
+            .exec(&mut con)
             .unwrap();
 
         // Ensure that a write command fails with a READONLY error
@@ -639,10 +639,10 @@ mod basic {
         let mut con = ctx.connection();
 
         let key = "the_key";
-        let _: () = redis::cmd("SET").arg(key).arg(42).query(&mut con).unwrap();
+        redis::cmd("SET").arg(key).arg(42).exec(&mut con).unwrap();
 
         loop {
-            let _: () = redis::cmd("WATCH").arg(key).query(&mut con).unwrap();
+            redis::cmd("WATCH").arg(key).exec(&mut con).unwrap();
             let val: isize = redis::cmd("GET").arg(key).query(&mut con).unwrap();
             let response: Option<(isize,)> = redis::pipe()
                 .atomic()
@@ -673,7 +673,7 @@ mod basic {
         let mut con = ctx.connection();
 
         let key = "the_key";
-        let _: () = redis::cmd("SET").arg(key).arg(42).query(&mut con).unwrap();
+        redis::cmd("SET").arg(key).arg(42).exec(&mut con).unwrap();
 
         let response: (isize,) = redis::transaction(&mut con, &[key], |con, pipe| {
             let val: isize = redis::cmd("GET").arg(key).query(con)?;
@@ -1619,7 +1619,7 @@ mod basic {
         let _ = cmd("CLIENT")
             .arg("TRACKING")
             .arg("ON")
-            .query::<()>(&mut con)
+            .exec(&mut con)
             .unwrap();
         let pipe = build_simple_pipeline_for_invalidation();
         for _ in 0..10 {

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -239,7 +239,7 @@ mod cluster {
             .arg(42)
             .ignore()
             .cmd(" SCRIPT kill ")
-            .query::<()>(&mut con)
+            .exec(&mut con)
             .unwrap_err();
 
         assert_eq!(
@@ -247,7 +247,7 @@ mod cluster {
         "This command cannot be safely routed in cluster mode - ClientError: Command 'SCRIPT KILL' can't be executed in a cluster pipeline."
     );
 
-        let err = cluster_pipe().keys("*").query::<()>(&mut con).unwrap_err();
+        let err = cluster_pipe().keys("*").exec(&mut con).unwrap_err();
 
         assert_eq!(
         err.to_string(),
@@ -301,7 +301,7 @@ mod cluster {
                 expected.push(r);
             }
         }
-        pipe.query::<()>(&mut con).unwrap_err();
+        pipe.exec(&mut con).unwrap_err();
 
         std::thread::sleep(std::time::Duration::from_secs(5));
 

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -23,8 +23,12 @@ mod cluster {
         redis::cmd("SET")
             .arg("{x}key1")
             .arg(b"foo")
-            .execute(&mut con);
-        redis::cmd("SET").arg(&["{x}key2", "bar"]).execute(&mut con);
+            .exec(&mut con)
+            .unwrap();
+        redis::cmd("SET")
+            .arg(&["{x}key2", "bar"])
+            .exec(&mut con)
+            .unwrap();
 
         assert_eq!(
             redis::cmd("MGET")
@@ -48,8 +52,12 @@ mod cluster {
         redis::cmd("SET")
             .arg("{x}key1")
             .arg(b"foo")
-            .execute(&mut con);
-        redis::cmd("SET").arg(&["{x}key2", "bar"]).execute(&mut con);
+            .exec(&mut con)
+            .unwrap();
+        redis::cmd("SET")
+            .arg(&["{x}key2", "bar"])
+            .exec(&mut con)
+            .unwrap();
 
         assert_eq!(
             redis::cmd("MGET")
@@ -81,8 +89,12 @@ mod cluster {
         redis::cmd("SET")
             .arg("{x}key1")
             .arg(b"foo")
-            .execute(&mut con);
-        redis::cmd("SET").arg(&["{x}key2", "bar"]).execute(&mut con);
+            .exec(&mut con)
+            .unwrap();
+        redis::cmd("SET")
+            .arg(&["{x}key2", "bar"])
+            .exec(&mut con)
+            .unwrap();
 
         // Read commands would go to the replica nodes
         assert_eq!(
@@ -269,7 +281,7 @@ mod cluster {
             expected.push(format!("bar{i}"));
             pipe.set(&queries[i], &expected[i]).ignore();
         }
-        pipe.execute(&mut con);
+        pipe.exec(&mut con).unwrap();
 
         pipe.clear();
         for q in &queries {
@@ -1000,8 +1012,12 @@ mod cluster {
             redis::cmd("SET")
                 .arg("{x}key1")
                 .arg(b"foo")
-                .execute(&mut con);
-            redis::cmd("SET").arg(&["{x}key2", "bar"]).execute(&mut con);
+                .exec(&mut con)
+                .unwrap();
+            redis::cmd("SET")
+                .arg(&["{x}key2", "bar"])
+                .exec(&mut con)
+                .unwrap();
 
             assert_eq!(
                 redis::cmd("MGET")

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -34,7 +34,7 @@ mod cluster_async {
             cmd("SET")
                 .arg("test")
                 .arg("test_data")
-                .query_async::<()>(&mut connection)
+                .exec_async(&mut connection)
                 .await?;
             let res: String = cmd("GET")
                 .arg("test")
@@ -285,7 +285,7 @@ mod cluster_async {
             let mut pipe = redis::pipe();
             pipe.add_command(cmd("SET").arg("test").arg("test_data").clone());
             pipe.add_command(cmd("SET").arg("{test}3").arg("test_data3").clone());
-            pipe.query_async::<()>(&mut connection).await?;
+            pipe.exec_async(&mut connection).await?;
             let res: String = connection.get("test").await?;
             assert_eq!(res, "test_data");
             let res: String = connection.get("{test}3").await?;
@@ -333,10 +333,7 @@ mod cluster_async {
     async fn do_failover(
         redis: &mut redis::aio::MultiplexedConnection,
     ) -> Result<(), anyhow::Error> {
-        cmd("CLUSTER")
-            .arg("FAILOVER")
-            .query_async::<()>(redis)
-            .await?;
+        cmd("CLUSTER").arg("FAILOVER").exec_async(redis).await?;
         Ok(())
     }
 
@@ -387,7 +384,7 @@ mod cluster_async {
                         tokio::time::timeout(std::time::Duration::from_secs(3), async {
                             Ok(redis::Cmd::new()
                                 .arg("FLUSHALL")
-                                .query_async::<()>(&mut conn)
+                                .exec_async(&mut conn)
                                 .await?)
                         })
                         .await
@@ -433,7 +430,7 @@ mod cluster_async {
                             .arg(&key)
                             .arg(i)
                             .clone()
-                            .query_async::<()>(&mut connection)
+                            .exec_async(&mut connection)
                             .await?;
                         let res: i32 = cmd("GET")
                             .arg(key)
@@ -540,7 +537,7 @@ mod cluster_async {
             redis::cmd("SET")
                 .arg("test")
                 .arg("test_data")
-                .query_async::<()>(&mut connection)
+                .exec_async(&mut connection)
                 .await?;
             redis::cmd("GET")
                 .arg("test")
@@ -1657,7 +1654,7 @@ mod cluster_async {
             cmd("SET")
                 .arg("test")
                 .arg("test_data")
-                .query_async::<()>(&mut connection)
+                .exec_async(&mut connection)
                 .await?;
             let res: String = cmd("GET")
                 .arg("test")
@@ -1987,7 +1984,7 @@ mod cluster_async {
                 cmd("SET")
                     .arg("test")
                     .arg("test_data")
-                    .query_async::<()>(&mut connection)
+                    .exec_async(&mut connection)
                     .await?;
                 let res: String = cmd("GET")
                     .arg("test")

--- a/redis/tests/test_script.rs
+++ b/redis/tests/test_script.rs
@@ -14,10 +14,10 @@ mod script {
 
         let script = redis::Script::new(r"return {redis.call('GET', KEYS[1]), ARGV[1]}");
 
-        let _: () = redis::cmd("SET")
+        redis::cmd("SET")
             .arg("my_key")
             .arg("foo")
-            .query(&mut con)
+            .exec(&mut con)
             .unwrap();
         let response = script.key("my_key").arg(42).invoke(&mut con);
 


### PR DESCRIPTION
Adds missing generic declarations or return types for `()`, when until the 2024 edition ! was inferred. This fixes this warning:

```
warning: this function depends on never type fallback being `()`
 --> redis/examples/async-await.rs:4:7
  |
4 | async fn main() -> redis::RedisResult<()> {
  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
  = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
  = help: specify the types explicitly
note: in edition 2024, the requirement `!: FromRedisValue` will fail
 --> redis/examples/async-await.rs:8:9
  |
8 |     con.set("key1", b"foo").await?;
  |         ^^^
  = note: `-D dependency-on-unit-never-type-fallback` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(dependency_on_unit_never_type_fallback)]`
```

In order to make this easier, this also changes the generics used in `Cmd/Pipeline::query_async`/`Script::invoke_async`, so that the function declaration would only need to define a single generic value. This changed the usage from `cmd.query_async::<_, ()>(&mut conn).await;` to `cmd.query_async::<()>(&mut conn).await;`. This was done since the compiler doesn't always suggest to use `_` for the connection type, so the user might think they need to give a concrete connection type, which might be onerous to the user.
This can be reverted and replaced with `let _: () = cmd.query_async(&mut conn).await;`, as is done with other calls.