### PR TITLE
Add scan_options

### DIFF
--- a/redis/src/commands/macros.rs
+++ b/redis/src/commands/macros.rs
@@ -54,7 +54,16 @@ macro_rules! implement_commands {
                 c.iter(self)
             }
 
+            /// Incrementally iterate the keys space with options.
+            #[inline]
+            fn scan_options<RV: FromRedisValue>(&mut self, opts: ScanOptions) -> RedisResult<Iter<'_, RV>> {
+                let mut c = cmd("SCAN");
+                c.cursor_arg(opts.cursor).arg(opts);
+                c.iter(self)
+            }
+
             /// Incrementally iterate the keys space for keys matching a pattern.
+            #[deprecated(since="0.26.0", note="please use `scan_options` instead")]
             #[inline]
             fn scan_match<P: ToRedisArgs, RV: FromRedisValue>(&mut self, pattern: P) -> RedisResult<Iter<'_, RV>> {
                 let mut c = cmd("SCAN");
@@ -178,7 +187,16 @@ macro_rules! implement_commands {
                 Box::pin(async move { c.iter_async(self).await })
             }
 
+            /// Incrementally iterate the keys space with options.
+            #[inline]
+            fn scan_options<RV: FromRedisValue>(&mut self, opts: ScanOptions) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
+                let mut c = cmd("SCAN");
+                c.cursor_arg(opts.cursor).arg(opts);
+                Box::pin(async move { c.iter_async(self).await })
+            }
+
             /// Incrementally iterate set elements for elements matching a pattern.
+            #[deprecated(since="0.26.0", note="please use `scan_options` instead")]
             #[inline]
             fn scan_match<P: ToRedisArgs, RV: FromRedisValue>(&mut self, pattern: P) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
                 let mut c = cmd("SCAN");

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -388,7 +388,7 @@ pub use crate::client::AsyncConnectionConfig;
 pub use crate::client::Client;
 pub use crate::cmd::{cmd, pack_command, pipe, Arg, Cmd, Iter};
 pub use crate::commands::{
-    Commands, ControlFlow, Direction, LposOptions, PubSubCommands, SetOptions,
+    Commands, ControlFlow, Direction, LposOptions, PubSubCommands, ScanOptions, SetOptions,
 };
 pub use crate::connection::{
     parse_redis_url, transaction, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike,


### PR DESCRIPTION
Solves #1201 

Add new scan_options that receives cursor, pattern and count as arguments.

Also added deprecation warning for scan_match because in my eyes it is unusable without count anyway, but if you think we should leave it, I'll remove it.