### PR TITLE
Change is_single_arg to num_of_args in ToRedisArgs trait

### DIFF
--- a/redis/src/commands/json.rs
+++ b/redis/src/commands/json.rs
@@ -292,7 +292,7 @@ implement_json_commands! {
     /// in square brackets (or empty brackets if not found). If you want to deserialize it
     /// with e.g. `serde_json` you have to use `Vec<T>` for your output type instead of `T`.
     fn json_get<K: ToRedisArgs, P: ToRedisArgs>(key: K, path: P) {
-        let mut cmd = cmd(if key.is_single_arg() { "JSON.GET" } else { "JSON.MGET" });
+        let mut cmd = cmd(if key.num_of_args() <= 1 { "JSON.GET" } else { "JSON.MGET" });
 
         cmd.arg(key)
            .arg(path);

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -135,7 +135,7 @@ implement_commands! {
 
     /// Get the value of a key.  If key is a vec this becomes an `MGET`.
     fn get<K: ToRedisArgs>(key: K) {
-        cmd(if key.is_single_arg() { "GET" } else { "MGET" }).arg(key)
+        cmd(if key.num_of_args() <= 1 { "GET" } else { "MGET" }).arg(key)
     }
 
     /// Get values of keys
@@ -373,7 +373,7 @@ implement_commands! {
 
     /// Gets a single (or multiple) fields from a hash.
     fn hget<K: ToRedisArgs, F: ToRedisArgs>(key: K, field: F) {
-        cmd(if field.is_single_arg() { "HGET" } else { "HMGET" }).arg(key).arg(field)
+        cmd(if field.num_of_args() <= 1 { "HGET" } else { "HMGET" }).arg(key).arg(field)
     }
 
     /// Deletes a single (or multiple) fields from a hash.
@@ -673,20 +673,20 @@ implement_commands! {
 
     /// Intersect multiple sorted sets and store the resulting sorted set in
     /// a new key using SUM as aggregation function.
-    fn zinterstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: &'a [K]) {
-        cmd("ZINTERSTORE").arg(dstkey).arg(keys.len()).arg(keys)
+    fn zinterstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) {
+        cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys)
     }
 
     /// Intersect multiple sorted sets and store the resulting sorted set in
     /// a new key using MIN as aggregation function.
-    fn zinterstore_min<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: &'a [K]) {
-        cmd("ZINTERSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MIN")
+    fn zinterstore_min<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) {
+        cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MIN")
     }
 
     /// Intersect multiple sorted sets and store the resulting sorted set in
     /// a new key using MAX as aggregation function.
-    fn zinterstore_max<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: &'a [K]) {
-        cmd("ZINTERSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MAX")
+    fn zinterstore_max<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) {
+        cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MAX")
     }
 
     /// [`Commands::zinterstore`], but with the ability to specify a
@@ -694,7 +694,7 @@ implement_commands! {
     /// in a tuple.
     fn zinterstore_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> (&K, &W) {(key, weight)}).unzip();
-        cmd("ZINTERSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("WEIGHTS").arg(weights)
+        cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights)
     }
 
     /// [`Commands::zinterstore_min`], but with the ability to specify a
@@ -702,7 +702,7 @@ implement_commands! {
     /// in a tuple.
     fn zinterstore_min_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> (&K, &W) {(key, weight)}).unzip();
-        cmd("ZINTERSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MIN").arg("WEIGHTS").arg(weights)
+        cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MIN").arg("WEIGHTS").arg(weights)
     }
 
     /// [`Commands::zinterstore_max`], but with the ability to specify a
@@ -710,7 +710,7 @@ implement_commands! {
     /// in a tuple.
     fn zinterstore_max_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> (&K, &W) {(key, weight)}).unzip();
-        cmd("ZINTERSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MAX").arg("WEIGHTS").arg(weights)
+        cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MAX").arg("WEIGHTS").arg(weights)
     }
 
     /// Count the number of members in a sorted set between a given lexicographical range.
@@ -743,27 +743,27 @@ implement_commands! {
     /// Removes and returns up to count members with the highest scores,
     /// from the first non-empty sorted set in the provided list of key names.
     /// Blocks until a member is available otherwise.
-    fn bzmpop_max<K: ToRedisArgs>(timeout: f64, keys: &'a [K], count: isize) {
-        cmd("BZMPOP").arg(timeout).arg(keys.len()).arg(keys).arg("MAX").arg("COUNT").arg(count)
+    fn bzmpop_max<K: ToRedisArgs>(timeout: f64, keys: K, count: isize) {
+        cmd("BZMPOP").arg(timeout).arg(keys.num_of_args()).arg(keys).arg("MAX").arg("COUNT").arg(count)
     }
 
     /// Removes and returns up to count members with the highest scores,
     /// from the first non-empty sorted set in the provided list of key names.
-    fn zmpop_max<K: ToRedisArgs>(keys: &'a [K], count: isize) {
-        cmd("ZMPOP").arg(keys.len()).arg(keys).arg("MAX").arg("COUNT").arg(count)
+    fn zmpop_max<K: ToRedisArgs>(keys: K, count: isize) {
+        cmd("ZMPOP").arg(keys.num_of_args()).arg(keys).arg("MAX").arg("COUNT").arg(count)
     }
 
     /// Removes and returns up to count members with the lowest scores,
     /// from the first non-empty sorted set in the provided list of key names.
     /// Blocks until a member is available otherwise.
-    fn bzmpop_min<K: ToRedisArgs>(timeout: f64, keys: &'a [K], count: isize) {
-        cmd("BZMPOP").arg(timeout).arg(keys.len()).arg(keys).arg("MIN").arg("COUNT").arg(count)
+    fn bzmpop_min<K: ToRedisArgs>(timeout: f64, keys: K, count: isize) {
+        cmd("BZMPOP").arg(timeout).arg(keys.num_of_args()).arg(keys).arg("MIN").arg("COUNT").arg(count)
     }
 
     /// Removes and returns up to count members with the lowest scores,
     /// from the first non-empty sorted set in the provided list of key names.
-    fn zmpop_min<K: ToRedisArgs>(keys: &'a [K], count: isize) {
-        cmd("ZMPOP").arg(keys.len()).arg(keys).arg("MIN").arg("COUNT").arg(count)
+    fn zmpop_min<K: ToRedisArgs>(keys: K, count: isize) {
+        cmd("ZMPOP").arg(keys.num_of_args()).arg(keys).arg("MIN").arg("COUNT").arg(count)
     }
 
     /// Return up to count random members in a sorted set (or 1 if `count == None`)
@@ -910,20 +910,20 @@ implement_commands! {
 
     /// Unions multiple sorted sets and store the resulting sorted set in
     /// a new key using SUM as aggregation function.
-    fn zunionstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: &'a [K]) {
-        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.len()).arg(keys)
+    fn zunionstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) {
+        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys)
     }
 
     /// Unions multiple sorted sets and store the resulting sorted set in
     /// a new key using MIN as aggregation function.
-    fn zunionstore_min<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: &'a [K]) {
-        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MIN")
+    fn zunionstore_min<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) {
+        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MIN")
     }
 
     /// Unions multiple sorted sets and store the resulting sorted set in
     /// a new key using MAX as aggregation function.
-    fn zunionstore_max<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: &'a [K]) {
-        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MAX")
+    fn zunionstore_max<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) {
+        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MAX")
     }
 
     /// [`Commands::zunionstore`], but with the ability to specify a
@@ -931,7 +931,7 @@ implement_commands! {
     /// in a tuple.
     fn zunionstore_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> (&K, &W) {(key, weight)}).unzip();
-        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("WEIGHTS").arg(weights)
+        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights)
     }
 
     /// [`Commands::zunionstore_min`], but with the ability to specify a
@@ -939,7 +939,7 @@ implement_commands! {
     /// in a tuple.
     fn zunionstore_min_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> (&K, &W) {(key, weight)}).unzip();
-        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MIN").arg("WEIGHTS").arg(weights)
+        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MIN").arg("WEIGHTS").arg(weights)
     }
 
     /// [`Commands::zunionstore_max`], but with the ability to specify a
@@ -947,7 +947,7 @@ implement_commands! {
     /// in a tuple.
     fn zunionstore_max_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> (&K, &W) {(key, weight)}).unzip();
-        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.len()).arg(keys).arg("AGGREGATE").arg("MAX").arg("WEIGHTS").arg(weights)
+        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MAX").arg("WEIGHTS").arg(weights)
     }
 
     // hyperloglog commands
@@ -2229,8 +2229,15 @@ impl ToRedisArgs for ScanOptions {
         }
     }
 
-    fn is_single_arg(&self) -> bool {
-        false
+    fn num_of_args(&self) -> usize {
+        let mut len = 0;
+        if self.pattern.is_some() {
+            len += 2;
+        }
+        if self.count.is_some() {
+            len += 2;
+        }
+        len
     }
 }
 
@@ -2303,8 +2310,18 @@ impl ToRedisArgs for LposOptions {
         }
     }
 
-    fn is_single_arg(&self) -> bool {
-        false
+    fn num_of_args(&self) -> usize {
+        let mut len = 0;
+        if self.count.is_some() {
+            len += 2;
+        }
+        if self.rank.is_some() {
+            len += 2;
+        }
+        if self.maxlen.is_some() {
+            len += 2;
+        }
+        len
     }
 }
 

--- a/redis/src/geo.rs
+++ b/redis/src/geo.rs
@@ -95,8 +95,8 @@ impl<T: ToRedisArgs> ToRedisArgs for Coord<T> {
         ToRedisArgs::write_redis_args(&self.latitude, out);
     }
 
-    fn is_single_arg(&self) -> bool {
-        false
+    fn num_of_args(&self) -> usize {
+        2
     }
 }
 
@@ -233,8 +233,29 @@ impl ToRedisArgs for RadiusOptions {
         }
     }
 
-    fn is_single_arg(&self) -> bool {
-        false
+    fn num_of_args(&self) -> usize {
+        let mut n: usize = 0;
+        if self.with_coord {
+            n += 1;
+        }
+        if self.with_dist {
+            n += 1;
+        }
+        if self.count.is_some() {
+            n += 2;
+        }
+        match self.order {
+            RadiusOrder::Asc => n += 1,
+            RadiusOrder::Desc => n += 1,
+            _ => {}
+        };
+        if self.store.is_some() {
+            n += 1 + self.store.as_ref().unwrap().len();
+        }
+        if self.store_dist.is_some() {
+            n += 1 + self.store_dist.as_ref().unwrap().len();
+        }
+        n
     }
 }
 

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -1619,12 +1619,12 @@ mod basic {
         );
 
         if redis_version.0 >= 7 {
-            let min = con.bzmpop_min::<&str, (String, Vec<Vec<(String, String)>>)>(
+            let min = con.bzmpop_min::<&[&str], (String, Vec<Vec<(String, String)>>)>(
                 0.0,
                 vec!["a", "b", "c", "d"].as_slice(),
                 1,
             );
-            let max = con.bzmpop_max::<&str, (String, Vec<Vec<(String, String)>>)>(
+            let max = con.bzmpop_max::<&[&str], (String, Vec<Vec<(String, String)>>)>(
                 0.0,
                 vec!["a", "b", "c", "d"].as_slice(),
                 1,

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -23,18 +23,18 @@ mod types {
         let twobytesslice: &[_] = &[bytes, bytes][..];
         let twobytesvec = vec![bytes, bytes];
 
-        assert!("foo".is_single_arg());
-        assert!(sslice.is_single_arg());
-        assert!(nestslice.is_single_arg());
-        assert!(nestvec.is_single_arg());
-        assert!(bytes.is_single_arg());
-        assert!(Arc::new(sslice).is_single_arg());
-        assert!(Rc::new(nestslice).is_single_arg());
+        assert_eq!("foo".num_of_args(), 1);
+        assert_eq!(sslice.num_of_args(), 1);
+        assert_eq!(nestslice.num_of_args(), 1);
+        assert_eq!(nestvec.num_of_args(), 1);
+        assert_eq!(bytes.num_of_args(), 1);
+        assert_eq!(Arc::new(sslice).num_of_args(), 1);
+        assert_eq!(Rc::new(nestslice).num_of_args(), 1);
 
-        assert!(!twobytesslice.is_single_arg());
-        assert!(!twobytesvec.is_single_arg());
-        assert!(!Arc::new(twobytesslice).is_single_arg());
-        assert!(!Rc::new(twobytesslice).is_single_arg());
+        assert_eq!(twobytesslice.num_of_args(), 2);
+        assert_eq!(twobytesvec.num_of_args(), 2);
+        assert_eq!(Arc::new(twobytesslice).num_of_args(), 2);
+        assert_eq!(Rc::new(twobytesslice).num_of_args(), 2);
     }
 
     /// The `FromRedisValue` trait provides two methods for parsing:


### PR DESCRIPTION
As discussed in https://github.com/redis-rs/redis-rs/pull/1232#discussion_r1648820067, @nihohit proposes to change `is_single_arg` to the length of args to make it possible to retrieve the number of arguments.

The purpose of this PR is to loosen the generic constraints on functions that today require a slice, so that they can take any collection that is convertible to many redis args - for example, a `VecDeque`.