### PR TITLE
Use pipelines to setup connections

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -2487,15 +2487,13 @@ impl ToRedisArgs for SetOptions {
 pub fn resp3_hello(connection_info: &RedisConnectionInfo) -> Cmd {
     let mut hello_cmd = cmd("HELLO");
     hello_cmd.arg("3");
-    if connection_info.password.is_some() {
+    if let Some(password) = &connection_info.password {
         let username: &str = match connection_info.username.as_ref() {
             None => "default",
             Some(username) => username,
         };
-        hello_cmd
-            .arg("AUTH")
-            .arg(username)
-            .arg(connection_info.password.as_ref().unwrap());
+        hello_cmd.arg("AUTH").arg(username).arg(password);
     }
+
     hello_cmd
 }

--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -80,6 +80,10 @@ impl Pipeline {
         write_pipeline(out, &self.commands, self.transaction_mode)
     }
 
+    pub(crate) fn len(&self) -> usize {
+        self.commands.len()
+    }
+
     fn execute_pipelined(&self, con: &mut dyn ConnectionLike) -> RedisResult<Value> {
         self.make_pipeline_results(con.req_packed_commands(
             &encode_pipeline(&self.commands, false),

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -1085,4 +1085,25 @@ mod basic_async {
         })
         .unwrap();
     }
+
+    #[test]
+    fn test_select_db() {
+        let ctx = TestContext::new();
+        let mut connection_info = ctx.client.get_connection_info().clone();
+        connection_info.redis.db = 5;
+        let client = redis::Client::open(connection_info).unwrap();
+        block_on_all(async move {
+            let mut connection = client.get_multiplexed_async_connection().await.unwrap();
+
+            let info: String = redis::cmd("CLIENT")
+                .arg("info")
+                .query_async(&mut connection)
+                .await
+                .unwrap();
+            assert!(info.contains("db=5"));
+
+            Ok(())
+        })
+        .unwrap();
+    }
 }

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -1873,4 +1873,18 @@ mod basic {
             (kind, data)
         );
     }
+
+    #[test]
+    fn test_select_db() {
+        let ctx = TestContext::new();
+        let mut connection_info = ctx.client.get_connection_info().clone();
+        connection_info.redis.db = 5;
+        let client = redis::Client::open(connection_info).unwrap();
+        let mut connection = client.get_connection().unwrap();
+        let info: String = redis::cmd("CLIENT")
+            .arg("info")
+            .query(&mut connection)
+            .unwrap();
+        assert!(info.contains("db=5"));
+    }
 }


### PR DESCRIPTION
This change speeds up the setup phase of each new connection, by pipelining all of the commands, instead of sending them one after the other.