### PR TITLE
Close connection on read timeout

### DIFF
--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -1242,9 +1242,10 @@ impl Connection {
         };
         // shutdown connection on protocol error
         if let Err(e) = &result {
-            let shutdown = match e.as_io_error() {
-                Some(e) => e.kind() == io::ErrorKind::UnexpectedEof,
-                None => false,
+            let shutdown = match e.as_io_error().map(|e| e.kind()) {
+                Some(io::ErrorKind::UnexpectedEof) => true,
+                Some(io::ErrorKind::WouldBlock) => true,
+                _ => false,
             };
             if shutdown {
                 // Notify the PushManager that the connection was lost

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -1242,11 +1242,14 @@ impl Connection {
         };
         // shutdown connection on protocol error
         if let Err(e) = &result {
-            let shutdown = match e.as_io_error().map(|e| e.kind()) {
-                Some(io::ErrorKind::UnexpectedEof) => true,
-                Some(io::ErrorKind::WouldBlock) => true,
-                Some(io::ErrorKind::TimedOut) => true,
-                _ => false,
+            let shutdown = match e.as_io_error() {
+                Some(e) => matches!(
+                    e.kind(),
+                    io::ErrorKind::UnexpectedEof
+                        | io::ErrorKind::WouldBlock
+                        | io::ErrorKind::TimedOut
+                ),
+                None => false,
             };
             if shutdown {
                 // Notify the PushManager that the connection was lost

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -1245,6 +1245,7 @@ impl Connection {
             let shutdown = match e.as_io_error().map(|e| e.kind()) {
                 Some(io::ErrorKind::UnexpectedEof) => true,
                 Some(io::ErrorKind::WouldBlock) => true,
+                Some(io::ErrorKind::TimedOut) => true,
                 _ => false,
             };
             if shutdown {

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1029,6 +1029,7 @@ impl RedisError {
                     io::ErrorKind::BrokenPipe => RetryMethod::Reconnect,
                     io::ErrorKind::UnexpectedEof => RetryMethod::Reconnect,
 
+                    io::ErrorKind::WouldBlock => RetryMethod::NoRetry,
                     io::ErrorKind::PermissionDenied => RetryMethod::NoRetry,
                     io::ErrorKind::Unsupported => RetryMethod::NoRetry,
 

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1029,6 +1029,7 @@ impl RedisError {
                     io::ErrorKind::BrokenPipe => RetryMethod::Reconnect,
                     io::ErrorKind::UnexpectedEof => RetryMethod::Reconnect,
 
+                    io::ErrorKind::TimedOut => RetryMethod::NoRetry,
                     io::ErrorKind::WouldBlock => RetryMethod::NoRetry,
                     io::ErrorKind::PermissionDenied => RetryMethod::NoRetry,
                     io::ErrorKind::Unsupported => RetryMethod::NoRetry,

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -1749,20 +1749,20 @@ mod basic {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
-        redis::cmd("SET").arg("key1").arg("key1").execute(&mut con);
-        redis::cmd("SET").arg("key2").arg("key2").execute(&mut con);
+        redis::cmd("SET").arg("key").arg("key").execute(&mut con);
 
-        con.set_read_timeout(Some(Duration::from_nanos(1))).unwrap();
+        con.set_read_timeout(Some(Duration::from_millis(500)))
+            .unwrap();
 
-        let res = redis::cmd("GET").arg("key1").query::<()>(&mut con);
+        let res = redis::cmd("BLPOP").arg("foo").arg(1).query::<()>(&mut con);
         assert!(res.unwrap_err().is_timeout());
         assert!(!con.is_open());
 
         let mut con = ctx.connection();
         let res = redis::cmd("GET")
-            .arg("key2")
+            .arg("key")
             .query::<String>(&mut con)
             .unwrap();
-        assert_eq!(res, "key2");
+        assert_eq!(res, "key");
     }
 }

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -322,12 +322,18 @@ mod cluster {
         let cluster = TestClusterContext::new();
         let mut con = cluster.connection();
 
-        redis::cmd("SET").arg("{key}1").arg("key1").execute(&mut con);
-        redis::cmd("SET").arg("{key}2").arg("key2").execute(&mut con);
+        redis::cmd("SET")
+            .arg("{key}2")
+            .arg("key2")
+            .execute(&mut con);
 
-        con.set_read_timeout(Some(Duration::from_nanos(1))).unwrap();
+        con.set_read_timeout(Some(Duration::from_millis(500)))
+            .unwrap();
 
-        let res = redis::cmd("GET").arg("{key}1").query::<()>(&mut con);
+        let res = redis::cmd("BLPOP")
+            .arg("{key}1")
+            .arg(1)
+            .query::<()>(&mut con);
         assert!(res.unwrap_err().is_timeout());
         assert!(!con.is_open());
 


### PR DESCRIPTION
Potential fix for #1252.

This only deals with the timeout case, not other IO errors. For clustered clients, a timeout does not cause a retry, the user probably wanted to limit the time it takes until the request returns.