### PR TITLE
Abort backing task to multiplexed connection on drop.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test:
 	@echo "===================================================================="
 	@echo "Testing Connection Type UNIX SOCKETS"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo test --locked -p redis --all-features -- --test-threads=1 --skip test_cluster --skip test_async_cluster --skip test_module
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo test --locked -p redis --all-features -- --test-threads=1 --skip test_cluster --skip cluster_async --skip test_module
 
 	@echo "===================================================================="
 	@echo "Testing async-std with Rustls"

--- a/redis/src/aio/async_std.rs
+++ b/redis/src/aio/async_std.rs
@@ -21,6 +21,7 @@ use crate::connection::create_rustls_config;
 #[cfg(feature = "tls-rustls")]
 use futures_rustls::{client::TlsStream, TlsConnector};
 
+use super::TaskHandle;
 use async_std::net::TcpStream;
 #[cfg(unix)]
 use async_std::os::unix::net::UnixStream;
@@ -250,8 +251,8 @@ impl RedisRuntime for AsyncStd {
             .map(|con| Self::Unix(AsyncStdWrapped::new(con)))?)
     }
 
-    fn spawn(f: impl Future<Output = ()> + Send + 'static) {
-        async_std::task::spawn(f);
+    fn spawn(f: impl Future<Output = ()> + Send + 'static) -> TaskHandle {
+        TaskHandle::AsyncStd(async_std::task::spawn(f))
     }
 
     fn boxed(self) -> Pin<Box<dyn AsyncStream + Send + Sync>> {

--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -51,7 +51,7 @@ pub(crate) trait RedisRuntime: AsyncStream + Send + Sync + Sized + 'static {
     #[cfg(unix)]
     async fn connect_unix(path: &Path) -> RedisResult<Self>;
 
-    fn spawn(f: impl Future<Output = ()> + Send + 'static);
+    fn spawn(f: impl Future<Output = ()> + Send + 'static) -> TaskHandle;
 
     fn boxed(self) -> Pin<Box<dyn AsyncStream + Send + Sync>> {
         Box::pin(self)

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -1,4 +1,4 @@
-use super::{new_shared_handle, ConnectionLike, Runtime, SharedHandleContainer, TaskHandle};
+use super::{ConnectionLike, Runtime, SharedHandleContainer, TaskHandle};
 use crate::aio::{check_resp3, setup_connection};
 use crate::cmd::Cmd;
 #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
@@ -517,7 +517,7 @@ impl MultiplexedConnection {
     /// This should be called strictly before the multiplexed connection is cloned - that is, before it is returned to the user.
     /// Otherwise some clones will be able to kill the backing task, while other clones are still alive.
     pub(crate) fn set_task_handle(&mut self, handle: TaskHandle) {
-        self._task_handle = Some(new_shared_handle(handle));
+        self._task_handle = Some(SharedHandleContainer::new(handle));
     }
 
     /// Sets the time that the multiplexer will wait for responses on operations before failing.

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -1,4 +1,4 @@
-use super::{ConnectionLike, Runtime};
+use super::{new_shared_handle, ConnectionLike, Runtime, SharedHandleContainer, TaskHandle};
 use crate::aio::{check_resp3, setup_connection};
 use crate::cmd::Cmd;
 #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
@@ -405,16 +405,20 @@ impl Pipeline {
 /// A side-effect of this is that the underlying connection won't be closed until all sent requests have been answered,
 /// which means that in case of blocking commands, the underlying connection resource might not be released,
 /// even when all clones of the multiplexed connection have been dropped (see <https://github.com/redis-rs/redis-rs/issues/1236>).
-/// If that is an issue, the user can, instead of using [crate::Client::get_multiplexed_async_connection], use either [MultiplexedConnection::new] or
-/// [crate::Client::create_multiplexed_tokio_connection]/[crate::Client::create_multiplexed_async_std_connection],
-/// manually spawn the returned driver function, keep the spawned task's handle and abort the task whenever they want,
-/// at the cost of effectively closing the clones of the multiplexed connection.
+/// This isn't an issue in a connection that was created in a canonical way, which ensures that `_task_handle` is set, so that
+/// once all of the connection's clones are dropped, the task will also be dropped. If the user creates the connection in
+/// another way and `_task_handle` isn't set, they should manually spawn the returned driver function, keep the spawned task's
+/// handle and abort the task whenever they want, at the risk of effectively closing the clones of the multiplexed connection.
 #[derive(Clone)]
 pub struct MultiplexedConnection {
     pipeline: Pipeline,
     db: i64,
     response_timeout: Option<Duration>,
     protocol: ProtocolVersion,
+    // This handle ensures that once all the clones of the connection will be dropped, the underlying task will stop.
+    // This handle is only set for connection whose task was spawned by the crate, not for users who spawned their own
+    // task.
+    _task_handle: Option<SharedHandleContainer>,
 }
 
 impl Debug for MultiplexedConnection {
@@ -487,6 +491,7 @@ impl MultiplexedConnection {
             db: connection_info.db,
             response_timeout: config.response_timeout,
             protocol: connection_info.protocol,
+            _task_handle: None,
         };
         let driver = {
             let auth = setup_connection(connection_info, &mut con);
@@ -507,6 +512,12 @@ impl MultiplexedConnection {
             }
         };
         Ok((con, driver))
+    }
+
+    /// This should be called strictly before the multiplexed connection is cloned - that is, before it is returned to the user.
+    /// Otherwise some clones will be able to kill the backing task, while other clones are still alive.
+    pub(crate) fn set_task_handle(&mut self, handle: TaskHandle) {
+        self._task_handle = Some(new_shared_handle(handle));
     }
 
     /// Sets the time that the multiplexer will wait for responses on operations before failing.

--- a/redis/src/aio/pubsub.rs
+++ b/redis/src/aio/pubsub.rs
@@ -1,4 +1,4 @@
-use crate::aio::{new_shared_handle, Runtime};
+use crate::aio::Runtime;
 use crate::connection::{
     check_connection_setup, connection_setup_pipeline, AuthResult, ConnectionSetupComponents,
 };
@@ -371,7 +371,7 @@ impl PubSub {
         let (sender, receiver) = unbounded_channel();
         let (sink, driver) = PubSubSink::new(codec, sender);
         let handle = Runtime::locate().spawn(driver);
-        let _task_handle = Some(new_shared_handle(handle));
+        let _task_handle = Some(SharedHandleContainer::new(handle));
         let stream = PubSubStream {
             receiver,
             _task_handle,

--- a/redis/src/aio/runtime.rs
+++ b/redis/src/aio/runtime.rs
@@ -47,10 +47,15 @@ impl Drop for HandleContainer {
     }
 }
 
-pub(crate) type SharedHandleContainer = Arc<HandleContainer>;
+#[derive(Clone)]
+// we allow dead code here because the container isn't used directly, only in the derived drop.
+#[allow(dead_code)]
+pub(crate) struct SharedHandleContainer(Arc<HandleContainer>);
 
-pub(crate) fn new_shared_handle(handle: TaskHandle) -> SharedHandleContainer {
-    Arc::new(HandleContainer::new(handle))
+impl SharedHandleContainer {
+    pub(crate) fn new(handle: TaskHandle) -> Self {
+        Self(Arc::new(HandleContainer::new(handle)))
+    }
 }
 
 impl Runtime {

--- a/redis/src/aio/tokio.rs
+++ b/redis/src/aio/tokio.rs
@@ -1,4 +1,4 @@
-use super::{AsyncStream, RedisResult, RedisRuntime, SocketAddr};
+use super::{AsyncStream, RedisResult, RedisRuntime, SocketAddr, TaskHandle};
 use async_trait::async_trait;
 use std::{
     future::Future,
@@ -174,12 +174,12 @@ impl RedisRuntime for Tokio {
     }
 
     #[cfg(feature = "tokio-comp")]
-    fn spawn(f: impl Future<Output = ()> + Send + 'static) {
-        tokio::spawn(f);
+    fn spawn(f: impl Future<Output = ()> + Send + 'static) -> TaskHandle {
+        TaskHandle::Tokio(tokio::spawn(f))
     }
 
     #[cfg(not(feature = "tokio-comp"))]
-    fn spawn(_: impl Future<Output = ()> + Send + 'static) {
+    fn spawn(_: impl Future<Output = ()> + Send + 'static) -> TokioTaskHandle {
         unreachable!()
     }
 

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -644,10 +644,11 @@ impl Client {
     where
         T: crate::aio::RedisRuntime,
     {
-        let (connection, driver) = self
+        let (mut connection, driver) = self
             .create_multiplexed_async_connection_inner::<T>(config)
             .await?;
-        T::spawn(driver);
+        let handle = T::spawn(driver);
+        connection.set_task_handle(handle);
         Ok(connection)
     }
 

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -79,9 +79,7 @@ use std::{
 mod request;
 mod routing;
 use crate::{
-    aio::{
-        new_shared_handle, ConnectionLike, MultiplexedConnection, Runtime, SharedHandleContainer,
-    },
+    aio::{ConnectionLike, MultiplexedConnection, Runtime, SharedHandleContainer},
     cluster::{get_connection_info, slot_cmd},
     cluster_client::ClusterParams,
     cluster_routing::{
@@ -128,7 +126,7 @@ where
                         .forward(inner)
                         .await;
                 };
-                let _task_handle = new_shared_handle(Runtime::locate().spawn(stream));
+                let _task_handle = SharedHandleContainer::new(Runtime::locate().spawn(stream));
 
                 ClusterConnection {
                     sender,

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -5,6 +5,7 @@ mod basic_async {
     use std::{collections::HashMap, time::Duration};
 
     use futures::{prelude::*, StreamExt};
+    use futures_time::task::sleep;
     #[cfg(feature = "connection-manager")]
     use redis::aio::ConnectionManager;
     use redis::{
@@ -1091,6 +1092,47 @@ mod basic_async {
             if ctx.protocol != ProtocolVersion::RESP2 {
                 assert!(rx.try_recv().is_err());
             }
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_multiplexed_connection_kills_connection_on_drop_even_when_blocking() {
+        let ctx = TestContext::new();
+        block_on_all(async move {
+            let mut conn = ctx.async_connection().await.unwrap();
+            let mut connection_to_dispose_of = ctx.async_connection().await.unwrap();
+            connection_to_dispose_of.set_response_timeout(Duration::from_millis(1));
+
+            async fn count_ids(conn: &mut impl redis::aio::ConnectionLike) -> RedisResult<usize> {
+                let initial_connections: String =
+                    cmd("CLIENT").arg("LIST").query_async(conn).await?;
+
+                Ok(initial_connections
+                    .as_bytes()
+                    .windows(3)
+                    .filter(|substr| substr == b"id=")
+                    .count())
+            }
+
+            assert_eq!(count_ids(&mut conn).await.unwrap(), 2);
+
+            let command_that_blocks = cmd("BLPOP")
+                .arg("foo")
+                .arg(0)
+                .exec_async(&mut connection_to_dispose_of)
+                .await;
+
+            let err = command_that_blocks.unwrap_err();
+            assert_eq!(err.kind(), ErrorKind::IoError);
+
+            drop(connection_to_dispose_of);
+
+            sleep(Duration::from_millis(10).into()).await;
+
+            assert_eq!(count_ids(&mut conn).await.unwrap(), 1);
+
             Ok(())
         })
         .unwrap();


### PR DESCRIPTION
This change will ensure that a multiplexed connection will
abort the spawned task driving the connection once all
of the connection's clones have been dropped.

This change only affects users who have created a
multiplexed connection without manually spawning its
backing task. Those who do should manage the task by themselves.

https://github.com/redis-rs/redis-rs/issues/1236