### PR TITLE
Remove tokio dependency from non-aio build.

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -41,7 +41,7 @@ bytes = { version = "1", optional = true }
 futures-util = { version = "0.3.15", default-features = false, optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 tokio-util = { version = "0.7", optional = true }
-tokio = { version = "1", features = ["rt", "net", "time", "sync"] }
+tokio = { version = "1", features = ["rt", "net", "time", "sync"], optional = true }
 socket2 = { version = "0.5", default-features = false, optional = true }
 
 # Only needed for the connection manager

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -2,7 +2,7 @@ use super::RedisFuture;
 use crate::{
     aio::{check_resp3, ConnectionLike, MultiplexedConnection, Runtime},
     cmd,
-    types::{PushSender, RedisError, RedisResult, Value},
+    types::{AsyncPushSender, RedisError, RedisResult, Value},
     AsyncConnectionConfig, Client, Cmd, ToRedisArgs,
 };
 #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
@@ -36,7 +36,7 @@ pub struct ConnectionManagerConfig {
     /// Each connection attempt to the server will time out after `connection_timeout`.
     connection_timeout: std::time::Duration,
     /// sender channel for push values
-    push_sender: Option<PushSender>,
+    push_sender: Option<AsyncPushSender>,
 }
 
 impl ConnectionManagerConfig {
@@ -105,7 +105,7 @@ impl ConnectionManagerConfig {
     }
 
     /// Sets sender channel for push values. Will fail client creation if the connection isn't configured for RESP3 communications.
-    pub fn set_push_sender(mut self, sender: PushSender) -> Self {
+    pub fn set_push_sender(mut self, sender: AsyncPushSender) -> Self {
         self.push_sender = Some(sender);
         self
     }

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 #[cfg(feature = "aio")]
-use crate::types::PushSender;
+use crate::types::AsyncPushSender;
 use crate::{
     connection::{connect, Connection, ConnectionInfo, ConnectionLike, IntoConnectionInfo},
     types::{RedisResult, Value},
@@ -76,7 +76,7 @@ pub struct AsyncConnectionConfig {
     pub(crate) response_timeout: Option<std::time::Duration>,
     /// Maximum time to wait for a connection to be established
     pub(crate) connection_timeout: Option<std::time::Duration>,
-    pub(crate) push_sender: Option<PushSender>,
+    pub(crate) push_sender: Option<AsyncPushSender>,
 }
 
 #[cfg(feature = "aio")]
@@ -99,7 +99,7 @@ impl AsyncConnectionConfig {
     }
 
     /// Sets sender channel for push values. Will fail client creation if the connection isn't configured for RESP3 communications.
-    pub fn set_push_sender(mut self, sender: PushSender) -> Self {
+    pub fn set_push_sender(mut self, sender: AsyncPushSender) -> Self {
         self.push_sender = Some(sender);
         self
     }

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -12,8 +12,8 @@ use crate::cmd::{cmd, pipe, Cmd};
 use crate::parser::Parser;
 use crate::pipeline::Pipeline;
 use crate::types::{
-    from_redis_value, ErrorKind, FromRedisValue, HashMap, PushKind, PushSender, RedisError,
-    RedisResult, ToRedisArgs, Value,
+    from_redis_value, ErrorKind, FromRedisValue, HashMap, PushKind, RedisError, RedisResult,
+    SyncPushSender, ToRedisArgs, Value,
 };
 use crate::{from_owned_redis_value, ProtocolVersion};
 
@@ -544,7 +544,7 @@ pub struct Connection {
     protocol: ProtocolVersion,
 
     /// This is used to manage Push messages in RESP3 mode.
-    push_sender: Option<PushSender>,
+    push_sender: Option<SyncPushSender>,
 }
 
 /// Represents a pubsub connection.
@@ -1300,7 +1300,7 @@ impl Connection {
     }
 
     /// Sets sender channel for push values.
-    pub fn set_push_sender(&mut self, sender: PushSender) {
+    pub fn set_push_sender(&mut self, sender: SyncPushSender) {
         self.push_sender = Some(sender);
     }
 

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -14,7 +14,6 @@ use std::io;
 use std::ops::Deref;
 use std::str::{from_utf8, Utf8Error};
 use std::string::FromUtf8Error;
-use tokio::sync::mpsc;
 
 macro_rules! invalid_type_error {
     ($v:expr, $det:expr) => {{
@@ -2562,4 +2561,7 @@ pub struct PushInfo {
     pub data: Vec<Value>,
 }
 
-pub(crate) type PushSender = mpsc::UnboundedSender<PushInfo>;
+#[cfg(feature = "aio")]
+pub(crate) type AsyncPushSender = tokio::sync::mpsc::UnboundedSender<PushInfo>;
+
+pub(crate) type SyncPushSender = std::sync::mpsc::SyncSender<PushInfo>;

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2564,4 +2564,4 @@ pub struct PushInfo {
 #[cfg(feature = "aio")]
 pub(crate) type AsyncPushSender = tokio::sync::mpsc::UnboundedSender<PushInfo>;
 
-pub(crate) type SyncPushSender = std::sync::mpsc::SyncSender<PushInfo>;
+pub(crate) type SyncPushSender = std::sync::mpsc::Sender<PushInfo>;

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -16,7 +16,6 @@ mod basic {
     use std::thread::{sleep, spawn};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
     use std::vec;
-    use tokio::sync::mpsc::error::TryRecvError;
 
     use crate::{assert_args, support::*};
 
@@ -811,7 +810,7 @@ mod basic {
 
         // Connection for subscriber api
         let mut pubsub_con = ctx.connection();
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, rx) = std::sync::mpsc::sync_channel(100);
         // Only useful when RESP3 is enabled
         pubsub_con.set_push_sender(tx);
 
@@ -886,7 +885,7 @@ mod basic {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, rx) = std::sync::mpsc::sync_channel(100);
         // Only useful when RESP3 is enabled
         con.set_push_sender(tx);
         {
@@ -1737,7 +1736,7 @@ mod basic {
         let client = redis::Client::open(connection_info).unwrap();
 
         let mut con = client.get_connection().unwrap();
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, rx) = std::sync::mpsc::sync_channel(100);
         con.set_push_sender(tx);
         let _ = cmd("CLIENT")
             .arg("TRACKING")
@@ -1759,7 +1758,7 @@ mod basic {
                 (kind, data)
             );
         }
-        let (new_tx, mut new_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (new_tx, new_rx) = std::sync::mpsc::sync_channel(100);
         con.set_push_sender(new_tx.clone());
         drop(rx);
         let _: RedisResult<()> = pipe.query(&mut con);
@@ -1793,11 +1792,14 @@ mod basic {
         let client = redis::Client::open(connection_info).unwrap();
 
         let mut con = client.get_connection().unwrap();
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, rx) = std::sync::mpsc::sync_channel(100);
         con.set_push_sender(tx.clone());
 
         let _: () = con.set("A", "1").unwrap();
-        assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Empty);
+        assert_eq!(
+            rx.try_recv().unwrap_err(),
+            std::sync::mpsc::TryRecvError::Empty
+        );
         drop(ctx);
         let x: RedisResult<()> = con.set("A", "1");
         assert!(x.is_err());
@@ -1813,7 +1815,7 @@ mod basic {
         }
         let mut con = ctx.connection();
 
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, rx) = std::sync::mpsc::sync_channel(100);
         let mut pubsub_con = ctx.connection();
         pubsub_con.set_push_sender(tx);
 

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -810,7 +810,7 @@ mod basic {
 
         // Connection for subscriber api
         let mut pubsub_con = ctx.connection();
-        let (tx, rx) = std::sync::mpsc::sync_channel(100);
+        let (tx, rx) = std::sync::mpsc::channel();
         // Only useful when RESP3 is enabled
         pubsub_con.set_push_sender(tx);
 
@@ -885,7 +885,7 @@ mod basic {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
-        let (tx, rx) = std::sync::mpsc::sync_channel(100);
+        let (tx, rx) = std::sync::mpsc::channel();
         // Only useful when RESP3 is enabled
         con.set_push_sender(tx);
         {
@@ -1736,7 +1736,7 @@ mod basic {
         let client = redis::Client::open(connection_info).unwrap();
 
         let mut con = client.get_connection().unwrap();
-        let (tx, rx) = std::sync::mpsc::sync_channel(100);
+        let (tx, rx) = std::sync::mpsc::channel();
         con.set_push_sender(tx);
         let _ = cmd("CLIENT")
             .arg("TRACKING")
@@ -1758,7 +1758,7 @@ mod basic {
                 (kind, data)
             );
         }
-        let (new_tx, new_rx) = std::sync::mpsc::sync_channel(100);
+        let (new_tx, new_rx) = std::sync::mpsc::channel();
         con.set_push_sender(new_tx.clone());
         drop(rx);
         let _: RedisResult<()> = pipe.query(&mut con);
@@ -1792,7 +1792,7 @@ mod basic {
         let client = redis::Client::open(connection_info).unwrap();
 
         let mut con = client.get_connection().unwrap();
-        let (tx, rx) = std::sync::mpsc::sync_channel(100);
+        let (tx, rx) = std::sync::mpsc::channel();
         con.set_push_sender(tx.clone());
 
         let _: () = con.set("A", "1").unwrap();
@@ -1815,7 +1815,7 @@ mod basic {
         }
         let mut con = ctx.connection();
 
-        let (tx, rx) = std::sync::mpsc::sync_channel(100);
+        let (tx, rx) = std::sync::mpsc::channel();
         let mut pubsub_con = ctx.connection();
         pubsub_con.set_push_sender(tx);
 


### PR DESCRIPTION
This is done by changing the sync Connection's push sender to the std sender instead of tokio sender.
The decision to use the tokio sender in the sync implementation came from the previous design, where all connections used the same PushManager, and so had to use the same channel type.

https://github.com/redis-rs/redis-rs/pull/898#discussion_r1297473079

based over https://github.com/redis-rs/redis-rs/pull/1251