### PR TITLE
CI: Build major features without aio.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,16 @@ test:
 	@RUSTFLAGS="-D warnings" cargo build --locked --all-features -p redis -p redis-test
 
 	@echo "===================================================================="
+	@echo "Build major features without aio"
+	@echo "===================================================================="
+	@RUSTFLAGS="-D warnings" cargo build --locked --features=cluster,sentinel,streams,script,r2d2 -p redis -p redis-test
+
+	@echo "===================================================================="
+	@echo "Build major features without sentinel & aio"
+	@echo "===================================================================="
+	@RUSTFLAGS="-D warnings" cargo build --locked --features=cluster,streams,script,r2d2 -p redis -p redis-test
+
+	@echo "===================================================================="
 	@echo "Testing Connection Type TCP without features"
 	@echo "===================================================================="
 	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo test --locked -p redis --no-default-features -- --nocapture --test-threads=1 --skip test_module

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -238,7 +238,7 @@ where
             connections: RefCell::new(HashMap::new()),
             slots: RefCell::new(SlotMap::new(cluster_params.read_from_replicas)),
             auto_reconnect: RefCell::new(true),
-            read_timeout: RefCell::new(None),
+            read_timeout: RefCell::new(Some(cluster_params.response_timeout)),
             write_timeout: RefCell::new(None),
             initial_nodes: initial_nodes.to_vec(),
             cluster_params,
@@ -410,7 +410,7 @@ where
         let params = self.cluster_params.clone();
         let info = get_connection_info(node, params)?;
 
-        let mut conn = C::connect(info, None)?;
+        let mut conn: C = C::connect(info, Some(self.cluster_params.connection_timeout))?;
         if self.cluster_params.read_from_replicas {
             // If READONLY is sent to primary nodes, it will have no effect
             cmd("READONLY").exec(&mut conn)?;

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -706,6 +706,7 @@ impl SlotMap {
         }
     }
 
+    #[cfg(feature = "aio")]
     pub fn fill_slots(&mut self, slots: Vec<Slot>) {
         for slot in slots {
             self.slots.insert(slot.end, SlotMapValue::from_slot(slot));
@@ -730,6 +731,7 @@ impl SlotMap {
             })
     }
 
+    #[cfg(feature = "aio")]
     pub fn clear(&mut self) {
         self.slots.clear();
     }

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -458,6 +458,8 @@ let primary = sentinel.get_connection().unwrap();
 An async API also exists:
 
 ```rust,no_run
+# #[cfg(feature = "aio")]
+# {
 use futures::prelude::*;
 use redis::{ Commands, RedisConnectionInfo };
 use redis::sentinel::{ SentinelServerType, SentinelClient, SentinelNodeConnectionInfo };
@@ -477,7 +479,7 @@ let mut sentinel = SentinelClient::build(
 .unwrap();
 
 let primary = sentinel.get_async_connection().await.unwrap();
-# Ok(()) }
+# Ok(()) }}
 "##
 )]
 //!


### PR DESCRIPTION
This will catch some compilation issues. For example, #1272,
and will warn about fields that are only used in async features.