### PR TITLE
Bump MSRV to 1.70

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.65.0
+          - 1.70.0
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ redis = "0.26.1"
 Documentation on the library can be found at
 [docs.rs/redis](https://docs.rs/redis).
 
-**Note: redis-rs requires at least Rust 1.60.**
-
 ## Basic Operation
 
 To open a connection you need to create a client and then to fetch a

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/redis-rs/redis-rs"
 documentation = "https://docs.rs/redis"
 license = "BSD-3-Clause"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 readme = "../README.md"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
removed MSRV from docs, because it is now handled by the `rust-version` field.

affected PRs:
https://github.com/redis-rs/redis-rs/pull/1123
https://github.com/redis-rs/redis-rs/pull/1275