### PR TITLE
Align verification of protocol & TLS during cluster creation.

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -989,7 +989,7 @@ pub(crate) fn get_connection_info(
         redis: RedisConnectionInfo {
             password: cluster_params.password,
             username: cluster_params.username,
-            protocol: cluster_params.protocol,
+            protocol: cluster_params.protocol.unwrap_or_default(),
             db: 0,
         },
     })

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -213,7 +213,7 @@ impl ClusterClientBuilder {
             if protocol.is_some() && Some(node.redis.protocol) != protocol {
                 return Err(RedisError::from((
                     ErrorKind::InvalidClientConfig,
-                    "Cannot use different password among initial nodes.",
+                    "Cannot use different protocol among initial nodes.",
                 )));
             }
 

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -191,7 +191,7 @@ impl ClusterClientBuilder {
         };
 
         // Verify that the initial nodes match the cluster client's configuration.
-        for node in initial_nodes.iter() {
+        for node in &initial_nodes {
             if let ConnectionAddr::Unix(_) = node.addr {
                 return Err(RedisError::from((ErrorKind::InvalidClientConfig,
                                              "This library cannot use unix socket because Redis's cluster command returns only cluster's IP and port.")));

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -190,7 +190,7 @@ impl ClusterClientBuilder {
             None
         };
 
-        // verify that the initial nodes match the cluster client's configuration.
+        // Verify that the initial nodes match the cluster client's configuration.
         for node in initial_nodes.iter() {
             if let ConnectionAddr::Unix(_) = node.addr {
                 return Err(RedisError::from((ErrorKind::InvalidClientConfig,

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -104,7 +104,7 @@ pub fn parse_redis_url(input: &str) -> Option<url::Url> {
 
 /// TlsMode indicates use or do not use verification of certification.
 /// Check [ConnectionAddr](ConnectionAddr::TcpTls::insecure) for more.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum TlsMode {
     /// Secure verify certification.
     Secure,
@@ -187,6 +187,20 @@ impl ConnectionAddr {
                 cfg!(any(feature = "tls-native-tls", feature = "tls-rustls"))
             }
             ConnectionAddr::Unix(_) => cfg!(unix),
+        }
+    }
+
+    #[cfg(feature = "cluster")]
+    pub(crate) fn tls_mode(&self) -> Option<TlsMode> {
+        match self {
+            ConnectionAddr::TcpTls { insecure, .. } => {
+                if *insecure {
+                    Some(TlsMode::Insecure)
+                } else {
+                    Some(TlsMode::Secure)
+                }
+            }
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
Like username & password, Protocol & TLS will now be copied from the first node if not explicitly set, and then verified that the same value is set for all other initial nodes.

https://github.com/redis-rs/redis-rs/issues/1288