### PR TITLE
Sync connection: Handle timed-out responses by ignoring them.

### DIFF
--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -1354,31 +1354,24 @@ impl Connection {
     fn read_response(&mut self) -> RedisResult<Value> {
         let result = match self.con {
             ActualConnection::Tcp(TcpConnection { ref mut reader, .. }) => {
-                let result = self.parser.parse_value(reader);
-                self.try_send(&result);
-                result
+                self.parser.parse_value(reader)
             }
             #[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
             ActualConnection::TcpNativeTls(ref mut boxed_tls_connection) => {
                 let reader = &mut boxed_tls_connection.reader;
-                let result = self.parser.parse_value(reader);
-                self.try_send(&result);
-                result
+                self.parser.parse_value(reader)
             }
             #[cfg(feature = "tls-rustls")]
             ActualConnection::TcpRustls(ref mut boxed_tls_connection) => {
                 let reader = &mut boxed_tls_connection.reader;
-                let result = self.parser.parse_value(reader);
-                self.try_send(&result);
-                result
+                self.parser.parse_value(reader)
             }
             #[cfg(unix)]
             ActualConnection::Unix(UnixConnection { ref mut sock, .. }) => {
-                let result = self.parser.parse_value(sock);
-                self.try_send(&result);
-                result
+                self.parser.parse_value(sock)
             }
         };
+        self.try_send(&result);
         // shutdown connection on protocol error
         if let Err(e) = &result {
             let shutdown = match e.as_io_error() {
@@ -1410,6 +1403,7 @@ impl Connection {
                     }
                 }
             }
+            let non_redis_error = !matches!(e.)
         }
         result
     }

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -545,6 +545,10 @@ pub struct Connection {
 
     /// This is used to manage Push messages in RESP3 mode.
     push_sender: Option<SyncPushSender>,
+
+    /// The number of messages that are expected to be returned from the server,
+    /// but the user no longer waits for - answers for requests that already returned a transient error.
+    messages_to_skip: usize,
 }
 
 /// Represents a pubsub connection.
@@ -1134,6 +1138,7 @@ fn setup_connection(
         pubsub: false,
         protocol: connection_info.protocol,
         push_sender: None,
+        messages_to_skip: 0,
     };
 
     if execute_connection_pipeline(&mut rv, connection_setup_pipeline(connection_info, true))?
@@ -1350,62 +1355,79 @@ impl Connection {
         })
     }
 
-    /// Fetches a single response from the connection.
-    fn read_response(&mut self) -> RedisResult<Value> {
-        let result = match self.con {
-            ActualConnection::Tcp(TcpConnection { ref mut reader, .. }) => {
-                self.parser.parse_value(reader)
+    fn close_connection(&mut self) {
+        // Notify the PushManager that the connection was lost
+        self.send_disconnect();
+        match self.con {
+            ActualConnection::Tcp(ref mut connection) => {
+                let _ = connection.reader.shutdown(net::Shutdown::Both);
+                connection.open = false;
             }
             #[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
-            ActualConnection::TcpNativeTls(ref mut boxed_tls_connection) => {
-                let reader = &mut boxed_tls_connection.reader;
-                self.parser.parse_value(reader)
+            ActualConnection::TcpNativeTls(ref mut connection) => {
+                let _ = connection.reader.shutdown();
+                connection.open = false;
             }
             #[cfg(feature = "tls-rustls")]
-            ActualConnection::TcpRustls(ref mut boxed_tls_connection) => {
-                let reader = &mut boxed_tls_connection.reader;
-                self.parser.parse_value(reader)
+            ActualConnection::TcpRustls(ref mut connection) => {
+                let _ = connection.reader.get_mut().shutdown(net::Shutdown::Both);
+                connection.open = false;
             }
             #[cfg(unix)]
-            ActualConnection::Unix(UnixConnection { ref mut sock, .. }) => {
-                self.parser.parse_value(sock)
+            ActualConnection::Unix(ref mut connection) => {
+                let _ = connection.sock.shutdown(net::Shutdown::Both);
+                connection.open = false;
             }
-        };
-        self.try_send(&result);
-        // shutdown connection on protocol error
-        if let Err(e) = &result {
-            let shutdown = match e.as_io_error() {
-                Some(e) => e.kind() == io::ErrorKind::UnexpectedEof,
-                None => false,
-            };
-            if shutdown {
-                // Notify the PushManager that the connection was lost
-                self.send_disconnect();
-                match self.con {
-                    ActualConnection::Tcp(ref mut connection) => {
-                        let _ = connection.reader.shutdown(net::Shutdown::Both);
-                        connection.open = false;
-                    }
-                    #[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
-                    ActualConnection::TcpNativeTls(ref mut connection) => {
-                        let _ = connection.reader.shutdown();
-                        connection.open = false;
-                    }
-                    #[cfg(feature = "tls-rustls")]
-                    ActualConnection::TcpRustls(ref mut connection) => {
-                        let _ = connection.reader.get_mut().shutdown(net::Shutdown::Both);
-                        connection.open = false;
-                    }
-                    #[cfg(unix)]
-                    ActualConnection::Unix(ref mut connection) => {
-                        let _ = connection.sock.shutdown(net::Shutdown::Both);
-                        connection.open = false;
-                    }
-                }
-            }
-            let non_redis_error = !matches!(e.)
         }
-        result
+    }
+
+    /// Fetches a single response from the connection.
+    fn read_response(&mut self) -> RedisResult<Value> {
+        loop {
+            let result = match self.con {
+                ActualConnection::Tcp(TcpConnection { ref mut reader, .. }) => {
+                    self.parser.parse_value(reader)
+                }
+                #[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
+                ActualConnection::TcpNativeTls(ref mut boxed_tls_connection) => {
+                    let reader = &mut boxed_tls_connection.reader;
+                    self.parser.parse_value(reader)
+                }
+                #[cfg(feature = "tls-rustls")]
+                ActualConnection::TcpRustls(ref mut boxed_tls_connection) => {
+                    let reader = &mut boxed_tls_connection.reader;
+                    self.parser.parse_value(reader)
+                }
+                #[cfg(unix)]
+                ActualConnection::Unix(UnixConnection { ref mut sock, .. }) => {
+                    self.parser.parse_value(sock)
+                }
+            };
+            self.try_send(&result);
+
+            let Err(err) = &result else {
+                if self.messages_to_skip > 0 {
+                    self.messages_to_skip -= 1;
+                    continue;
+                }
+                return result;
+            };
+            let Some(io_error) = err.as_io_error() else {
+                if self.messages_to_skip > 0 {
+                    self.messages_to_skip -= 1;
+                    continue;
+                }
+                return result;
+            };
+            // shutdown connection on protocol error
+            if io_error.kind() == io::ErrorKind::UnexpectedEof {
+                self.close_connection();
+            } else {
+                self.messages_to_skip += 1;
+            }
+
+            return result;
+        }
     }
 
     /// Sets sender channel for push values.

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -403,6 +403,15 @@ impl RedisServer {
     }
 }
 
+pub fn get_listener_on_free_port() -> TcpListener {
+    let addr = &"127.0.0.1:0".parse::<SocketAddr>().unwrap().into();
+    let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+    socket.set_reuse_address(true).unwrap();
+    socket.bind(addr).unwrap();
+    socket.listen(1).unwrap();
+    TcpListener::from(socket)
+}
+
 /// Finds a random open port available for listening at, by spawning a TCP server with
 /// port "zero" (which prompts the OS to just use any available port). Between calling
 /// this function and trying to bind to this port, the port may be given to another
@@ -410,12 +419,7 @@ impl RedisServer {
 /// mostly okay).
 pub fn get_random_available_port() -> u16 {
     for _ in 0..10000 {
-        let addr = &"127.0.0.1:0".parse::<SocketAddr>().unwrap().into();
-        let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
-        socket.set_reuse_address(true).unwrap();
-        socket.bind(addr).unwrap();
-        socket.listen(1).unwrap();
-        let listener = TcpListener::from(socket);
+        let listener = get_listener_on_free_port();
         let port = listener.local_addr().unwrap().port();
         if port < 55535 {
             return port;


### PR DESCRIPTION
the sync client will keep a counter for requests that were answered before the response was received by the server, and will skip those responses before answering the user.

fixes https://github.com/redis-rs/redis-rs/issues/1252