### PR TITLE
Add r2d2 support for SentinelClient

### DIFF
--- a/redis/src/r2d2.rs
+++ b/redis/src/r2d2.rs
@@ -1,4 +1,4 @@
-use crate::sentinel::{LockedSentinelClient};
+use crate::sentinel::LockedSentinelClient;
 use crate::{ConnectionLike, RedisError};
 use std::io;
 

--- a/redis/src/r2d2.rs
+++ b/redis/src/r2d2.rs
@@ -1,6 +1,6 @@
-use std::io;
-
+use crate::sentinel::{LockedSentinelClient};
 use crate::{ConnectionLike, RedisError};
+use std::io;
 
 macro_rules! impl_manage_connection {
     ($client:ty, $connection:ty) => {
@@ -34,3 +34,6 @@ impl_manage_connection!(
     crate::cluster::ClusterClient,
     crate::cluster::ClusterConnection
 );
+
+#[cfg(feature = "sentinel")]
+impl_manage_connection!(LockedSentinelClient, crate::Connection);

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -106,6 +106,7 @@
 #[cfg(feature = "aio")]
 use futures_util::StreamExt;
 use rand::Rng;
+#[cfg(feature = "r2d2")]
 use std::sync::Mutex;
 use std::{collections::HashMap, num::NonZeroUsize};
 


### PR DESCRIPTION
Hi, I apologize beforehand for I'm a newbie in Rust.

Regarding #1294,  I've introduced a new struct wrapper around `SentinelClient` to make it possible to use it with the macro used in `r2d2.rs`.

The usage will be something like this: 
```rust
pub struct PooledSentinelClient;

impl PooledSentinelClient {
    pub fn new_pool(
        cfg: &crate::config::RedisSentinelConfig,
        server_type: &str,
    ) -> anyhow::Result<Pool<sentinel::LockedSentinelClient>> {
        let server_type = match server_type {
            "master" => SentinelServerType::Master,
            "slave" => SentinelServerType::Replica,
            _ => bail!("invalid server type provided: {}", cfg.sentinel.master_name),
        };

        let sentinel_client = SentinelClient::build(
            vec![format!("redis://{}", cfg.address)],
            cfg.sentinel.master_name.clone(),
            None,
            server_type,
        )?;

        let pool = Pool::builder()
            .min_idle(Some(cfg.min_idle_conns))
            .max_size(cfg.max_pool_size)
            .idle_timeout(Some(cfg.idle_timeout))
            .connection_timeout(cfg.pool_timeout)
            .build(LockedSentinelClient::new(sentinel_client))?;

        Ok(pool)
    }
}
```

And to use the pool:
```
        let mut conn = pool.get().unwrap();
        let val: String = conn.get("key").unwrap();
```

What do you think about it?

