### PR TITLE
fix sentinel feature error and update dependency

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -46,11 +46,11 @@ socket2 = { version = "0.5", default-features = false, optional = true }
 
 # Only needed for the connection manager
 arc-swap = { version = "1.7.1" }
-futures = { version = "0.3.3", optional = true }
+futures = { version = "0.3.30", optional = true }
 tokio-retry = { version = "0.3.0", optional = true }
 
 # Only needed for the r2d2 feature
-r2d2 = { version = "0.8.8", optional = true }
+r2d2 = { version = "0.8.10", optional = true }
 
 # Only needed for cluster
 crc16 = { version = "0.4", optional = true }

--- a/redis/src/r2d2.rs
+++ b/redis/src/r2d2.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "sentinel")]
 use crate::sentinel::LockedSentinelClient;
 use crate::{ConnectionLike, RedisError};
 use std::io;


### PR DESCRIPTION
The new 'sentinel' feature in redis-0.27.0 will cause a compile error when the configuration includes `features = ["tokio-comp","r2d2", "connection-manager"]` without sentinel

error log:
```
error[E0432]: unresolved import `crate::sentinel`
   --> /home/.cargo/registry/src/index.crates.io-6f17d22bba15001f/redis-0.27.0/src/r2d2.rs:1:12
    |
1   | use crate::sentinel::LockedSentinelClient;
    |            ^^^^^^^^ could not find `sentinel` in the crate root
    |
note: found an item that was configured out
   --> /home/.cargo/registry/src/index.crates.io-6f17d22bba15001f/redis-0.27.0/src/lib.rs:607:9
    |
607 | pub mod sentinel;
    |         ^^^^^^^^
note: the item is gated behind the `sentinel` feature
   --> /home/.cargo/registry/src/index.crates.io-6f17d22bba15001f/redis-0.27.0/src/lib.rs:605:7
    |
605 | #[cfg(feature = "sentinel")]
    |       ^^^^^^^^^^^^^^^^^^^^
```

