### PR TITLE
Add support for [TYPE type] in SCAN commands

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -2262,7 +2262,7 @@ impl ScanOptions {
         self
     }
     
-    // Limit the results to those with the given Redis type
+    /// Limit the results to those with the given Redis type
     pub fn with_type(mut self, t: impl Into<String>) -> Self {
         self.scan_type = Some(t.into());
         self

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -2246,6 +2246,7 @@ impl PubSubCommands for Connection {
 pub struct ScanOptions {
     pattern: Option<String>,
     count: Option<usize>,
+    scan_type: Option<String>,
 }
 
 impl ScanOptions {
@@ -2258,6 +2259,12 @@ impl ScanOptions {
     /// Pattern for scan
     pub fn with_pattern(mut self, p: impl Into<String>) -> Self {
         self.pattern = Some(p.into());
+        self
+    }
+    
+    // Limit the results to those with the given Redis type
+    pub fn with_type(mut self, t: impl Into<String>) -> Self {
+        self.scan_type = Some(t.into());
         self
     }
 }
@@ -2276,6 +2283,11 @@ impl ToRedisArgs for ScanOptions {
             out.write_arg(b"COUNT");
             out.write_arg_fmt(n);
         }
+        
+        if let Some(t) = &self.scan_type {
+            out.write_arg(b"TYPE");
+            out.write_arg_fmt(t);
+        }
     }
 
     fn num_of_args(&self) -> usize {
@@ -2284,6 +2296,9 @@ impl ToRedisArgs for ScanOptions {
             len += 2;
         }
         if self.count.is_some() {
+            len += 2;
+        }
+        if self.scan_type.is_some() {
             len += 2;
         }
         len

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -2261,7 +2261,7 @@ impl ScanOptions {
         self.pattern = Some(p.into());
         self
     }
-    
+
     /// Limit the results to those with the given Redis type
     pub fn with_type(mut self, t: impl Into<String>) -> Self {
         self.scan_type = Some(t.into());
@@ -2283,7 +2283,7 @@ impl ToRedisArgs for ScanOptions {
             out.write_arg(b"COUNT");
             out.write_arg_fmt(n);
         }
-        
+
         if let Some(t) = &self.scan_type {
             out.write_arg(b"TYPE");
             out.write_arg_fmt(t);

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -534,6 +534,7 @@ mod basic {
             let _: () = con.append(format!("test/{i}"), i).unwrap();
             let _: () = con.append(format!("other/{i}"), i).unwrap();
         }
+        let _: () = con.hset("test-hset", "test-field", "test-value").unwrap();
 
         // scan with pattern
         let opts = ScanOptions::default().with_count(20).with_pattern("test/*");
@@ -544,7 +545,17 @@ mod basic {
         let opts = ScanOptions::default();
         let values = con.scan_options::<String>(opts).unwrap();
         let values: Vec<_> = values.collect();
+        assert_eq!(values.len(), 41);
+        // scan with type string
+        let opts = ScanOptions::default().with_type("string");
+        let values = con.scan_options::<String>(opts).unwrap();
+        let values: Vec<_> = values.collect();
         assert_eq!(values.len(), 40);
+        // scan with type hash
+        let opts = ScanOptions::default().with_type("hash");
+        let values = con.scan_options::<String>(opts).unwrap();
+        let values: Vec<_> = values.collect();
+        assert_eq!(values.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
Redis supports adding a `[TYPE type]` subcommand to SCAN since 6.0.0
Similar to a `[MATCH pattern]`, this will filter the returned values, but does not actually reduce the amount of work done by Redis. The TYPE subcommand is only supported on SCAN. SSCAN, HSCAN and ZSCAN does not support it. 

This PR adds basic support for the `[TYPE type]` subcommand. It simply adds a `with_type` method to the existing `ScanOptions`. Currently it takes an arbitrary string, which should be a Redis type, e.g. "string" or "hash". 

This PR should be fully backwards compatible.