### PR TITLE
Updates unmaintained tokio-retry to tokio-retry2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,18 +1259,18 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1563,7 +1563,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-native-tls",
- "tokio-retry",
+ "tokio-retry2",
  "tokio-rustls",
  "tokio-util",
  "url",
@@ -2089,13 +2089,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-retry"
-version = "0.3.0"
+name = "tokio-retry2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+checksum = "1af686b421a51318f526be5148eb81138fd1e1dcfc9ddce3b2e449b84eae98a9"
 dependencies = [
  "pin-project",
- "rand",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,6 +2095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1af686b421a51318f526be5148eb81138fd1e1dcfc9ddce3b2e449b84eae98a9"
 dependencies = [
  "pin-project",
+ "rand",
  "tokio",
 ]
 

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -47,7 +47,7 @@ socket2 = { version = "0.5", default-features = false, optional = true }
 # Only needed for the connection manager
 arc-swap = { version = "1.7.1" }
 futures = { version = "0.3.30", optional = true }
-tokio-retry = { version = "0.3.0", optional = true }
+tokio-retry2 = { version = "0.5.3", optional = true }
 
 # Only needed for the r2d2 feature
 r2d2 = { version = "0.8.10", optional = true }
@@ -108,7 +108,7 @@ async-std-rustls-comp = ["async-std-comp", "futures-rustls", "tls-rustls"]
 tokio-comp = ["aio", "tokio/net"]
 tokio-native-tls-comp = ["tokio-comp", "tls-native-tls", "tokio-native-tls"]
 tokio-rustls-comp = ["tokio-comp", "tls-rustls", "tokio-rustls"]
-connection-manager = ["futures", "aio", "tokio-retry"]
+connection-manager = ["futures", "aio", "tokio-retry2"]
 streams = []
 cluster-async = ["cluster", "futures", "futures-util", "log"]
 keep-alive = ["socket2"]

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -47,7 +47,7 @@ socket2 = { version = "0.5", default-features = false, optional = true }
 # Only needed for the connection manager
 arc-swap = { version = "1.7.1" }
 futures = { version = "0.3.30", optional = true }
-tokio-retry2 = { version = "0.5.3", optional = true }
+tokio-retry2 = { version = "0.5.3", optional = true, features = ["jitter"]}
 
 # Only needed for the r2d2 feature
 r2d2 = { version = "0.8.10", optional = true }

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -14,8 +14,7 @@ use futures::{
 };
 use futures_util::future::BoxFuture;
 use std::sync::Arc;
-use tokio_retry::strategy::{jitter, ExponentialBackoff};
-use tokio_retry::Retry;
+use tokio_retry2::{strategy::ExponentialBackoff, MapErr, Retry};
 
 /// ConnectionManager is the configuration for reconnect mechanism and request timing
 #[derive(Clone, Debug)]
@@ -316,10 +315,13 @@ impl ConnectionManager {
         number_of_retries: usize,
         connection_config: &AsyncConnectionConfig,
     ) -> RedisResult<MultiplexedConnection> {
-        let retry_strategy = exponential_backoff.map(jitter).take(number_of_retries);
+        let retry_strategy = exponential_backoff.take(number_of_retries);
         let connection_config = connection_config.clone();
-        Retry::spawn(retry_strategy, || {
-            client.get_multiplexed_async_connection_with_config(&connection_config)
+        Retry::spawn(retry_strategy, || async {
+            client
+                .get_multiplexed_async_connection_with_config(&connection_config)
+                .await
+                .map_transient_err()
         })
         .await
     }


### PR DESCRIPTION
[`tokio-retry`](https://crates.io/crates/tokio-retry) has been unmaintained for over 3 years now, so this new crate, [tokio-retry2](https://crates.io/crates/tokio-retry2), is being used by my project. 

It has new features like the ability to early exit with wrapping errors (RetryError::Permanent), or continue the retry loop (`RetryError::Transient`), as well a notification on fail system (which was not included in this PR, but can be easily done replacing `Retry::spawn(..)` with `Retry::spawn_notify(..)` .