### PR TITLE
Allow configuring Sentinel with custom TLS certificates

### DIFF
--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -155,7 +155,7 @@ impl Client {
     ) -> RedisResult<Client> {
         let connection_info = conn_info.into_connection_info()?;
 
-        inner_build_with_tls(connection_info, tls_certs)
+        inner_build_with_tls(connection_info, &tls_certs)
     }
 }
 

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -102,7 +102,7 @@ impl ClusterParams {
 
         #[cfg(feature = "tls-rustls")]
         let tls_params = {
-            let retrieved_tls_params = value.certs.clone().map(retrieve_tls_certificates);
+            let retrieved_tls_params = value.certs.as_ref().map(retrieve_tls_certificates);
 
             retrieved_tls_params.transpose()?
         };

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -479,6 +479,7 @@ let mut sentinel = SentinelClient::build(
     Some(SentinelNodeConnectionInfo {
         tls_mode: Some(redis::TlsMode::Insecure),
         redis_connection_info: None,
+        certs: None
     }),
     redis::sentinel::SentinelServerType::Master,
 )
@@ -503,6 +504,7 @@ let mut sentinel = SentinelClient::build(
     Some(SentinelNodeConnectionInfo {
         tls_mode: Some(redis::TlsMode::Insecure),
         redis_connection_info: None,
+        certs: None,
     }),
     redis::sentinel::SentinelServerType::Master,
 )

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -479,7 +479,7 @@ let mut sentinel = SentinelClient::build(
     Some(SentinelNodeConnectionInfo {
         tls_mode: Some(redis::TlsMode::Insecure),
         redis_connection_info: None,
-        certs: None
+        certs: None,
     }),
     redis::sentinel::SentinelServerType::Master,
 )

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -479,7 +479,6 @@ let mut sentinel = SentinelClient::build(
     Some(SentinelNodeConnectionInfo {
         tls_mode: Some(redis::TlsMode::Insecure),
         redis_connection_info: None,
-        certs: None,
     }),
     redis::sentinel::SentinelServerType::Master,
 )
@@ -504,7 +503,6 @@ let mut sentinel = SentinelClient::build(
     Some(SentinelNodeConnectionInfo {
         tls_mode: Some(redis::TlsMode::Insecure),
         redis_connection_info: None,
-        certs: None,
     }),
     redis::sentinel::SentinelServerType::Master,
 )

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -107,8 +107,8 @@
 //! # Example
 //! ```rust,no_run
 //! use redis::sentinel::SentinelClientBuilder;
-//! use redis::TlsCertificates;
-//! let nodes = vec!["redis://127.0.0.1:6379/", "redis://127.0.0.1:6378/", "redis://127.0.0.1:6377/"];
+//! use redis::{ConnectionAddr, TlsCertificates};
+//! let nodes = vec![ConnectionAddr::Tcp(String::from("redis://127.0.0.1"), 6379), ConnectionAddr::Tcp(String::from("redis://127.0.0.1"), 6378), ConnectionAddr::Tcp(String::from("redis://127.0.0.1"), 6377)];
 //!
 //! let mut builder = SentinelClientBuilder::new(nodes, String::from("master"), redis::sentinel::SentinelServerType::Master).unwrap();
 //!

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -1029,31 +1029,31 @@ impl SentinelClientBuilder {
         )
     }
 
-    /// Set tls mode for the connection between sentinels and redis nodes
+    /// Set tls mode for the connection to redis
     pub fn set_client_to_redis_tls_mode(mut self, tls_mode: TlsMode) -> SentinelClientBuilder {
         self.client_to_redis_params.tls_mode = Some(tls_mode);
         self
     }
 
-    /// Set db for the connection between sentinels and redis nodes
+    /// Set db for the connection to redis
     pub fn set_client_to_redis_db(mut self, db: i64) -> SentinelClientBuilder {
         self.client_to_redis_params.db = Some(db);
         self
     }
 
-    /// Set username for the connection between sentinels and redis nodes
+    /// Set username for the connection to redis
     pub fn set_client_to_redis_username(mut self, username: String) -> SentinelClientBuilder {
         self.client_to_redis_params.username = Some(username);
         self
     }
 
-    /// Set password for the connection between sentinels and redis nodes
+    /// Set password for the connection to redis
     pub fn set_client_to_redis_password(mut self, password: String) -> SentinelClientBuilder {
         self.client_to_redis_params.password = Some(password);
         self
     }
 
-    /// Set protocol for the connection between sentinels and redis nodes
+    /// Set protocol for the connection to redis
     pub fn set_client_to_redis_protocol(
         mut self,
         protocol: ProtocolVersion,
@@ -1062,7 +1062,7 @@ impl SentinelClientBuilder {
         self
     }
 
-    /// Set certificates for the connection between sentinels and redis nodes
+    /// Set certificates for the connection to redis
     pub fn set_client_to_redis_certificates(
         mut self,
         certificates: TlsCertificates,

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -744,7 +744,7 @@ fn patch_with_tls_certificates(
             port: _,
             insecure: _,
             ref mut tls_params,
-        } = &mut node.addr
+        } = node.addr
         {
             *tls_params = Some(new_tls_params.clone());
         }

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -1077,12 +1077,6 @@ impl SentinelClientBuilder {
         self
     }
 
-    /// Set db for the connection to the sentinels
-    pub fn set_client_to_sentinel_db(mut self, db: i64) -> SentinelClientBuilder {
-        self.client_to_sentinel_params.db = Some(db);
-        self
-    }
-
     /// Set username for the connection to the sentinels
     pub fn set_client_to_sentinel_username(mut self, username: String) -> SentinelClientBuilder {
         self.client_to_sentinel_params.username = Some(username);

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -105,6 +105,28 @@
 //! .unwrap();
 //! ```
 //!
+//! In addition, there is a `SentinelClientBuilder` to provide the most fine-grained configuration possibilities
+//!
+//! # Example
+//! ```rust,no_run
+//! use redis::sentinel::SentinelClientBuilder;
+//! use redis::TlsCertificates;
+//! let nodes = vec!["redis://127.0.0.1:6379/", "redis://127.0.0.1:6378/", "redis://127.0.0.1:6377/"];
+//!
+//! let mut builder = SentinelClientBuilder::new(nodes, String::from("master"), redis::sentinel::SentinelServerType::Master).unwrap();
+//!
+//! builder = builder.client_to_sentinel_username(String::from("username1"));
+//! builder = builder.client_to_sentinel_password(String::from("password1"));
+//! builder = builder.client_to_sentinel_tls_mode(redis::TlsMode::Insecure);
+//!
+//! builder = builder.sentinel_to_redis_username(String::from("username2"));
+//! builder = builder.sentinel_to_redis_password(String::from("password2"));
+//! builder = builder.sentinel_to_redis_tls_mode(redis::TlsMode::Secure);
+//!
+//!
+//! let client = builder.build().unwrap();
+//! ```
+//!
 
 #[cfg(feature = "aio")]
 use futures_util::StreamExt;
@@ -858,6 +880,9 @@ pub struct SentinelClientBuilder {
 
 impl SentinelClientBuilder {
     /// Creates a new `SentinelClientBuilder`
+    /// - `sentinels` - Addresses of sentinel nodes
+    /// - `service_name` - The name of the service to be queried via the sentinels
+    /// - `server_type` - The server type to be queried via the sentinels
     pub fn new<T: IntoIterator<Item = ConnectionAddr>>(
         sentinels: T,
         service_name: String,

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -115,13 +115,13 @@
 //!
 //! let mut builder = SentinelClientBuilder::new(nodes, String::from("master"), redis::sentinel::SentinelServerType::Master).unwrap();
 //!
-//! builder = builder.client_to_sentinel_username(String::from("username1"));
-//! builder = builder.client_to_sentinel_password(String::from("password1"));
-//! builder = builder.client_to_sentinel_tls_mode(redis::TlsMode::Insecure);
+//! builder = builder.set_client_to_sentinel_username(String::from("username1"));
+//! builder = builder.set_client_to_sentinel_password(String::from("password1"));
+//! builder = builder.set_client_to_sentinel_tls_mode(redis::TlsMode::Insecure);
 //!
-//! builder = builder.client_to_redis_username(String::from("username2"));
-//! builder = builder.client_to_redis_password(String::from("password2"));
-//! builder = builder.client_to_redis_tls_mode(redis::TlsMode::Secure);
+//! builder = builder.set_client_to_redis_username(String::from("username2"));
+//! builder = builder.set_client_to_redis_password(String::from("password2"));
+//! builder = builder.set_client_to_redis_tls_mode(redis::TlsMode::Secure);
 //!
 //!
 //! let client = builder.build().unwrap();
@@ -1030,31 +1030,31 @@ impl SentinelClientBuilder {
     }
 
     /// Set tls mode for the connection between sentinels and redis nodes
-    pub fn client_to_redis_tls_mode(mut self, tls_mode: TlsMode) -> SentinelClientBuilder {
+    pub fn set_client_to_redis_tls_mode(mut self, tls_mode: TlsMode) -> SentinelClientBuilder {
         self.client_to_redis_params.tls_mode = Some(tls_mode);
         self
     }
 
     /// Set db for the connection between sentinels and redis nodes
-    pub fn client_to_redis_db(mut self, db: i64) -> SentinelClientBuilder {
+    pub fn set_client_to_redis_db(mut self, db: i64) -> SentinelClientBuilder {
         self.client_to_redis_params.db = Some(db);
         self
     }
 
     /// Set username for the connection between sentinels and redis nodes
-    pub fn client_to_redis_username(mut self, username: String) -> SentinelClientBuilder {
+    pub fn set_client_to_redis_username(mut self, username: String) -> SentinelClientBuilder {
         self.client_to_redis_params.username = Some(username);
         self
     }
 
     /// Set password for the connection between sentinels and redis nodes
-    pub fn client_to_redis_password(mut self, password: String) -> SentinelClientBuilder {
+    pub fn set_client_to_redis_password(mut self, password: String) -> SentinelClientBuilder {
         self.client_to_redis_params.password = Some(password);
         self
     }
 
     /// Set protocol for the connection between sentinels and redis nodes
-    pub fn client_to_redis_protocol(
+    pub fn set_client_to_redis_protocol(
         mut self,
         protocol: ProtocolVersion,
     ) -> SentinelClientBuilder {
@@ -1063,7 +1063,7 @@ impl SentinelClientBuilder {
     }
 
     /// Set certificates for the connection between sentinels and redis nodes
-    pub fn client_to_redis_certificates(
+    pub fn set_client_to_redis_certificates(
         mut self,
         certificates: TlsCertificates,
     ) -> SentinelClientBuilder {
@@ -1072,31 +1072,31 @@ impl SentinelClientBuilder {
     }
 
     /// Set tls mode for the connection to the sentinels
-    pub fn client_to_sentinel_tls_mode(mut self, tls_mode: TlsMode) -> SentinelClientBuilder {
+    pub fn set_client_to_sentinel_tls_mode(mut self, tls_mode: TlsMode) -> SentinelClientBuilder {
         self.client_to_sentinel_params.tls_mode = Some(tls_mode);
         self
     }
 
     /// Set db for the connection to the sentinels
-    pub fn client_to_sentinel_db(mut self, db: i64) -> SentinelClientBuilder {
+    pub fn set_client_to_sentinel_db(mut self, db: i64) -> SentinelClientBuilder {
         self.client_to_sentinel_params.db = Some(db);
         self
     }
 
     /// Set username for the connection to the sentinels
-    pub fn client_to_sentinel_username(mut self, username: String) -> SentinelClientBuilder {
+    pub fn set_client_to_sentinel_username(mut self, username: String) -> SentinelClientBuilder {
         self.client_to_sentinel_params.username = Some(username);
         self
     }
 
     /// Set password for the connection to the sentinels
-    pub fn client_to_sentinel_password(mut self, password: String) -> SentinelClientBuilder {
+    pub fn set_client_to_sentinel_password(mut self, password: String) -> SentinelClientBuilder {
         self.client_to_sentinel_params.password = Some(password);
         self
     }
 
     /// Set protocol for the connection to the sentinels
-    pub fn client_to_sentinel_protocol(
+    pub fn set_client_to_sentinel_protocol(
         mut self,
         protocol: ProtocolVersion,
     ) -> SentinelClientBuilder {
@@ -1105,7 +1105,7 @@ impl SentinelClientBuilder {
     }
 
     /// Set certificate for the connection to the sentinels
-    pub fn client_to_sentinel_certificates(
+    pub fn set_client_to_sentinel_certificates(
         mut self,
         certificates: TlsCertificates,
     ) -> SentinelClientBuilder {

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -172,7 +172,12 @@ pub struct SentinelNodeConnectionInfo {
 }
 
 impl SentinelNodeConnectionInfo {
-    fn create_connection_info(&self, ip: String, port: u16, certs: &Option<TlsCertificates>,) -> RedisResult<ConnectionInfo> {
+    fn create_connection_info(
+        &self,
+        ip: String,
+        port: u16,
+        certs: &Option<TlsCertificates>,
+    ) -> RedisResult<ConnectionInfo> {
         let addr = match self.tls_mode {
             None => crate::ConnectionAddr::Tcp(ip, port),
             Some(TlsMode::Secure) => crate::ConnectionAddr::TcpTls {
@@ -182,7 +187,10 @@ impl SentinelNodeConnectionInfo {
                 #[cfg(not(feature = "tls-rustls"))]
                 tls_params: None,
                 #[cfg(feature = "tls-rustls")]
-                tls_params: certs.as_ref().map(|certs| retrieve_tls_certificates(certs)).transpose()?,
+                tls_params: certs
+                    .as_ref()
+                    .map(|certs| retrieve_tls_certificates(certs))
+                    .transpose()?,
             },
             Some(TlsMode::Insecure) => crate::ConnectionAddr::TcpTls {
                 host: ip,
@@ -476,14 +484,16 @@ fn try_single_sentinel<T: FromRedisValue>(
 
 // non-async methods
 impl Sentinel {
-
     /// Creates a Sentinel client performing some basic
     /// checks on the URLs that might make the operation fail.
     pub fn build<T: IntoConnectionInfo>(params: Vec<T>) -> RedisResult<Sentinel> {
         Self::build_with_certs(params, None)
     }
 
-    fn build_with_certs<T: IntoConnectionInfo>(params: Vec<T>, certs: Option<TlsCertificates>,) -> RedisResult<Sentinel> {
+    fn build_with_certs<T: IntoConnectionInfo>(
+        params: Vec<T>,
+        certs: Option<TlsCertificates>,
+    ) -> RedisResult<Sentinel> {
         if params.is_empty() {
             fail!((
                 ErrorKind::EmptySentinelList,
@@ -582,11 +592,7 @@ impl Sentinel {
         node_connection_info: &SentinelNodeConnectionInfo,
     ) -> RedisResult<Vec<ConnectionInfo>> {
         let replicas = self.get_sentinel_replicas(service_name)?;
-        get_valid_replicas_addresses(
-            replicas,
-            node_connection_info,
-            &self.certs
-        )
+        get_valid_replicas_addresses(replicas, node_connection_info, &self.certs)
     }
 
     /// Determines the masters address for the given name, and returns a client for that
@@ -804,7 +810,7 @@ impl SentinelClient {
         service_name: String,
         node_connection_info: Option<SentinelNodeConnectionInfo>,
         server_type: SentinelServerType,
-        certs: Option<TlsCertificates>
+        certs: Option<TlsCertificates>,
     ) -> RedisResult<Self> {
         Ok(SentinelClient {
             sentinel: Sentinel::build_with_certs(params, certs)?,

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -177,8 +177,7 @@ impl SentinelNodeConnectionInfo {
         &self,
         ip: String,
         port: u16,
-        #[cfg(feature = "tls-rustls")]
-        certs: &Option<TlsCertificates>,
+        #[cfg(feature = "tls-rustls")] certs: &Option<TlsCertificates>,
     ) -> RedisResult<ConnectionInfo> {
         let addr = match self.tls_mode {
             None => crate::ConnectionAddr::Tcp(ip, port),
@@ -189,10 +188,7 @@ impl SentinelNodeConnectionInfo {
                 #[cfg(not(feature = "tls-rustls"))]
                 tls_params: None,
                 #[cfg(feature = "tls-rustls")]
-                tls_params: certs
-                    .as_ref()
-                    .map(retrieve_tls_certificates)
-                    .transpose()?,
+                tls_params: certs.as_ref().map(retrieve_tls_certificates).transpose()?,
             },
             Some(TlsMode::Insecure) => crate::ConnectionAddr::TcpTls {
                 host: ip,
@@ -330,8 +326,7 @@ fn find_valid_master(
     masters: Vec<HashMap<String, String>>,
     service_name: &str,
     node_connection_info: &SentinelNodeConnectionInfo,
-    #[cfg(feature = "tls-rustls")]
-    certs: &Option<TlsCertificates>,
+    #[cfg(feature = "tls-rustls")] certs: &Option<TlsCertificates>,
 ) -> RedisResult<ConnectionInfo> {
     for (ip, port) in valid_addrs(masters, |m| is_master_valid(m, service_name)) {
         #[cfg(not(feature = "tls-rustls"))]
@@ -366,8 +361,7 @@ async fn async_find_valid_master(
     masters: Vec<HashMap<String, String>>,
     service_name: &str,
     node_connection_info: &SentinelNodeConnectionInfo,
-    #[cfg(feature = "tls-rustls")]
-    certs: &Option<TlsCertificates>,
+    #[cfg(feature = "tls-rustls")] certs: &Option<TlsCertificates>,
 ) -> RedisResult<ConnectionInfo> {
     for (ip, port) in valid_addrs(masters, |m| is_master_valid(m, service_name)) {
         #[cfg(not(feature = "tls-rustls"))]
@@ -921,12 +915,7 @@ impl SentinelClient {
         node_connection_info: Option<SentinelNodeConnectionInfo>,
         server_type: SentinelServerType,
     ) -> RedisResult<Self> {
-        Self::build_inner(
-            params,
-            service_name,
-            node_connection_info,
-            server_type,
-        )
+        Self::build_inner(params, service_name, node_connection_info, server_type)
     }
 
     #[cfg(feature = "tls-rustls")]
@@ -952,8 +941,7 @@ impl SentinelClient {
         service_name: String,
         node_connection_info: Option<SentinelNodeConnectionInfo>,
         server_type: SentinelServerType,
-        #[cfg(feature = "tls-rustls")]
-        certs: Option<TlsCertificates>,
+        #[cfg(feature = "tls-rustls")] certs: Option<TlsCertificates>,
     ) -> RedisResult<Self> {
         Ok(SentinelClient {
             #[cfg(not(feature = "tls-rustls"))]
@@ -1199,7 +1187,8 @@ impl SentinelClientBuilder {
             self.service_name,
             Some(client_to_redis_connection_info),
             self.server_type,
-            #[cfg(feature = "tls-rustls")] self.client_to_redis_params.certificates,
+            #[cfg(feature = "tls-rustls")]
+            self.client_to_redis_params.certificates,
         )
     }
 

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -189,7 +189,7 @@ impl SentinelNodeConnectionInfo {
                 #[cfg(feature = "tls-rustls")]
                 tls_params: certs
                     .as_ref()
-                    .map(|certs| retrieve_tls_certificates(certs))
+                    .map(retrieve_tls_certificates)
                     .transpose()?,
             },
             Some(TlsMode::Insecure) => crate::ConnectionAddr::TcpTls {
@@ -331,7 +331,7 @@ fn find_valid_master(
     certs: &Option<TlsCertificates>,
 ) -> RedisResult<ConnectionInfo> {
     for (ip, port) in valid_addrs(masters, |m| is_master_valid(m, service_name)) {
-        let connection_info = node_connection_info.create_connection_info(ip, port, &certs)?;
+        let connection_info = node_connection_info.create_connection_info(ip, port, certs)?;
         if check_role(&connection_info, "master") {
             return Ok(connection_info);
         }

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -166,7 +166,7 @@ impl SentinelNodeConnectionInfo {
                 #[cfg(not(feature = "tls-rustls"))]
                 tls_params: None,
                 #[cfg(feature = "tls-rustls")]
-                tls_params: Some(retrieve_tls_certificates(self.certs.clone().unwrap()).unwrap())
+                tls_params: Some(retrieve_tls_certificates(self.certs.clone().unwrap()).unwrap()),
             },
             Some(TlsMode::Insecure) => crate::ConnectionAddr::TcpTls {
                 host: ip,
@@ -854,7 +854,7 @@ impl SentinelClientBuilder {
             sentinels: sentinels.into_iter().collect::<Vec<_>>(),
             service_name,
             server_type,
-            sentinel_to_redis_params : BuilderConnectionParams {
+            sentinel_to_redis_params: BuilderConnectionParams {
                 tls_mode: None,
                 db: None,
                 username: None,
@@ -875,7 +875,6 @@ impl SentinelClientBuilder {
 
     /// Creates a new `SentinelClient` from the parameters
     pub fn build(mut self) -> RedisResult<SentinelClient> {
-
         let mut sentinel_to_redis_connection_info = RedisConnectionInfo::default();
 
         if let Some(db) = self.sentinel_to_redis_params.db {
@@ -972,12 +971,14 @@ impl SentinelClientBuilder {
             client_to_sentinel_redis_connection_info.protocol = protocol;
         }
 
-        let sentinels = self.sentinels.into_iter().map(|connection_addr| {
-            ConnectionInfo {
+        let sentinels = self
+            .sentinels
+            .into_iter()
+            .map(|connection_addr| ConnectionInfo {
                 addr: connection_addr,
                 redis: client_to_sentinel_redis_connection_info.clone(),
-            }
-        }).collect();
+            })
+            .collect();
 
         SentinelClient::build(
             sentinels,
@@ -1012,13 +1013,19 @@ impl SentinelClientBuilder {
     }
 
     /// Set protocol for the connection between sentinels and redis nodes
-    pub fn sentinel_to_redis_protocol(mut self, protocol: ProtocolVersion) -> SentinelClientBuilder {
+    pub fn sentinel_to_redis_protocol(
+        mut self,
+        protocol: ProtocolVersion,
+    ) -> SentinelClientBuilder {
         self.sentinel_to_redis_params.protocol = Some(protocol);
         self
     }
 
     /// Set certificates for the connection between sentinels and redis nodes
-    pub fn sentinel_to_redis_certificates(mut self, certificates: TlsCertificates) -> SentinelClientBuilder {
+    pub fn sentinel_to_redis_certificates(
+        mut self,
+        certificates: TlsCertificates,
+    ) -> SentinelClientBuilder {
         self.sentinel_to_redis_params.certificates = Some(certificates);
         self
     }
@@ -1048,14 +1055,19 @@ impl SentinelClientBuilder {
     }
 
     /// Set protocol for the connection to the sentinels
-
-    pub fn client_to_sentinel_protocol(mut self, protocol: ProtocolVersion) -> SentinelClientBuilder {
+    pub fn client_to_sentinel_protocol(
+        mut self,
+        protocol: ProtocolVersion,
+    ) -> SentinelClientBuilder {
         self.client_to_sentinel_params.protocol = Some(protocol);
         self
     }
 
     /// Set certificate for the connection to the sentinels
-    pub fn client_to_sentinel_certificates(mut self, certificates: TlsCertificates) -> SentinelClientBuilder {
+    pub fn client_to_sentinel_certificates(
+        mut self,
+        certificates: TlsCertificates,
+    ) -> SentinelClientBuilder {
         self.client_to_sentinel_params.certificates = Some(certificates);
         self
     }

--- a/redis/src/tls.rs
+++ b/redis/src/tls.rs
@@ -70,7 +70,7 @@ pub(crate) fn retrieve_tls_certificates(
         client_key,
     }) = client_tls
     {
-        let client_cert_chain = CertificateDer::pem_slice_iter(&client_cert)
+        let client_cert_chain = CertificateDer::pem_slice_iter(client_cert)
             .collect::<Result<Vec<_>, _>>()
             .map_err(|err| {
                 Error::new(
@@ -79,7 +79,7 @@ pub(crate) fn retrieve_tls_certificates(
                 )
             })?;
 
-        let client_key = PrivateKeyDer::from_pem_slice(&client_key).map_err(|err| {
+        let client_key = PrivateKeyDer::from_pem_slice(client_key).map_err(|err| {
             Error::new(
                 io::ErrorKind::Other,
                 format!("Unable to extract private key from PEM file: {err}"),
@@ -96,7 +96,7 @@ pub(crate) fn retrieve_tls_certificates(
 
     let root_cert_store = if let Some(root_cert) = root_cert {
         let mut root_cert_store = RootCertStore::empty();
-        for result in CertificateDer::pem_slice_iter(&root_cert) {
+        for result in CertificateDer::pem_slice_iter(root_cert) {
             let cert = result.map_err(|err| {
                 Error::new(
                     io::ErrorKind::Other,

--- a/redis/src/tls.rs
+++ b/redis/src/tls.rs
@@ -30,7 +30,7 @@ pub struct TlsCertificates {
 
 pub(crate) fn inner_build_with_tls(
     mut connection_info: ConnectionInfo,
-    certificates: TlsCertificates,
+    certificates: &TlsCertificates,
 ) -> RedisResult<Client> {
     let tls_params = retrieve_tls_certificates(certificates)?;
 
@@ -58,7 +58,7 @@ pub(crate) fn inner_build_with_tls(
 }
 
 pub(crate) fn retrieve_tls_certificates(
-    certificates: TlsCertificates,
+    certificates: &TlsCertificates,
 ) -> RedisResult<TlsConnParams> {
     let TlsCertificates {
         client_tls,

--- a/redis/tests/support/sentinel.rs
+++ b/redis/tests/support/sentinel.rs
@@ -71,6 +71,7 @@ impl TestSentinelContext {
                 None
             },
             redis_connection_info: None,
+            certs: None,
         }
     }
 

--- a/redis/tests/support/sentinel.rs
+++ b/redis/tests/support/sentinel.rs
@@ -59,19 +59,21 @@ impl TestSentinelContext {
 
     pub fn sentinel_node_connection_info(&self) -> SentinelNodeConnectionInfo {
         SentinelNodeConnectionInfo {
-            tls_mode: if let ConnectionAddr::TcpTls { insecure, .. } =
-                self.cluster.servers[0].client_addr()
-            {
-                if *insecure {
-                    Some(TlsMode::Insecure)
-                } else {
-                    Some(TlsMode::Secure)
-                }
-            } else {
-                None
-            },
+            tls_mode: self.tls_mode(),
             redis_connection_info: None,
             certs: None,
+        }
+    }
+
+    pub fn tls_mode(&self) -> Option<TlsMode> {
+        if let ConnectionAddr::TcpTls { insecure, .. } = self.cluster.servers[0].client_addr() {
+            if *insecure {
+                Some(TlsMode::Insecure)
+            } else {
+                Some(TlsMode::Secure)
+            }
+        } else {
+            None
         }
     }
 

--- a/redis/tests/support/sentinel.rs
+++ b/redis/tests/support/sentinel.rs
@@ -61,7 +61,6 @@ impl TestSentinelContext {
         SentinelNodeConnectionInfo {
             tls_mode: self.tls_mode(),
             redis_connection_info: None,
-            certs: None,
         }
     }
 


### PR DESCRIPTION
We would like to be able to configure the TLS certificates that are used with Sentinel. Similar functionality was already included in https://github.com/redis-rs/redis-rs/pull/858, but it was reverted and was said to better be included in a separate PR.

There are two connections for which we would like to configure the certificates:

1. Client <-> Redis. This is done in 2954990dcee076d9d3fbca1b771e12d05379be24 by adding a field `certs` to `SentinelNodeConnectionInfo`. This is a breaking change but I think it's quite hard to include this functionality without any breaking changes. For example, `Sentinel` offers several `pub fn`, such as `master_for`, which would need some access to the certificates. If we don't want to change the signature of these function we would need to duplicate them. I haven't thought this all the way through, but feel like the solution in this PR is much cleaner.
2. Client <-> Sentinel. This is done in 20248c160d73631d89a20fa38e6cf0c711e5bfb2 by adding a new function `SentinelClient::build_with_certs`, which patches the nodes in `params` with the certificates. The reason why this is not possible in the first place ist because `TlsConnParam` is opaque (https://github.com/redis-rs/redis-rs/issues/1006).