### PR TITLE
Use cargo-nextest for testing.

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,6 @@
+[profile.default]
+retries = 2
+test-threads = 1
+failure-output = "immediate-final" # show test failures inline, and also at the end of the run
+fail-fast = false # run all tests, even if some failed
+slow-timeout = { period = "5s", terminate-after = 4 }

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,6 +71,11 @@ jobs:
 
     - uses: Swatinem/rust-cache@v2
 
+    - name: Install cargo-nextest
+      uses: taiki-e/install-action@v2
+      with:
+        tool: nextest
+
     - uses: actions/checkout@v4
 
     - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -5,59 +5,64 @@ test:
 	@echo "===================================================================="
 	@echo "Build all features with lock file"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" cargo build --locked --all-features -p redis -p redis-test
+	@RUSTFLAGS="-D warnings" cargo build --locked -p redis -p redis-test --all-features
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP without features"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo test --locked -p redis --no-default-features -- --nocapture --test-threads=1 --skip test_module
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run --locked -p redis --no-default-features --no-capture  -E 'not test(test_module)'
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features and RESP2"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo test --locked -p redis --all-features -- --nocapture --test-threads=1 --skip test_module
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features --no-capture -E 'not test(test_module)'
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features and RESP3"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=tcp PROTOCOL=RESP3 cargo test -p redis --all-features -- --nocapture --test-threads=1 --skip test_module
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run --locked -p redis --all-features --no-capture  -E 'not test(test_module)'
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features and Rustls support"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo test --locked -p redis --all-features -- --nocapture --test-threads=1 --skip test_module
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features --no-capture -E 'not test(test_module)'
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with native-TLS support"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo test --locked -p redis --features=json,tokio-native-tls-comp,async-std-native-tls-comp,connection-manager,cluster-async -- --nocapture --test-threads=1 --skip test_module
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo nextest run --locked -p redis --features=json,tokio-native-tls-comp,async-std-native-tls-comp,connection-manager,cluster-async --no-capture -E 'not test(test_module)'
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type UNIX"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo test --locked -p redis --test parser --test test_basic --test test_types --all-features -- --test-threads=1 --skip test_module
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo nextest run --locked -p redis --test parser --test test_basic --test test_types --all-features --no-capture -E 'not test(test_module)'
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type UNIX SOCKETS"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo test --locked -p redis --all-features -- --test-threads=1 --skip test_cluster --skip cluster_async --skip test_module
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features --no-capture -E 'not (test(test_module) | test(cluster))'
 
 	@echo "===================================================================="
 	@echo "Testing redis-test"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" RUST_BACKTRACE=1 cargo test --locked -p redis-test 
+	@RUSTFLAGS="-D warnings" RUST_BACKTRACE=1 cargo nextest run --locked -p redis-test --no-capture
+
+	@echo "===================================================================="
+	@echo "Run doc tests"
+	@echo "===================================================================="
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo test  --doc --locked --all-features
 
 
 test-module:
 	@echo "===================================================================="
 	@echo "Testing RESP2 with module support enabled (currently only RedisJSON)"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo test -p redis --locked --all-features test_module -- --test-threads=1
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features e -E 'test(test_module)' --no-capture
 
 	@echo "===================================================================="
 	@echo "Testing RESP3 with module support enabled (currently only RedisJSON)"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 RESP3=true cargo test -p redis --all-features test_module -- --test-threads=1
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 RESP3=true cargo nextest run -p redis --all-features e -E 'test(test_module)' --no-capture
 
 test-single: test
 


### PR DESCRIPTION
nextest provides better outputs on tests, and will allow us to find slow & flakey tests.