### PR TITLE
Improve docs.

### DIFF
--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -400,6 +400,7 @@ impl Pipeline {
 
 /// A connection object which can be cloned, allowing requests to be be sent concurrently
 /// on the same underlying connection (tcp/unix socket).
+///
 /// This connection object is cancellation-safe, and the user can drop request future without polling them to completion,
 /// but this doesn't mean that the actual request sent to the server is cancelled.
 /// A side-effect of this is that the underlying connection won't be closed until all sent requests have been answered,

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -213,9 +213,10 @@ impl Connect for Connection {
     }
 }
 
-/// This represents a Redis Cluster connection. It stores the
-/// underlying connections maintained for each node in the cluster, as well
-/// as common parameters for connecting to nodes and executing commands.
+/// This represents a Redis Cluster connection.
+///
+/// It stores the underlying connections maintained for each node in the cluster,
+/// as well as common parameters for connecting to nodes and executing commands.
 pub struct ClusterConnection<C = Connection> {
     initial_nodes: Vec<ConnectionInfo>,
     connections: RefCell<HashMap<String, C>>,

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -99,9 +99,10 @@ use request::{CmdArg, PendingRequest, Request, RequestState, Retry};
 use routing::{route_for_pipeline, InternalRoutingInfo, InternalSingleNodeRouting};
 use tokio::sync::{mpsc, oneshot, RwLock};
 
-/// This represents an async Redis Cluster connection. It stores the
-/// underlying connections maintained for each node in the cluster, as well
-/// as common parameters for connecting to nodes and executing commands.
+/// This represents an async Redis Cluster connection.
+///
+/// It stores the underlying connections maintained for each node in the cluster,
+/// as well as common parameters for connecting to nodes and executing commands.
 #[derive(Clone)]
 pub struct ClusterConnection<C = MultiplexedConnection> {
     sender: mpsc::Sender<Message<C>>,

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -340,7 +340,7 @@ impl ClusterClientBuilder {
     }
 }
 
-/// This is a Redis Cluster client.
+/// A Redis Cluster client, used to create connections.
 #[derive(Clone)]
 pub struct ClusterClient {
     initial_nodes: Vec<ConnectionInfo>,

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -102,7 +102,9 @@ pub enum MultipleNodeRoutingInfo {
     MultiSlot(Vec<(Route, Vec<usize>)>),
 }
 
-/// Takes a routable and an iterator of indices, which is assumed to be created from`MultipleNodeRoutingInfo::MultiSlot`,
+/// Splits a command into a sub-command that won't generate a CROSSLOTS error.
+///
+///  Takes a routable and an iterator of indices, which is assumed to be created from`MultipleNodeRoutingInfo::MultiSlot`,
 /// and returns a command with the arguments matching the indices.
 pub fn command_for_multi_slot_indices<'a, 'b>(
     original_cmd: &'a impl Routable,

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -618,10 +618,12 @@ pub fn cmd(name: &str) -> Cmd {
     rv
 }
 
-/// Packs a bunch of commands into a request.  This is generally a quite
-/// useless function as this functionality is nicely wrapped through the
-/// `Cmd` object, but in some cases it can be useful.  The return value
-/// of this can then be send to the low level `ConnectionLike` methods.
+/// Packs a bunch of commands into a request.
+///
+/// This is generally a quite useless function as this functionality is
+/// nicely wrapped through the `Cmd` object, but in some cases it can be
+/// useful.  The return value of this can then be send to the low level
+/// `ConnectionLike` methods.
 ///
 /// Example:
 ///

--- a/redis/src/commands/macros.rs
+++ b/redis/src/commands/macros.rs
@@ -8,9 +8,10 @@ macro_rules! implement_commands {
         )*
     ) =>
     (
-        /// Implements common redis commands for connection like objects.  This
-        /// allows you to send commands straight to a connection or client.  It
-        /// is also implemented for redis results of clients which makes for
+        /// Implements common redis commands for connection like objects.
+        ///
+        /// This allows you to send commands straight to a connection or client.
+        /// It is also implemented for redis results of clients which makes for
         /// very convenient access in some basic cases.
         ///
         /// This allows you to use nicer syntax for some common operations.
@@ -133,8 +134,9 @@ macro_rules! implement_commands {
             )*
         }
 
-        /// Implements common redis commands over asynchronous connections. This
-        /// allows you to send commands straight to a connection or client.
+        /// Implements common redis commands over asynchronous connections.
+        ///
+        /// This allows you to send commands straight to a connection or client.
         ///
         /// This allows you to use nicer syntax for some common operations.
         /// For instance this code:

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -90,8 +90,9 @@ fn connect_tcp_timeout(addr: &SocketAddr, timeout: Duration) -> io::Result<TcpSt
 }
 
 /// This function takes a redis URL string and parses it into a URL
-/// as used by rust-url.  This is necessary as the default parser does
-/// not understand how redis URLs function.
+/// as used by rust-url.
+///
+/// This is necessary as the default parser does not understand how redis URLs function.
 pub fn parse_redis_url(input: &str) -> Option<url::Url> {
     match url::Url::parse(input) {
         Ok(result) => match result.scheme() {
@@ -103,6 +104,7 @@ pub fn parse_redis_url(input: &str) -> Option<url::Url> {
 }
 
 /// TlsMode indicates use or do not use verification of certification.
+///
 /// Check [ConnectionAddr](ConnectionAddr::TcpTls::insecure) for more.
 #[derive(Clone, Copy)]
 pub enum TlsMode {
@@ -1146,9 +1148,10 @@ fn setup_connection(
 }
 
 /// Implements the "stateless" part of the connection interface that is used by the
-/// different objects in redis-rs.  Primarily it obviously applies to `Connection`
-/// object but also some other objects implement the interface (for instance
-/// whole clients or certain redis results).
+/// different objects in redis-rs.
+///
+/// Primarily it obviously applies to `Connection` object but also some other objects
+///  implement the interface (for instance whole clients or certain redis results).
 ///
 /// Generally clients and connections (as well as redis results of those) implement
 /// this trait.  Actual connections provide more functionality which can be used

--- a/redis/src/geo.rs
+++ b/redis/src/geo.rs
@@ -43,8 +43,9 @@ impl ToRedisArgs for Unit {
     }
 }
 
-/// A coordinate (longitude, latitude). Can be used with [`geo_pos`][1]
-/// to parse response from Redis.
+/// A coordinate (longitude, latitude).
+///
+/// Can be used with [`geo_pos`][1] to parse response from Redis.
 ///
 /// [1]: ../trait.Commands.html#method.geo_pos
 ///

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -694,9 +694,9 @@ pub enum SentinelServerType {
     Replica,
 }
 
-/// LockedSentinelClient is a wrapper around SentinelClient since
-/// it SentinelClient requires &mut ref for get_connection()
-/// and we can't use it like this inside the r2d2 Manager
+/// LockedSentinelClient is a wrapper around SentinelClient usable in r2d2.
+// [internal comment]: this was added since SentinelClient requires &mut ref for get_connection()
+// and we can't use it like this inside the r2d2 Manager, which requires a shared reference.
 #[cfg(feature = "r2d2")]
 pub struct LockedSentinelClient(pub(crate) Mutex<SentinelClient>);
 
@@ -714,10 +714,10 @@ impl LockedSentinelClient {
     }
 }
 
-/// An alternative to the Client type which creates connections from clients created
-/// on-demand based on information fetched from the sentinels. Uses the Sentinel type
-/// internally. This is basic an utility to help make it easier to use sentinels but
-/// with an interface similar to the client (`get_connection` and
+/// A utility wrapping `Sentinel` with an interface similar to [Client].
+///
+/// Uses the Sentinel type internally. This is a utility to help make it easier
+/// to use sentinels but with an interface similar to the client (`get_connection` and
 /// `get_async_connection`). The type of server (master or replica) and name of the
 /// desired master are specified when constructing an instance, so it will always
 /// return connections to the same target (for example, always to the master with name

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -576,9 +576,10 @@ impl fmt::Debug for Value {
     }
 }
 
-/// Represents a redis error.  For the most part you should be using
-/// the Error trait to interact with this rather than the actual
-/// struct.
+/// Represents a redis error.
+///
+/// For the most part you should be using the Error trait to interact with this
+/// rather than the actual struct.
 pub struct RedisError {
     repr: ErrorRepr,
 }
@@ -1702,7 +1703,9 @@ impl<T: FromRedisValue, const N: usize> FromRedisValue for [T; N] {
 }
 
 /// This trait is used to convert a redis value into a more appropriate
-/// type.  While a redis `Value` can represent any response that comes
+/// type.  
+///
+/// While a redis `Value` can represent any response that comes
 /// back from the redis server, usually you want to map this into something
 /// that works better in rust.  For instance you might want to convert the
 /// return value into a `String` or an integer.
@@ -2511,8 +2514,10 @@ pub fn from_owned_redis_value<T: FromRedisValue>(v: Value) -> RedisResult<T> {
     FromRedisValue::from_owned_redis_value(v)
 }
 
-/// Enum representing the communication protocol with the server. This enum represents the types
-/// of data that the server can send to the client, and the capabilities that the client can use.
+/// Enum representing the communication protocol with the server.
+///
+/// This enum represents the types of data that the server can send to the client,
+/// and the capabilities that the client can use.
 #[derive(Clone, Eq, PartialEq, Default, Debug, Copy)]
 pub enum ProtocolVersion {
     /// <https://github.com/redis/redis-specifications/blob/master/protocol/RESP2.md>


### PR DESCRIPTION
Most of the changes here involve taking a large block of test and splitting off the first line. docs.rs shows only the first paragraph of a doc in an upper scope as blurb, and these types had outlandishly long blurbs.