### PR TITLE
Add ping support to commands & pubsubs.

### DIFF
--- a/redis/src/aio/pubsub.rs
+++ b/redis/src/aio/pubsub.rs
@@ -295,30 +295,28 @@ impl PubSubSink {
 
     /// Subscribes to a new channel.
     pub async fn subscribe(&mut self, channel_name: impl ToRedisArgs) -> RedisResult<()> {
-        let mut cmd = cmd("SUBSCRIBE");
-        cmd.arg(channel_name);
-        self.send_recv(cmd.get_packed_command()).await.map(|_| ())
+        let cmd = cmd("SUBSCRIBE").arg(channel_name).get_packed_command();
+        self.send_recv(cmd).await.map(|_| ())
     }
 
     /// Unsubscribes from channel.
     pub async fn unsubscribe(&mut self, channel_name: impl ToRedisArgs) -> RedisResult<()> {
-        let mut cmd = cmd("UNSUBSCRIBE");
-        cmd.arg(channel_name);
-        self.send_recv(cmd.get_packed_command()).await.map(|_| ())
+        let cmd = cmd("UNSUBSCRIBE").arg(channel_name).get_packed_command();
+        self.send_recv(cmd).await.map(|_| ())
     }
 
     /// Subscribes to a new channel with pattern.
     pub async fn psubscribe(&mut self, channel_pattern: impl ToRedisArgs) -> RedisResult<()> {
-        let mut cmd = cmd("PSUBSCRIBE");
-        cmd.arg(channel_pattern);
-        self.send_recv(cmd.get_packed_command()).await.map(|_| ())
+        let cmd = cmd("PSUBSCRIBE").arg(channel_pattern).get_packed_command();
+        self.send_recv(cmd).await.map(|_| ())
     }
 
     /// Unsubscribes from channel pattern.
     pub async fn punsubscribe(&mut self, channel_pattern: impl ToRedisArgs) -> RedisResult<()> {
-        let mut cmd = cmd("PUNSUBSCRIBE");
-        cmd.arg(channel_pattern);
-        self.send_recv(cmd.get_packed_command()).await.map(|_| ())
+        let cmd = cmd("PUNSUBSCRIBE")
+            .arg(channel_pattern)
+            .get_packed_command();
+        self.send_recv(cmd).await.map(|_| ())
     }
 
     /// Sends a ping with a message to the server
@@ -326,15 +324,16 @@ impl PubSubSink {
         &mut self,
         message: impl ToRedisArgs,
     ) -> RedisResult<T> {
-        let mut cmd = cmd("PING");
-        cmd.arg(message);
-        from_owned_redis_value(self.send_recv(cmd.get_packed_command()).await?)
+        let cmd = cmd("PING").arg(message).get_packed_command();
+        let response = self.send_recv(cmd).await?;
+        from_owned_redis_value(response)
     }
 
     /// Sends a ping to the server
     pub async fn ping<T: FromRedisValue>(&mut self) -> RedisResult<T> {
-        let cmd = cmd("PING");
-        from_owned_redis_value(self.send_recv(cmd.get_packed_command()).await?)
+        let cmd = cmd("PING").get_packed_command();
+        let response = self.send_recv(cmd).await?;
+        from_owned_redis_value(response)
     }
 }
 

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -587,6 +587,11 @@ implement_commands! {
         cmd("LSET").arg(key).arg(index).arg(value)
     }
 
+    /// Sends a ping to the server
+    fn ping<K: ToRedisArgs>(message: K) {
+         cmd("PING").arg(message)
+    }
+
     /// Removes and returns the up to `count` last elements of the list stored at key
     ///
     /// If `count` is not specified, then defaults to last element.
@@ -2264,7 +2269,7 @@ pub trait PubSubCommands: Sized {
 impl<T> Commands for T where T: ConnectionLike {}
 
 #[cfg(feature = "aio")]
-impl<T> AsyncCommands for T where T: crate::aio::ConnectionLike + Send + Sized {}
+impl<T> AsyncCommands for T where T: crate::aio::ConnectionLike + Send + Sync + Sized {}
 
 impl PubSubCommands for Connection {
     fn subscribe<C, F, U>(&mut self, channels: C, mut func: F) -> RedisResult<U>

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -588,7 +588,12 @@ implement_commands! {
     }
 
     /// Sends a ping to the server
-    fn ping<K: ToRedisArgs>(message: K) {
+    fn ping<>() {
+         &mut cmd("PING")
+    }
+
+    /// Sends a ping with a message to the server
+    fn ping_message<K: ToRedisArgs>(message: K) {
          cmd("PING").arg(message)
     }
 

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -1667,39 +1667,61 @@ impl<'a> PubSub<'a> {
         }
     }
 
-    fn cache_messages_until_received_response(&mut self, cmd: &mut Cmd) -> RedisResult<()> {
-        if self.con.protocol != ProtocolVersion::RESP2 {
-            cmd.set_no_response(true);
-        }
-        let mut response = cmd.query(self.con)?;
+    fn cache_messages_until_received_response(
+        &mut self,
+        cmd: &mut Cmd,
+        is_sub_unsub: bool,
+    ) -> RedisResult<Value> {
+        let ignore_response = self.con.protocol != ProtocolVersion::RESP2 && is_sub_unsub;
+        cmd.set_no_response(ignore_response);
+
+        self.con.send_packed_command(&cmd.get_packed_command())?;
+
         loop {
-            if let Some(msg) = Msg::from_owned_value(response) {
+            let response = self.con.recv_response()?;
+            if let Some(msg) = Msg::from_value(&response) {
                 self.waiting_messages.push_back(msg);
             } else {
-                return Ok(());
+                return Ok(response);
             }
-            response = self.con.recv_response()?;
         }
     }
 
     /// Subscribes to a new channel.
     pub fn subscribe<T: ToRedisArgs>(&mut self, channel: T) -> RedisResult<()> {
-        self.cache_messages_until_received_response(cmd("SUBSCRIBE").arg(channel))
+        self.cache_messages_until_received_response(cmd("SUBSCRIBE").arg(channel), true)?;
+        Ok(())
     }
 
     /// Subscribes to a new channel with a pattern.
     pub fn psubscribe<T: ToRedisArgs>(&mut self, pchannel: T) -> RedisResult<()> {
-        self.cache_messages_until_received_response(cmd("PSUBSCRIBE").arg(pchannel))
+        self.cache_messages_until_received_response(cmd("PSUBSCRIBE").arg(pchannel), true)?;
+        Ok(())
     }
 
     /// Unsubscribes from a channel.
     pub fn unsubscribe<T: ToRedisArgs>(&mut self, channel: T) -> RedisResult<()> {
-        self.cache_messages_until_received_response(cmd("UNSUBSCRIBE").arg(channel))
+        self.cache_messages_until_received_response(cmd("UNSUBSCRIBE").arg(channel), true)?;
+        Ok(())
     }
 
     /// Unsubscribes from a channel with a pattern.
     pub fn punsubscribe<T: ToRedisArgs>(&mut self, pchannel: T) -> RedisResult<()> {
-        self.cache_messages_until_received_response(cmd("PUNSUBSCRIBE").arg(pchannel))
+        self.cache_messages_until_received_response(cmd("PUNSUBSCRIBE").arg(pchannel), true)?;
+        Ok(())
+    }
+
+    /// Sends a ping with a message to the server
+    pub fn ping_message<T: FromRedisValue>(&mut self, message: impl ToRedisArgs) -> RedisResult<T> {
+        from_owned_redis_value(
+            self.cache_messages_until_received_response(cmd("PING").arg(message), false)?,
+        )
+    }
+    /// Sends a ping to the server
+    pub fn ping<T: FromRedisValue>(&mut self) -> RedisResult<T> {
+        from_owned_redis_value(
+            self.cache_messages_until_received_response(&mut cmd("PING"), false)?,
+        )
     }
 
     /// Fetches the next message from the pubsub connection.  Blocks until

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -205,6 +205,17 @@ mod basic {
     }
 
     #[test]
+    fn test_ping() {
+        let ctx = TestContext::new();
+        let mut con = ctx.connection();
+
+        let res: String = con.ping_message("foobar").unwrap();
+        assert_eq!(&res, "foobar");
+        let res: String = con.ping().unwrap();
+        assert_eq!(&res, "PONG");
+    }
+
+    #[test]
     fn test_getdel() {
         let ctx = TestContext::new();
         let mut con = ctx.connection();


### PR DESCRIPTION
RESP2 allows pubsub connections to send PINGs on the connection without breaking from the pub/sub contract. This change adds `ping` and `ping_message` methods to all pubsub implementations, so that they could send the pings.
For the sync pubsub connection this requires saving responses from the server which aren't pubsub messages, instead of just returning completion from user requests.

https://github.com/redis-rs/redis-rs/issues/639