### PR TITLE
Include the StreamExt use statement in docs

### DIFF
--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -305,7 +305,7 @@
 //!
 //! ```rust,no_run
 //! # #[cfg(feature = "aio")]
-//! # use futures_util::StreamExt;
+//! use futures_util::StreamExt;
 //! # #[cfg(feature = "aio")]
 //! # async fn do_something() -> redis::RedisResult<()> {
 //! let client = redis::Client::open("redis://127.0.0.1/")?;


### PR DESCRIPTION
Discord user magefulrage suggested having the `use futures_util::StreamExt;` line in the PubSub example in the documentation would be helpful.