### PR TITLE
Add lastid option to xclaim

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -1563,7 +1563,7 @@ implement_commands! {
     /// ```text
     /// XCLAIM <key> <group> <consumer> <min-idle-time> <ID-1> <ID-2>
     ///     [IDLE <milliseconds>] [TIME <mstime>] [RETRYCOUNT <count>]
-    ///     [FORCE] [JUSTID]
+    ///     [FORCE] [JUSTID] [LASTID <lastid>]
     /// ```
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]

--- a/redis/src/streams.rs
+++ b/redis/src/streams.rs
@@ -101,6 +101,8 @@ pub struct StreamClaimOptions {
     /// Set `JUSTID` cmd arg. Be advised: the response
     /// type changes with this option.
     justid: bool,
+    /// Set `LASTID <lastid>` cmd arg.
+    lastid: Option<String>,
 }
 
 impl StreamClaimOptions {
@@ -134,6 +136,12 @@ impl StreamClaimOptions {
         self.justid = true;
         self
     }
+
+    /// Set `LASTID <lastid>` cmd arg.
+    pub fn with_lastid(mut self, lastid: impl Into<String>) -> Self {
+        self.lastid = Some(lastid.into());
+        self
+    }
 }
 
 impl ToRedisArgs for StreamClaimOptions {
@@ -158,6 +166,10 @@ impl ToRedisArgs for StreamClaimOptions {
         }
         if self.justid {
             out.write_arg(b"JUSTID");
+        }
+        if let Some(ref lastid) = self.lastid {
+            out.write_arg(b"LASTID");
+            lastid.write_redis_args(out);
         }
     }
 }


### PR DESCRIPTION
Adds the lastid option to xclaim

https://redis.io/docs/latest/commands/xclaim/

This is one of the items in #1153

Behavior of LASTID is documented here:
https://github.com/redis/redis/blob/unstable/src/t_stream.c#L3123

(docs are missing on official redis docs https://redis.io/docs/latest/commands/xclaim/ )
