### PR TITLE
Allow disabling timeouts in `ConnectionManager`

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -134,7 +134,7 @@ futures-time = "3"
 criterion = "0.4"
 partial-io = { version = "0.5", features = ["tokio", "quickcheck1"] }
 quickcheck = "1.0.3"
-tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "time"] }
+tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "test-util", "time"] }
 tempfile = "=3.10.1"
 once_cell = "1"
 anyhow = "1"

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -81,6 +81,7 @@ mod basic_async {
     }
 
     fn test_with_all_connection_types_with_context<Fut, T>(
+        setup: impl Fn(),
         test: impl Fn(TestContext, Wrapper) -> Fut,
         runtime: RuntimeType,
     ) where
@@ -88,6 +89,7 @@ mod basic_async {
     {
         block_on_all(
             async move {
+                setup();
                 let ctx = TestContext::new();
                 let conn = ctx.async_connection().await.unwrap().into();
                 test(ctx, conn).await.unwrap();
@@ -107,11 +109,15 @@ mod basic_async {
         .unwrap();
     }
 
-    fn test_with_all_connection_types<Fut, T>(test: impl Fn(Wrapper) -> Fut, runtime: RuntimeType)
-    where
+    fn test_with_all_connection_types_with_setup<Fut, T>(
+        setup: impl Fn(),
+        test: impl Fn(Wrapper) -> Fut,
+        runtime: RuntimeType,
+    ) where
         Fut: Future<Output = redis::RedisResult<T>>,
     {
         test_with_all_connection_types_with_context(
+            setup,
             |_ctx, conn| async {
                 let res = test(conn).await;
                 // we drop it here in order to ensure that the context isn't dropped before `test` completes.
@@ -120,6 +126,13 @@ mod basic_async {
             },
             runtime,
         )
+    }
+
+    fn test_with_all_connection_types<Fut, T>(test: impl Fn(Wrapper) -> Fut, runtime: RuntimeType)
+    where
+        Fut: Future<Output = redis::RedisResult<T>>,
+    {
+        test_with_all_connection_types_with_setup(|| {}, test, runtime)
     }
 
     #[rstest]
@@ -143,6 +156,36 @@ mod basic_async {
                     .await;
                 assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
                 result
+            },
+            runtime,
+        );
+    }
+
+    #[rstest]
+    #[case::tokio(RuntimeType::Tokio)]
+    fn test_works_with_paused_time(#[case] runtime: RuntimeType) {
+        test_with_all_connection_types_with_setup(
+            || tokio::time::pause(),
+            |mut conn| async move {
+                // Force the Redis command to take enough time that we have to park the task.  If
+                // any timeouts have been created, Tokio will then auto-advance the paused clock to
+                // the timeout's expiry time, resulting in a "timed out" error.
+                redis::cmd("EVAL")
+                    .arg(
+                        r#"
+                          local function now()
+                             local t = redis.call("TIME")
+                             return t[1] + 0.000001 * t[2]
+                          end
+                          local t = now() + 0.5
+                          while now() < t do end
+                        "#,
+                    )
+                    .arg(0)
+                    .exec_async(&mut conn)
+                    .await
+                    .unwrap();
+                Ok(())
             },
             runtime,
         );


### PR DESCRIPTION
The connection and response timeouts in `MultiplexedConnection` are truly optional: they are wrapped in `Option`, and if they are `None`, the runtime's `timeout` function is never called at all.

`ConnectionManager` currently mimics an optional timeout by using `Duration::MAX` as the default timeout value.  The runtime's `timeout` function is called, but with an incredibly large duration.

In normal operation, this would not be a problem, since the timeouts will not fire unless the process runs for ~half a trillion years.  But it breaks test cases that use Tokio's [pausable clock][].  If the task invoking Redis is parked (e.g. while waiting for the Redis command to complete), Tokio will [auto-advance the clock][] to the next sleep point, allowing the timeout to fire.

This patch updates the `ConnectionManager` timeouts to be consistent with the `MultiplexedConnection` timeouts, so that the runtime's `timeout` function is only called if you set connection and/or response timeouts.

[pausable clock]: https://docs.rs/tokio/latest/tokio/time/fn.pause.html
[auto-advance the clock]: https://thomask.sdf.org/blog/2022/12/28/auto-advance-vs-time-guards.html