### PR TITLE
implement high level command `AUTH`

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -1054,6 +1054,11 @@ implement_commands! {
         cmd("CLIENT").arg("ID")
     }
 
+    /// Authenticates the current connection
+    fn auth<K: ToRedisArgs, P: ToRedisArgs>(username: Option<K>, password: P) {
+        cmd("AUTH").arg(username).arg(password)
+    }
+
     // ACL commands
 
     /// When Redis is configured to use an ACL file (with the aclfile

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -2058,4 +2058,38 @@ mod basic {
         let mut con = ctx.connection();
         let _num: i64 = con.client_id().unwrap();
     }
+
+    #[test]
+    fn test_auth_command() {
+        let ctx = TestContext::new();
+        let mut con = ctx.connection();
+
+        redis::cmd("ACL")
+            .arg("SETUSER")
+            .arg("alice")
+            .arg("on")
+            .arg(">p1pp0")
+            .arg("+ACL")
+            .exec(&mut con)
+            .unwrap();
+
+        assert_eq!(con.auth(Some("alice"), "p1pp0"), Ok(()));
+        let r: String = redis::cmd("ACL").arg("WHOAMI").query(&mut con).unwrap();
+        assert_eq!(r, "alice");
+
+        redis::cmd("ACL")
+            .arg("SETUSER")
+            .arg("default")
+            .arg(">password")
+            .exec(&mut con)
+            .unwrap();
+
+        assert_eq!(con.auth(None::<&str>, "password"), Ok(()));
+        redis::cmd("ACL")
+            .arg("SETUSER")
+            .arg("default")
+            .arg("nopass")
+            .exec(&mut con)
+            .unwrap();
+    }
 }


### PR DESCRIPTION
Hi. High-level authentication command is implemented. True, you have authentication at the moment of connection creation and that's great! I also want to be able to authenticate by a reserved user.
AUTH - https://valkey.io/commands/auth/
Test example - https://valkey.io/topics/acl/