### PR TITLE
impl QUIT

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -1044,6 +1044,11 @@ implement_commands! {
         cmd("OBJECT").arg("REFCOUNT").arg(key)
     }
 
+    /// Ask the server to close the connection.
+    fn quit<>() {
+        Cmd::new().arg("QUIT")
+    }
+
     // ACL commands
 
     /// When Redis is configured to use an ACL file (with the aclfile

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -2015,4 +2015,12 @@ mod basic {
             .unwrap();
         assert!(info.contains("db=5"));
     }
+
+    #[test]
+    fn test_quit() {
+        let ctx = TestContext::new();
+        let mut con = ctx.connection();
+        let _: () = con.quit().unwrap();
+        assert_eq!(con.check_connection(), false);
+    }
 }


### PR DESCRIPTION
deprecated, but not deleted `quit`. https://valkey.io/commands/quit/