### PR TITLE
suggestion to use default fmt

### DIFF
--- a/afl/parser/Cargo.toml
+++ b/afl/parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fuzz-target-parser"
 version = "0.1.0"
 authors = ["redis-rs developers"]
-edition = "2018"
+edition = "2021"
 
 [[bin]]
 name = "fuzz-target"

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -479,7 +479,12 @@ where
         };
 
         let convert_result = |res: Result<RedisResult<Response>, _>| {
-            res.map_err(|_| RedisError::from((ErrorKind::ResponseError, "request wasn't handled due to internal failure"))) // this happens only if the result sender is dropped before usage.
+            res.map_err(|_| {
+                RedisError::from((
+                    ErrorKind::ResponseError,
+                    "request wasn't handled due to internal failure",
+                ))
+            }) // this happens only if the result sender is dropped before usage.
             .and_then(|res| res.map(extract_result))
         };
 

--- a/redis/src/cluster_async/routing.rs
+++ b/redis/src/cluster_async/routing.rs
@@ -144,8 +144,10 @@ mod pipeline_routing_tests {
         pipeline
             .get("foo") // route to replica of slot 12182
             .add_command(cmd("FLUSHALL")) // route to all masters
-            .add_command(cmd("EVAL"))// route randomly
-            .cmd("CONFIG").arg("GET").arg("timeout") // unkeyed command
+            .add_command(cmd("EVAL")) // route randomly
+            .cmd("CONFIG")
+            .arg("GET")
+            .arg("timeout") // unkeyed command
             .set("foo", "bar"); // route to primary of slot 12182
 
         assert_eq!(
@@ -175,10 +177,15 @@ mod pipeline_routing_tests {
 
         pipeline
             .set("{foo}bar", "baz") // route to primary of slot 12182
-            .cmd("CONFIG").arg("GET").arg("timeout") // unkeyed command
+            .cmd("CONFIG")
+            .arg("GET")
+            .arg("timeout") // unkeyed command
             .set("foo", "bar") // route to primary of slot 12182
-            .cmd("DEBUG").arg("PAUSE").arg("100") // unkeyed command
-            .cmd("ECHO").arg("hello world"); // unkeyed command
+            .cmd("DEBUG")
+            .arg("PAUSE")
+            .arg("100") // unkeyed command
+            .cmd("ECHO")
+            .arg("hello world"); // unkeyed command
 
         assert_eq!(
             route_for_pipeline(&pipeline),

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -1258,10 +1258,11 @@ mod basic_async {
                     conn.lpush::<&str, &str, ()>("key", "value").await?;
 
                     redis::pipe()
-                .get("key") // WRONGTYPE
-                .llen("key")
-                .exec_async(&mut conn)
-                .await.unwrap_err();
+                        .get("key") // WRONGTYPE
+                        .llen("key")
+                        .exec_async(&mut conn)
+                        .await
+                        .unwrap_err();
 
                     let list: Vec<String> = conn.lrange("key", 0, -1).await?;
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,0 @@
-use_try_shorthand = true
-edition = "2018"


### PR DESCRIPTION
I would like to suggest using formatting by default. 
It is a pity that you can't format macros yet. This would help make macros clearer.