### PR TITLE
Use runtime agnostic retry mechanism.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4fa97bb310c33c811334143cf64c5bb2b7b3c06e453db6b095d7061eff8f113"
+dependencies = [
+ "fastrand 2.0.1",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,26 +1291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "pin-project"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.79",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,6 +1542,7 @@ dependencies = [
  "async-native-tls",
  "async-std",
  "async-trait",
+ "backon",
  "bigdecimal",
  "bytes",
  "combine",
@@ -1587,7 +1579,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-native-tls",
- "tokio-retry2",
  "tokio-rustls",
  "tokio-util",
  "url",
@@ -2145,17 +2136,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-retry2"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ea1e33e92c083b1ef5a8d8c65c6d65854af898ed5d24c171be5a453eef782d"
-dependencies = [
- "pin-project",
- "rand",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,8 +295,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4fa97bb310c33c811334143cf64c5bb2b7b3c06e453db6b095d7061eff8f113"
 dependencies = [
  "fastrand 2.0.1",
- "gloo-timers",
- "tokio",
 ]
 
 [[package]]

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -47,7 +47,7 @@ socket2 = { version = "0.5", default-features = false, optional = true }
 # Only needed for the connection manager
 arc-swap = { version = "1.7.1" }
 futures = { version = "0.3.30", optional = true }
-backon = { version = "1.2.0", optional = true }
+backon = { version = "1.2.0", optional = true, default-features = false }
 
 # Only needed for the r2d2 feature
 r2d2 = { version = "0.8.10", optional = true }

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -47,7 +47,7 @@ socket2 = { version = "0.5", default-features = false, optional = true }
 # Only needed for the connection manager
 arc-swap = { version = "1.7.1" }
 futures = { version = "0.3.30", optional = true }
-tokio-retry2 = { version = "0.5.4", optional = true, features = ["jitter"]}
+backon = { version = "1.2.0", optional = true }
 
 # Only needed for the r2d2 feature
 r2d2 = { version = "0.8.10", optional = true }
@@ -111,7 +111,7 @@ async-std-rustls-comp = ["async-std-comp", "futures-rustls", "tls-rustls"]
 tokio-comp = ["aio", "tokio/net"]
 tokio-native-tls-comp = ["tokio-comp", "tls-native-tls", "tokio-native-tls"]
 tokio-rustls-comp = ["tokio-comp", "tls-rustls", "tokio-rustls"]
-connection-manager = ["futures", "aio", "tokio-retry2"]
+connection-manager = ["futures", "aio", "backon"]
 streams = []
 cluster-async = ["cluster", "futures", "futures-util", "log"]
 keep-alive = ["socket2"]

--- a/redis/src/aio/runtime.rs
+++ b/redis/src/aio/runtime.rs
@@ -111,6 +111,20 @@ impl Runtime {
                 .map_err(|_| Elapsed(())),
         }
     }
+
+    #[cfg(feature = "connection-manager")]
+    pub(crate) async fn sleep(&self, duration: Duration) {
+        match self {
+            #[cfg(feature = "tokio-comp")]
+            Runtime::Tokio => {
+                tokio::time::sleep(duration).await;
+            }
+            #[cfg(feature = "async-std-comp")]
+            Runtime::AsyncStd => {
+                async_std::task::sleep(duration).await;
+            }
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -462,6 +462,10 @@ impl TestContext {
         Self::with_modules_and_tls(modules, mtls_enabled, None)
     }
 
+    pub fn new_with_addr(addr: ConnectionAddr) -> Self {
+        Self::with_modules_addr_and_tls(&[], false, addr, None)
+    }
+
     fn with_modules_and_tls(
         modules: &[Module],
         mtls_enabled: bool,
@@ -469,7 +473,15 @@ impl TestContext {
     ) -> Self {
         let redis_port = get_random_available_port();
         let addr = RedisServer::get_addr(redis_port);
+        Self::with_modules_addr_and_tls(modules, mtls_enabled, addr, tls_files)
+    }
 
+    fn with_modules_addr_and_tls(
+        modules: &[Module],
+        mtls_enabled: bool,
+        addr: ConnectionAddr,
+        tls_files: Option<TlsFilePaths>,
+    ) -> Self {
         let server = RedisServer::new_with_addr_tls_modules_and_spawner(
             addr,
             None,

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -1485,7 +1485,7 @@ mod basic_async {
     fn test_connection_manager_reconnect_after_delay(#[case] runtime: RuntimeType) {
         use redis::ProtocolVersion;
 
-        let max_delay_between_attempts = 50;
+        let max_delay_between_attempts = 2;
 
         let mut config = redis::aio::ConnectionManagerConfig::new()
             .set_factor(10000)
@@ -1498,6 +1498,7 @@ mod basic_async {
         let tls_files = build_keys_and_certs_for_tls(&tempdir);
 
         let ctx = TestContext::with_tls(tls_files.clone(), false);
+        let protocol = ctx.protocol;
         block_on_all(
             async move {
                 let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -1508,21 +1509,29 @@ mod basic_async {
                     redis::aio::ConnectionManager::new_with_config(ctx.client.clone(), config)
                         .await
                         .unwrap();
-                kill_client_async(&mut manager, &ctx.client).await.unwrap();
-
+                let addr = ctx.server.client_addr().clone();
+                drop(ctx);
                 let result: RedisResult<redis::Value> = manager.set("foo", "bar").await;
                 // we expect a connection failure error.
                 assert!(result.unwrap_err().is_unrecoverable_error());
-                if ctx.protocol != ProtocolVersion::RESP2 {
+                if protocol != ProtocolVersion::RESP2 {
                     assert_eq!(rx.recv().await.unwrap().kind, PushKind::Disconnection);
                 }
 
-                let result: redis::Value = manager.set("foo", "bar").await.unwrap();
-                assert_eq!(result, redis::Value::Okay);
-                if ctx.protocol != ProtocolVersion::RESP2 {
-                    assert!(rx.try_recv().is_err());
+                let _server = RedisServer::new_with_addr_and_modules(addr, &[], false);
+
+                for _ in 0..5 {
+                    let Ok(result) = manager.set::<_, _, Value>("foo", "bar").await else {
+                        sleep(Duration::from_millis(3).into()).await;
+                        continue;
+                    };
+                    assert_eq!(result, redis::Value::Okay);
+                    if protocol != ProtocolVersion::RESP2 {
+                        assert!(rx.try_recv().is_err());
+                    }
+                    return Ok(());
                 }
-                Ok(())
+                panic!("failed to reconnect");
             },
             runtime,
         )
@@ -1532,7 +1541,6 @@ mod basic_async {
     #[rstest]
     #[case::tokio(RuntimeType::Tokio)]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
-    #[cfg(feature = "connection-manager")]
     fn test_multiplexed_connection_kills_connection_on_drop_even_when_blocking(
         #[case] runtime: RuntimeType,
     ) {


### PR DESCRIPTION
tokio_retry apparently doesn't work with async-std, and we didn't notice that because the tests enabled immediate reconnection. This happened because the reconnection was tested with a working server, so the connection manager could reconnect immediately.