### PR TITLE
warn on `missing-debug-implementations`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 members = ["redis", "redis-test", "valkey", "afl/parser"]
 resolver = "2"
+
+[workspace.lints.rust]
+missing-debug-implementations = "warn"

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -11,6 +11,9 @@ edition = "2021"
 rust-version = "1.70"
 readme = "../README.md"
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/redis/src/aio/async_std.rs
+++ b/redis/src/aio/async_std.rs
@@ -59,6 +59,7 @@ use crate::connection::TlsConnParams;
 pin_project_lite::pin_project! {
     /// Wraps the async_std `AsyncRead/AsyncWrite` in order to implement the required the tokio traits
     /// for it
+    #[derive(Debug)]
     pub struct AsyncStdWrapped<T> {  #[pin] inner: T }
 }
 
@@ -115,6 +116,7 @@ where
 }
 
 /// Represents an AsyncStd connectable
+#[derive(Debug)]
 pub enum AsyncStd {
     /// Represents an Async_std TCP connection.
     Tcp(AsyncStdWrapped<TcpStream>),

--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -24,6 +24,7 @@ use futures_util::{
     future::FutureExt,
     stream::{Stream, StreamExt},
 };
+use std::fmt;
 use std::net::SocketAddr;
 use std::pin::Pin;
 #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
@@ -45,6 +46,22 @@ pub struct Connection<C = Pin<Box<dyn AsyncStream + Send + Sync>>> {
 
     // Field indicating which protocol to use for server communications.
     protocol: ProtocolVersion,
+}
+
+impl<C> fmt::Debug for Connection<C>
+where
+    C: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Connection")
+            .field("con", &self.con)
+            .field("buf", &self.buf)
+            .field("decoder", &format_args!("<Decoder>"))
+            .field("db", &self.db)
+            .field("pubsub", &self.pubsub)
+            .field("protocol", &self.protocol)
+            .finish()
+    }
 }
 
 fn assert_sync<T: Sync>() {}
@@ -312,9 +329,11 @@ where
 }
 
 /// Represents a `PubSub` connection.
+#[derive(Debug)]
 pub struct PubSub<C = Pin<Box<dyn AsyncStream + Send + Sync>>>(Connection<C>);
 
 /// Represents a `Monitor` connection.
+#[derive(Debug)]
 pub struct Monitor<C = Pin<Box<dyn AsyncStream + Send + Sync>>>(Connection<C>);
 
 impl<C> PubSub<C>

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -142,7 +142,7 @@ impl Default for ConnectionManagerConfig {
 ///   new reconnection attempt will be triggered if the error is an I/O error.
 ///
 /// [multiplexed-connection]: struct.MultiplexedConnection.html
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ConnectionManager {
     /// Information used for the connection. This is needed to be able to reconnect.
     client: Client,

--- a/redis/src/aio/pubsub.rs
+++ b/redis/src/aio/pubsub.rs
@@ -45,6 +45,7 @@ struct PipelineMessage {
 /// stop working.
 /// The sink isn't independent from the stream - dropping
 /// the stream will cause the sink to return errors on requests.
+#[derive(Debug)]
 pub struct PubSubSink {
     sender: UnboundedSender<PipelineMessage>,
 }
@@ -59,6 +60,7 @@ pin_project! {
     /// stop working.
     /// The sink isn't independent from the stream - dropping
     /// the stream will cause the sink to return errors on requests.
+    #[derive(Debug)]
     pub struct PubSubStream {
         #[pin]
         receiver: tokio::sync::mpsc::UnboundedReceiver<Msg>,
@@ -323,6 +325,7 @@ impl PubSubSink {
 }
 
 /// A connection dedicated to pubsub messages.
+#[derive(Debug)]
 pub struct PubSub {
     sink: PubSubSink,
     stream: PubSubStream,

--- a/redis/src/aio/runtime.rs
+++ b/redis/src/aio/runtime.rs
@@ -17,6 +17,7 @@ pub(crate) enum Runtime {
     AsyncStd,
 }
 
+#[derive(Debug)]
 pub(crate) enum TaskHandle {
     #[cfg(feature = "tokio-comp")]
     Tokio(tokio::task::JoinHandle<()>),
@@ -24,6 +25,7 @@ pub(crate) enum TaskHandle {
     AsyncStd(async_std::task::JoinHandle<()>),
 }
 
+#[derive(Debug)]
 pub(crate) struct HandleContainer(Option<TaskHandle>);
 
 impl HandleContainer {
@@ -47,7 +49,7 @@ impl Drop for HandleContainer {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 // we allow dead code here because the container isn't used directly, only in the derived drop.
 #[allow(dead_code)]
 pub(crate) struct SharedHandleContainer(Arc<HandleContainer>);

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -158,7 +158,7 @@ impl Client {
 
 /// Options for creation of async connection
 #[cfg(feature = "aio")]
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct AsyncConnectionConfig {
     /// Maximum time to wait for a response from the server
     pub(crate) response_timeout: Option<std::time::Duration>,

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -216,6 +216,7 @@ impl Connect for Connection {
 /// This represents a Redis Cluster connection. It stores the
 /// underlying connections maintained for each node in the cluster, as well
 /// as common parameters for connecting to nodes and executing commands.
+#[derive(Debug)]
 pub struct ClusterConnection<C = Connection> {
     initial_nodes: Vec<ConnectionInfo>,
     connections: RefCell<HashMap<String, C>>,

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -102,7 +102,7 @@ use tokio::sync::{mpsc, oneshot, RwLock};
 /// This represents an async Redis Cluster connection. It stores the
 /// underlying connections maintained for each node in the cluster, as well
 /// as common parameters for connecting to nodes and executing commands.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ClusterConnection<C = MultiplexedConnection> {
     sender: mpsc::Sender<Message<C>>,
     _task_handle: SharedHandleContainer,

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -19,7 +19,7 @@ use crate::tls::{retrieve_tls_certificates, TlsCertificates};
 /// Parameters specific to builder, so that
 /// builder parameters may have different types
 /// than final ClusterParams
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct BuilderParams {
     password: Option<String>,
     username: Option<String>,
@@ -33,7 +33,7 @@ struct BuilderParams {
     protocol: Option<ProtocolVersion>,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct RetryParams {
     pub(crate) number_of_retries: u32,
     max_wait_time: u64,
@@ -71,7 +71,7 @@ impl RetryParams {
 }
 
 /// Redis cluster specific parameters.
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub(crate) struct ClusterParams {
     pub(crate) password: Option<String>,
     pub(crate) username: Option<String>,
@@ -114,6 +114,7 @@ impl ClusterParams {
 }
 
 /// Used to configure and build a [`ClusterClient`].
+#[derive(Debug)]
 pub struct ClusterClientBuilder {
     initial_nodes: RedisResult<Vec<ConnectionInfo>>,
     builder_params: BuilderParams,
@@ -350,7 +351,7 @@ impl ClusterClientBuilder {
 }
 
 /// This is a Redis Cluster client.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ClusterClient {
     initial_nodes: Vec<ConnectionInfo>,
     cluster_params: ClusterParams,

--- a/redis/src/cluster_pipeline.rs
+++ b/redis/src/cluster_pipeline.rs
@@ -42,7 +42,7 @@ fn is_illegal_cmd(cmd: &str) -> bool {
 }
 
 /// Represents a Redis Cluster command pipeline.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ClusterPipeline {
     commands: Vec<Cmd>,
     ignored_commands: HashSet<usize>,

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -2191,6 +2191,7 @@ assert_eq!(b, 5);
 /// Allows pubsub callbacks to stop receiving messages.
 ///
 /// Arbitrary data may be returned from `Break`.
+#[derive(Debug)]
 pub enum ControlFlow<U> {
     /// Continues.
     Continue,
@@ -2314,7 +2315,7 @@ impl PubSubCommands for Connection {
 ///     con.scan_options(opts)
 /// }
 /// ```
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct ScanOptions {
     pattern: Option<String>,
     count: Option<usize>,
@@ -2398,7 +2399,7 @@ impl ToRedisArgs for ScanOptions {
 ///     con.lpos(key, value, opts)
 /// }
 /// ```
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct LposOptions {
     count: Option<usize>,
     maxlen: Option<usize>,
@@ -2462,6 +2463,7 @@ impl ToRedisArgs for LposOptions {
 }
 
 /// Enum for the LEFT | RIGHT args used by some commands
+#[derive(Debug)]
 pub enum Direction {
     /// Targets the first element (head) of the list
     Left,
@@ -2499,7 +2501,7 @@ impl ToRedisArgs for Direction {
 ///     con.set_options(key, value, opts)
 /// }
 /// ```
-#[derive(Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct SetOptions {
     conditional_set: Option<ExistenceCheck>,
     get: bool,

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -104,7 +104,7 @@ pub fn parse_redis_url(input: &str) -> Option<url::Url> {
 
 /// TlsMode indicates use or do not use verification of certification.
 /// Check [ConnectionAddr](ConnectionAddr::TcpTls::insecure) for more.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TlsMode {
     /// Secure verify certification.
     Secure,
@@ -461,6 +461,7 @@ impl IntoConnectionInfo for url::Url {
     }
 }
 
+#[derive(Debug)]
 struct TcpConnection {
     reader: TcpStream,
     open: bool,
@@ -473,6 +474,7 @@ struct TcpNativeTlsConnection {
 }
 
 #[cfg(feature = "tls-rustls")]
+#[derive(Debug)]
 struct TcpRustlsConnection {
     reader: StreamOwned<rustls::ClientConnection, TcpStream>,
     open: bool,
@@ -484,6 +486,7 @@ struct UnixConnection {
     open: bool,
 }
 
+#[derive(Debug)]
 enum ActualConnection {
     Tcp(TcpConnection),
     #[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
@@ -543,6 +546,7 @@ impl fmt::Debug for NoCertificateVerification {
 }
 
 /// Represents a stateful redis TCP connection.
+#[derive(Debug)]
 pub struct Connection {
     con: ActualConnection,
     parser: Parser,
@@ -566,6 +570,7 @@ pub struct Connection {
 }
 
 /// Represents a pubsub connection.
+#[derive(Debug)]
 pub struct PubSub<'a> {
     con: &'a mut Connection,
     waiting_messages: VecDeque<Msg>,

--- a/redis/src/geo.rs
+++ b/redis/src/geo.rs
@@ -17,6 +17,7 @@ macro_rules! invalid_type_error {
 ///
 /// [1]: ../trait.Commands.html#method.geo_dist
 /// [2]: ../trait.Commands.html#method.geo_radius
+#[derive(Debug)]
 pub enum Unit {
     /// Represents meters.
     Meters,
@@ -104,7 +105,7 @@ impl<T: ToRedisArgs> ToRedisArgs for Coord<T> {
 ///
 /// [1]: https://redis.io/commands/georadius
 /// [2]: https://redis.io/commands/georadiusbymember
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub enum RadiusOrder {
     /// Don't sort the results
     #[default]
@@ -141,7 +142,7 @@ pub enum RadiusOrder {
 ///     con.geo_radius(key, longitude, latitude, meters, Unit::Meters, opts)
 /// }
 /// ```
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct RadiusOptions {
     with_coord: bool,
     with_dist: bool,
@@ -263,6 +264,7 @@ impl ToRedisArgs for RadiusOptions {
 ///
 /// [1]: ../trait.Commands.html#method.geo_radius
 /// [2]: ../trait.Commands.html#method.geo_radius_by_member
+#[derive(Debug)]
 pub struct RadiusSearchResult {
     /// The name that was found.
     pub name: String,

--- a/redis/src/parser.rs
+++ b/redis/src/parser.rs
@@ -429,6 +429,12 @@ pub struct Parser {
     decoder: Decoder<AnySendSyncPartialState, PointerOffset<[u8]>>,
 }
 
+impl std::fmt::Debug for Parser {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Parser").field("decoder", &"..").finish()
+    }
+}
+
 impl Default for Parser {
     fn default() -> Self {
         Parser::new()

--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -7,7 +7,7 @@ use crate::types::{
 };
 
 /// Represents a redis command pipeline.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Pipeline {
     commands: Vec<Cmd>,
     transaction_mode: bool,

--- a/redis/src/script.rs
+++ b/redis/src/script.rs
@@ -106,6 +106,7 @@ impl Script {
 }
 
 /// Represents a prepared script call.
+#[derive(Debug)]
 pub struct ScriptInvocation<'a> {
     script: &'a Script,
     args: Vec<Vec<u8>>,

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -123,6 +123,7 @@ use crate::{
 
 /// The Sentinel type, serves as a special purpose client which builds other clients on
 /// demand.
+#[derive(Debug)]
 pub struct Sentinel {
     sentinels_connection_info: Vec<ConnectionInfo>,
     connections_cache: Vec<Option<Connection>>,
@@ -133,7 +134,7 @@ pub struct Sentinel {
 
 /// Holds the connection information that a sentinel should use when connecting to the
 /// servers (masters and replicas) belonging to it.
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SentinelNodeConnectionInfo {
     /// The TLS mode of the connection, or None if we do not want to connect using TLS
     /// (just a plain TCP connection).
@@ -698,6 +699,7 @@ pub enum SentinelServerType {
 /// it SentinelClient requires &mut ref for get_connection()
 /// and we can't use it like this inside the r2d2 Manager
 #[cfg(feature = "r2d2")]
+#[derive(Debug)]
 pub struct LockedSentinelClient(pub(crate) Mutex<SentinelClient>);
 
 #[cfg(feature = "r2d2")]
@@ -722,6 +724,7 @@ impl LockedSentinelClient {
 /// desired master are specified when constructing an instance, so it will always
 /// return connections to the same target (for example, always to the master with name
 /// "mymaster123", or always to replicas of the master "another-master-abc").
+#[derive(Debug)]
 pub struct SentinelClient {
     sentinel: Sentinel,
     service_name: String,

--- a/redis/src/tls.rs
+++ b/redis/src/tls.rs
@@ -7,7 +7,7 @@ use crate::{Client, ConnectionAddr, ConnectionInfo, ErrorKind, RedisError, Redis
 
 /// Structure to hold mTLS client _certificate_ and _key_ binaries in PEM format
 ///
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ClientTlsConfig {
     /// client certificate byte stream in PEM format
     pub client_cert: Vec<u8>,
@@ -19,7 +19,7 @@ pub struct ClientTlsConfig {
 /// - `client_tls`: binaries of clientkey and certificate within a `ClientTlsConfig` structure if mTLS is used
 /// - `root_cert`: binary CA certificate in PEM format if CA is not in local truststore
 ///
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct TlsCertificates {
     /// 'ClientTlsConfig' containing client certificate and key if mTLS is to be used
     pub client_tls: Option<ClientTlsConfig>,

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -31,6 +31,7 @@ macro_rules! invalid_type_error_inner {
 }
 
 /// Helper enum that is used to define expiry time
+#[derive(Debug)]
 pub enum Expiry {
     /// EX seconds -- Set the specified expire time, in seconds.
     EX(u64),
@@ -45,7 +46,7 @@ pub enum Expiry {
 }
 
 /// Helper enum that is used to define expiry time for SET command
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum SetExpiry {
     /// EX seconds -- Set the specified expire time, in seconds.
     EX(u64),
@@ -60,7 +61,7 @@ pub enum SetExpiry {
 }
 
 /// Helper enum that is used to define existence checks
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum ExistenceCheck {
     /// NX -- Only set the key if it does not already exist.
     NX,
@@ -376,6 +377,7 @@ impl fmt::Display for PushKind {
     }
 }
 
+#[derive(Debug)]
 pub enum MapIter<'a> {
     Array(std::slice::Iter<'a, Value>),
     Map(std::slice::Iter<'a, (Value, Value)>),
@@ -402,6 +404,7 @@ impl<'a> Iterator for MapIter<'a> {
     }
 }
 
+#[derive(Debug)]
 pub enum OwnedMapIter {
     Array(std::vec::IntoIter<Value>),
     Map(std::vec::IntoIter<(Value, Value)>),
@@ -2487,7 +2490,7 @@ pub enum ProtocolVersion {
 }
 
 /// Helper enum that is used to define option for the hash expire commands
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum ExpireOption {
     /// NONE -- Set expiration regardless of the field's current expiration.
     NONE,


### PR DESCRIPTION
All public types should implement `Debug`. See <https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#missing-debug-implementations>.

I was writing a library that depends on this and came across the case where I couldn't derive `Debug` because the underlying types don't implement `Debug`.