### PR TITLE
Update README to use rustls

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,22 @@ redis = { version = "0.27.5", features = ["tokio-rustls-comp"] }
 
 # if you use async-std
 redis = { version = "0.27.5", features = ["async-std-rustls-comp"] }
+```
 
-# Add rustls
+Add `rustls` to dependencies
+
+```
 rustls = { version = "0.23", features = ["ring"] }
 ```
+
+And then, early in the main fn, add:
+
+```
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install rustls crypto provider");
+```
+
 
 With `rustls`, you can add the following feature flags on top of other feature flags to enable additional features:
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Add `rustls` to dependencies
 rustls = { version = "0.23", features = ["ring"] }
 ```
 
-And then, early in the main fn, add:
+And then, before creating a connection, ensure that you install a crypto provider. For example:
 
 ```rust
     rustls::crypto::ring::default_provider()

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ redis = { version = "0.27.5", features = ["tokio-rustls-comp"] }
 
 # if you use async-std
 redis = { version = "0.27.5", features = ["async-std-rustls-comp"] }
+
+# Add rustls
+rustls = { version = "0.23", features = ["ring"] }
 ```
 
 With `rustls`, you can add the following feature flags on top of other feature flags to enable additional features:

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ rustls = { version = "0.23", features = ["ring"] }
 
 And then, early in the main fn, add:
 
-```
+```rust
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("Failed to install rustls crypto provider");


### PR DESCRIPTION
To use rustls, we have to add `rustls` to the dependencies, then install the crypto provider in the main fn

```toml
[dependencies]
rustls = { version = "0.23", features = ["ring"] }
```

```rust
fn main() {
    rustls::crypto::ring::default_provider()
        .install_default()
        .expect("Failed to install rustls crypto provider");
    
    // ...rest of your code
}

```