### PR TITLE
ConnectionManager: reconnect on disconnect pushes.

### DIFF
--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -1395,10 +1395,7 @@ impl Connection {
     }
 
     fn send_disconnect(&self) {
-        self.send_push(PushInfo {
-            kind: PushKind::Disconnection,
-            data: vec![],
-        })
+        self.send_push(PushInfo::disconnect())
     }
 
     fn close_connection(&mut self) {

--- a/redis/src/r2d2.rs
+++ b/redis/src/r2d2.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "sentinel")]
 use crate::sentinel::LockedSentinelClient;
+use crate::types::closed_connection_error;
 use crate::{ConnectionLike, RedisError};
-use std::io;
 
 macro_rules! impl_manage_connection {
     ($client:ty, $connection:ty) => {
@@ -17,7 +17,7 @@ macro_rules! impl_manage_connection {
                 if conn.check_connection() {
                     Ok(())
                 } else {
-                    Err(RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe)))
+                    Err(closed_connection_error())
                 }
             }
 

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2700,10 +2700,19 @@ pub struct PushInfo {
     pub data: Vec<Value>,
 }
 
+impl PushInfo {
+    pub(crate) fn disconnect() -> Self {
+        PushInfo {
+            kind: crate::PushKind::Disconnection,
+            data: vec![],
+        }
+    }
+}
+
 pub(crate) type SyncPushSender = std::sync::mpsc::Sender<PushInfo>;
 
 // A consistent error value for connections closed without a reason.
-#[cfg(feature = "aio")]
+#[cfg(any(feature = "aio", feature = "r2d2"))]
 pub(crate) fn closed_connection_error() -> RedisError {
     RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe))
 }


### PR DESCRIPTION
This change allows the ConnectionManager to reconnect not only when receiving errors on requests, but also when receiving disconnect pushes on the push channel from the internal connection.

Based over https://github.com/redis-rs/redis-rs/pull/1392