### PR TITLE
Make iterator return an Option<RedisResult>

### DIFF
--- a/redis/examples/basic.rs
+++ b/redis/examples/basic.rs
@@ -62,13 +62,7 @@ fn do_show_scanning(con: &mut redis::Connection) -> redis::RedisResult<()> {
     // as a simple exercise we just sum up the iterator.  Since the fold
     // method carries an initial value we do not need to define the
     // type of the iterator, rust will figure "int" out for us.
-
-    let mut iterator = cmd.iter::<i32>(con)?;
-
-    let mut sum: i32 = 0;
-    while let Some(Ok(x)) = iterator.next() {
-        sum += x;
-    }
+    let sum: i32 = cmd.iter::<i32>(con)?.sum();
 
     println!("The sum of all numbers in the set 0-1000: {sum}");
 

--- a/redis/examples/basic.rs
+++ b/redis/examples/basic.rs
@@ -62,7 +62,13 @@ fn do_show_scanning(con: &mut redis::Connection) -> redis::RedisResult<()> {
     // as a simple exercise we just sum up the iterator.  Since the fold
     // method carries an initial value we do not need to define the
     // type of the iterator, rust will figure "int" out for us.
-    let sum: i32 = cmd.iter::<i32>(con)?.sum();
+
+    let mut iterator = cmd.iter::<i32>(con)?;
+
+    let mut sum: i32 = 0;
+    while let Some(Ok(x)) = iterator.next() {
+        sum += x;
+    }
 
     println!("The sum of all numbers in the set 0-1000: {sum}");
 

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -8,11 +8,11 @@ use futures_util::{
 use std::pin::Pin;
 #[cfg(feature = "cache-aio")]
 use std::time::Duration;
-use std::{fmt, io};
+use std::{fmt, io, marker::PhantomData};
 
-use crate::connection::ConnectionLike;
 use crate::pipeline::Pipeline;
 use crate::types::{from_owned_redis_value, FromRedisValue, RedisResult, RedisWrite, ToRedisArgs};
+use crate::{connection::ConnectionLike, Value};
 
 /// An argument to a redis command
 #[derive(Clone)]
@@ -88,32 +88,40 @@ pub struct Cmd {
 
 /// Represents a redis iterator.
 pub struct Iter<'a, T: FromRedisValue> {
-    batch: std::vec::IntoIter<T>,
+    batch: std::vec::IntoIter<Value>,
     cursor: u64,
     con: &'a mut (dyn ConnectionLike + 'a),
     cmd: Cmd,
+    _phantom: PhantomData<T>,
 }
 
 impl<T: FromRedisValue> Iterator for Iter<'_, T> {
-    type Item = T;
+    type Item = RedisResult<T>;
 
     #[inline]
-    fn next(&mut self) -> Option<T> {
+    fn next(&mut self) -> Option<RedisResult<T>> {
         // we need to do this in a loop until we produce at least one item
         // or we find the actual end of the iteration.  This is necessary
         // because with filtering an iterator it is possible that a whole
         // chunk is not matching the pattern and thus yielding empty results.
         loop {
             if let Some(v) = self.batch.next() {
-                return Some(v);
+                return Some(T::from_owned_redis_value(v));
             };
             if self.cursor == 0 {
                 return None;
             }
 
             let pcmd = self.cmd.get_packed_command_with_cursor(self.cursor)?;
-            let rv = self.con.req_packed_command(&pcmd).ok()?;
-            let (cur, batch): (u64, Vec<T>) = from_owned_redis_value(rv).ok()?;
+            let rv = match self.con.req_packed_command(&pcmd) {
+                Ok(v) => v,
+                Err(e) => return Some(Err(e)),
+            };
+
+            let (cur, batch): (u64, Vec<Value>) = match from_owned_redis_value(rv) {
+                Ok(v) => v,
+                Err(e) => return Some(Err(e)),
+            };
 
             self.cursor = cur;
             self.batch = batch.into_iter();
@@ -537,7 +545,7 @@ impl Cmd {
         let rv = con.req_command(&self)?;
 
         let (cursor, batch) = if rv.looks_like_cursor() {
-            from_owned_redis_value::<(u64, Vec<T>)>(rv)?
+            from_owned_redis_value::<(u64, Vec<Value>)>(rv)?
         } else {
             (0, from_owned_redis_value(rv)?)
         };
@@ -547,6 +555,7 @@ impl Cmd {
             cursor,
             con,
             cmd: self,
+            _phantom: PhantomData,
         })
     }
 

--- a/redis/src/commands/macros.rs
+++ b/redis/src/commands/macros.rs
@@ -63,6 +63,14 @@ macro_rules! implement_commands {
                 c.iter(self)
             }
 
+            /// Incrementally iterate the keys space safely, with options.
+            #[inline]
+            fn checked_scan_options<RV: FromRedisValue>(&mut self, opts: ScanOptions) -> RedisResult<CheckedIter<'_, RV>> {
+                let mut c = cmd("SCAN");
+                c.cursor_arg(0).arg(opts);
+                c.checked_iter(self)
+            }
+
             /// Incrementally iterate the keys space for keys matching a pattern.
             #[inline]
             fn scan_match<P: ToRedisArgs, RV: FromRedisValue>(&mut self, pattern: P) -> RedisResult<Iter<'_, RV>> {

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -1,4 +1,4 @@
-use crate::cmd::{cmd, Cmd, Iter};
+use crate::cmd::{cmd, CheckedIter, Cmd, Iter};
 use crate::connection::{Connection, ConnectionLike, Msg};
 use crate::pipeline::Pipeline;
 use crate::types::{

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -36,7 +36,7 @@ mod basic {
     use std::io::Read;
     use std::thread::{self, sleep, spawn};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
-    use std::{panic, vec};
+    use std::vec;
 
     use crate::{assert_args, support::*};
 
@@ -1133,17 +1133,15 @@ mod basic {
 
         for x in iter {
             // type inference limitations
-            match x {
-                Ok(x) => unseen.remove(&x),
-                Err(e) => panic!("err: {}", e), // TODO: Should handle error
-            };
+            let x: usize = x;
+            unseen.remove(&x);
         }
 
         assert_eq!(unseen.len(), 0);
     }
 
     #[test]
-    fn test_scanning_error() {
+    fn test_checked_scanning_error() {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
@@ -1166,7 +1164,7 @@ mod basic {
         // get an iterator for SCAN over all redis keys
         // Specify count=1 so we don't get the invalid UTF-8 scenario in the first scan
         let mut iter = con
-            .scan_options::<String>(ScanOptions::default().with_count(1))
+            .checked_scan_options::<String>(ScanOptions::default().with_count(1))
             .unwrap();
 
         let mut err_flag = false;
@@ -1209,13 +1207,8 @@ mod basic {
             .hscan_match::<&str, &str, (String, usize)>("foo", "key_0_*")
             .unwrap();
 
-        for element in iter {
-            match element {
-                Ok((_field, value)) => {
-                    unseen.remove(&value);
-                }
-                Err(e) => panic!("err: {}", e), // TODO: Should handle error
-            }
+        for (_field, value) in iter {
+            unseen.remove(&value);
         }
 
         assert_eq!(unseen.len(), 0);
@@ -2024,10 +2017,7 @@ mod basic {
         let iter: redis::Iter<'_, (String, isize)> = con.hscan("my_hash").unwrap();
         let mut found = HashSet::new();
         for item in iter {
-            match item {
-                Ok(item) => found.insert(item),
-                Err(e) => panic!("err: {}", e), // TODO: Should handle error
-            };
+            found.insert(item);
         }
 
         assert_eq!(found.len(), 2);


### PR DESCRIPTION
This is an example PR of how it would look like if the iterator returned a `RedisResult`, instead of silently failing and returning None if it failed to parse the next set of keys.

I faced this when I was trying to iterate over the keyspace of my DB to perform a migration, but the target DB had way less keys! I realized that the iterator was incorrectly "ending" early.

For me the current workaround is to just use `Vec<u8>` instead of `String` since in redis everything should be able to be represented as raw bytes, especially keys.

Hopefully this can help prevent other application logic bugs.

Some related issues:
* https://github.com/redis-rs/redis-rs/issues/773
* https://github.com/redis-rs/redis-rs/issues/66

This is obviously backwards incompatible, as noted in: https://github.com/redis-rs/redis-rs/issues/1043#issuecomment-2367507019

I tried to make a unit test to illustrate how this would work, and had to patch some existing tests as well. I'm new to rust, so my style may not be the most idiomatic :-)