### PR TITLE
Describe as "for Redis"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![crates.io](https://img.shields.io/crates/v/redis.svg)](https://crates.io/crates/redis)
 [![Chat](https://img.shields.io/discord/976380008299917365?logo=discord)](https://discord.gg/WHKcJK9AKP)
 
-Redis-rs is a high level redis library for Rust. It provides convenient access
+Redis-rs is a high level Rust library for Redis. It provides convenient access
 to all Redis functionality through a very flexible but low-level API. It
 uses a customizable type conversion trait so that any operation can return
 results in just the type you are expecting. This makes for a very pleasant

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -1,4 +1,4 @@
-//! redis-rs is a Rust implementation of a Redis client library.  It exposes
+//! redis-rs is a Rust implementation of a client library for Redis.  It exposes
 //! a general purpose interface to Redis and also provides specific helpers for
 //! commonly used functionality.
 //!
@@ -109,7 +109,7 @@
 //!
 //! `redis+unix:///<path>[?db=<db>[&pass=<password>][&user=<username>][&protocol=<protocol>]]`
 //!
-//! For compatibility with some other redis libraries, the "unix" scheme
+//! For compatibility with some other libraries for Redis, the "unix" scheme
 //! is also supported:
 //!
 //! `unix:///<path>[?db=<db>][&pass=<password>][&user=<username>][&protocol=<protocol>]]`


### PR DESCRIPTION
To avoid trademark issues, describe this as a library "for Redis" rather than a "Redis library".