### PR TITLE
Report slow tests more eagerly.

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,4 +3,5 @@ retries = 2
 test-threads = 1
 failure-output = "immediate-final" # show test failures inline, and also at the end of the run
 fail-fast = false # run all tests, even if some failed
-slow-timeout = { period = "5s", terminate-after = 4 }
+slow-timeout = { period = "1s", terminate-after = 20 }
+status-level = "skip"


### PR DESCRIPTION
Slow tests are now defined as any test taking longer than 1 second.