### PR TITLE
Replace `get_multiplexed_tokio_connection` in examples & tests.

### DIFF
--- a/redis/examples/async-connection-loss.rs
+++ b/redis/examples/async-connection-loss.rs
@@ -79,7 +79,7 @@ async fn main() -> RedisResult<()> {
 
     let client = redis::Client::open("redis://127.0.0.1/").unwrap();
     match mode {
-        Mode::Default => run_multi(client.get_multiplexed_tokio_connection().await?).await?,
+        Mode::Default => run_multi(client.get_multiplexed_async_connection().await?).await?,
         Mode::Reconnect => run_multi(client.get_connection_manager().await?).await?,
         #[allow(deprecated)]
         Mode::Deprecated => run_single(client.get_async_connection().await?).await?,

--- a/redis/examples/async-multiplexed.rs
+++ b/redis/examples/async-multiplexed.rs
@@ -33,7 +33,7 @@ async fn test_cmd(con: &MultiplexedConnection, i: i32) -> RedisResult<()> {
 async fn main() {
     let client = redis::Client::open("redis://127.0.0.1/").unwrap();
 
-    let con = client.get_multiplexed_tokio_connection().await.unwrap();
+    let con = client.get_multiplexed_async_connection().await.unwrap();
 
     let cmds = (0..100).map(|i| test_cmd(&con, i));
     let result = future::try_join_all(cmds).await.unwrap();

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -256,7 +256,7 @@ impl Client {
     #[cfg(feature = "tokio-comp")]
     #[cfg_attr(docsrs, doc(cfg(feature = "tokio-comp")))]
     #[deprecated(
-        note = "aio::Connection is deprecated. Use client::get_multiplexed_tokio_connection instead."
+        note = "aio::Connection is deprecated. Use client::get_multiplexed_async_connection instead."
     )]
     #[allow(deprecated)]
     pub async fn get_tokio_connection(&self) -> RedisResult<crate::aio::Connection> {
@@ -456,7 +456,7 @@ impl Client {
     }
 
     /// Returns an async multiplexed connection from the client and a future which must be polled
-    /// to drive any requests submitted to it (see `get_multiplexed_tokio_connection`).
+    /// to drive any requests submitted to it (see [Self::get_multiplexed_async_connection]).
     ///
     /// A multiplexed connection can be cloned, allowing requests to be sent concurrently
     /// on the same underlying connection (tcp/unix socket).
@@ -477,7 +477,7 @@ impl Client {
     }
 
     /// Returns an async multiplexed connection from the client and a future which must be polled
-    /// to drive any requests submitted to it (see `get_multiplexed_tokio_connection`).
+    /// to drive any requests submitted to it (see [Self::get_multiplexed_async_connection]).
     ///
     /// A multiplexed connection can be cloned, allowing requests to be sent concurrently
     /// on the same underlying connection (tcp/unix socket).
@@ -496,7 +496,7 @@ impl Client {
     }
 
     /// Returns an async multiplexed connection from the client and a future which must be polled
-    /// to drive any requests submitted to it (see `get_multiplexed_tokio_connection`).
+    /// to drive any requests submitted to it (see [Self::get_multiplexed_async_connection]).
     ///
     /// A multiplexed connection can be cloned, allowing requests to be sent concurrently
     /// on the same underlying connection (tcp/unix socket).
@@ -517,7 +517,7 @@ impl Client {
     }
 
     /// Returns an async multiplexed connection from the client and a future which must be polled
-    /// to drive any requests submitted to it (see `get_multiplexed_tokio_connection`).
+    /// to drive any requests submitted to it (see [Self::get_multiplexed_async_connection]).
     ///
     /// A multiplexed connection can be cloned, allowing requests to be sent concurrently
     /// on the same underlying connection (tcp/unix socket).

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -563,7 +563,7 @@ impl TestContext {
     pub async fn multiplexed_async_connection_tokio(
         &self,
     ) -> RedisResult<redis::aio::MultiplexedConnection> {
-        self.client.get_multiplexed_tokio_connection().await
+        self.client.get_multiplexed_async_connection().await
     }
 
     pub fn get_version(&self) -> Version {


### PR DESCRIPTION
Replaced with the more general `get_multiplexed_async_connection`.