### PR TITLE
Update README.md regarding cargo-nextest

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,11 @@ To build:
 
 To test:
 
-    $ make test
+Note: `make test` requires cargo-nextest installed, to learn more about it please visit [homepage of cargo-nextest](https://nexte.st/).
 
+
+    $ make test
+    
 To run benchmarks:
 
     $ make bench


### PR DESCRIPTION
Running make test is advised in README.md , it's better to document what it requires to run it.

Related to: https://github.com/redis-rs/redis-rs/pull/1336