### PR TITLE
Async Cluster: Add pubsub support.

### DIFF
--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -109,7 +109,7 @@ fn send_push(push_sender: &Option<Arc<dyn AsyncPushSender>>, info: PushInfo) {
     };
 }
 
-fn send_disconnect(push_sender: &Option<Arc<dyn AsyncPushSender>>) {
+pub(crate) fn send_disconnect(push_sender: &Option<Arc<dyn AsyncPushSender>>) {
     send_push(push_sender, PushInfo::disconnect());
 }
 

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -89,9 +89,11 @@ use crate::{
         Slot, SlotMap,
     },
     cluster_topology::parse_slots,
+    cmd,
+    subscription_tracker::SubscriptionTracker,
     types::closed_connection_error,
-    Cmd, ConnectionInfo, ErrorKind, IntoConnectionInfo, RedisError, RedisFuture, RedisResult,
-    Value,
+    AsyncConnectionConfig, Cmd, ConnectionInfo, ErrorKind, IntoConnectionInfo, RedisError,
+    RedisFuture, RedisResult, ToRedisArgs, Value,
 };
 
 use futures_sink::Sink;
@@ -206,6 +208,81 @@ where
                 Response::Single(_) => unreachable!(),
             })
     }
+
+    /// Subscribes to a new channel.
+    ///
+    /// Updates from the sender will be sent on the push sender that was passed to the manager.
+    /// If the manager was configured without a push sender, the connection won't be able to pass messages back to the user..
+    ///
+    /// This method is only available when the connection is using RESP3 protocol, and will return an error otherwise.
+    /// It should be noted that the subscription will be automatically resubscribed after disconnections, so the user might
+    /// receive additional pushes with [crate::PushKind::SSubcribe], later after the subscription completed.
+    pub async fn subscribe(&mut self, channel_name: impl ToRedisArgs) -> RedisResult<()> {
+        let mut cmd = cmd("SUBSCRIBE");
+        cmd.arg(channel_name);
+        cmd.exec_async(self).await?;
+        Ok(())
+    }
+
+    /// Unsubscribes from channel.
+    ///
+    /// This method is only available when the connection is using RESP3 protocol, and will return an error otherwise.
+    pub async fn unsubscribe(&mut self, channel_name: impl ToRedisArgs) -> RedisResult<()> {
+        let mut cmd = cmd("UNSUBSCRIBE");
+        cmd.arg(channel_name);
+        cmd.exec_async(self).await?;
+        Ok(())
+    }
+
+    /// Subscribes to a new channel pattern.
+    ///
+    /// Updates from the sender will be sent on the push sender that was passed to the manager.
+    /// If the manager was configured without a push sender, the manager won't be able to pass messages back to the user..
+    ///
+    /// This method is only available when the connection is using RESP3 protocol, and will return an error otherwise.
+    /// It should be noted that the subscription will be automatically resubscribed after disconnections, so the user might
+    /// receive additional pushes with [crate::PushKind::SSubcribe], later after the subscription completed.
+    pub async fn psubscribe(&mut self, channel_pattern: impl ToRedisArgs) -> RedisResult<()> {
+        let mut cmd = cmd("PSUBSCRIBE");
+        cmd.arg(channel_pattern);
+        cmd.exec_async(self).await?;
+        Ok(())
+    }
+
+    /// Unsubscribes from channel pattern.
+    ///
+    /// This method is only available when the connection is using RESP3 protocol, and will return an error otherwise.
+    pub async fn punsubscribe(&mut self, channel_pattern: impl ToRedisArgs) -> RedisResult<()> {
+        let mut cmd = cmd("PUNSUBSCRIBE");
+        cmd.arg(channel_pattern);
+        cmd.exec_async(self).await?;
+        Ok(())
+    }
+
+    /// Subscribes to a new sharded channel.
+    ///
+    /// Updates from the sender will be sent on the push sender that was passed to the manager.
+    /// If the manager was configured without a push sender, the manager won't be able to pass messages back to the user..
+    ///
+    /// This method is only available when the connection is using RESP3 protocol, and will return an error otherwise.
+    /// It should be noted that the subscription will be automatically resubscribed after disconnections, so the user might
+    /// receive additional pushes with [crate::PushKind::SSubcribe], later after the subscription completed.
+    pub async fn ssubscribe(&mut self, channel_name: impl ToRedisArgs) -> RedisResult<()> {
+        let mut cmd = cmd("SSUBSCRIBE");
+        cmd.arg(channel_name);
+        cmd.exec_async(self).await?;
+        Ok(())
+    }
+
+    /// Unsubscribes from channel pattern.
+    ///
+    /// This method is only available when the connection is using RESP3 protocol, and will return an error otherwise.
+    pub async fn sunsubscribe(&mut self, channel_name: impl ToRedisArgs) -> RedisResult<()> {
+        let mut cmd = cmd("SUNSUBSCRIBE");
+        cmd.arg(channel_name);
+        cmd.exec_async(self).await?;
+        Ok(())
+    }
 }
 
 type ConnectionFuture<C> = future::Shared<BoxFuture<'static, C>>;
@@ -219,6 +296,7 @@ struct InnerCore<C> {
     cluster_params: ClusterParams,
     pending_requests: Mutex<Vec<PendingRequest<C>>>,
     initial_nodes: Vec<ConnectionInfo>,
+    subscription_tracker: Option<Mutex<SubscriptionTracker>>,
 }
 
 type Core<C> = Arc<InnerCore<C>>;
@@ -294,11 +372,17 @@ where
         cluster_params: ClusterParams,
     ) -> RedisResult<Self> {
         let connections = Self::create_initial_connections(initial_nodes, &cluster_params).await?;
+        let subscription_tracker = if cluster_params.async_push_sender.is_some() {
+            Some(Mutex::new(SubscriptionTracker::default()))
+        } else {
+            None
+        };
         let inner = Arc::new(InnerCore {
             conn_lock: RwLock::new((connections, SlotMap::new(cluster_params.read_from_replicas))),
             cluster_params,
             pending_requests: Mutex::new(Vec::new()),
             initial_nodes: initial_nodes.to_vec(),
+            subscription_tracker,
         });
         let connection = ClusterConnInner {
             inner,
@@ -345,6 +429,33 @@ where
             )));
         }
         Ok(connections)
+    }
+
+    fn resubscribe(&self) {
+        let Some(subscription_tracker) = self.inner.subscription_tracker.as_ref() else {
+            return;
+        };
+
+        let subscription_pipe = subscription_tracker
+            .lock()
+            .unwrap()
+            .get_subscription_pipeline();
+
+        // we send request per cmd, instead of sending the pipe together, in order to send each command to the relevant node, instead of all together to a single node.
+        let requests = subscription_pipe.cmd_iter().map(|cmd| {
+            let routing = RoutingInfo::for_routable(cmd)
+                .unwrap_or(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random))
+                .into();
+            PendingRequest {
+                retry: 0,
+                sender: request::ResultExpectation::Internal,
+                cmd: CmdArg::Cmd {
+                    cmd: Arc::new(cmd.clone()),
+                    routing,
+                },
+            }
+        });
+        self.inner.pending_requests.lock().unwrap().extend(requests);
     }
 
     fn reconnect_to_initial_nodes(&mut self) -> impl Future<Output = ()> {
@@ -398,7 +509,7 @@ where
     }
 
     // Query a node to discover slot-> master mappings.
-    async fn refresh_slots(inner: Arc<InnerCore<C>>) -> RedisResult<()> {
+    async fn refresh_slots(inner: Core<C>) -> RedisResult<()> {
         let mut write_guard = inner.conn_lock.write().await;
         let mut connections = mem::take(&mut write_guard.0);
         let slots = &mut write_guard.1;
@@ -589,7 +700,7 @@ where
                         (addr.clone(), receiver),
                         PendingRequest {
                             retry: 0,
-                            sender,
+                            sender: request::ResultExpectation::External(sender),
                             cmd: CmdArg::Cmd {
                                 cmd,
                                 routing: InternalSingleNodeRouting::Connection {
@@ -808,26 +919,30 @@ where
             ConnectionState::PollComplete => return Poll::Ready(Ok(())),
             ConnectionState::Recover(future) => future,
         };
-        match recover_future {
+        let res = match recover_future {
             RecoverFuture::RecoverSlots(ref mut future) => match ready!(future.as_mut().poll(cx)) {
                 Ok(_) => {
                     trace!("Recovered!");
                     self.state = ConnectionState::PollComplete;
-                    Poll::Ready(Ok(()))
+                    Ok(())
                 }
                 Err(err) => {
                     trace!("Recover slots failed!");
                     *future = Box::pin(Self::refresh_slots(self.inner.clone()));
-                    Poll::Ready(Err(err))
+                    Err(err)
                 }
             },
             RecoverFuture::Reconnect(ref mut future) => {
                 ready!(future.as_mut().poll(cx));
                 trace!("Reconnected connections");
                 self.state = ConnectionState::PollComplete;
-                Poll::Ready(Ok(()))
+                Ok(())
             }
+        };
+        if res.is_ok() {
+            self.resubscribe();
         }
+        Poll::Ready(res)
     }
 
     fn poll_complete(&mut self, cx: &mut task::Context<'_>) -> Poll<PollFlushAction> {
@@ -911,7 +1026,7 @@ where
                     .as_mut()
                     .respond(Err(self.refresh_error.take().unwrap()));
             } else if let Some(request) = self.inner.pending_requests.lock().unwrap().pop() {
-                let _ = request.sender.send(Err(self.refresh_error.take().unwrap()));
+                request.sender.send(Err(self.refresh_error.take().unwrap()));
             }
         }
     }
@@ -977,13 +1092,24 @@ where
         trace!("start_send");
         let Message { cmd, sender } = msg;
 
+        if let Some(tracker) = &self.inner.subscription_tracker {
+            // TODO - benchmark whether checking whether the command is a subscription outside of the mutex is more performant.
+            let mut tracker = tracker.lock().unwrap();
+            match &cmd {
+                CmdArg::Cmd { cmd, .. } => tracker.update_with_cmd(cmd.as_ref()),
+                CmdArg::Pipeline { pipeline, .. } => {
+                    tracker.update_with_pipeline(pipeline.as_ref())
+                }
+            }
+        };
+
         self.inner
             .pending_requests
             .lock()
             .unwrap()
             .push(PendingRequest {
                 retry: 0,
-                sender,
+                sender: request::ResultExpectation::External(sender),
                 cmd,
             });
         Ok(())
@@ -1083,6 +1209,19 @@ where
 /// and obtaining a connection handle.
 pub trait Connect: Sized {
     /// Connect to a node, returning handle for command execution.
+    fn connect_with_config<'a, T>(info: T, config: AsyncConnectionConfig) -> RedisFuture<'a, Self>
+    where
+        T: IntoConnectionInfo + Send + 'a,
+    {
+        // default implementation, for backwards compatibility
+        Self::connect(
+            info,
+            config.response_timeout.unwrap_or(Duration::MAX),
+            config.connection_timeout.unwrap_or(Duration::MAX),
+        )
+    }
+
+    /// Connect to a node, returning handle for command execution.
     fn connect<'a, T>(
         info: T,
         response_timeout: Duration,
@@ -1093,6 +1232,20 @@ pub trait Connect: Sized {
 }
 
 impl Connect for MultiplexedConnection {
+    fn connect_with_config<'a, T>(info: T, config: AsyncConnectionConfig) -> RedisFuture<'a, Self>
+    where
+        T: IntoConnectionInfo + Send + 'a,
+    {
+        async move {
+            let connection_info = info.into_connection_info()?;
+            let client = crate::Client::open(connection_info)?;
+            client
+                .get_multiplexed_async_connection_with_config(&config)
+                .await
+        }
+        .boxed()
+    }
+
     fn connect<'a, T>(
         info: T,
         response_timeout: Duration,
@@ -1140,13 +1293,24 @@ where
     let read_from_replicas = params.read_from_replicas;
     let connection_timeout = params.connection_timeout;
     let response_timeout = params.response_timeout;
+    let push_sender = params.async_push_sender.clone();
     let info = get_connection_info(node, params)?;
-    let mut conn: C = C::connect(info, response_timeout, connection_timeout).await?;
-    check_connection(&mut conn).await?;
-    if read_from_replicas {
-        // If READONLY is sent to primary nodes, it will have no effect
-        crate::cmd("READONLY").exec_async(&mut conn).await?;
+    let mut config = AsyncConnectionConfig::default()
+        .set_connection_timeout(connection_timeout)
+        .set_response_timeout(response_timeout);
+    if let Some(push_sender) = push_sender {
+        config = config.set_push_sender_internal(push_sender);
     }
+    let mut conn: C = C::connect_with_config(info, config).await?;
+
+    let check = if read_from_replicas {
+        // If READONLY is sent to primary nodes, it will have no effect
+        cmd("READONLY")
+    } else {
+        cmd("PING")
+    };
+
+    conn.req_packed_command(&check).await?;
     Ok(conn)
 }
 

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "cluster-async")]
 use crate::aio::AsyncPushSender;
 use crate::connection::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo};
 use crate::types::{ErrorKind, ProtocolVersion, RedisError, RedisResult};
@@ -116,6 +117,7 @@ impl ClusterParams {
             connection_timeout: value.connection_timeout.unwrap_or(Duration::from_secs(1)),
             response_timeout: value.response_timeout.unwrap_or(Duration::MAX),
             protocol: value.protocol,
+            #[cfg(feature = "cluster-async")]
             async_push_sender: value.async_push_sender,
         })
     }

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -369,14 +369,17 @@ impl ClusterClientBuilder {
     /// ```rust
     /// # use redis::cluster::ClusterClientBuilder;
     /// let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    /// let config = ClusterClientBuilder::new(vec!["rediss://127.0.0.1:6379/"]).set_push_sender(tx);
+    /// let config = ClusterClientBuilder::new(vec!["redis://127.0.0.1:6379/"])
+    ///     .use_protocol(redis::ProtocolVersion::RESP3)
+    ///     .set_push_sender(tx);
     /// ```
     ///
     /// ```rust
     /// # use std::sync::{Mutex, Arc};
     /// # use redis::cluster::ClusterClientBuilder;
     /// let messages = Arc::new(Mutex::new(Vec::new()));
-    /// let config = ClusterClientBuilder::new(vec!["rediss://127.0.0.1:6379/"])
+    /// let config = ClusterClientBuilder::new(vec!["redis://127.0.0.1:6379/"])
+    ///     .use_protocol(redis::ProtocolVersion::RESP3)
     ///     .set_push_sender(move |msg|{
     ///         let Ok(mut messages) = messages.lock() else {
     ///             return Err(redis::aio::SendError);

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -371,7 +371,7 @@ impl ClusterClientBuilder {
     /// let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
     /// let config = ClusterClientBuilder::new(vec!["redis://127.0.0.1:6379/"])
     ///     .use_protocol(redis::ProtocolVersion::RESP3)
-    ///     .set_push_sender(tx);
+    ///     .push_sender(tx);
     /// ```
     ///
     /// ```rust
@@ -380,7 +380,7 @@ impl ClusterClientBuilder {
     /// let messages = Arc::new(Mutex::new(Vec::new()));
     /// let config = ClusterClientBuilder::new(vec!["redis://127.0.0.1:6379/"])
     ///     .use_protocol(redis::ProtocolVersion::RESP3)
-    ///     .set_push_sender(move |msg|{
+    ///     .push_sender(move |msg|{
     ///         let Ok(mut messages) = messages.lock() else {
     ///             return Err(redis::aio::SendError);
     ///         };
@@ -388,7 +388,7 @@ impl ClusterClientBuilder {
     ///         Ok(())
     ///     });
     /// ```
-    pub fn set_push_sender(mut self, push_sender: impl AsyncPushSender) -> ClusterClientBuilder {
+    pub fn push_sender(mut self, push_sender: impl AsyncPushSender) -> ClusterClientBuilder {
         self.builder_params.async_push_sender = Some(Arc::new(push_sender));
         self
     }

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -1,7 +1,10 @@
+use crate::aio::AsyncPushSender;
 use crate::connection::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo};
 use crate::types::{ErrorKind, ProtocolVersion, RedisError, RedisResult};
 use crate::{cluster, cluster::TlsMode};
 use rand::Rng;
+#[cfg(feature = "cluster-async")]
+use std::sync::Arc;
 use std::time::Duration;
 
 #[cfg(feature = "tls-rustls")]
@@ -31,6 +34,8 @@ struct BuilderParams {
     connection_timeout: Option<Duration>,
     response_timeout: Option<Duration>,
     protocol: Option<ProtocolVersion>,
+    #[cfg(feature = "cluster-async")]
+    async_push_sender: Option<Arc<dyn AsyncPushSender>>,
 }
 
 #[derive(Clone)]
@@ -85,6 +90,8 @@ pub(crate) struct ClusterParams {
     pub(crate) connection_timeout: Duration,
     pub(crate) response_timeout: Duration,
     pub(crate) protocol: Option<ProtocolVersion>,
+    #[cfg(feature = "cluster-async")]
+    pub(crate) async_push_sender: Option<Arc<dyn AsyncPushSender>>,
 }
 
 impl ClusterParams {
@@ -109,6 +116,7 @@ impl ClusterParams {
             connection_timeout: value.connection_timeout.unwrap_or(Duration::from_secs(1)),
             response_timeout: value.response_timeout.unwrap_or(Duration::MAX),
             protocol: value.protocol,
+            async_push_sender: value.async_push_sender,
         })
     }
 }
@@ -345,6 +353,38 @@ impl ClusterClientBuilder {
     #[deprecated(since = "0.22.0", note = "Use read_from_replicas()")]
     pub fn readonly(mut self, read_from_replicas: bool) -> ClusterClientBuilder {
         self.builder_params.read_from_replicas = read_from_replicas;
+        self
+    }
+
+    #[cfg(feature = "cluster-async")]
+    /// Sets sender sender for push values.
+    ///
+    /// The sender can be a channel, or an arbitrary function that handles [crate::PushInfo] values.
+    /// This will fail client creation if the connection isn't configured for RESP3 communications via the [crate::RedisConnectionInfo::protocol] field.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use redis::cluster::ClusterClientBuilder;
+    /// let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    /// let config = ClusterClientBuilder::new(vec!["rediss://127.0.0.1:6379/"]).set_push_sender(tx);
+    /// ```
+    ///
+    /// ```rust
+    /// # use std::sync::{Mutex, Arc};
+    /// # use redis::cluster::ClusterClientBuilder;
+    /// let messages = Arc::new(Mutex::new(Vec::new()));
+    /// let config = ClusterClientBuilder::new(vec!["rediss://127.0.0.1:6379/"])
+    ///     .set_push_sender(move |msg|{
+    ///         let Ok(mut messages) = messages.lock() else {
+    ///             return Err(redis::aio::SendError);
+    ///         };
+    ///         messages.push(msg);
+    ///         Ok(())
+    ///     });
+    /// ```
+    pub fn set_push_sender(mut self, push_sender: impl AsyncPushSender) -> ClusterClientBuilder {
+        self.builder_params.async_push_sender = Some(Arc::new(push_sender));
         self
     }
 }

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -1032,6 +1032,11 @@ implement_commands! {
         cmd("PUBLISH").arg(channel).arg(message)
     }
 
+    /// Posts a message to the given sharded channel.
+    fn spublish<K: ToRedisArgs, E: ToRedisArgs>(channel: K, message: E) {
+        cmd("SPUBLISH").arg(channel).arg(message)
+    }
+
     // Object commands
 
     /// Returns the encoding of a key.

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -605,7 +605,7 @@ pub use crate::commands::JsonAsyncCommands;
 #[cfg_attr(docsrs, doc(cfg(feature = "geospatial")))]
 pub mod geo;
 
-#[cfg(feature = "connection-manager")]
+#[cfg(any(feature = "connection-manager", feature = "cluster-async"))]
 mod subscription_tracker;
 
 #[cfg(feature = "cluster")]

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2706,7 +2706,7 @@ impl ToRedisArgs for ExpireOption {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 /// A push message from the server.
 pub struct PushInfo {
     /// Push Kind

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -221,11 +221,19 @@ impl aio::ConnectionLike for MockConnection {
 
     fn req_packed_commands<'a>(
         &'a mut self,
-        _pipeline: &'a redis::Pipeline,
+        pipeline: &'a redis::Pipeline,
         _offset: usize,
         _count: usize,
     ) -> RedisFuture<'a, Vec<Value>> {
-        Box::pin(future::ok(vec![]))
+        Box::pin(future::ready(
+            pipeline
+                .cmd_iter()
+                .map(|cmd| {
+                    (self.handler)(&cmd.get_packed_command(), self.port)
+                        .expect_err("Handler did not specify a response")
+                })
+                .collect(),
+        ))
     }
 
     fn get_db(&self) -> i64 {

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -355,8 +355,7 @@ where
 
 pub type Version = (u16, u16, u16);
 
-fn get_version(conn: &mut impl redis::ConnectionLike) -> Version {
-    let info: InfoDict = redis::Cmd::new().arg("INFO").query(conn).unwrap();
+pub fn parse_version(info: InfoDict) -> Version {
     let version: String = info.get("redis_version").unwrap();
     let versions: Vec<u16> = version
         .split('.')
@@ -364,6 +363,11 @@ fn get_version(conn: &mut impl redis::ConnectionLike) -> Version {
         .collect();
     assert_eq!(versions.len(), 3);
     (versions[0], versions[1], versions[2])
+}
+
+fn get_version(conn: &mut impl redis::ConnectionLike) -> Version {
+    let info: InfoDict = redis::Cmd::new().arg("INFO").query(conn).unwrap();
+    parse_version(info)
 }
 
 pub fn is_major_version(expected_version: u16, version: Version) -> bool {

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -2310,9 +2310,8 @@ mod cluster_async {
                 )
                 .await
                 .unwrap();
-            let res = from_owned_redis_value::<String>(response).unwrap();
-            println!("res: {:?}, {}", res, res.contains("redis_version:6"));
-            true
+            let info = from_owned_redis_value::<InfoDict>(response).unwrap();
+            parse_version(info).0 >= 6
         }
 
         async fn subscribe_to_channels(

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -2296,6 +2296,501 @@ mod cluster_async {
         assert_eq!(request_counter.load(Ordering::Relaxed), 1);
     }
 
+    mod pubsub {
+        use redis::{PushInfo, PushKind};
+        use tokio::join;
+
+        use super::*;
+
+        async fn subscribe_to_channels(
+            pubsub_conn: &mut redis::cluster_async::ClusterConnection,
+            rx: &mut tokio::sync::mpsc::UnboundedReceiver<PushInfo>,
+        ) -> RedisResult<()> {
+            let _: () = pubsub_conn.subscribe("regular-phonewave").await?;
+            let push: PushInfo = rx.recv().await.unwrap();
+            assert_eq!(
+                push,
+                PushInfo {
+                    kind: PushKind::Subscribe,
+                    data: vec![
+                        Value::BulkString(b"regular-phonewave".to_vec()),
+                        Value::Int(1)
+                    ]
+                }
+            );
+
+            let _: () = pubsub_conn.psubscribe("phonewave*").await?;
+            let push = rx.recv().await.unwrap();
+            assert_eq!(
+                push,
+                PushInfo {
+                    kind: PushKind::PSubscribe,
+                    data: vec![Value::BulkString(b"phonewave*".to_vec()), Value::Int(2)]
+                }
+            );
+
+            let _: () = pubsub_conn.ssubscribe("sphonewave").await?;
+            let push = rx.recv().await.unwrap();
+            assert_eq!(
+                push,
+                PushInfo {
+                    kind: PushKind::SSubscribe,
+                    data: vec![Value::BulkString(b"sphonewave".to_vec()), Value::Int(1)]
+                }
+            );
+
+            Ok(())
+        }
+
+        async fn check_publishing(
+            publish_conn: &mut redis::cluster_async::ClusterConnection,
+            rx: &mut tokio::sync::mpsc::UnboundedReceiver<PushInfo>,
+        ) -> RedisResult<()> {
+            let _: () = publish_conn.publish("regular-phonewave", "banana").await?;
+            let push = rx.recv().await.unwrap();
+            assert_eq!(
+                push,
+                PushInfo {
+                    kind: PushKind::Message,
+                    data: vec![
+                        Value::BulkString(b"regular-phonewave".to_vec()),
+                        Value::BulkString(b"banana".to_vec()),
+                    ]
+                }
+            );
+
+            let _: () = publish_conn.publish("phonewave-pattern", "banana").await?;
+            let push = rx.recv().await.unwrap();
+            assert_eq!(
+                push,
+                PushInfo {
+                    kind: PushKind::PMessage,
+                    data: vec![
+                        Value::BulkString(b"phonewave*".to_vec()),
+                        Value::BulkString(b"phonewave-pattern".to_vec()),
+                        Value::BulkString(b"banana".to_vec()),
+                    ]
+                }
+            );
+
+            let _: () = publish_conn.spublish("sphonewave", "banana").await?;
+            let push = rx.recv().await.unwrap();
+            assert_eq!(
+                push,
+                PushInfo {
+                    kind: PushKind::SMessage,
+                    data: vec![
+                        Value::BulkString(b"sphonewave".to_vec()),
+                        Value::BulkString(b"banana".to_vec()),
+                    ]
+                }
+            );
+            Ok(())
+        }
+
+        #[rstest]
+        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        fn pub_sub_subscription(#[case] runtime: RuntimeType) {
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+            let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
+                builder
+                    .use_protocol(ProtocolVersion::RESP3)
+                    .set_push_sender(tx.clone())
+            });
+
+            block_on_all(
+                async move {
+                    let (mut publish_conn, mut pubsub_conn) =
+                        join!(ctx.async_connection(), ctx.async_connection());
+
+                    subscribe_to_channels(&mut pubsub_conn, &mut rx).await?;
+
+                    check_publishing(&mut publish_conn, &mut rx).await?;
+
+                    Ok::<_, RedisError>(())
+                },
+                runtime,
+            )
+            .unwrap();
+        }
+
+        #[rstest]
+        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        fn pub_sub_unsubscription(#[case] runtime: RuntimeType) {
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+            let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
+                builder
+                    .use_protocol(ProtocolVersion::RESP3)
+                    .set_push_sender(tx.clone())
+            });
+
+            block_on_all(
+                async move {
+                    let (mut publish_conn, mut pubsub_conn) =
+                        join!(ctx.async_connection(), ctx.async_connection());
+
+                    let _: () = pubsub_conn.subscribe("regular-phonewave").await?;
+                    let push = rx.recv().await.unwrap();
+                    assert_eq!(
+                        push,
+                        PushInfo {
+                            kind: PushKind::Subscribe,
+                            data: vec![
+                                Value::BulkString(b"regular-phonewave".to_vec()),
+                                Value::Int(1)
+                            ]
+                        }
+                    );
+                    let _: () = pubsub_conn.unsubscribe("regular-phonewave").await?;
+                    let push = rx.recv().await.unwrap();
+                    assert_eq!(
+                        push,
+                        PushInfo {
+                            kind: PushKind::Unsubscribe,
+                            data: vec![
+                                Value::BulkString(b"regular-phonewave".to_vec()),
+                                Value::Int(0)
+                            ]
+                        }
+                    );
+
+                    let _: () = pubsub_conn.psubscribe("phonewave*").await?;
+                    let push = rx.recv().await.unwrap();
+                    assert_eq!(
+                        push,
+                        PushInfo {
+                            kind: PushKind::PSubscribe,
+                            data: vec![Value::BulkString(b"phonewave*".to_vec()), Value::Int(1)]
+                        }
+                    );
+                    let _: () = pubsub_conn.punsubscribe("phonewave*").await?;
+                    let push = rx.recv().await.unwrap();
+                    assert_eq!(
+                        push,
+                        PushInfo {
+                            kind: PushKind::PUnsubscribe,
+                            data: vec![Value::BulkString(b"phonewave*".to_vec()), Value::Int(0)]
+                        }
+                    );
+
+                    let _: () = pubsub_conn.ssubscribe("sphonewave").await?;
+                    let push = rx.recv().await.unwrap();
+                    assert_eq!(
+                        push,
+                        PushInfo {
+                            kind: PushKind::SSubscribe,
+                            data: vec![Value::BulkString(b"sphonewave".to_vec()), Value::Int(1)]
+                        }
+                    );
+                    let _: () = pubsub_conn.sunsubscribe("sphonewave").await?;
+                    let push = rx.recv().await.unwrap();
+                    assert_eq!(
+                        push,
+                        PushInfo {
+                            kind: PushKind::SUnsubscribe,
+                            data: vec![Value::BulkString(b"sphonewave".to_vec()), Value::Int(0)]
+                        }
+                    );
+
+                    let _: () = publish_conn.publish("regular-phonewave", "banana").await?;
+                    let _: () = publish_conn.publish("phonewave-pattern", "banana").await?;
+                    let _: () = publish_conn.spublish("sphonewave", "banana").await?;
+
+                    assert_eq!(
+                        rx.try_recv(),
+                        Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+                    );
+
+                    Ok::<_, RedisError>(())
+                },
+                runtime,
+            )
+            .unwrap();
+        }
+
+        #[rstest]
+        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        fn connection_is_still_usable_if_pubsub_receiver_is_dropped(#[case] runtime: RuntimeType) {
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+            let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
+                builder
+                    .use_protocol(ProtocolVersion::RESP3)
+                    .set_push_sender(tx.clone())
+            });
+
+            block_on_all(
+                async move {
+                    let mut pubsub_conn = ctx.async_connection().await;
+
+                    subscribe_to_channels(&mut pubsub_conn, &mut rx).await?;
+
+                    drop(rx);
+
+                    assert_eq!(
+                        cmd("PING")
+                            .query_async::<String>(&mut pubsub_conn)
+                            .await
+                            .unwrap(),
+                        "PONG".to_string()
+                    );
+
+                    Ok::<_, RedisError>(())
+                },
+                runtime,
+            )
+            .unwrap();
+        }
+
+        #[rstest]
+        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        fn multiple_subscribes_and_unsubscribes_work(#[case] runtime: RuntimeType) {
+            // In this test we subscribe on all subscription variations to 3 channels in a single call, then unsubscribe from 2 channels.
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+            let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
+                builder
+                    .use_protocol(ProtocolVersion::RESP3)
+                    .set_push_sender(tx.clone())
+            });
+
+            block_on_all(
+                async move {
+                    let mut pubsub_conn = ctx.async_connection().await;
+
+                    let _: () = pubsub_conn
+                        .subscribe(&[
+                            "regular-phonewave1",
+                            "regular-phonewave2",
+                            "regular-phonewave3",
+                        ])
+                        .await?;
+                    for i in 1..4 {
+                        let push = rx.recv().await.unwrap();
+                        assert_eq!(
+                            push,
+                            PushInfo {
+                                kind: PushKind::Subscribe,
+                                data: vec![
+                                    Value::BulkString(
+                                        format!("regular-phonewave{i}").as_bytes().to_vec()
+                                    ),
+                                    Value::Int(i)
+                                ]
+                            }
+                        );
+                    }
+                    let _: () = pubsub_conn
+                        .unsubscribe(&["regular-phonewave1", "regular-phonewave2"])
+                        .await?;
+                    for i in 1..3 {
+                        let push = rx.recv().await.unwrap();
+                        assert_eq!(
+                            push,
+                            PushInfo {
+                                kind: PushKind::Unsubscribe,
+                                data: vec![
+                                    Value::BulkString(
+                                        format!("regular-phonewave{i}").as_bytes().to_vec()
+                                    ),
+                                    Value::Int(3 - i)
+                                ]
+                            }
+                        );
+                    }
+
+                    let _: () = pubsub_conn
+                        .psubscribe(&["phonewave*1", "phonewave*2", "phonewave*3"])
+                        .await?;
+                    for i in 1..4 {
+                        let push = rx.recv().await.unwrap();
+                        assert_eq!(
+                            push,
+                            PushInfo {
+                                kind: PushKind::PSubscribe,
+                                data: vec![
+                                    Value::BulkString(format!("phonewave*{i}").as_bytes().to_vec()),
+                                    Value::Int(i)
+                                ]
+                            }
+                        );
+                    }
+
+                    let _: () = pubsub_conn
+                        .punsubscribe(&["phonewave*1", "phonewave*2"])
+                        .await?;
+                    for i in 1..3 {
+                        let push = rx.recv().await.unwrap();
+                        assert_eq!(
+                            push,
+                            PushInfo {
+                                kind: PushKind::PUnsubscribe,
+                                data: vec![
+                                    Value::BulkString(format!("phonewave*{i}").as_bytes().to_vec()),
+                                    Value::Int(3 - i)
+                                ]
+                            }
+                        );
+                    }
+
+                    // we use the curly braces in order to avoid cross slots errors.
+                    let _: () = pubsub_conn
+                        .ssubscribe(&["{sphonewave}1", "{sphonewave}2", "{sphonewave}3"])
+                        .await?;
+                    for i in 1..4 {
+                        let push = rx.recv().await.unwrap();
+                        assert_eq!(
+                            push,
+                            PushInfo {
+                                kind: PushKind::SSubscribe,
+                                data: vec![
+                                    Value::BulkString(
+                                        format!("{{sphonewave}}{i}").as_bytes().to_vec()
+                                    ),
+                                    Value::Int(i)
+                                ]
+                            }
+                        );
+                    }
+
+                    let _: () = pubsub_conn
+                        .sunsubscribe(&["{sphonewave}1", "{sphonewave}2"])
+                        .await?;
+                    for i in 1..3 {
+                        let push = rx.recv().await.unwrap();
+                        assert_eq!(
+                            push,
+                            PushInfo {
+                                kind: PushKind::SUnsubscribe,
+                                data: vec![
+                                    Value::BulkString(
+                                        format!("{{sphonewave}}{i}").as_bytes().to_vec()
+                                    ),
+                                    Value::Int(3 - i)
+                                ]
+                            }
+                        );
+                    }
+
+                    assert_eq!(
+                        rx.try_recv(),
+                        Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+                    );
+
+                    Ok::<_, RedisError>(())
+                },
+                runtime,
+            )
+            .unwrap();
+        }
+
+        #[rstest]
+        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        fn pub_sub_reconnect_after_disconnect(#[case] runtime: RuntimeType) {
+            // in this test we will subscribe to channels, then restart the server, and check that the connection
+            // doesn't send disconnect message, but instead resubscribes automatically.
+
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+            let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
+                builder
+                    .use_protocol(ProtocolVersion::RESP3)
+                    .set_push_sender(tx.clone())
+            });
+
+            block_on_all(
+                async move {
+                    let ports: Vec<_> = ctx
+                        .nodes
+                        .iter()
+                        .map(|info| match info.addr {
+                            redis::ConnectionAddr::Tcp(_, port) => port,
+                            redis::ConnectionAddr::TcpTls { port, .. } => port,
+                            redis::ConnectionAddr::Unix(_) => {
+                                panic!("no unix sockets in cluster tests")
+                            }
+                        })
+                        .collect();
+
+                    let (mut publish_conn, mut pubsub_conn) =
+                        join!(ctx.async_connection(), ctx.async_connection());
+
+                    subscribe_to_channels(&mut pubsub_conn, &mut rx).await?;
+
+                    println!("dropped");
+                    drop(ctx);
+
+                    // we expect 1 disconnect per connection to node. 2 connections * 3 node = 6 disconnects.
+                    for _ in 0..6 {
+                        let push = rx.recv().await.unwrap();
+                        assert_eq!(
+                            push,
+                            PushInfo {
+                                kind: PushKind::Disconnection,
+                                data: vec![]
+                            }
+                        );
+                    }
+
+                    // recreate cluster
+                    let _cluster = RedisCluster::new(RedisClusterConfiguration {
+                        ports: ports.clone(),
+                        ..Default::default()
+                    });
+
+                    // verify that we didn't get any disconnect notices.
+                    assert_eq!(
+                        rx.try_recv(),
+                        Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+                    );
+
+                    // send request to trigger reconnection.
+                    let cmd = cmd("PING");
+                    let _ = pubsub_conn
+                        .route_command(
+                            &cmd,
+                            RoutingInfo::MultiNode((
+                                MultipleNodeRoutingInfo::AllMasters,
+                                Some(redis::cluster_routing::ResponsePolicy::AllSucceeded),
+                            )),
+                        )
+                        .await?;
+
+                    // the resubsriptions can be received in any order, so we assert without assuming order.
+                    let mut pushes = Vec::new();
+                    pushes.push(rx.recv().await.unwrap());
+                    pushes.push(rx.recv().await.unwrap());
+                    pushes.push(rx.recv().await.unwrap());
+                    // we expect only 3 resubscriptions.
+                    assert!(rx.try_recv().is_err());
+                    assert!(pushes.contains(&PushInfo {
+                        kind: PushKind::Subscribe,
+                        data: vec![
+                            Value::BulkString(b"regular-phonewave".to_vec()),
+                            Value::Int(1)
+                        ]
+                    }));
+                    assert!(pushes.contains(&PushInfo {
+                        kind: PushKind::PSubscribe,
+                        data: vec![Value::BulkString(b"phonewave*".to_vec()), Value::Int(2)]
+                    }));
+                    assert!(pushes.contains(&PushInfo {
+                        kind: PushKind::SSubscribe,
+                        data: vec![Value::BulkString(b"sphonewave".to_vec()), Value::Int(1)]
+                    }));
+
+                    check_publishing(&mut publish_conn, &mut rx).await?;
+
+                    Ok::<_, RedisError>(())
+                },
+                runtime,
+            )
+            .unwrap();
+        }
+    }
+
     #[cfg(feature = "tls-rustls")]
     mod mtls_test {
         use crate::support::mtls_test::create_cluster_client_from_cluster;

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -2415,7 +2415,7 @@ mod cluster_async {
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
                 builder
                     .use_protocol(ProtocolVersion::RESP3)
-                    .set_push_sender(tx.clone())
+                    .push_sender(tx.clone())
             });
 
             block_on_all(
@@ -2443,7 +2443,7 @@ mod cluster_async {
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
                 builder
                     .use_protocol(ProtocolVersion::RESP3)
-                    .set_push_sender(tx.clone())
+                    .push_sender(tx.clone())
             });
 
             block_on_all(
@@ -2549,7 +2549,7 @@ mod cluster_async {
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
                 builder
                     .use_protocol(ProtocolVersion::RESP3)
-                    .set_push_sender(tx.clone())
+                    .push_sender(tx.clone())
             });
 
             block_on_all(
@@ -2585,7 +2585,7 @@ mod cluster_async {
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
                 builder
                     .use_protocol(ProtocolVersion::RESP3)
-                    .set_push_sender(tx.clone())
+                    .push_sender(tx.clone())
             });
 
             block_on_all(
@@ -2731,7 +2731,7 @@ mod cluster_async {
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
                 builder
                     .use_protocol(ProtocolVersion::RESP3)
-                    .set_push_sender(tx.clone())
+                    .push_sender(tx.clone())
             });
 
             block_on_all(


### PR DESCRIPTION
This change allows users to set a push sender on a cluster connection, subcscribe & unsubscribe from channels, channel patterns, and sharded channels, and receive pubsub messages.
The cluster connection will automatically resubscribe when a connection will disconnect, or after a topology change.