### PR TITLE
Mark more `Connection` functions as deprecated.

### DIFF
--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -95,11 +95,13 @@ where
     }
 
     /// Converts this [`Connection`] into [`PubSub`].
+    #[deprecated(note = "aio::Connection is deprecated. Use [Client::get_async_pubsub] instead")]
     pub fn into_pubsub(self) -> PubSub<C> {
         PubSub::new(self)
     }
 
     /// Converts this [`Connection`] into [`Monitor`]
+    #[deprecated(note = "aio::Connection is deprecated. Use [Client::get_async_pubsub] instead")]
     pub fn into_monitor(self) -> Monitor<C> {
         Monitor::new(self)
     }

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -1280,6 +1280,7 @@ mod basic_async {
             let ctx = TestContext::new();
             block_on_all(
                 async move {
+                    #[allow(deprecated)]
                     let mut pubsub_conn = ctx.deprecated_async_connection().await?.into_pubsub();
                     pubsub_conn.subscribe("phonewave").await?;
                     pubsub_conn.psubscribe("*").await?;


### PR DESCRIPTION
This is in preparation of actually deleting the type from the library.