### PR TITLE
Clean up feature dependencies

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -38,7 +38,7 @@ combine = { version = "4.6", default-features = false, features = ["std"] }
 
 # Only needed for AIO
 bytes = { version = "1", optional = true }
-futures-util = { version = "0.3.31", default-features = false, optional = true }
+futures-util = { version = "0.3.31", default-features = false, features = ["std", "sink"], optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 tokio-util = { version = "0.7", optional = true }
 tokio = { version = "1", features = ["rt", "net", "time", "sync"], optional = true }
@@ -116,7 +116,7 @@ tokio-native-tls-comp = ["tokio-comp", "tls-native-tls", "dep:tokio-native-tls"]
 tokio-rustls-comp = ["tokio-comp", "tls-rustls", "dep:tokio-rustls"]
 connection-manager = ["dep:futures-channel", "aio", "dep:backon"]
 streams = []
-cluster-async = ["cluster", "dep:futures-sink", "dep:futures-util", "dep:log"]
+cluster-async = ["aio", "cluster", "dep:futures-sink", "dep:log"]
 keep-alive = ["dep:socket2"]
 sentinel = ["dep:rand"]
 tcp_nodelay = []
@@ -127,7 +127,7 @@ disable-client-setinfo = []
 tls = ["tls-native-tls"] # use "tls-native-tls" instead
 async-std-tls-comp = ["async-std-native-tls-comp"] # use "async-std-native-tls-comp" instead
 # Instead of specifying "aio", use either "tokio-comp" or "async-std-comp".
-aio = ["bytes", "dep:pin-project-lite", "dep:futures-util", "futures-util/alloc", "futures-util/std", "futures-util/sink", "dep:tokio", "tokio/io-util", "dep:tokio-util", "tokio-util/codec", "combine/tokio"]
+aio = ["bytes", "dep:pin-project-lite", "dep:futures-util", "dep:tokio", "tokio/io-util", "dep:tokio-util", "tokio-util/codec", "combine/tokio"]
 
 [dev-dependencies]
 assert_approx_eq = "1.0"


### PR DESCRIPTION
- cluster-async requires aio
- futures-util is always used with the same features, declare them in the [dependencies] table rather than the only feature that activates the dependency