### PR TITLE
Double test_async_cluster_basic_failover timeout.

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,5 +2,10 @@
 retries = 2
 failure-output = "immediate-final" # show test failures inline, and also at the end of the run
 fail-fast = false # run all tests, even if some failed
-slow-timeout = { period = "1s", terminate-after = 20 }
+slow-timeout = { period = "3s", terminate-after = 7 }
 status-level = "skip"
+
+
+[[profile.default.overrides]]
+filter = 'test(cluster_async::test_async_cluster_basic_failover)'
+slow-timeout = { period = "20s", terminate-after = 2 }


### PR DESCRIPTION
Locally it runs in about ~13 seconds, in CI it occasionally reaches even higher. Also increase the slow marking level to 2 seconds, since a lot of tests run in the range of 1-2 seconds.

https://github.com/redis-rs/redis-rs/issues/1477