### PR TITLE
Add new set of typed commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![crates.io](https://img.shields.io/crates/v/redis.svg)](https://crates.io/crates/redis)
 [![Chat](https://img.shields.io/discord/976380008299917365?logo=discord)](https://discord.gg/WHKcJK9AKP)
 
-Redis-rs is a high level Rust library for Redis, Valkey and any other RESP
+Redis-rs is a high level Rust library for Redis, Valkey and any other RESP 
 (Redis Serialization Protocol) compliant DB. It provides convenient access
 to all Redis functionality through a very flexible but low-level API. It
 uses a customizable type conversion trait so that any operation can return
@@ -33,15 +33,15 @@ command creation is also possible.
 use redis::Commands;
 
 fn fetch_an_integer() -> redis::RedisResult<isize> {
-	// connect to redis
-	let client = redis::Client::open("redis://127.0.0.1/")?;
-	let mut con = client.get_connection()?;
-	// throw away the result, just make sure it does not fail
-	let _: () = con.set("my_key", 42)?;
-	// read back the key and return it.  Because the return value
-	// from the function is a result for integer this will automatically
-	// convert into one.
-	con.get("my_key")
+    // connect to redis
+    let client = redis::Client::open("redis://127.0.0.1/")?;
+    let mut con = client.get_connection()?;
+    // throw away the result, just make sure it does not fail
+    let _: () = con.set("my_key", 42)?;
+    // read back the key and return it.  Because the return value
+    // from the function is a result for integer this will automatically
+    // convert into one.
+    con.get("my_key")
 }
 ```
 
@@ -96,8 +96,8 @@ redis = { version = "0.31.0", features = ["r2d2"] }
 ```
 
 For async connections, connection pooling isn't necessary, unless blocking commands are used.
-The `MultiplexedConnection` is cloneable and can be used safely from multiple threads, so a
-single connection can be easily reused. For automatic reconnections consider using
+The `MultiplexedConnection` is cloneable and can be used safely from multiple threads, so a 
+single connection can be easily reused. For automatic reconnections consider using 
 `ConnectionManager` with the `connection-manager` feature.
 Async cluster connections also don't require pooling and are thread-safe and reusable.
 
@@ -151,29 +151,29 @@ And then, before creating a connection, ensure that you install a crypto provide
 
 ```rust
     rustls::crypto::ring::default_provider()
-.install_default()
-.expect("Failed to install rustls crypto provider");
+        .install_default()
+        .expect("Failed to install rustls crypto provider");
 ```
+
 
 With `rustls`, you can add the following feature flags on top of other feature flags to enable additional features:
 
-- `tls-rustls-insecure`: Allow insecure TLS connections
-- `tls-rustls-webpki-roots`: Use `webpki-roots` (Mozilla's root certificates) instead of native root certificates
+-   `tls-rustls-insecure`: Allow insecure TLS connections
+-   `tls-rustls-webpki-roots`: Use `webpki-roots` (Mozilla's root certificates) instead of native root certificates
 
 then you should be able to connect to a redis instance using the `rediss://` URL scheme:
 
 ```rust
-let client = redis::Client::open("rediss://127.0.0.1/") ?;
+let client = redis::Client::open("rediss://127.0.0.1/")?;
 ```
 
 To enable insecure mode, append `#insecure` at the end of the URL:
 
 ```rust
-let client = redis::Client::open("rediss://127.0.0.1/#insecure") ?;
+let client = redis::Client::open("rediss://127.0.0.1/#insecure")?;
 ```
 
-**Deprecation Notice:** If you were using the `tls` or `async-std-tls-comp` features, please use the `tls-native-tls` or
-`async-std-native-tls-comp` features respectively.
+**Deprecation Notice:** If you were using the `tls` or `async-std-tls-comp` features, please use the `tls-native-tls` or `async-std-native-tls-comp` features respectively.
 
 ## Cluster Support
 
@@ -190,12 +190,12 @@ use redis::cluster::ClusterClient;
 use redis::Commands;
 
 fn fetch_an_integer() -> String {
-	let nodes = vec!["redis://127.0.0.1/"];
-	let client = ClusterClient::new(nodes).unwrap();
-	let mut connection = client.get_connection().unwrap();
-	let _: () = connection.set("test", "test_data").unwrap();
-	let rv: String = connection.get("test").unwrap();
-	return rv;
+    let nodes = vec!["redis://127.0.0.1/"];
+    let client = ClusterClient::new(nodes).unwrap();
+    let mut connection = client.get_connection().unwrap();
+    let _: () = connection.set("test", "test_data").unwrap();
+    let rv: String = connection.get("test").unwrap();
+    return rv;
 }
 ```
 
@@ -209,12 +209,12 @@ use redis::cluster::ClusterClient;
 use redis::AsyncCommands;
 
 async fn fetch_an_integer() -> String {
-	let nodes = vec!["redis://127.0.0.1/"];
-	let client = ClusterClient::new(nodes).unwrap();
-	let mut connection = client.get_async_connection().await.unwrap();
-	let _: () = connection.set("test", "test_data").await.unwrap();
-	let rv: String = connection.get("test").await.unwrap();
-	return rv;
+    let nodes = vec!["redis://127.0.0.1/"];
+    let client = ClusterClient::new(nodes).unwrap();
+    let mut connection = client.get_async_connection().await.unwrap();
+    let _: () = connection.set("test", "test_data").await.unwrap();
+    let rv: String = connection.get("test").await.unwrap();
+    return rv;
 }
 ```
 
@@ -224,8 +224,7 @@ Support for the RedisJSON Module can be enabled by specifying "json" as a featur
 
 `redis = { version = "0.31.0", features = ["json"] }`
 
-Then you can simply import the `JsonCommands` trait which will add the `json` commands to all Redis Connections (not to
-be confused with just `Commands` which only adds the default commands)
+Then you can simply import the `JsonCommands` trait which will add the `json` commands to all Redis Connections (not to be confused with just `Commands` which only adds the default commands)
 
 ```rust
 use redis::Client;
@@ -236,11 +235,11 @@ use redis::ToRedisArgs;
 // Result returns Ok(true) if the value was set
 // Result returns Err(e) if there was an error with the server itself OR serde_json was unable to serialize the boolean
 fn set_json_bool<P: ToRedisArgs>(key: P, path: P, b: bool) -> RedisResult<bool> {
-	let client = Client::open("redis://127.0.0.1").unwrap();
-	let connection = client.get_connection().unwrap();
+    let client = Client::open("redis://127.0.0.1").unwrap();
+    let connection = client.get_connection().unwrap();
 
-	// runs `JSON.SET {key} {path} {b}`
-	connection.json_set(key, path, b)?
+    // runs `JSON.SET {key} {path} {b}`
+    connection.json_set(key, path, b)?
 }
 
 ```
@@ -256,10 +255,9 @@ you can use the `Json` wrapper from the
 To test `redis` you're going to need to be able to test with the Redis Modules, to do this
 you must set the following environment variable before running the test script
 
-- `REDIS_RS_REDIS_JSON_PATH` = The absolute path to the RedisJSON module (Either `librejson.so` for Linux or
-  `librejson.dylib` for MacOS).
+-   `REDIS_RS_REDIS_JSON_PATH` = The absolute path to the RedisJSON module (Either `librejson.so` for Linux or `librejson.dylib` for MacOS).
 
-- Please refer to this [link](https://github.com/RedisJSON/RedisJSON) to access the RedisJSON module:
+-   Please refer to this [link](https://github.com/RedisJSON/RedisJSON) to access the RedisJSON module:
 
 <!-- As support for modules are added later, it would be wise to update this list -->
 
@@ -272,22 +270,20 @@ To build the core crate:
 
 To test:
 
-Note: `make test` requires cargo-nextest installed, to learn more about it please
-visit [homepage of cargo-nextest](https://nexte.st/).
+Note: `make test` requires cargo-nextest installed, to learn more about it please visit [homepage of cargo-nextest](https://nexte.st/).
+
 
     $ make test
-
+    
 To run benchmarks:
 
     $ make bench
 
-To build the docs (require nightly compiler,
-see [rust-lang/rust#43781](https://github.com/rust-lang/rust/issues/43781)):
+To build the docs (require nightly compiler, see [rust-lang/rust#43781](https://github.com/rust-lang/rust/issues/43781)):
 
     $ make docs
 
-We encourage you to run `clippy` prior to seeking a merge for your work. The lints can be quite strict. Running this on
-your own workstation can save you time, since Travis CI will fail any build that doesn't satisfy `clippy`:
+We encourage you to run `clippy` prior to seeking a merge for your work. The lints can be quite strict. Running this on your own workstation can save you time, since Travis CI will fail any build that doesn't satisfy `clippy`:
 
     $ cargo clippy --all-features --all --tests --examples -- -D clippy::all -D warnings
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![crates.io](https://img.shields.io/crates/v/redis.svg)](https://crates.io/crates/redis)
 [![Chat](https://img.shields.io/discord/976380008299917365?logo=discord)](https://discord.gg/WHKcJK9AKP)
 
-Redis-rs is a high level Rust library for Redis, Valkey and any other RESP 
+Redis-rs is a high level Rust library for Redis, Valkey and any other RESP
 (Redis Serialization Protocol) compliant DB. It provides convenient access
 to all Redis functionality through a very flexible but low-level API. It
 uses a customizable type conversion trait so that any operation can return
@@ -33,15 +33,15 @@ command creation is also possible.
 use redis::Commands;
 
 fn fetch_an_integer() -> redis::RedisResult<isize> {
-    // connect to redis
-    let client = redis::Client::open("redis://127.0.0.1/")?;
-    let mut con = client.get_connection()?;
-    // throw away the result, just make sure it does not fail
-    let _: () = con.set("my_key", 42)?;
-    // read back the key and return it.  Because the return value
-    // from the function is a result for integer this will automatically
-    // convert into one.
-    con.get("my_key")
+	// connect to redis
+	let client = redis::Client::open("redis://127.0.0.1/")?;
+	let mut con = client.get_connection()?;
+	// throw away the result, just make sure it does not fail
+	let _: () = con.set("my_key", 42)?;
+	// read back the key and return it.  Because the return value
+	// from the function is a result for integer this will automatically
+	// convert into one.
+	con.get("my_key")
 }
 ```
 
@@ -49,6 +49,24 @@ Variables are converted to and from the Redis format for a wide variety of types
 (`String`, num types, tuples, `Vec<u8>`). If you want to use it with your own types,
 you can implement the `FromRedisValue` and `ToRedisArgs` traits, or derive it with the
 [redis-macros](https://github.com/daniel7grant/redis-macros/#json-wrapper-with-redisjson) crate.
+
+If you wish to avoid having to specify a return type for every command, you can use the `TypedCommands` trait instead,
+which has
+pre-specified and opinionated return types.
+
+```rust
+use redis::TypedCommands;
+
+fn fetch_an_integer() -> redis::RedisResult<isize> {
+	// connect to redis
+	let client = redis::Client::open("redis://127.0.0.1/")?;
+	let mut con = client.get_connection()?;
+	// `set` returns a `()`, so we don't need to specify the return type manually unlike in the previous example.
+	con.set("my_key", 42)?;
+	// `get_int` returns Option<isize>, as the key may not be found.
+	con.get_int("my_key").unwrap()
+}
+```
 
 ## Async support
 
@@ -66,6 +84,8 @@ redis = { version = "0.31.0", features = ["smol-comp"] }
 redis = { version = "0.31.0", features = ["async-std-comp"] }
 ```
 
+You can then use either the `AsyncCommands` or `AsyncTypedCommands` trait.
+
 ## Connection Pooling
 
 When using a sync connection, it is recommended to use a connection pool in order to handle
@@ -76,8 +96,8 @@ redis = { version = "0.31.0", features = ["r2d2"] }
 ```
 
 For async connections, connection pooling isn't necessary, unless blocking commands are used.
-The `MultiplexedConnection` is cloneable and can be used safely from multiple threads, so a 
-single connection can be easily reused. For automatic reconnections consider using 
+The `MultiplexedConnection` is cloneable and can be used safely from multiple threads, so a
+single connection can be easily reused. For automatic reconnections consider using
 `ConnectionManager` with the `connection-manager` feature.
 Async cluster connections also don't require pooling and are thread-safe and reusable.
 
@@ -131,29 +151,29 @@ And then, before creating a connection, ensure that you install a crypto provide
 
 ```rust
     rustls::crypto::ring::default_provider()
-        .install_default()
-        .expect("Failed to install rustls crypto provider");
+.install_default()
+.expect("Failed to install rustls crypto provider");
 ```
-
 
 With `rustls`, you can add the following feature flags on top of other feature flags to enable additional features:
 
--   `tls-rustls-insecure`: Allow insecure TLS connections
--   `tls-rustls-webpki-roots`: Use `webpki-roots` (Mozilla's root certificates) instead of native root certificates
+- `tls-rustls-insecure`: Allow insecure TLS connections
+- `tls-rustls-webpki-roots`: Use `webpki-roots` (Mozilla's root certificates) instead of native root certificates
 
 then you should be able to connect to a redis instance using the `rediss://` URL scheme:
 
 ```rust
-let client = redis::Client::open("rediss://127.0.0.1/")?;
+let client = redis::Client::open("rediss://127.0.0.1/") ?;
 ```
 
 To enable insecure mode, append `#insecure` at the end of the URL:
 
 ```rust
-let client = redis::Client::open("rediss://127.0.0.1/#insecure")?;
+let client = redis::Client::open("rediss://127.0.0.1/#insecure") ?;
 ```
 
-**Deprecation Notice:** If you were using the `tls` or `async-std-tls-comp` features, please use the `tls-native-tls` or `async-std-native-tls-comp` features respectively.
+**Deprecation Notice:** If you were using the `tls` or `async-std-tls-comp` features, please use the `tls-native-tls` or
+`async-std-native-tls-comp` features respectively.
 
 ## Cluster Support
 
@@ -170,12 +190,12 @@ use redis::cluster::ClusterClient;
 use redis::Commands;
 
 fn fetch_an_integer() -> String {
-    let nodes = vec!["redis://127.0.0.1/"];
-    let client = ClusterClient::new(nodes).unwrap();
-    let mut connection = client.get_connection().unwrap();
-    let _: () = connection.set("test", "test_data").unwrap();
-    let rv: String = connection.get("test").unwrap();
-    return rv;
+	let nodes = vec!["redis://127.0.0.1/"];
+	let client = ClusterClient::new(nodes).unwrap();
+	let mut connection = client.get_connection().unwrap();
+	let _: () = connection.set("test", "test_data").unwrap();
+	let rv: String = connection.get("test").unwrap();
+	return rv;
 }
 ```
 
@@ -189,12 +209,12 @@ use redis::cluster::ClusterClient;
 use redis::AsyncCommands;
 
 async fn fetch_an_integer() -> String {
-    let nodes = vec!["redis://127.0.0.1/"];
-    let client = ClusterClient::new(nodes).unwrap();
-    let mut connection = client.get_async_connection().await.unwrap();
-    let _: () = connection.set("test", "test_data").await.unwrap();
-    let rv: String = connection.get("test").await.unwrap();
-    return rv;
+	let nodes = vec!["redis://127.0.0.1/"];
+	let client = ClusterClient::new(nodes).unwrap();
+	let mut connection = client.get_async_connection().await.unwrap();
+	let _: () = connection.set("test", "test_data").await.unwrap();
+	let rv: String = connection.get("test").await.unwrap();
+	return rv;
 }
 ```
 
@@ -204,7 +224,8 @@ Support for the RedisJSON Module can be enabled by specifying "json" as a featur
 
 `redis = { version = "0.31.0", features = ["json"] }`
 
-Then you can simply import the `JsonCommands` trait which will add the `json` commands to all Redis Connections (not to be confused with just `Commands` which only adds the default commands)
+Then you can simply import the `JsonCommands` trait which will add the `json` commands to all Redis Connections (not to
+be confused with just `Commands` which only adds the default commands)
 
 ```rust
 use redis::Client;
@@ -215,11 +236,11 @@ use redis::ToRedisArgs;
 // Result returns Ok(true) if the value was set
 // Result returns Err(e) if there was an error with the server itself OR serde_json was unable to serialize the boolean
 fn set_json_bool<P: ToRedisArgs>(key: P, path: P, b: bool) -> RedisResult<bool> {
-    let client = Client::open("redis://127.0.0.1").unwrap();
-    let connection = client.get_connection().unwrap();
+	let client = Client::open("redis://127.0.0.1").unwrap();
+	let connection = client.get_connection().unwrap();
 
-    // runs `JSON.SET {key} {path} {b}`
-    connection.json_set(key, path, b)?
+	// runs `JSON.SET {key} {path} {b}`
+	connection.json_set(key, path, b)?
 }
 
 ```
@@ -235,9 +256,10 @@ you can use the `Json` wrapper from the
 To test `redis` you're going to need to be able to test with the Redis Modules, to do this
 you must set the following environment variable before running the test script
 
--   `REDIS_RS_REDIS_JSON_PATH` = The absolute path to the RedisJSON module (Either `librejson.so` for Linux or `librejson.dylib` for MacOS).
+- `REDIS_RS_REDIS_JSON_PATH` = The absolute path to the RedisJSON module (Either `librejson.so` for Linux or
+  `librejson.dylib` for MacOS).
 
--   Please refer to this [link](https://github.com/RedisJSON/RedisJSON) to access the RedisJSON module:
+- Please refer to this [link](https://github.com/RedisJSON/RedisJSON) to access the RedisJSON module:
 
 <!-- As support for modules are added later, it would be wise to update this list -->
 
@@ -250,20 +272,22 @@ To build the core crate:
 
 To test:
 
-Note: `make test` requires cargo-nextest installed, to learn more about it please visit [homepage of cargo-nextest](https://nexte.st/).
-
+Note: `make test` requires cargo-nextest installed, to learn more about it please
+visit [homepage of cargo-nextest](https://nexte.st/).
 
     $ make test
-    
+
 To run benchmarks:
 
     $ make bench
 
-To build the docs (require nightly compiler, see [rust-lang/rust#43781](https://github.com/rust-lang/rust/issues/43781)):
+To build the docs (require nightly compiler,
+see [rust-lang/rust#43781](https://github.com/rust-lang/rust/issues/43781)):
 
     $ make docs
 
-We encourage you to run `clippy` prior to seeking a merge for your work. The lints can be quite strict. Running this on your own workstation can save you time, since Travis CI will fail any build that doesn't satisfy `clippy`:
+We encourage you to run `clippy` prior to seeking a merge for your work. The lints can be quite strict. Running this on
+your own workstation can save you time, since Travis CI will fail any build that doesn't satisfy `clippy`:
 
     $ cargo clippy --all-features --all --tests --examples -- -D clippy::all -D warnings
 

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -279,5 +279,8 @@ name = "async-typed"
 required-features = ["aio"]
 
 [[example]]
+name = "typed"
+
+[[example]]
 name = "async-caching"
 required-features = ["tokio-comp", "cache-aio"]

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -275,5 +275,9 @@ name = "streams"
 required-features = ["streams"]
 
 [[example]]
+name = "async-typed"
+required-features = ["aio"]
+
+[[example]]
 name = "async-caching"
 required-features = ["tokio-comp", "cache-aio"]

--- a/redis/examples/async-typed.rs
+++ b/redis/examples/async-typed.rs
@@ -1,0 +1,38 @@
+use redis::AsyncTypedCommands;
+
+#[tokio::main]
+async fn main() -> redis::RedisResult<()> {
+	let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+	let mut con = client.get_multiplexed_async_connection().await?;
+
+	con.set("hello", "world").await?;
+
+	let hello = con.get("hello").await?;
+
+	assert_eq!(hello, Some("world".to_string()));
+
+	con.set("counter", 0).await?;
+
+	con.incr("counter", 1).await?;
+
+	let new_value = con.incr("counter", 3).await?;
+	assert_eq!(new_value, 4);
+
+	con.set("goodbye", "world").await?;
+
+	let num_deleted = con.del("goodbye").await?;
+
+	assert_eq!(num_deleted, 1);
+
+	let value_type = con.key_type("hello").await?;
+	assert_eq!(value_type, redis::ValueType::String);
+
+	con.lpush("mylist", "a").await?;
+	con.lpush("mylist", "b").await?;
+	con.lpush("mylist", "c").await?;
+
+	let list = con.lrange("mylist", 0, -1).await?;
+	assert_eq!(list, vec!["c", "b", "a"]);
+
+	Ok(())
+}

--- a/redis/examples/async-typed.rs
+++ b/redis/examples/async-typed.rs
@@ -2,37 +2,37 @@ use redis::AsyncTypedCommands;
 
 #[tokio::main]
 async fn main() -> redis::RedisResult<()> {
-	let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-	let mut con = client.get_multiplexed_async_connection().await?;
+    let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+    let mut con = client.get_multiplexed_async_connection().await?;
 
-	con.set("hello", "world").await?;
+    con.set("hello", "world").await?;
 
-	let hello = con.get("hello").await?;
+    let hello = con.get("hello").await?;
 
-	assert_eq!(hello, Some("world".to_string()));
+    assert_eq!(hello, Some("world".to_string()));
 
-	con.set("counter", 0).await?;
+    con.set("counter", 0).await?;
 
-	con.incr("counter", 1).await?;
+    con.incr("counter", 1).await?;
 
-	let new_value = con.incr("counter", 3).await?;
-	assert_eq!(new_value, 4);
+    let new_value = con.incr("counter", 3).await?;
+    assert_eq!(new_value, 4);
 
-	con.set("goodbye", "world").await?;
+    con.set("goodbye", "world").await?;
 
-	let num_deleted = con.del("goodbye").await?;
+    let num_deleted = con.del("goodbye").await?;
 
-	assert_eq!(num_deleted, 1);
+    assert_eq!(num_deleted, 1);
 
-	let value_type = con.key_type("hello").await?;
-	assert_eq!(value_type, redis::ValueType::String);
+    let value_type = con.key_type("hello").await?;
+    assert_eq!(value_type, redis::ValueType::String);
 
-	con.lpush("mylist", "a").await?;
-	con.lpush("mylist", "b").await?;
-	con.lpush("mylist", "c").await?;
+    con.lpush("mylist", "a").await?;
+    con.lpush("mylist", "b").await?;
+    con.lpush("mylist", "c").await?;
 
-	let list = con.lrange("mylist", 0, -1).await?;
-	assert_eq!(list, vec!["c", "b", "a"]);
+    let list = con.lrange("mylist", 0, -1).await?;
+    assert_eq!(list, vec!["c", "b", "a"]);
 
-	Ok(())
+    Ok(())
 }

--- a/redis/examples/async-typed.rs
+++ b/redis/examples/async-typed.rs
@@ -27,6 +27,8 @@ async fn main() -> redis::RedisResult<()> {
     let value_type = con.key_type("hello").await?;
     assert_eq!(value_type, redis::ValueType::String);
 
+    con.del("mylist").await?;
+
     con.lpush("mylist", "a").await?;
     con.lpush("mylist", "b").await?;
     con.lpush("mylist", "c").await?;

--- a/redis/examples/typed.rs
+++ b/redis/examples/typed.rs
@@ -1,0 +1,39 @@
+use redis::TypedCommands;
+
+fn main() -> redis::RedisResult<()> {
+    let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+    let mut con = client.get_connection()?;
+
+    con.set("hello", "world")?;
+
+    let hello = con.get("hello")?;
+
+    assert_eq!(hello, Some("world".to_string()));
+
+    con.set("counter", 0)?;
+
+    con.incr("counter", 1)?;
+
+    let new_value = con.incr("counter", 3)?;
+    assert_eq!(new_value, 4);
+
+    con.set("goodbye", "world")?;
+
+    let num_deleted = con.del("goodbye")?;
+
+    assert_eq!(num_deleted, 1);
+
+    let value_type = con.key_type("hello")?;
+    assert_eq!(value_type, redis::ValueType::String);
+
+    con.del("mylist")?;
+    
+    con.lpush("mylist", "a")?;
+    con.lpush("mylist", "b")?;
+    con.lpush("mylist", "c")?;
+
+    let list = con.lrange("mylist", 0, -1)?;
+    assert_eq!(list, vec!["c", "b", "a"]);
+
+    Ok(())
+}

--- a/redis/examples/typed.rs
+++ b/redis/examples/typed.rs
@@ -27,7 +27,7 @@ fn main() -> redis::RedisResult<()> {
     assert_eq!(value_type, redis::ValueType::String);
 
     con.del("mylist")?;
-    
+
     con.lpush("mylist", "a")?;
     con.lpush("mylist", "b")?;
     con.lpush("mylist", "c")?;

--- a/redis/src/commands/macros.rs
+++ b/redis/src/commands/macros.rs
@@ -1,6 +1,6 @@
 // Generate implementation for function skeleton, we use this for `AsyncTypedCommands` because we want to be able to handle having a return type specified or unspecified with a fallback
-#[allow(unused_macros)]
-macro_rules! implement_command {
+#[cfg(feature = "aio")]
+macro_rules! implement_command_async {
 	// If return type is specified in the input skeleton, then we will return it in the generated function (note match rule `$rettype:ty`)
 	(
         $lifetime: lifetime
@@ -36,6 +36,46 @@ macro_rules! implement_command {
 		) -> crate::types::RedisFuture<'a, crate::Value>
 		{
 			Box::pin(async move { ($body).query_async(self).await })
+		}
+	}
+}
+
+macro_rules! implement_command_sync {
+	// If return type is specified in the input skeleton, then we will return it in the generated function (note match rule `$rettype:ty`)
+	(
+        $lifetime: lifetime
+		$(#[$attr:meta])+
+		fn $name:ident<$($tyargs:ident : $ty:ident),*>(
+			$($argname:ident: $argty:ty),*) $body:block $rettype:ty
+    ) => {
+		$(#[$attr])*
+		#[inline]
+		#[allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
+		fn $name<$lifetime, $($tyargs: $ty + Send + Sync + $lifetime,)*>(
+			& $lifetime mut self
+			$(, $argname: $argty)*
+		) -> RedisResult<$rettype>
+
+		{
+			Cmd::$name($($argname),*).query(self)
+		}
+	};
+	// If no return type is specified in the input skeleton, we default to returning `redis::Value` in the generated function (note lack of match rule `$rettype:ty`)
+	(
+        $lifetime: lifetime
+		$(#[$attr:meta])+
+		fn $name:ident<$($tyargs:ident : $ty:ident),*>(
+			$($argname:ident: $argty:ty),*) $body:block
+    ) => {
+		$(#[$attr])*
+		#[inline]
+		#[allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
+		fn $name<$lifetime, $($tyargs: $ty + Send + Sync + $lifetime,)*>(
+			& $lifetime mut self
+			$(, $argname: $argty)*
+		) -> RedisResult<crate::Value>
+		{
+			Cmd::$name($($argname),*).query(self)
 		}
 	}
 }
@@ -299,12 +339,107 @@ macro_rules! implement_commands {
             }
         }
 
+        /// Implements common redis commands.
+        /// The return types are concrete and opinionated. If you want to choose the return type you should use the `Commands` trait.
+        pub trait TypedCommands : ConnectionLike+Sized {
+            $(
+				implement_command_sync! {
+					$lifetime
+					$(#[$attr])*
+					fn $name<$($tyargs: $ty),*>(
+						$($argname: $argty),*
+					)
+
+					{
+						$body
+					} $($rettype)?
+				}
+            )*
+
+            /// Incrementally iterate the keys space.
+            #[inline]
+            fn scan<RV: FromRedisValue>(&mut self) -> RedisResult<Iter<'_, RV>> {
+                let mut c = cmd("SCAN");
+                c.cursor_arg(0);
+                c.iter(self)
+            }
+
+            /// Incrementally iterate the keys space with options.
+            #[inline]
+            fn scan_options<RV: FromRedisValue>(&mut self, opts: ScanOptions) -> RedisResult<Iter<'_, RV>> {
+                let mut c = cmd("SCAN");
+                c.cursor_arg(0).arg(opts);
+                c.iter(self)
+            }
+
+            /// Incrementally iterate the keys space for keys matching a pattern.
+            #[inline]
+            fn scan_match<P: ToRedisArgs, RV: FromRedisValue>(&mut self, pattern: P) -> RedisResult<Iter<'_, RV>> {
+                let mut c = cmd("SCAN");
+                c.cursor_arg(0).arg("MATCH").arg(pattern);
+                c.iter(self)
+            }
+
+            /// Incrementally iterate hash fields and associated values.
+            #[inline]
+            fn hscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisResult<Iter<'_, RV>> {
+                let mut c = cmd("HSCAN");
+                c.arg(key).cursor_arg(0);
+                c.iter(self)
+            }
+
+            /// Incrementally iterate hash fields and associated values for
+            /// field names matching a pattern.
+            #[inline]
+            fn hscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
+                    (&mut self, key: K, pattern: P) -> RedisResult<Iter<'_, RV>> {
+                let mut c = cmd("HSCAN");
+                c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
+                c.iter(self)
+            }
+
+            /// Incrementally iterate set elements.
+            #[inline]
+            fn sscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisResult<Iter<'_, RV>> {
+                let mut c = cmd("SSCAN");
+                c.arg(key).cursor_arg(0);
+                c.iter(self)
+            }
+
+            /// Incrementally iterate set elements for elements matching a pattern.
+            #[inline]
+            fn sscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
+                    (&mut self, key: K, pattern: P) -> RedisResult<Iter<'_, RV>> {
+                let mut c = cmd("SSCAN");
+                c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
+                c.iter(self)
+            }
+
+            /// Incrementally iterate sorted set elements.
+            #[inline]
+            fn zscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisResult<Iter<'_, RV>> {
+                let mut c = cmd("ZSCAN");
+                c.arg(key).cursor_arg(0);
+                c.iter(self)
+            }
+
+            /// Incrementally iterate sorted set elements for elements matching a pattern.
+            #[inline]
+            fn zscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
+                    (&mut self, key: K, pattern: P) -> RedisResult<Iter<'_, RV>> {
+                let mut c = cmd("ZSCAN");
+                c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
+                c.iter(self)
+            }
+        }
+
+
 		/// Implements common redis commands over asynchronous connections.
-		/// The return types are concrete and opinionated. If you want to choose the return type you should use the `AsyncCommands` trait.
+        /// The return types are concrete and opinionated. If you want to choose the return type you should use the `AsyncCommands` trait.
 		#[cfg(feature = "aio")]
         pub trait AsyncTypedCommands : crate::aio::ConnectionLike + Send + Sized {
             $(
-				implement_command! {
+				implement_command_async! {
 					$lifetime
 					$(#[$attr])*
 					fn $name<$($tyargs: $ty),*>(
@@ -350,7 +485,7 @@ macro_rules! implement_commands {
             }
 
             /// Incrementally iterate hash fields and associated values for
-			/// field names matching a pattern.
+            /// field names matching a pattern.
             #[inline]
             fn hscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
                     (&mut self, key: K, pattern: P) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {

--- a/redis/src/commands/macros.rs
+++ b/redis/src/commands/macros.rs
@@ -1,4 +1,5 @@
 // Generate implementation for function skeleton, we use this for `AsyncTypedCommands` because we want to be able to handle having a return type specified or unspecified with a fallback
+#[allow(unused_macros)]
 macro_rules! implement_command {
 	// If return type is specified in the input skeleton, then we will return it in the generated function (note match rule `$rettype:ty`)
 	(

--- a/redis/src/commands/macros.rs
+++ b/redis/src/commands/macros.rs
@@ -1,5 +1,6 @@
-#[allow(unused_macros)]
+// Generate implementation for function skeleton, we use this for `AsyncTypedCommands` because we want to be able to handle having a return type specified or unspecified with a fallback
 macro_rules! implement_command {
+	// If return type is specified in the input skeleton, then we will return it in the generated function (note match rule `$rettype:ty`)
 	(
         $lifetime: lifetime
 		$(#[$attr:meta])+
@@ -18,6 +19,7 @@ macro_rules! implement_command {
 			Box::pin(async move { ($body).query_async(self).await })
 		}
 	};
+	// If no return type is specified in the input skeleton, we default to returning `redis::Value` in the generated function (note lack of match rule `$rettype:ty`)
 	(
         $lifetime: lifetime
 		$(#[$attr:meta])+

--- a/redis/src/commands/macros.rs
+++ b/redis/src/commands/macros.rs
@@ -82,6 +82,95 @@ macro_rules! implement_command_sync {
 	};
 }
 
+macro_rules! implement_iterators {
+    ($iter:expr, $ret:ty) => {
+        /// Incrementally iterate the keys space.
+        #[inline]
+        fn scan<RV: FromRedisValue>(&mut self) -> $ret {
+            let mut c = cmd("SCAN");
+            c.cursor_arg(0);
+            $iter(c, self)
+        }
+
+        /// Incrementally iterate the keys space with options.
+        #[inline]
+        fn scan_options<RV: FromRedisValue>(&mut self, opts: ScanOptions) -> $ret {
+            let mut c = cmd("SCAN");
+            c.cursor_arg(0).arg(opts);
+            $iter(c, self)
+        }
+
+        /// Incrementally iterate the keys space for keys matching a pattern.
+        #[inline]
+        fn scan_match<P: ToRedisArgs, RV: FromRedisValue>(&mut self, pattern: P) -> $ret {
+            let mut c = cmd("SCAN");
+            c.cursor_arg(0).arg("MATCH").arg(pattern);
+            $iter(c, self)
+        }
+
+        /// Incrementally iterate hash fields and associated values.
+        #[inline]
+        fn hscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> $ret {
+            let mut c = cmd("HSCAN");
+            c.arg(key).cursor_arg(0);
+            $iter(c, self)
+        }
+
+        /// Incrementally iterate hash fields and associated values for
+        /// field names matching a pattern.
+        #[inline]
+        fn hscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>(
+            &mut self,
+            key: K,
+            pattern: P,
+        ) -> $ret {
+            let mut c = cmd("HSCAN");
+            c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
+            $iter(c, self)
+        }
+
+        /// Incrementally iterate set elements.
+        #[inline]
+        fn sscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> $ret {
+            let mut c = cmd("SSCAN");
+            c.arg(key).cursor_arg(0);
+            $iter(c, self)
+        }
+
+        /// Incrementally iterate set elements for elements matching a pattern.
+        #[inline]
+        fn sscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>(
+            &mut self,
+            key: K,
+            pattern: P,
+        ) -> $ret {
+            let mut c = cmd("SSCAN");
+            c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
+            $iter(c, self)
+        }
+
+        /// Incrementally iterate sorted set elements.
+        #[inline]
+        fn zscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> $ret {
+            let mut c = cmd("ZSCAN");
+            c.arg(key).cursor_arg(0);
+            $iter(c, self)
+        }
+
+        /// Incrementally iterate sorted set elements for elements matching a pattern.
+        #[inline]
+        fn zscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>(
+            &mut self,
+            key: K,
+            pattern: P,
+        ) -> $ret {
+            let mut c = cmd("ZSCAN");
+            c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
+            $iter(c, self)
+        }
+    };
+}
+
 macro_rules! implement_commands {
     (
         $lifetime: lifetime
@@ -131,81 +220,10 @@ macro_rules! implement_commands {
                     { Cmd::$name($($argname),*).query(self) }
             )*
 
-            /// Incrementally iterate the keys space.
-            #[inline]
-            fn scan<RV: FromRedisValue>(&mut self) -> RedisResult<Iter<'_, RV>> {
-                let mut c = cmd("SCAN");
-                c.cursor_arg(0);
-                c.iter(self)
-            }
-
-            /// Incrementally iterate the keys space with options.
-            #[inline]
-            fn scan_options<RV: FromRedisValue>(&mut self, opts: ScanOptions) -> RedisResult<Iter<'_, RV>> {
-                let mut c = cmd("SCAN");
-                c.cursor_arg(0).arg(opts);
-                c.iter(self)
-            }
-
-            /// Incrementally iterate the keys space for keys matching a pattern.
-            #[inline]
-            fn scan_match<P: ToRedisArgs, RV: FromRedisValue>(&mut self, pattern: P) -> RedisResult<Iter<'_, RV>> {
-                let mut c = cmd("SCAN");
-                c.cursor_arg(0).arg("MATCH").arg(pattern);
-                c.iter(self)
-            }
-
-            /// Incrementally iterate hash fields and associated values.
-            #[inline]
-            fn hscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisResult<Iter<'_, RV>> {
-                let mut c = cmd("HSCAN");
-                c.arg(key).cursor_arg(0);
-                c.iter(self)
-            }
-
-            /// Incrementally iterate hash fields and associated values for
-            /// field names matching a pattern.
-            #[inline]
-            fn hscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&mut self, key: K, pattern: P) -> RedisResult<Iter<'_, RV>> {
-                let mut c = cmd("HSCAN");
-                c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
-                c.iter(self)
-            }
-
-            /// Incrementally iterate set elements.
-            #[inline]
-            fn sscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisResult<Iter<'_, RV>> {
-                let mut c = cmd("SSCAN");
-                c.arg(key).cursor_arg(0);
-                c.iter(self)
-            }
-
-            /// Incrementally iterate set elements for elements matching a pattern.
-            #[inline]
-            fn sscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&mut self, key: K, pattern: P) -> RedisResult<Iter<'_, RV>> {
-                let mut c = cmd("SSCAN");
-                c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
-                c.iter(self)
-            }
-
-            /// Incrementally iterate sorted set elements.
-            #[inline]
-            fn zscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisResult<Iter<'_, RV>> {
-                let mut c = cmd("ZSCAN");
-                c.arg(key).cursor_arg(0);
-                c.iter(self)
-            }
-
-            /// Incrementally iterate sorted set elements for elements matching a pattern.
-            #[inline]
-            fn zscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&mut self, key: K, pattern: P) -> RedisResult<Iter<'_, RV>> {
-                let mut c = cmd("ZSCAN");
-                c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
-                c.iter(self)
-            }
+            implement_iterators! {
+				|c: Cmd, this| c.iter(this),
+				RedisResult<Iter<'_, RV>>
+			}
         }
 
         impl Cmd {
@@ -264,80 +282,9 @@ macro_rules! implement_commands {
                 }
             )*
 
-            /// Incrementally iterate the keys space.
-            #[inline]
-            fn scan<RV: FromRedisValue>(&mut self) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
-                let mut c = cmd("SCAN");
-                c.cursor_arg(0);
-                Box::pin(async move { c.iter_async(self).await })
-            }
-
-            /// Incrementally iterate the keys space with options.
-            #[inline]
-            fn scan_options<RV: FromRedisValue>(&mut self, opts: ScanOptions) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
-                let mut c = cmd("SCAN");
-                c.cursor_arg(0).arg(opts);
-                Box::pin(async move { c.iter_async(self).await })
-            }
-
-            /// Incrementally iterate set elements for elements matching a pattern.
-            #[inline]
-            fn scan_match<P: ToRedisArgs, RV: FromRedisValue>(&mut self, pattern: P) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
-                let mut c = cmd("SCAN");
-                c.cursor_arg(0).arg("MATCH").arg(pattern);
-                Box::pin(async move { c.iter_async(self).await })
-            }
-
-            /// Incrementally iterate hash fields and associated values.
-            #[inline]
-            fn hscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
-                let mut c = cmd("HSCAN");
-                c.arg(key).cursor_arg(0);
-                Box::pin(async move {c.iter_async(self).await })
-            }
-
-            /// Incrementally iterate hash fields and associated values for
-            /// field names matching a pattern.
-            #[inline]
-            fn hscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&mut self, key: K, pattern: P) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
-                let mut c = cmd("HSCAN");
-                c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
-                Box::pin(async move {c.iter_async(self).await })
-            }
-
-            /// Incrementally iterate set elements.
-            #[inline]
-            fn sscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
-                let mut c = cmd("SSCAN");
-                c.arg(key).cursor_arg(0);
-                Box::pin(async move {c.iter_async(self).await })
-            }
-
-            /// Incrementally iterate set elements for elements matching a pattern.
-            #[inline]
-            fn sscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&mut self, key: K, pattern: P) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
-                let mut c = cmd("SSCAN");
-                c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
-                Box::pin(async move {c.iter_async(self).await })
-            }
-
-            /// Incrementally iterate sorted set elements.
-            #[inline]
-            fn zscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
-                let mut c = cmd("ZSCAN");
-                c.arg(key).cursor_arg(0);
-                Box::pin(async move {c.iter_async(self).await })
-            }
-
-            /// Incrementally iterate sorted set elements for elements matching a pattern.
-            #[inline]
-            fn zscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&mut self, key: K, pattern: P) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
-                let mut c = cmd("ZSCAN");
-                c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
-                Box::pin(async move {c.iter_async(self).await })
+			implement_iterators! {
+                |c: Cmd, this| Box::pin(async move { c.iter_async(this).await }),
+				crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>>
             }
         }
 
@@ -358,80 +305,9 @@ macro_rules! implement_commands {
 				}
             )*
 
-            /// Incrementally iterate the keys space.
-            #[inline]
-            fn scan<RV: FromRedisValue>(&mut self) -> RedisResult<Iter<'_, RV>> {
-                let mut c = cmd("SCAN");
-                c.cursor_arg(0);
-                c.iter(self)
-            }
-
-            /// Incrementally iterate the keys space with options.
-            #[inline]
-            fn scan_options<RV: FromRedisValue>(&mut self, opts: ScanOptions) -> RedisResult<Iter<'_, RV>> {
-                let mut c = cmd("SCAN");
-                c.cursor_arg(0).arg(opts);
-                c.iter(self)
-            }
-
-            /// Incrementally iterate the keys space for keys matching a pattern.
-            #[inline]
-            fn scan_match<P: ToRedisArgs, RV: FromRedisValue>(&mut self, pattern: P) -> RedisResult<Iter<'_, RV>> {
-                let mut c = cmd("SCAN");
-                c.cursor_arg(0).arg("MATCH").arg(pattern);
-                c.iter(self)
-            }
-
-            /// Incrementally iterate hash fields and associated values.
-            #[inline]
-            fn hscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisResult<Iter<'_, RV>> {
-                let mut c = cmd("HSCAN");
-                c.arg(key).cursor_arg(0);
-                c.iter(self)
-            }
-
-            /// Incrementally iterate hash fields and associated values for
-            /// field names matching a pattern.
-            #[inline]
-            fn hscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&mut self, key: K, pattern: P) -> RedisResult<Iter<'_, RV>> {
-                let mut c = cmd("HSCAN");
-                c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
-                c.iter(self)
-            }
-
-            /// Incrementally iterate set elements.
-            #[inline]
-            fn sscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisResult<Iter<'_, RV>> {
-                let mut c = cmd("SSCAN");
-                c.arg(key).cursor_arg(0);
-                c.iter(self)
-            }
-
-            /// Incrementally iterate set elements for elements matching a pattern.
-            #[inline]
-            fn sscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&mut self, key: K, pattern: P) -> RedisResult<Iter<'_, RV>> {
-                let mut c = cmd("SSCAN");
-                c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
-                c.iter(self)
-            }
-
-            /// Incrementally iterate sorted set elements.
-            #[inline]
-            fn zscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisResult<Iter<'_, RV>> {
-                let mut c = cmd("ZSCAN");
-                c.arg(key).cursor_arg(0);
-                c.iter(self)
-            }
-
-            /// Incrementally iterate sorted set elements for elements matching a pattern.
-            #[inline]
-            fn zscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&mut self, key: K, pattern: P) -> RedisResult<Iter<'_, RV>> {
-                let mut c = cmd("ZSCAN");
-                c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
-                c.iter(self)
+            implement_iterators! {
+                |c: Cmd, this| c.iter(this),
+				RedisResult<Iter<'_, RV>>
             }
         }
 
@@ -453,81 +329,10 @@ macro_rules! implement_commands {
 				}
             )*
 
-            /// Incrementally iterate the keys space.
-            #[inline]
-            fn scan<RV: FromRedisValue>(&mut self) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
-                let mut c = cmd("SCAN");
-                c.cursor_arg(0);
-                Box::pin(async move { c.iter_async(self).await })
-            }
-
-            /// Incrementally iterate the keys space with options.
-            #[inline]
-            fn scan_options<RV: FromRedisValue>(&mut self, opts: ScanOptions) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
-                let mut c = cmd("SCAN");
-                c.cursor_arg(0).arg(opts);
-                Box::pin(async move { c.iter_async(self).await })
-            }
-
-            /// Incrementally iterate set elements for elements matching a pattern.
-            #[inline]
-            fn scan_match<P: ToRedisArgs, RV: FromRedisValue>(&mut self, pattern: P) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
-                let mut c = cmd("SCAN");
-                c.cursor_arg(0).arg("MATCH").arg(pattern);
-                Box::pin(async move { c.iter_async(self).await })
-            }
-
-            /// Incrementally iterate hash fields and associated values.
-            #[inline]
-            fn hscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
-                let mut c = cmd("HSCAN");
-                c.arg(key).cursor_arg(0);
-                Box::pin(async move {c.iter_async(self).await })
-            }
-
-            /// Incrementally iterate hash fields and associated values for
-            /// field names matching a pattern.
-            #[inline]
-            fn hscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&mut self, key: K, pattern: P) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
-                let mut c = cmd("HSCAN");
-                c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
-                Box::pin(async move {c.iter_async(self).await })
-            }
-
-            /// Incrementally iterate set elements.
-            #[inline]
-            fn sscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
-                let mut c = cmd("SSCAN");
-                c.arg(key).cursor_arg(0);
-                Box::pin(async move {c.iter_async(self).await })
-            }
-
-            /// Incrementally iterate set elements for elements matching a pattern.
-            #[inline]
-            fn sscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&mut self, key: K, pattern: P) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
-                let mut c = cmd("SSCAN");
-                c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
-                Box::pin(async move {c.iter_async(self).await })
-            }
-
-            /// Incrementally iterate sorted set elements.
-            #[inline]
-            fn zscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
-                let mut c = cmd("ZSCAN");
-                c.arg(key).cursor_arg(0);
-                Box::pin(async move {c.iter_async(self).await })
-            }
-
-            /// Incrementally iterate sorted set elements for elements matching a pattern.
-            #[inline]
-            fn zscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&mut self, key: K, pattern: P) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
-                let mut c = cmd("ZSCAN");
-                c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
-                Box::pin(async move {c.iter_async(self).await })
-            }
+            implement_iterators! {
+				|c: Cmd, this| Box::pin(async move { c.iter_async(this).await }),
+				crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>>
+			}
         }
 
         /// Implements common redis commands for pipelines.  Unlike the regular

--- a/redis/src/commands/macros.rs
+++ b/redis/src/commands/macros.rs
@@ -1,12 +1,12 @@
 // Generate implementation for function skeleton, we use this for `AsyncTypedCommands` because we want to be able to handle having a return type specified or unspecified with a fallback
 #[cfg(feature = "aio")]
 macro_rules! implement_command_async {
-	// If the return type is `GENERIC`, then we require the user to specify the return type
+	// If the return type is `Generic`, then we require the user to specify the return type
 	(
         $lifetime: lifetime
 		$(#[$attr:meta])+
 		fn $name:ident<$($tyargs:ident : $ty:ident),*>(
-			$($argname:ident: $argty:ty),*) $body:block GENERIC
+			$($argname:ident: $argty:ty),*) $body:block Generic
     ) => {
 		$(#[$attr])*
 		#[inline]
@@ -42,12 +42,12 @@ macro_rules! implement_command_async {
 }
 
 macro_rules! implement_command_sync {
-	// If the return type is `GENERIC`, then we require the user to specify the return type
+	// If the return type is `Generic`, then we require the user to specify the return type
 	(
         $lifetime: lifetime
 		$(#[$attr:meta])+
 		fn $name:ident<$($tyargs:ident : $ty:ident),*>(
-			$($argname:ident: $argty:ty),*) $body:block GENERIC
+			$($argname:ident: $argty:ty),*) $body:block Generic
     ) => {
 		$(#[$attr])*
 		#[inline]

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -140,17 +140,17 @@ implement_commands! {
     // most common operations
 
     /// Get the value of a key.  If key is a vec this becomes an `MGET`.
-    fn get<K: ToRedisArgs>(key: K) {
+    fn get<K: ToRedisArgs>(key: K) -> String {
         cmd(if key.num_of_args() <= 1 { "GET" } else { "MGET" }).arg(key)
     }
 
     /// Get values of keys
-    fn mget<K: ToRedisArgs>(key: K){
+    fn mget<K: ToRedisArgs>(key: K) -> Vec<String> {
         cmd("MGET").arg(key)
     }
 
     /// Gets all keys matching pattern
-    fn keys<K: ToRedisArgs>(key: K) {
+    fn keys<K: ToRedisArgs>(key: K) -> Vec<String> {
         cmd("KEYS").arg(key)
     }
 
@@ -2337,6 +2337,9 @@ impl<T> Commands for T where T: ConnectionLike {}
 
 #[cfg(feature = "aio")]
 impl<T> AsyncCommands for T where T: crate::aio::ConnectionLike + Send + Sync + Sized {}
+
+#[cfg(feature = "aio")]
+impl<T> AsyncTypedCommands for T where T: crate::aio::ConnectionLike + Send + Sync + Sized {}
 
 impl PubSubCommands for Connection {
     fn subscribe<C, F, U>(&mut self, channels: C, mut func: F) -> RedisResult<U>

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -141,26 +141,31 @@ implement_commands! {
     // most common operations
 
     /// Get the value of a key.  If key is a vec this becomes an `MGET`.
+    /// [Redis Docs](https://redis.io/commands/get/)
     fn get<K: ToRedisArgs>(key: K) -> Option<String> {
         cmd(if key.num_of_args() <= 1 { "GET" } else { "MGET" }).arg(key)
     }
 
     /// Get values of keys
+    /// [Redis Docs](https://redis.io/commands/MGET)
     fn mget<K: ToRedisArgs>(key: K) -> Vec<Option<String>> {
         cmd("MGET").arg(key)
     }
 
     /// Gets all keys matching pattern
+    /// [Redis Docs](https://redis.io/commands/KEYS)
     fn keys<K: ToRedisArgs>(key: K) -> Vec<String> {
         cmd("KEYS").arg(key)
     }
 
     /// Set the string value of a key.
+    /// [Redis Docs](https://redis.io/commands/SET)
     fn set<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> () {
         cmd("SET").arg(key).arg(value)
     }
 
     /// Set the string value of a key with options.
+    /// [Redis Docs](https://redis.io/commands/SET)
     fn set_options<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V, options: SetOptions) -> GENERIC {
         cmd("SET").arg(key).arg(value).arg(options)
     }
@@ -168,133 +173,157 @@ implement_commands! {
     /// Sets multiple keys to their values.
     #[allow(deprecated)]
     #[deprecated(since = "0.22.4", note = "Renamed to mset() to reflect Redis name")]
+    /// [Redis Docs](https://redis.io/commands/MSET)
     fn set_multiple<K: ToRedisArgs, V: ToRedisArgs>(items: &'a [(K, V)]) -> () {
         cmd("MSET").arg(items)
     }
 
     /// Sets multiple keys to their values.
+    /// [Redis Docs](https://redis.io/commands/MSET)
     fn mset<K: ToRedisArgs, V: ToRedisArgs>(items: &'a [(K, V)]) -> () {
         cmd("MSET").arg(items)
     }
 
     /// Set the value and expiration of a key.
+    /// [Redis Docs](https://redis.io/commands/SETEX)
     fn set_ex<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V, seconds: u64) -> () {
         cmd("SETEX").arg(key).arg(seconds).arg(value)
     }
 
     /// Set the value and expiration in milliseconds of a key.
+    /// [Redis Docs](https://redis.io/commands/PSETEX)
     fn pset_ex<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V, milliseconds: u64) -> () {
         cmd("PSETEX").arg(key).arg(milliseconds).arg(value)
     }
 
     /// Set the value of a key, only if the key does not exist
+    /// [Redis Docs](https://redis.io/commands/SETNX)
     fn set_nx<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> bool {
         cmd("SETNX").arg(key).arg(value)
     }
 
     /// Sets multiple keys to their values failing if at least one already exists.
+    /// [Redis Docs](https://redis.io/commands/MSETNX)
     fn mset_nx<K: ToRedisArgs, V: ToRedisArgs>(items: &'a [(K, V)]) -> bool {
         cmd("MSETNX").arg(items)
     }
 
     /// Set the string value of a key and return its old value.
+    /// [Redis Docs](https://redis.io/commands/GETSET)
     fn getset<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> Option<String> {
         cmd("GETSET").arg(key).arg(value)
     }
 
     /// Get a range of bytes/substring from the value of a key. Negative values provide an offset from the end of the value.
     /// Redis returns an empty string if the key doesn't exist, not Nil
+    /// [Redis Docs](https://redis.io/commands/GETRANGE)
     fn getrange<K: ToRedisArgs>(key: K, from: isize, to: isize) -> String {
         cmd("GETRANGE").arg(key).arg(from).arg(to)
     }
 
     /// Overwrite the part of the value stored in key at the specified offset.
+    /// [Redis Docs](https://redis.io/commands/SETRANGE)
     fn setrange<K: ToRedisArgs, V: ToRedisArgs>(key: K, offset: isize, value: V) -> usize {
         cmd("SETRANGE").arg(key).arg(offset).arg(value)
     }
 
     /// Delete one or more keys.
     /// Returns the number of keys deleted.
+    /// [Redis Docs](https://redis.io/commands/DEL)
     fn del<K: ToRedisArgs>(key: K) -> usize {
         cmd("DEL").arg(key)
     }
 
     /// Determine if a key exists.
+    /// [Redis Docs](https://redis.io/commands/EXISTS)
     fn exists<K: ToRedisArgs>(key: K) -> bool {
         cmd("EXISTS").arg(key)
     }
 
     /// Determine the type of key.
+    /// [Redis Docs](https://redis.io/commands/TYPE)
     fn key_type<K: ToRedisArgs>(key: K) -> crate::types::ValueType {
         cmd("TYPE").arg(key)
     }
 
     /// Set a key's time to live in seconds.
     /// Returns whether expiration was set.
+    /// [Redis Docs](https://redis.io/commands/EXPIRE)
     fn expire<K: ToRedisArgs>(key: K, seconds: i64) -> bool {
         cmd("EXPIRE").arg(key).arg(seconds)
     }
 
     /// Set the expiration for a key as a UNIX timestamp.
     /// Returns whether expiration was set.
+    /// [Redis Docs](https://redis.io/commands/EXPIREAT)
     fn expire_at<K: ToRedisArgs>(key: K, ts: i64) -> bool {
         cmd("EXPIREAT").arg(key).arg(ts)
     }
 
     /// Set a key's time to live in milliseconds.
     /// Returns whether expiration was set.
+    /// [Redis Docs](https://redis.io/commands/PEXPIRE)
     fn pexpire<K: ToRedisArgs>(key: K, ms: i64) -> bool {
         cmd("PEXPIRE").arg(key).arg(ms)
     }
 
     /// Set the expiration for a key as a UNIX timestamp in milliseconds.
     /// Returns whether expiration was set.
+    /// [Redis Docs](https://redis.io/commands/PEXPIREAT)
     fn pexpire_at<K: ToRedisArgs>(key: K, ts: i64) -> bool {
         cmd("PEXPIREAT").arg(key).arg(ts)
     }
 
     /// Get the absolute Unix expiration timestamp in seconds.
     /// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
+    /// [Redis Docs](https://redis.io/commands/EXPIRETIME)
     fn expire_time<K: ToRedisArgs>(key: K) -> IntegerReplyOrNoOp {
         cmd("EXPIRETIME").arg(key)
     }
 
     /// Get the absolute Unix expiration timestamp in milliseconds.
     /// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
+    /// [Redis Docs](https://redis.io/commands/PEXPIRETIME)
     fn pexpire_time<K: ToRedisArgs>(key: K) -> IntegerReplyOrNoOp {
         cmd("PEXPIRETIME").arg(key)
     }
 
     /// Remove the expiration from a key.
     /// Returns whether a timeout was removed.
+    /// [Redis Docs](https://redis.io/commands/PERSIST)
     fn persist<K: ToRedisArgs>(key: K) -> bool {
         cmd("PERSIST").arg(key)
     }
 
     /// Get the time to live for a key in seconds.
     /// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
+    /// [Redis Docs](https://redis.io/commands/TTL)
     fn ttl<K: ToRedisArgs>(key: K) -> IntegerReplyOrNoOp {
         cmd("TTL").arg(key)
     }
 
     /// Get the time to live for a key in milliseconds.
     /// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
-    fn pttl<K: ToRedisArgs>(key: K) -> isize {
+    /// [Redis Docs](https://redis.io/commands/PTTL)
+    fn pttl<K: ToRedisArgs>(key: K) -> IntegerReplyOrNoOp {
         cmd("PTTL").arg(key)
     }
 
     /// Get the value of a key and set expiration
+    /// [Redis Docs](https://redis.io/commands/GETEX)
     fn get_ex<K: ToRedisArgs>(key: K, expire_at: Expiry) -> Option<String> {
         cmd("GETEX").arg(key).arg(expire_at)
     }
 
     /// Get the value of a key and delete it
+    /// [Redis Docs](https://redis.io/commands/GETDEL)
     fn get_del<K: ToRedisArgs>(key: K) -> Option<String> {
         cmd("GETDEL").arg(key)
     }
 
     /// Rename a key.
     /// Errors if key does not exist.
+    /// [Redis Docs](https://redis.io/commands/RENAME)
     fn rename<K: ToRedisArgs, N: ToRedisArgs>(key: K, new_key: N) -> () {
         cmd("RENAME").arg(key).arg(new_key)
     }
@@ -302,12 +331,14 @@ implement_commands! {
     /// Rename a key, only if the new key does not exist.
     /// Errors if key does not exist.
     /// Returns whether the key was renamed, or false if the new key already exists.
+    /// [Redis Docs](https://redis.io/commands/RENAMENX)
     fn rename_nx<K: ToRedisArgs, N: ToRedisArgs>(key: K, new_key: N) -> bool {
         cmd("RENAMENX").arg(key).arg(new_key)
     }
 
     /// Unlink one or more keys. This is a non-blocking version of `DEL`.
     /// Returns number of keys unlinked.
+    /// [Redis Docs](https://redis.io/commands/UNLINK)
     fn unlink<K: ToRedisArgs>(key: K) -> usize {
         cmd("UNLINK").arg(key)
     }
@@ -316,6 +347,7 @@ implement_commands! {
 
     /// Append a value to a key.
     /// Returns length of string after operation.
+    /// [Redis Docs](https://redis.io/commands/APPEND)
     fn append<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> usize {
         cmd("APPEND").arg(key).arg(value)
     }
@@ -333,29 +365,34 @@ implement_commands! {
 
     /// Decrement the numeric value of a key by the given amount.
     /// If the key does not exist, it is set to 0 before performing the operation.
+    /// [Redis Docs](https://redis.io/commands/DECRBY)
     fn decr<K: ToRedisArgs, V: ToRedisArgs>(key: K, delta: V) -> isize {
         cmd("DECRBY").arg(key).arg(delta)
     }
 
     /// Sets or clears the bit at offset in the string value stored at key.
     /// Returns the original bit value stored at offset.
+    /// [Redis Docs](https://redis.io/commands/SETBIT)
     fn setbit<K: ToRedisArgs>(key: K, offset: usize, value: bool) -> u8 {
         cmd("SETBIT").arg(key).arg(offset).arg(i32::from(value))
     }
 
     /// Returns the bit value at offset in the string value stored at key.
+    /// [Redis Docs](https://redis.io/commands/GETBIT)
     fn getbit<K: ToRedisArgs>(key: K, offset: usize) -> u8 {
         cmd("GETBIT").arg(key).arg(offset)
     }
 
     /// Count set bits in a string.
     /// Returns 0 if key does not exist.
+    /// [Redis Docs](https://redis.io/commands/BITCOUNT)
     fn bitcount<K: ToRedisArgs>(key: K) -> usize {
         cmd("BITCOUNT").arg(key)
     }
 
     /// Count set bits in a string in a range.
     /// Returns 0 if key does not exist.
+    /// [Redis Docs](https://redis.io/commands/BITCOUNT)
     fn bitcount_range<K: ToRedisArgs>(key: K, start: usize, end: usize) -> usize {
         cmd("BITCOUNT").arg(key).arg(start).arg(end)
     }
@@ -363,6 +400,7 @@ implement_commands! {
     /// Perform a bitwise AND between multiple keys (containing string values)
     /// and store the result in the destination key.
     /// Returns size of destination string after operation.
+    /// [Redis Docs](https://redis.io/commands/BITOP").arg("AND)
     fn bit_and<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) -> usize {
         cmd("BITOP").arg("AND").arg(dstkey).arg(srckeys)
     }
@@ -370,6 +408,7 @@ implement_commands! {
     /// Perform a bitwise OR between multiple keys (containing string values)
     /// and store the result in the destination key.
     /// Returns size of destination string after operation.
+    /// [Redis Docs](https://redis.io/commands/BITOP").arg("OR)
     fn bit_or<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) -> usize {
         cmd("BITOP").arg("OR").arg(dstkey).arg(srckeys)
     }
@@ -377,6 +416,7 @@ implement_commands! {
     /// Perform a bitwise XOR between multiple keys (containing string values)
     /// and store the result in the destination key.
     /// Returns size of destination string after operation.
+    /// [Redis Docs](https://redis.io/commands/BITOP").arg("XOR)
     fn bit_xor<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) -> usize {
         cmd("BITOP").arg("XOR").arg(dstkey).arg(srckeys)
     }
@@ -384,12 +424,14 @@ implement_commands! {
     /// Perform a bitwise NOT of the key (containing string values)
     /// and store the result in the destination key.
     /// Returns size of destination string after operation.
+    /// [Redis Docs](https://redis.io/commands/BITOP").arg("NOT)
     fn bit_not<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckey: S) -> usize {
         cmd("BITOP").arg("NOT").arg(dstkey).arg(srckey)
     }
 
     /// Get the length of the value stored in a key.
     /// 0 if key does not exist.
+    /// [Redis Docs](https://redis.io/commands/STRLEN)
     fn strlen<K: ToRedisArgs>(key: K) -> usize {
         cmd("STRLEN").arg(key)
     }
@@ -402,39 +444,46 @@ implement_commands! {
     }
 
     /// Get the value of one or more fields of a given hash key, and optionally set their expiration
+    /// [Redis Docs](https://redis.io/commands/HGETEX").arg(key).arg(expire_at).arg("FIELDS)
     fn hget_ex<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F, expire_at: Expiry) -> Vec<String> {
         cmd("HGETEX").arg(key).arg(expire_at).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
 
     /// Deletes a single (or multiple) fields from a hash.
     /// Returns number of fields deleted.
+    /// [Redis Docs](https://redis.io/commands/HDEL)
     fn hdel<K: ToRedisArgs, F: ToRedisArgs>(key: K, field: F) -> usize {
         cmd("HDEL").arg(key).arg(field)
     }
 
     /// Get and delete the value of one or more fields of a given hash key
+    /// [Redis Docs](https://redis.io/commands/HGETDEL").arg(key).arg("FIELDS)
     fn hget_del<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F) -> Vec<Option<String>> {
         cmd("HGETDEL").arg(key).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
 
     /// Sets a single field in a hash.
     /// Returns number of fields added.
+    /// [Redis Docs](https://redis.io/commands/HSET)
     fn hset<K: ToRedisArgs, F: ToRedisArgs, V: ToRedisArgs>(key: K, field: F, value: V) -> usize {
         cmd("HSET").arg(key).arg(field).arg(value)
     }
 
     /// Set the value of one or more fields of a given hash key, and optionally set their expiration
+    /// [Redis Docs](https://redis.io/commands/HSETEX").arg(key).arg(hash_field_expiration_options).arg("FIELDS)
     fn hset_ex<K: ToRedisArgs, F: ToRedisArgs, V: ToRedisArgs>(key: K, hash_field_expiration_options: &'a HashFieldExpirationOptions, fields_values: &'a [(F, V)]) -> bool {
         cmd("HSETEX").arg(key).arg(hash_field_expiration_options).arg("FIELDS").arg(fields_values.len()).arg(fields_values)
     }
 
     /// Sets a single field in a hash if it does not exist.
     /// Returns whether the field was added.
+    /// [Redis Docs](https://redis.io/commands/HSETNX)
     fn hset_nx<K: ToRedisArgs, F: ToRedisArgs, V: ToRedisArgs>(key: K, field: F, value: V) -> bool {
         cmd("HSETNX").arg(key).arg(field).arg(value)
     }
 
     /// Sets multiple fields in a hash.
+    /// [Redis Docs](https://redis.io/commands/HMSET)
     fn hset_multiple<K: ToRedisArgs, F: ToRedisArgs, V: ToRedisArgs>(key: K, items: &'a [(F, V)]) -> () {
         cmd("HMSET").arg(key).arg(items)
     }
@@ -450,16 +499,19 @@ implement_commands! {
     }
 
     /// Checks if a field in a hash exists.
+    /// [Redis Docs](https://redis.io/commands/HEXISTS)
     fn hexists<K: ToRedisArgs, F: ToRedisArgs>(key: K, field: F) -> bool {
         cmd("HEXISTS").arg(key).arg(field)
     }
 
     /// Get one or more fields' TTL in seconds.
+    /// [Redis Docs](https://redis.io/commands/HTTL").arg(key).arg("FIELDS)
     fn httl<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F) -> IntegerReplyOrNoOp {
         cmd("HTTL").arg(key).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
 
     /// Get one or more fields' TTL in milliseconds.
+    /// [Redis Docs](https://redis.io/commands/HPTTL").arg(key).arg("FIELDS)
     fn hpttl<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F) -> IntegerReplyOrNoOp {
         cmd("HPTTL").arg(key).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
@@ -471,6 +523,7 @@ implement_commands! {
     /// 1 if the expiration time was updated.
     /// 2 if called with 0 seconds.
     /// Errors if provided key exists but is not a hash.
+    /// [Redis Docs](https://redis.io/commands/HEXPIRE").arg(key).arg(seconds).arg(opt).arg("FIELDS)
     fn hexpire<K: ToRedisArgs, F: ToRedisArgs>(key: K, seconds: i64, opt: ExpireOption, fields: F) -> Vec<IntegerReplyOrNoOp> {
        cmd("HEXPIRE").arg(key).arg(seconds).arg(opt).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
@@ -483,17 +536,20 @@ implement_commands! {
     /// 1 if the expiration time was updated.
     /// 2 if called with a time in the past.
     /// Errors if provided key exists but is not a hash.
+    /// [Redis Docs](https://redis.io/commands/HEXPIREAT").arg(key).arg(ts).arg(opt).arg("FIELDS)
     fn hexpire_at<K: ToRedisArgs, F: ToRedisArgs>(key: K, ts: i64, opt: ExpireOption, fields: F) -> Vec<IntegerReplyOrNoOp>{
         cmd("HEXPIREAT").arg(key).arg(ts).arg(opt).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
 
     /// Returns the absolute Unix expiration timestamp in seconds.
+    /// [Redis Docs](https://redis.io/commands/HEXPIRETIME").arg(key).arg("FIELDS)
     fn hexpire_time<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F) -> IntegerReplyOrNoOp {
         cmd("HEXPIRETIME").arg(key).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
 
     /// Remove the expiration from a key.
     /// Returns 1 if the expiration was removed.
+    /// [Redis Docs](https://redis.io/commands/HPERSIST").arg(key).arg("FIELDS)
     fn hpersist<K: ToRedisArgs, F :ToRedisArgs>(key: K, fields: F) -> IntegerReplyOrNoOp{
         cmd("HPERSIST").arg(key).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
@@ -505,6 +561,7 @@ implement_commands! {
     /// 1 if the expiration time was updated.
     /// 2 if called with 0 seconds.
     /// Errors if provided key exists but is not a hash.
+    /// [Redis Docs](https://redis.io/commands/HPEXPIRE").arg(key).arg(milliseconds).arg(opt).arg("FIELDS)
     fn hpexpire<K: ToRedisArgs, F: ToRedisArgs>(key: K, milliseconds: i64, opt: ExpireOption, fields: F) -> Vec<IntegerReplyOrNoOp>{
         cmd("HPEXPIRE").arg(key).arg(milliseconds).arg(opt).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
@@ -516,32 +573,38 @@ implement_commands! {
     /// 1 if the expiration time was updated.
     /// 2 if called with a time in the past.
     /// Errors if provided key exists but is not a hash.
+    /// [Redis Docs](https://redis.io/commands/HPEXPIREAT").arg(key).arg(ts).arg(opt).arg("FIELDS)
     fn hpexpire_at<K: ToRedisArgs, F: ToRedisArgs>(key: K, ts: i64,  opt: ExpireOption, fields: F) -> Vec<IntegerReplyOrNoOp>{
         cmd("HPEXPIREAT").arg(key).arg(ts).arg(opt).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
 
     /// Returns the absolute Unix expiration timestamp in seconds.
+    /// [Redis Docs](https://redis.io/commands/HPEXPIRETIME").arg(key).arg("FIELDS)
     fn hpexpire_time<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F) -> IntegerReplyOrNoOp {
         cmd("HPEXPIRETIME").arg(key).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
 
     /// Gets all the keys in a hash.
+    /// [Redis Docs](https://redis.io/commands/HKEYS)
     fn hkeys<K: ToRedisArgs>(key: K) -> Vec<String> {
         cmd("HKEYS").arg(key)
     }
 
     /// Gets all the values in a hash.
+    /// [Redis Docs](https://redis.io/commands/HVALS)
     fn hvals<K: ToRedisArgs>(key: K) -> Vec<String> {
         cmd("HVALS").arg(key)
     }
 
     /// Gets all the fields and values in a hash.
+    /// [Redis Docs](https://redis.io/commands/HGETALL)
     fn hgetall<K: ToRedisArgs>(key: K) -> std::collections::HashMap<String, String> {
         cmd("HGETALL").arg(key)
     }
 
     /// Gets the length of a hash.
     /// Returns 0 if key does not exist.
+    /// [Redis Docs](https://redis.io/commands/HLEN)
     fn hlen<K: ToRedisArgs>(key: K) -> usize {
         cmd("HLEN").arg(key)
     }
@@ -550,61 +613,72 @@ implement_commands! {
 
     /// Pop an element from a list, push it to another list
     /// and return it; or block until one is available
+    /// [Redis Docs](https://redis.io/commands/BLMOVE)
     fn blmove<S: ToRedisArgs, D: ToRedisArgs>(srckey: S, dstkey: D, src_dir: Direction, dst_dir: Direction, timeout: f64) -> Option<String> {
         cmd("BLMOVE").arg(srckey).arg(dstkey).arg(src_dir).arg(dst_dir).arg(timeout)
     }
 
     /// Pops `count` elements from the first non-empty list key from the list of
     /// provided key names; or blocks until one is available.
+    /// [Redis Docs](https://redis.io/commands/BLMPOP").arg(timeout).arg(numkeys).arg(key).arg(dir).arg("COUNT)
     fn blmpop<K: ToRedisArgs>(timeout: f64, numkeys: usize, key: K, dir: Direction, count: usize) -> Option<[String; 2]> {
         cmd("BLMPOP").arg(timeout).arg(numkeys).arg(key).arg(dir).arg("COUNT").arg(count)
     }
 
     /// Remove and get the first element in a list, or block until one is available.
+    /// [Redis Docs](https://redis.io/commands/BLPOP)
     fn blpop<K: ToRedisArgs>(key: K, timeout: f64) -> Option<[String; 2]> {
         cmd("BLPOP").arg(key).arg(timeout)
     }
 
     /// Remove and get the last element in a list, or block until one is available.
+    /// [Redis Docs](https://redis.io/commands/BRPOP)
     fn brpop<K: ToRedisArgs>(key: K, timeout: f64) -> Option<[String; 2]> {
         cmd("BRPOP").arg(key).arg(timeout)
     }
 
     /// Pop a value from a list, push it to another list and return it;
     /// or block until one is available.
+    /// [Redis Docs](https://redis.io/commands/BRPOPLPUSH)
     fn brpoplpush<S: ToRedisArgs, D: ToRedisArgs>(srckey: S, dstkey: D, timeout: f64) -> Option<String> {
         cmd("BRPOPLPUSH").arg(srckey).arg(dstkey).arg(timeout)
     }
 
     /// Get an element from a list by its index.
+    /// [Redis Docs](https://redis.io/commands/LINDEX)
     fn lindex<K: ToRedisArgs>(key: K, index: isize) -> Option<String> {
         cmd("LINDEX").arg(key).arg(index)
     }
 
     /// Insert an element before another element in a list.
+    /// [Redis Docs](https://redis.io/commands/LINSERT)
     fn linsert_before<K: ToRedisArgs, P: ToRedisArgs, V: ToRedisArgs>(
             key: K, pivot: P, value: V) -> isize {
         cmd("LINSERT").arg(key).arg("BEFORE").arg(pivot).arg(value)
     }
 
     /// Insert an element after another element in a list.
+    /// [Redis Docs](https://redis.io/commands/LINSERT)
     fn linsert_after<K: ToRedisArgs, P: ToRedisArgs, V: ToRedisArgs>(
             key: K, pivot: P, value: V) -> isize {
         cmd("LINSERT").arg(key).arg("AFTER").arg(pivot).arg(value)
     }
 
     /// Returns the length of the list stored at key.
+    /// [Redis Docs](https://redis.io/commands/LLEN)
     fn llen<K: ToRedisArgs>(key: K) -> usize {
         cmd("LLEN").arg(key)
     }
 
     /// Pop an element a list, push it to another list and return it
+    /// [Redis Docs](https://redis.io/commands/LMOVE)
     fn lmove<S: ToRedisArgs, D: ToRedisArgs>(srckey: S, dstkey: D, src_dir: Direction, dst_dir: Direction) -> String {
         cmd("LMOVE").arg(srckey).arg(dstkey).arg(src_dir).arg(dst_dir)
     }
 
     /// Pops `count` elements from the first non-empty list key from the list of
     /// provided key names.
+    /// [Redis Docs](https://redis.io/commands/LMPOP").arg(numkeys).arg(key).arg(dir).arg("COUNT)
     fn lmpop<K: ToRedisArgs>( numkeys: usize, key: K, dir: Direction, count: usize) -> Option<(String, Vec<String>)> {
         cmd("LMPOP").arg(numkeys).arg(key).arg(dir).arg("COUNT").arg(count)
     }
@@ -612,54 +686,64 @@ implement_commands! {
     /// Removes and returns the up to `count` first elements of the list stored at key.
     ///
     /// If `count` is not specified, then defaults to first element.
+    /// [Redis Docs](https://redis.io/commands/LPOP)
     fn lpop<K: ToRedisArgs>(key: K, count: Option<core::num::NonZeroUsize>) -> GENERIC {
         cmd("LPOP").arg(key).arg(count)
     }
 
     /// Returns the index of the first matching value of the list stored at key.
+    /// [Redis Docs](https://redis.io/commands/LPOS)
     fn lpos<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V, options: LposOptions) -> GENERIC {
         cmd("LPOS").arg(key).arg(value).arg(options)
     }
 
     /// Insert all the specified values at the head of the list stored at key.
+    /// [Redis Docs](https://redis.io/commands/LPUSH)
     fn lpush<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> usize {
         cmd("LPUSH").arg(key).arg(value)
     }
 
     /// Inserts a value at the head of the list stored at key, only if key
     /// already exists and holds a list.
+    /// [Redis Docs](https://redis.io/commands/LPUSHX)
     fn lpush_exists<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> usize {
         cmd("LPUSHX").arg(key).arg(value)
     }
 
     /// Returns the specified elements of the list stored at key.
+    /// [Redis Docs](https://redis.io/commands/LRANGE)
     fn lrange<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> Vec<String> {
         cmd("LRANGE").arg(key).arg(start).arg(stop)
     }
 
     /// Removes the first count occurrences of elements equal to value
     /// from the list stored at key.
+    /// [Redis Docs](https://redis.io/commands/LREM)
     fn lrem<K: ToRedisArgs, V: ToRedisArgs>(key: K, count: isize, value: V) -> usize {
         cmd("LREM").arg(key).arg(count).arg(value)
     }
 
     /// Trim an existing list so that it will contain only the specified
     /// range of elements specified.
+    /// [Redis Docs](https://redis.io/commands/LTRIM)
     fn ltrim<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> () {
         cmd("LTRIM").arg(key).arg(start).arg(stop)
     }
 
     /// Sets the list element at index to value
+    /// [Redis Docs](https://redis.io/commands/LSET)
     fn lset<K: ToRedisArgs, V: ToRedisArgs>(key: K, index: isize, value: V) -> () {
         cmd("LSET").arg(key).arg(index).arg(value)
     }
 
     /// Sends a ping to the server
+    /// [Redis Docs](https://redis.io/commands/PING)
     fn ping<>() -> String {
          &mut cmd("PING")
     }
 
     /// Sends a ping with a message to the server
+    /// [Redis Docs](https://redis.io/commands/PING)
     fn ping_message<K: ToRedisArgs>(message: K) -> String {
          cmd("PING").arg(message)
     }
@@ -667,22 +751,26 @@ implement_commands! {
     /// Removes and returns the up to `count` last elements of the list stored at key
     ///
     /// If `count` is not specified, then defaults to last element.
+    /// [Redis Docs](https://redis.io/commands/RPOP)
     fn rpop<K: ToRedisArgs>(key: K, count: Option<core::num::NonZeroUsize>) -> GENERIC {
         cmd("RPOP").arg(key).arg(count)
     }
 
     /// Pop a value from a list, push it to another list and return it.
+    /// [Redis Docs](https://redis.io/commands/RPOPLPUSH)
     fn rpoplpush<K: ToRedisArgs, D: ToRedisArgs>(key: K, dstkey: D) -> Option<String> {
         cmd("RPOPLPUSH").arg(key).arg(dstkey)
     }
 
     /// Insert all the specified values at the tail of the list stored at key.
+    /// [Redis Docs](https://redis.io/commands/RPUSH)
     fn rpush<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> usize {
         cmd("RPUSH").arg(key).arg(value)
     }
 
     /// Inserts value at the tail of the list stored at key, only if key
     /// already exists and holds a list.
+    /// [Redis Docs](https://redis.io/commands/RPUSHX)
     fn rpush_exists<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> usize {
         cmd("RPUSHX").arg(key).arg(value)
     }
@@ -690,81 +778,97 @@ implement_commands! {
     // set commands
 
     /// Add one or more members to a set.
+    /// [Redis Docs](https://redis.io/commands/SADD)
     fn sadd<K: ToRedisArgs, M: ToRedisArgs>(key: K, member: M) -> usize {
         cmd("SADD").arg(key).arg(member)
     }
 
     /// Get the number of members in a set.
+    /// [Redis Docs](https://redis.io/commands/SCARD)
     fn scard<K: ToRedisArgs>(key: K) -> usize {
         cmd("SCARD").arg(key)
     }
 
     /// Subtract multiple sets.
+    /// [Redis Docs](https://redis.io/commands/SDIFF)
     fn sdiff<K: ToRedisArgs>(keys: K) -> HashSet<String> {
         cmd("SDIFF").arg(keys)
     }
 
     /// Subtract multiple sets and store the resulting set in a key.
+    /// [Redis Docs](https://redis.io/commands/SDIFFSTORE)
     fn sdiffstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> usize {
         cmd("SDIFFSTORE").arg(dstkey).arg(keys)
     }
 
     /// Intersect multiple sets.
+    /// [Redis Docs](https://redis.io/commands/SINTER)
     fn sinter<K: ToRedisArgs>(keys: K) -> HashSet<String> {
         cmd("SINTER").arg(keys)
     }
 
     /// Intersect multiple sets and store the resulting set in a key.
+    /// [Redis Docs](https://redis.io/commands/SINTERSTORE)
     fn sinterstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> usize {
         cmd("SINTERSTORE").arg(dstkey).arg(keys)
     }
 
     /// Determine if a given value is a member of a set.
+    /// [Redis Docs](https://redis.io/commands/SISMEMBER)
     fn sismember<K: ToRedisArgs, M: ToRedisArgs>(key: K, member: M) -> bool {
         cmd("SISMEMBER").arg(key).arg(member)
     }
 
     /// Determine if given values are members of a set.
+    /// [Redis Docs](https://redis.io/commands/SMISMEMBER)
     fn smismember<K: ToRedisArgs, M: ToRedisArgs>(key: K, members: M) -> Vec<bool> {
         cmd("SMISMEMBER").arg(key).arg(members)
     }
 
     /// Get all the members in a set.
+    /// [Redis Docs](https://redis.io/commands/SMEMBERS)
     fn smembers<K: ToRedisArgs>(key: K) -> HashSet<String> {
         cmd("SMEMBERS").arg(key)
     }
 
     /// Move a member from one set to another.
+    /// [Redis Docs](https://redis.io/commands/SMOVE)
     fn smove<S: ToRedisArgs, D: ToRedisArgs, M: ToRedisArgs>(srckey: S, dstkey: D, member: M) -> bool {
         cmd("SMOVE").arg(srckey).arg(dstkey).arg(member)
     }
 
     /// Remove and return a random member from a set.
+    /// [Redis Docs](https://redis.io/commands/SPOP)
     fn spop<K: ToRedisArgs>(key: K) -> GENERIC {
         cmd("SPOP").arg(key)
     }
 
     /// Get one random member from a set.
+    /// [Redis Docs](https://redis.io/commands/SRANDMEMBER)
     fn srandmember<K: ToRedisArgs>(key: K) -> Option<String> {
         cmd("SRANDMEMBER").arg(key)
     }
 
     /// Get multiple random members from a set.
+    /// [Redis Docs](https://redis.io/commands/SRANDMEMBER)
     fn srandmember_multiple<K: ToRedisArgs>(key: K, count: usize) -> Vec<String> {
         cmd("SRANDMEMBER").arg(key).arg(count)
     }
 
     /// Remove one or more members from a set.
+    /// [Redis Docs](https://redis.io/commands/SREM)
     fn srem<K: ToRedisArgs, M: ToRedisArgs>(key: K, member: M) -> usize {
         cmd("SREM").arg(key).arg(member)
     }
 
     /// Add multiple sets.
+    /// [Redis Docs](https://redis.io/commands/SUNION)
     fn sunion<K: ToRedisArgs>(keys: K) -> HashSet<String> {
         cmd("SUNION").arg(keys)
     }
 
     /// Add multiple sets and store the resulting set in a key.
+    /// [Redis Docs](https://redis.io/commands/SUNIONSTORE)
     fn sunionstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> usize {
         cmd("SUNIONSTORE").arg(dstkey).arg(keys)
     }
@@ -772,45 +876,53 @@ implement_commands! {
     // sorted set commands
 
     /// Add one member to a sorted set, or update its score if it already exists.
+    /// [Redis Docs](https://redis.io/commands/ZADD)
     fn zadd<K: ToRedisArgs, S: ToRedisArgs, M: ToRedisArgs>(key: K, member: M, score: S) -> usize{
         cmd("ZADD").arg(key).arg(score).arg(member)
     }
 
     /// Add multiple members to a sorted set, or update its score if it already exists.
+    /// [Redis Docs](https://redis.io/commands/ZADD)
     fn zadd_multiple<K: ToRedisArgs, S: ToRedisArgs, M: ToRedisArgs>(key: K, items: &'a [(S, M)]) -> usize {
         cmd("ZADD").arg(key).arg(items)
     }
 
     /// Get the number of members in a sorted set.
+    /// [Redis Docs](https://redis.io/commands/ZCARD)
     fn zcard<K: ToRedisArgs>(key: K) -> usize {
         cmd("ZCARD").arg(key)
     }
 
     /// Count the members in a sorted set with scores within the given values.
+    /// [Redis Docs](https://redis.io/commands/ZCOUNT)
     fn zcount<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> usize {
         cmd("ZCOUNT").arg(key).arg(min).arg(max)
     }
 
     /// Increments the member in a sorted set at key by delta.
     /// If the member does not exist, it is added with delta as its score.
+    /// [Redis Docs](https://redis.io/commands/ZINCRBY)
     fn zincr<K: ToRedisArgs, M: ToRedisArgs, D: ToRedisArgs>(key: K, member: M, delta: D) -> f64 {
         cmd("ZINCRBY").arg(key).arg(delta).arg(member)
     }
 
     /// Intersect multiple sorted sets and store the resulting sorted set in
     /// a new key using SUM as aggregation function.
+    /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
     fn zinterstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> usize {
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys)
     }
 
     /// Intersect multiple sorted sets and store the resulting sorted set in
     /// a new key using MIN as aggregation function.
+    /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
     fn zinterstore_min<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> usize {
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MIN")
     }
 
     /// Intersect multiple sorted sets and store the resulting sorted set in
     /// a new key using MAX as aggregation function.
+    /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
     fn zinterstore_max<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> usize {
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MAX")
     }
@@ -818,6 +930,7 @@ implement_commands! {
     /// [`Commands::zinterstore`], but with the ability to specify a
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
+    /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
     fn zinterstore_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> usize {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> (&K, &W) {(key, weight)}).unzip();
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights)
@@ -826,6 +939,7 @@ implement_commands! {
     /// [`Commands::zinterstore_min`], but with the ability to specify a
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
+    /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
     fn zinterstore_min_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> usize {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> (&K, &W) {(key, weight)}).unzip();
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MIN").arg("WEIGHTS").arg(weights)
@@ -834,34 +948,40 @@ implement_commands! {
     /// [`Commands::zinterstore_max`], but with the ability to specify a
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
+    /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
     fn zinterstore_max_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> usize {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> (&K, &W) {(key, weight)}).unzip();
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MAX").arg("WEIGHTS").arg(weights)
     }
 
     /// Count the number of members in a sorted set between a given lexicographical range.
+    /// [Redis Docs](https://redis.io/commands/ZLEXCOUNT)
     fn zlexcount<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> usize {
         cmd("ZLEXCOUNT").arg(key).arg(min).arg(max)
     }
 
     /// Removes and returns the member with the highest score in a sorted set.
     /// Blocks until a member is available otherwise.
+    /// [Redis Docs](https://redis.io/commands/BZPOPMAX)
     fn bzpopmax<K: ToRedisArgs>(key: K, timeout: f64) -> Option<(String, String, f64)> {
         cmd("BZPOPMAX").arg(key).arg(timeout)
     }
 
     /// Removes and returns up to count members with the highest scores in a sorted set
+    /// [Redis Docs](https://redis.io/commands/ZPOPMAX)
     fn zpopmax<K: ToRedisArgs>(key: K, count: isize) -> Vec<String> {
         cmd("ZPOPMAX").arg(key).arg(count)
     }
 
     /// Removes and returns the member with the lowest score in a sorted set.
     /// Blocks until a member is available otherwise.
+    /// [Redis Docs](https://redis.io/commands/BZPOPMIN)
     fn bzpopmin<K: ToRedisArgs>(key: K, timeout: f64) -> Option<(String, String, f64)> {
         cmd("BZPOPMIN").arg(key).arg(timeout)
     }
 
     /// Removes and returns up to count members with the lowest scores in a sorted set
+    /// [Redis Docs](https://redis.io/commands/ZPOPMIN)
     fn zpopmin<K: ToRedisArgs>(key: K, count: isize) -> Vec<String> {
         cmd("ZPOPMIN").arg(key).arg(count)
     }
@@ -869,12 +989,14 @@ implement_commands! {
     /// Removes and returns up to count members with the highest scores,
     /// from the first non-empty sorted set in the provided list of key names.
     /// Blocks until a member is available otherwise.
+    /// [Redis Docs](https://redis.io/commands/BZMPOP)
     fn bzmpop_max<K: ToRedisArgs>(timeout: f64, keys: K, count: isize) -> Option<(String, Vec<(String, f64)>)> {
         cmd("BZMPOP").arg(timeout).arg(keys.num_of_args()).arg(keys).arg("MAX").arg("COUNT").arg(count)
     }
 
     /// Removes and returns up to count members with the highest scores,
     /// from the first non-empty sorted set in the provided list of key names.
+    /// [Redis Docs](https://redis.io/commands/ZMPOP)
     fn zmpop_max<K: ToRedisArgs>(keys: K, count: isize) -> Option<(String, Vec<(String, f64)>)> {
         cmd("ZMPOP").arg(keys.num_of_args()).arg(keys).arg("MAX").arg("COUNT").arg(count)
     }
@@ -882,77 +1004,91 @@ implement_commands! {
     /// Removes and returns up to count members with the lowest scores,
     /// from the first non-empty sorted set in the provided list of key names.
     /// Blocks until a member is available otherwise.
+    /// [Redis Docs](https://redis.io/commands/BZMPOP)
     fn bzmpop_min<K: ToRedisArgs>(timeout: f64, keys: K, count: isize) -> Option<(String, Vec<(String, f64)>)> {
         cmd("BZMPOP").arg(timeout).arg(keys.num_of_args()).arg(keys).arg("MIN").arg("COUNT").arg(count)
     }
 
     /// Removes and returns up to count members with the lowest scores,
     /// from the first non-empty sorted set in the provided list of key names.
+    /// [Redis Docs](https://redis.io/commands/ZMPOP)
     fn zmpop_min<K: ToRedisArgs>(keys: K, count: isize) -> Option<(String, Vec<(String, f64)>)> {
         cmd("ZMPOP").arg(keys.num_of_args()).arg(keys).arg("MIN").arg("COUNT").arg(count)
     }
 
     /// Return up to count random members in a sorted set (or 1 if `count == None`)
+    /// [Redis Docs](https://redis.io/commands/ZRANDMEMBER)
     fn zrandmember<K: ToRedisArgs>(key: K, count: Option<isize>) -> GENERIC {
         cmd("ZRANDMEMBER").arg(key).arg(count)
     }
 
     /// Return up to count random members in a sorted set with scores
+    /// [Redis Docs](https://redis.io/commands/ZRANDMEMBER)
     fn zrandmember_withscores<K: ToRedisArgs>(key: K, count: isize) -> GENERIC {
         cmd("ZRANDMEMBER").arg(key).arg(count).arg("WITHSCORES")
     }
 
     /// Return a range of members in a sorted set, by index
+    /// [Redis Docs](https://redis.io/commands/ZRANGE)
     fn zrange<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> Vec<String> {
         cmd("ZRANGE").arg(key).arg(start).arg(stop)
     }
 
     /// Return a range of members in a sorted set, by index with scores.
+    /// [Redis Docs](https://redis.io/commands/ZRANGE)
     fn zrange_withscores<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> Vec<String> {
         cmd("ZRANGE").arg(key).arg(start).arg(stop).arg("WITHSCORES")
     }
 
     /// Return a range of members in a sorted set, by lexicographical range.
+    /// [Redis Docs](https://redis.io/commands/ZRANGEBYLEX)
     fn zrangebylex<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> Vec<String> {
         cmd("ZRANGEBYLEX").arg(key).arg(min).arg(max)
     }
 
     /// Return a range of members in a sorted set, by lexicographical
     /// range with offset and limit.
+    /// [Redis Docs](https://redis.io/commands/ZRANGEBYLEX)
     fn zrangebylex_limit<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(
             key: K, min: M, max: MM, offset: isize, count: isize) -> Vec<String> {
         cmd("ZRANGEBYLEX").arg(key).arg(min).arg(max).arg("LIMIT").arg(offset).arg(count)
     }
 
     /// Return a range of members in a sorted set, by lexicographical range.
+    /// [Redis Docs](https://redis.io/commands/ZREVRANGEBYLEX)
     fn zrevrangebylex<K: ToRedisArgs, MM: ToRedisArgs, M: ToRedisArgs>(key: K, max: MM, min: M) -> Vec<String> {
         cmd("ZREVRANGEBYLEX").arg(key).arg(max).arg(min)
     }
 
     /// Return a range of members in a sorted set, by lexicographical
     /// range with offset and limit.
+    /// [Redis Docs](https://redis.io/commands/ZREVRANGEBYLEX)
     fn zrevrangebylex_limit<K: ToRedisArgs, MM: ToRedisArgs, M: ToRedisArgs>(
             key: K, max: MM, min: M, offset: isize, count: isize) -> Vec<String> {
         cmd("ZREVRANGEBYLEX").arg(key).arg(max).arg(min).arg("LIMIT").arg(offset).arg(count)
     }
 
     /// Return a range of members in a sorted set, by score.
+    /// [Redis Docs](https://redis.io/commands/ZRANGEBYSCORE)
     fn zrangebyscore<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> Vec<String> {
         cmd("ZRANGEBYSCORE").arg(key).arg(min).arg(max)
     }
 
     /// Return a range of members in a sorted set, by score with scores.
+    /// [Redis Docs](https://redis.io/commands/ZRANGEBYSCORE)
     fn zrangebyscore_withscores<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> Vec<String> {
         cmd("ZRANGEBYSCORE").arg(key).arg(min).arg(max).arg("WITHSCORES")
     }
 
     /// Return a range of members in a sorted set, by score with limit.
+    /// [Redis Docs](https://redis.io/commands/ZRANGEBYSCORE)
     fn zrangebyscore_limit<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>
             (key: K, min: M, max: MM, offset: isize, count: isize) -> Vec<String> {
         cmd("ZRANGEBYSCORE").arg(key).arg(min).arg(max).arg("LIMIT").arg(offset).arg(count)
     }
 
     /// Return a range of members in a sorted set, by score with limit with scores.
+    /// [Redis Docs](https://redis.io/commands/ZRANGEBYSCORE)
     fn zrangebyscore_limit_withscores<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>
             (key: K, min: M, max: MM, offset: isize, count: isize) -> Vec<String> {
         cmd("ZRANGEBYSCORE").arg(key).arg(min).arg(max).arg("WITHSCORES")
@@ -960,59 +1096,70 @@ implement_commands! {
     }
 
     /// Determine the index of a member in a sorted set.
+    /// [Redis Docs](https://redis.io/commands/ZRANK)
     fn zrank<K: ToRedisArgs, M: ToRedisArgs>(key: K, member: M) -> Option<usize> {
         cmd("ZRANK").arg(key).arg(member)
     }
 
     /// Remove one or more members from a sorted set.
+    /// [Redis Docs](https://redis.io/commands/ZREM)
     fn zrem<K: ToRedisArgs, M: ToRedisArgs>(key: K, members: M) -> usize {
         cmd("ZREM").arg(key).arg(members)
     }
 
     /// Remove all members in a sorted set between the given lexicographical range.
+    /// [Redis Docs](https://redis.io/commands/ZREMRANGEBYLEX)
     fn zrembylex<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> usize {
         cmd("ZREMRANGEBYLEX").arg(key).arg(min).arg(max)
     }
 
     /// Remove all members in a sorted set within the given indexes.
+    /// [Redis Docs](https://redis.io/commands/ZREMRANGEBYRANK)
     fn zremrangebyrank<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> usize {
         cmd("ZREMRANGEBYRANK").arg(key).arg(start).arg(stop)
     }
 
     /// Remove all members in a sorted set within the given scores.
+    /// [Redis Docs](https://redis.io/commands/ZREMRANGEBYSCORE)
     fn zrembyscore<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> usize {
         cmd("ZREMRANGEBYSCORE").arg(key).arg(min).arg(max)
     }
 
     /// Return a range of members in a sorted set, by index,
     /// ordered from high to low.
+    /// [Redis Docs](https://redis.io/commands/ZREVRANGE)
     fn zrevrange<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> Vec<String> {
         cmd("ZREVRANGE").arg(key).arg(start).arg(stop)
     }
 
     /// Return a range of members in a sorted set, by index, with scores
     /// ordered from high to low.
+    /// [Redis Docs](https://redis.io/commands/ZREVRANGE)
     fn zrevrange_withscores<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> Vec<String> {
         cmd("ZREVRANGE").arg(key).arg(start).arg(stop).arg("WITHSCORES")
     }
 
     /// Return a range of members in a sorted set, by score.
+    /// [Redis Docs](https://redis.io/commands/ZREVRANGEBYSCORE)
     fn zrevrangebyscore<K: ToRedisArgs, MM: ToRedisArgs, M: ToRedisArgs>(key: K, max: MM, min: M) -> Vec<String> {
         cmd("ZREVRANGEBYSCORE").arg(key).arg(max).arg(min)
     }
 
     /// Return a range of members in a sorted set, by score with scores.
+    /// [Redis Docs](https://redis.io/commands/ZREVRANGEBYSCORE)
     fn zrevrangebyscore_withscores<K: ToRedisArgs, MM: ToRedisArgs, M: ToRedisArgs>(key: K, max: MM, min: M) -> Vec<String> {
         cmd("ZREVRANGEBYSCORE").arg(key).arg(max).arg(min).arg("WITHSCORES")
     }
 
     /// Return a range of members in a sorted set, by score with limit.
+    /// [Redis Docs](https://redis.io/commands/ZREVRANGEBYSCORE)
     fn zrevrangebyscore_limit<K: ToRedisArgs, MM: ToRedisArgs, M: ToRedisArgs>
             (key: K, max: MM, min: M, offset: isize, count: isize) -> Vec<String> {
         cmd("ZREVRANGEBYSCORE").arg(key).arg(max).arg(min).arg("LIMIT").arg(offset).arg(count)
     }
 
     /// Return a range of members in a sorted set, by score with limit with scores.
+    /// [Redis Docs](https://redis.io/commands/ZREVRANGEBYSCORE)
     fn zrevrangebyscore_limit_withscores<K: ToRedisArgs, MM: ToRedisArgs, M: ToRedisArgs>
             (key: K, max: MM, min: M, offset: isize, count: isize) -> Vec<String> {
         cmd("ZREVRANGEBYSCORE").arg(key).arg(max).arg(min).arg("WITHSCORES")
@@ -1020,34 +1167,40 @@ implement_commands! {
     }
 
     /// Determine the index of a member in a sorted set, with scores ordered from high to low.
+    /// [Redis Docs](https://redis.io/commands/ZREVRANK)
     fn zrevrank<K: ToRedisArgs, M: ToRedisArgs>(key: K, member: M) -> Option<usize> {
         cmd("ZREVRANK").arg(key).arg(member)
     }
 
     /// Get the score associated with the given member in a sorted set.
+    /// [Redis Docs](https://redis.io/commands/ZSCORE)
     fn zscore<K: ToRedisArgs, M: ToRedisArgs>(key: K, member: M) -> Option<f64> {
         cmd("ZSCORE").arg(key).arg(member)
     }
 
     /// Get the scores associated with multiple members in a sorted set.
+    /// [Redis Docs](https://redis.io/commands/ZMSCORE)
     fn zscore_multiple<K: ToRedisArgs, M: ToRedisArgs>(key: K, members: &'a [M]) -> Option<Vec<f64>> {
         cmd("ZMSCORE").arg(key).arg(members)
     }
 
     /// Unions multiple sorted sets and store the resulting sorted set in
     /// a new key using SUM as aggregation function.
+    /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
     fn zunionstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> usize {
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys)
     }
 
     /// Unions multiple sorted sets and store the resulting sorted set in
     /// a new key using MIN as aggregation function.
+    /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
     fn zunionstore_min<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> usize {
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MIN")
     }
 
     /// Unions multiple sorted sets and store the resulting sorted set in
     /// a new key using MAX as aggregation function.
+    /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
     fn zunionstore_max<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> usize {
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MAX")
     }
@@ -1055,6 +1208,7 @@ implement_commands! {
     /// [`Commands::zunionstore`], but with the ability to specify a
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
+    /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
     fn zunionstore_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> usize {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> (&K, &W) {(key, weight)}).unzip();
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights)
@@ -1063,6 +1217,7 @@ implement_commands! {
     /// [`Commands::zunionstore_min`], but with the ability to specify a
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
+    /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
     fn zunionstore_min_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> usize {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> (&K, &W) {(key, weight)}).unzip();
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MIN").arg("WEIGHTS").arg(weights)
@@ -1071,6 +1226,7 @@ implement_commands! {
     /// [`Commands::zunionstore_max`], but with the ability to specify a
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
+    /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
     fn zunionstore_max_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> usize {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> (&K, &W) {(key, weight)}).unzip();
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MAX").arg("WEIGHTS").arg(weights)
@@ -1079,27 +1235,32 @@ implement_commands! {
     // hyperloglog commands
 
     /// Adds the specified elements to the specified HyperLogLog.
+    /// [Redis Docs](https://redis.io/commands/PFADD)
     fn pfadd<K: ToRedisArgs, E: ToRedisArgs>(key: K, element: E) -> bool {
         cmd("PFADD").arg(key).arg(element)
     }
 
     /// Return the approximated cardinality of the set(s) observed by the
     /// HyperLogLog at key(s).
+    /// [Redis Docs](https://redis.io/commands/PFCOUNT)
     fn pfcount<K: ToRedisArgs>(key: K) -> usize {
         cmd("PFCOUNT").arg(key)
     }
 
     /// Merge N different HyperLogLogs into a single one.
+    /// [Redis Docs](https://redis.io/commands/PFMERGE)
     fn pfmerge<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) -> () {
         cmd("PFMERGE").arg(dstkey).arg(srckeys)
     }
 
     /// Posts a message to the given channel.
+    /// [Redis Docs](https://redis.io/commands/PUBLISH)
     fn publish<K: ToRedisArgs, E: ToRedisArgs>(channel: K, message: E) -> usize {
         cmd("PUBLISH").arg(channel).arg(message)
     }
 
     /// Posts a message to the given sharded channel.
+    /// [Redis Docs](https://redis.io/commands/SPUBLISH)
     fn spublish<K: ToRedisArgs, E: ToRedisArgs>(channel: K, message: E) -> usize {
         cmd("SPUBLISH").arg(channel).arg(message)
     }
@@ -1107,36 +1268,43 @@ implement_commands! {
     // Object commands
 
     /// Returns the encoding of a key.
+    /// [Redis Docs](https://redis.io/commands/OBJECT)
     fn object_encoding<K: ToRedisArgs>(key: K) -> Option<String> {
         cmd("OBJECT").arg("ENCODING").arg(key)
     }
 
     /// Returns the time in seconds since the last access of a key.
+    /// [Redis Docs](https://redis.io/commands/OBJECT)
     fn object_idletime<K: ToRedisArgs>(key: K) -> Option<usize> {
         cmd("OBJECT").arg("IDLETIME").arg(key)
     }
 
     /// Returns the logarithmic access frequency counter of a key.
+    /// [Redis Docs](https://redis.io/commands/OBJECT)
     fn object_freq<K: ToRedisArgs>(key: K) -> Option<usize> {
         cmd("OBJECT").arg("FREQ").arg(key)
     }
 
     /// Returns the reference count of a key.
+    /// [Redis Docs](https://redis.io/commands/OBJECT)
     fn object_refcount<K: ToRedisArgs>(key: K) -> Option<usize> {
         cmd("OBJECT").arg("REFCOUNT").arg(key)
     }
 
     /// Returns the name of the current connection as set by CLIENT SETNAME.
+    /// [Redis Docs](https://redis.io/commands/CLIENT)
     fn client_getname<>() -> Option<String> {
         cmd("CLIENT").arg("GETNAME")
     }
 
     /// Returns the ID of the current connection.
+    /// [Redis Docs](https://redis.io/commands/CLIENT)
     fn client_id<>() -> usize {
         cmd("CLIENT").arg("ID")
     }
 
     /// Command assigns a name to the current connection.
+    /// [Redis Docs](https://redis.io/commands/CLIENT)
     fn client_setname<K: ToRedisArgs>(connection_name: K) -> () {
         cmd("CLIENT").arg("SETNAME").arg(connection_name)
     }
@@ -1148,6 +1316,7 @@ implement_commands! {
     /// replacing all the current ACL rules with the ones defined in the file.
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
+    /// [Redis Docs](https://redis.io/commands/ACL)
     fn acl_load<>() -> () {
         cmd("ACL").arg("LOAD")
     }
@@ -1157,6 +1326,7 @@ implement_commands! {
     /// ACLs from the server memory to the ACL file.
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
+    /// [Redis Docs](https://redis.io/commands/ACL)
     fn acl_save<>() -> () {
         cmd("ACL").arg("SAVE")
     }
@@ -1164,6 +1334,7 @@ implement_commands! {
     /// Shows the currently active ACL rules in the Redis server.
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
+    /// [Redis Docs](https://redis.io/commands/ACL)
     fn acl_list<>() -> Vec<String> {
         cmd("ACL").arg("LIST")
     }
@@ -1172,6 +1343,7 @@ implement_commands! {
     /// the Redis ACL system.
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
+    /// [Redis Docs](https://redis.io/commands/ACL)
     fn acl_users<>() -> Vec<String> {
         cmd("ACL").arg("USERS")
     }
@@ -1179,6 +1351,7 @@ implement_commands! {
     /// Returns all the rules defined for an existing ACL user.
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
+    /// [Redis Docs](https://redis.io/commands/ACL)
     fn acl_getuser<K: ToRedisArgs>(username: K) -> Option<HashMap<String, Value>> {
         cmd("ACL").arg("GETUSER").arg(username)
     }
@@ -1186,6 +1359,7 @@ implement_commands! {
     /// Creates an ACL user without any privilege.
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
+    /// [Redis Docs](https://redis.io/commands/ACL)
     fn acl_setuser<K: ToRedisArgs>(username: K) -> () {
         cmd("ACL").arg("SETUSER").arg(username)
     }
@@ -1194,6 +1368,7 @@ implement_commands! {
     /// an existing user.
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
+    /// [Redis Docs](https://redis.io/commands/ACL)
     fn acl_setuser_rules<K: ToRedisArgs>(username: K, rules: &'a [acl::Rule]) -> () {
         cmd("ACL").arg("SETUSER").arg(username).arg(rules)
     }
@@ -1202,6 +1377,7 @@ implement_commands! {
     /// that are authenticated with such users.
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
+    /// [Redis Docs](https://redis.io/commands/ACL)
     fn acl_deluser<K: ToRedisArgs>(usernames: &'a [K]) -> usize {
         cmd("ACL").arg("DELUSER").arg(usernames)
     }
@@ -1209,11 +1385,13 @@ implement_commands! {
     /// Simulate the execution of a given command by a given user.
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
+    /// [Redis Docs](https://redis.io/commands/ACL)
     fn acl_dryrun<K: ToRedisArgs, C: ToRedisArgs, A: ToRedisArgs>(username: K, command: C, args: A) -> String {
         cmd("ACL").arg("DRYRUN").arg(username).arg(command).arg(args)
     }
 
     /// Shows the available ACL categories.
+    /// [Redis Docs](https://redis.io/commands/ACL)
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_cat<>() -> Vec<String> {
@@ -1221,6 +1399,7 @@ implement_commands! {
     }
 
     /// Shows all the Redis commands in the specified category.
+    /// [Redis Docs](https://redis.io/commands/ACL)
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_cat_categoryname<K: ToRedisArgs>(categoryname: K) -> Vec<String> {
@@ -1228,6 +1407,7 @@ implement_commands! {
     }
 
     /// Generates a 256-bits password starting from /dev/urandom if available.
+    /// [Redis Docs](https://redis.io/commands/ACL)
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_genpass<>() -> String {
@@ -1235,6 +1415,7 @@ implement_commands! {
     }
 
     /// Generates a 1-to-1024-bits password starting from /dev/urandom if available.
+    /// [Redis Docs](https://redis.io/commands/ACL)
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_genpass_bits<>(bits: isize) -> String {
@@ -1242,6 +1423,7 @@ implement_commands! {
     }
 
     /// Returns the username the current connection is authenticated with.
+    /// [Redis Docs](https://redis.io/commands/ACL)
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_whoami<>() -> String {
@@ -1249,6 +1431,7 @@ implement_commands! {
     }
 
     /// Shows a list of recent ACL security events
+    /// [Redis Docs](https://redis.io/commands/ACL)
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_log<>(count: isize) -> Vec<String> {
@@ -1257,6 +1440,7 @@ implement_commands! {
     }
 
     /// Clears the ACL log.
+    /// [Redis Docs](https://redis.io/commands/ACL)
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_log_reset<>() -> () {
@@ -1264,6 +1448,7 @@ implement_commands! {
     }
 
     /// Returns a helpful text describing the different subcommands.
+    /// [Redis Docs](https://redis.io/commands/ACL)
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_help<>() -> String {
@@ -1307,6 +1492,7 @@ implement_commands! {
     ///     ])
     /// }
     /// ```
+    /// [Redis Docs](https://redis.io/commands/GEOADD)
     #[cfg(feature = "geospatial")]
     #[cfg_attr(docsrs, doc(cfg(feature = "geospatial")))]
     fn geo_add<K: ToRedisArgs, M: ToRedisArgs>(key: K, members: M) -> usize {
@@ -1344,6 +1530,7 @@ implement_commands! {
     ///     // x is Ok(None)
     /// }
     /// ```
+    /// [Redis Docs](https://redis.io/commands/GEODIST)
     #[cfg(feature = "geospatial")]
     #[cfg_attr(docsrs, doc(cfg(feature = "geospatial")))]
     fn geo_dist<K: ToRedisArgs, M1: ToRedisArgs, M2: ToRedisArgs>(
@@ -1378,6 +1565,7 @@ implement_commands! {
     ///     // x is vec!["sqc8b49rny0", "sqdtr74hyu0"]
     /// }
     /// ```
+    /// [Redis Docs](https://redis.io/commands/GEOHASH)
     #[cfg(feature = "geospatial")]
     #[cfg_attr(docsrs, doc(cfg(feature = "geospatial")))]
     fn geo_hash<K: ToRedisArgs, M: ToRedisArgs>(key: K, members: M) -> Vec<String> {
@@ -1407,6 +1595,7 @@ implement_commands! {
     ///     // x[0].latitude is 38.115556
     /// }
     /// ```
+    /// [Redis Docs](https://redis.io/commands/GEOPOS)
     #[cfg(feature = "geospatial")]
     #[cfg_attr(docsrs, doc(cfg(feature = "geospatial")))]
     fn geo_pos<K: ToRedisArgs, M: ToRedisArgs>(key: K, members: M) -> Vec<Option<(f64, f64)>> {
@@ -1432,6 +1621,7 @@ implement_commands! {
     ///     con.geo_radius("my_gis", 15.90, 37.21, 51.39, Unit::Kilometers, opts).unwrap()
     /// }
     /// ```
+    /// [Redis Docs](https://redis.io/commands/GEORADIUS)
     #[cfg(feature = "geospatial")]
     #[cfg_attr(docsrs, doc(cfg(feature = "geospatial")))]
     fn geo_radius<K: ToRedisArgs>(
@@ -1453,6 +1643,7 @@ implement_commands! {
 
     /// Retrieve members selected by distance with the center of `member`. The
     /// member itself is always contained in the results.
+    /// [Redis Docs](https://redis.io/commands/GEORADIUSBYMEMBER)
     #[cfg(feature = "geospatial")]
     #[cfg_attr(docsrs, doc(cfg(feature = "geospatial")))]
     fn geo_radius_by_member<K: ToRedisArgs, M: ToRedisArgs>(
@@ -1479,6 +1670,7 @@ implement_commands! {
     /// ```text
     /// XACK <key> <group> <id> <id> ... <id>
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XACK)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xack<K: ToRedisArgs, G: ToRedisArgs, I: ToRedisArgs>(
@@ -1497,6 +1689,7 @@ implement_commands! {
     /// ```text
     /// XADD key <ID or *> [field value] [field value] ...
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XADD)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xadd<K: ToRedisArgs, ID: ToRedisArgs, F: ToRedisArgs, V: ToRedisArgs>(
@@ -1514,6 +1707,7 @@ implement_commands! {
     /// ```text
     /// XADD key <ID or *> [rust BTreeMap] ...
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XADD)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xadd_map<K: ToRedisArgs, ID: ToRedisArgs, BTM: ToRedisArgs>(
@@ -1542,6 +1736,7 @@ implement_commands! {
     /// ```text
     /// XADD key [NOMKSTREAM] [<MAXLEN|MINID> [~|=] threshold [LIMIT count]] <* | ID> field value [field value] ...
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XADD)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xadd_options<
@@ -1565,6 +1760,7 @@ implement_commands! {
     /// ```text
     /// XADD key [MAXLEN [~|=] <count>] <ID or *> [field value] [field value] ...
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XADD)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xadd_maxlen<
@@ -1591,6 +1787,7 @@ implement_commands! {
     /// ```text
     /// XADD key [MAXLEN [~|=] <count>] <ID or *> [rust BTreeMap] ...
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XADD)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xadd_maxlen_map<K: ToRedisArgs, ID: ToRedisArgs, BTM: ToRedisArgs>(
@@ -1621,6 +1818,7 @@ implement_commands! {
     /// ```text
     /// XAUTOCLAIM <key> <group> <consumer> <min-idle-time> <start> [COUNT <count>] [JUSTID]
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XAUTOCLAIM)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xautoclaim_options<
@@ -1655,6 +1853,7 @@ implement_commands! {
     /// ```text
     /// XCLAIM <key> <group> <consumer> <min-idle-time> [<ID-1> <ID-2>]
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XCLAIM)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xclaim<K: ToRedisArgs, G: ToRedisArgs, C: ToRedisArgs, MIT: ToRedisArgs, ID: ToRedisArgs>(
@@ -1705,6 +1904,7 @@ implement_commands! {
     ///     [IDLE <milliseconds>] [TIME <mstime>] [RETRYCOUNT <count>]
     ///     [FORCE] [JUSTID] [LASTID <lastid>]
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XCLAIM)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xclaim_options<
@@ -1736,6 +1936,7 @@ implement_commands! {
     /// ```text
     /// XDEL <key> [<ID1> <ID2> ... <IDN>]
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XDEL)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xdel<K: ToRedisArgs, ID: ToRedisArgs>(
@@ -1754,6 +1955,7 @@ implement_commands! {
     /// ```text
     /// XGROUP CREATE <key> <groupname> <id or $>
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XGROUP)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xgroup_create<K: ToRedisArgs, G: ToRedisArgs, ID: ToRedisArgs>(
@@ -1777,6 +1979,7 @@ implement_commands! {
     /// ```text
     /// XGROUP CREATECONSUMER <key> <groupname> <consumername>
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XGROUP)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xgroup_createconsumer<K: ToRedisArgs, G: ToRedisArgs, C: ToRedisArgs>(
@@ -1797,6 +2000,7 @@ implement_commands! {
     /// ```text
     /// XGROUP CREATE <key> <groupname> <id or $> [MKSTREAM]
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XGROUP)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xgroup_create_mkstream<
@@ -1823,6 +2027,7 @@ implement_commands! {
     /// ```text
     /// XGROUP SETID <key> <groupname> <id or $>
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XGROUP)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xgroup_setid<K: ToRedisArgs, G: ToRedisArgs, ID: ToRedisArgs>(
@@ -1843,6 +2048,7 @@ implement_commands! {
     /// ```text
     /// XGROUP SETID <key> <groupname> <id or $>
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XGROUP)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xgroup_destroy<K: ToRedisArgs, G: ToRedisArgs>(
@@ -1858,6 +2064,7 @@ implement_commands! {
     /// ```text
     /// XGROUP DELCONSUMER <key> <groupname> <consumername>
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XGROUP)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xgroup_delconsumer<K: ToRedisArgs, G: ToRedisArgs, C: ToRedisArgs>(
@@ -1883,6 +2090,7 @@ implement_commands! {
     /// ```text
     /// XINFO CONSUMERS <key> <group>
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XINFO")
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xinfo_consumers<K: ToRedisArgs, G: ToRedisArgs>(
@@ -1905,8 +2113,10 @@ implement_commands! {
     /// ```text
     /// XINFO GROUPS <key>
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XINFO")
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
+    /// [Redis Docs](https://redis.io/commands/XINFO").arg("GROUPS)
     fn xinfo_groups<K: ToRedisArgs>(key: K) -> Vec<HashMap<String, Value>> {
         cmd("XINFO").arg("GROUPS").arg(key)
     }
@@ -1924,6 +2134,7 @@ implement_commands! {
     /// ```
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
+    /// [Redis Docs](https://redis.io/commands/XINFO").arg("STREAM)
     fn xinfo_stream<K: ToRedisArgs>(key: K) -> GENERIC {
         cmd("XINFO").arg("STREAM").arg(key)
     }
@@ -1935,6 +2146,7 @@ implement_commands! {
     /// ```
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
+    /// [Redis Docs](https://redis.io/commands/XLEN)
     fn xlen<K: ToRedisArgs>(key: K) -> usize {
         cmd("XLEN").arg(key)
     }
@@ -1954,6 +2166,7 @@ implement_commands! {
     /// ```text
     /// XPENDING <key> <group> [<start> <stop> <count> [<consumer>]]
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XPENDING)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xpending<K: ToRedisArgs, G: ToRedisArgs>(
@@ -1975,6 +2188,7 @@ implement_commands! {
     /// ```text
     /// XPENDING <key> <group> <start> <stop> <count>
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XPENDING)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xpending_count<
@@ -2009,6 +2223,7 @@ implement_commands! {
     /// ```text
     /// XPENDING <key> <group> <start> <stop> <count> <consumer>
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XPENDING)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xpending_consumer_count<
@@ -2046,6 +2261,7 @@ implement_commands! {
     /// ```text
     /// XRANGE key start end
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XRANGE)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xrange<K: ToRedisArgs, S: ToRedisArgs, E: ToRedisArgs>(
@@ -2065,6 +2281,7 @@ implement_commands! {
     /// ```
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
+    /// [Redis Docs](https://redis.io/commands/XRANGE").arg(key).arg("-").arg("+)
     fn xrange_all<K: ToRedisArgs>(key: K) -> GENERIC {
         cmd("XRANGE").arg(key).arg("-").arg("+")
     }
@@ -2075,6 +2292,7 @@ implement_commands! {
     /// ```text
     /// XRANGE key start end [COUNT <n>]
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XRANGE)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xrange_count<K: ToRedisArgs, S: ToRedisArgs, E: ToRedisArgs, C: ToRedisArgs>(
@@ -2100,6 +2318,7 @@ implement_commands! {
     /// ```text
     /// XREAD STREAMS key_1 key_2 ... key_N ID_1 ID_2 ... ID_N
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XREAD)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xread<K: ToRedisArgs, ID: ToRedisArgs>(
@@ -2145,6 +2364,7 @@ implement_commands! {
     ///     STREAMS key_1 key_2 ... key_N
     ///     ID_1 ID_2 ... ID_N
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XREAD)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xread_options<K: ToRedisArgs, ID: ToRedisArgs>(
@@ -2169,6 +2389,7 @@ implement_commands! {
     /// ```text
     /// XREVRANGE key end start
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XREVRANGE)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xrevrange<K: ToRedisArgs, E: ToRedisArgs, S: ToRedisArgs>(
@@ -2185,6 +2406,7 @@ implement_commands! {
     /// ```text
     /// XREVRANGE key + -
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XREVRANGE").arg(key).arg("+").arg("-)
     fn xrevrange_all<K: ToRedisArgs>(key: K) -> Vec<Value> {
         cmd("XREVRANGE").arg(key).arg("+").arg("-")
     }
@@ -2195,6 +2417,7 @@ implement_commands! {
     /// ```text
     /// XREVRANGE key end start [COUNT <n>]
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XREVRANGE)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xrevrange_count<K: ToRedisArgs, E: ToRedisArgs, S: ToRedisArgs, C: ToRedisArgs>(
@@ -2216,6 +2439,7 @@ implement_commands! {
     /// ```text
     /// XTRIM <key> MAXLEN [~|=] <count>  (Same as XADD MAXLEN option)
     /// ```
+    /// [Redis Docs](https://redis.io/commands/XTRIM)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xtrim<K: ToRedisArgs>(
@@ -2230,6 +2454,7 @@ implement_commands! {
      /// ```text
      /// XTRIM <key> <MAXLEN|MINID> [~|=] <threshold> [LIMIT <count>]  (Same as XADD MAXID|MINID options)
      /// ```
+     /// [Redis Docs](https://redis.io/commands/XTRIM)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xtrim_options<K: ToRedisArgs>(
@@ -2286,6 +2511,7 @@ assert_eq!(b, 5);
     /// ```text
     /// FLUSHALL
     /// ```
+    /// [Redis Docs](https://redis.io/commands/FLUSHALL)
     fn flushall<>() -> () {
         &mut cmd("FLUSHALL")
     }
@@ -2295,6 +2521,7 @@ assert_eq!(b, 5);
     /// ```text
     /// FLUSHALL [ASYNC|SYNC]
     /// ```
+    /// [Redis Docs](https://redis.io/commands/FLUSHALL)
     fn flushall_options<>(options: &'a FlushAllOptions) -> () {
         cmd("FLUSHALL").arg(options)
     }
@@ -2309,6 +2536,7 @@ assert_eq!(b, 5);
     /// ```text
     /// FLUSHDB
     /// ```
+    /// [Redis Docs](https://redis.io/commands/FLUSHDB)
     fn flushdb<>() -> () {
         &mut cmd("FLUSHDB")
     }
@@ -2318,6 +2546,7 @@ assert_eq!(b, 5);
     /// ```text
     /// FLUSHDB [ASYNC|SYNC]
     /// ```
+    /// [Redis Docs](https://redis.io/commands/FLUSHDB)
     fn flushdb_options<>(options: &'a FlushDbOptions) -> () {
         cmd("FLUSHDB").arg(options)
     }
@@ -2841,6 +3070,7 @@ impl ToRedisArgs for Expiry {
 }
 
 /// Creates HELLO command for RESP3 with RedisConnectionInfo
+/// [Redis Docs](https://redis.io/commands/HELLO)
 pub fn resp3_hello(connection_info: &RedisConnectionInfo) -> Cmd {
     let mut hello_cmd = cmd("HELLO");
     hello_cmd.arg("3");

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -145,7 +145,7 @@ implement_commands! {
     }
 
     /// Get values of keys
-    fn mget<K: ToRedisArgs>(key: K) -> Vec<String> {
+    fn mget<K: ToRedisArgs>(key: K) -> Vec<Option<String>> {
         cmd("MGET").arg(key)
     }
 

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -5,7 +5,7 @@ use crate::types::{
     ExistenceCheck, ExpireOption, Expiry, FieldExistenceCheck, FromRedisValue, IntegerReplyOrNoOp,
     NumericBehavior, RedisResult, RedisWrite, SetExpiry, ToRedisArgs,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 #[macro_use]
 mod macros;
@@ -1352,7 +1352,7 @@ implement_commands! {
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     /// [Redis Docs](https://redis.io/commands/ACL)
-    fn acl_getuser<K: ToRedisArgs>(username: K) -> Option<HashMap<String, Value>> {
+    fn acl_getuser<K: ToRedisArgs>(username: K) -> Option<std::collections::HashMap<String, Value>> {
         cmd("ACL").arg("GETUSER").arg(username)
     }
 
@@ -2096,7 +2096,7 @@ implement_commands! {
     fn xinfo_consumers<K: ToRedisArgs, G: ToRedisArgs>(
         key: K,
         group: G
-    ) -> Vec<HashMap<String, Value>> {
+    ) -> Vec<std::collections::HashMap<String, Value>> {
         cmd("XINFO")
             .arg("CONSUMERS")
             .arg(key)
@@ -2117,7 +2117,7 @@ implement_commands! {
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     /// [Redis Docs](https://redis.io/commands/XINFO").arg("GROUPS)
-    fn xinfo_groups<K: ToRedisArgs>(key: K) -> Vec<HashMap<String, Value>> {
+    fn xinfo_groups<K: ToRedisArgs>(key: K) -> Vec<std::collections::HashMap<String, Value>> {
         cmd("XINFO").arg("GROUPS").arg(key)
     }
 
@@ -2324,7 +2324,7 @@ implement_commands! {
     fn xread<K: ToRedisArgs, ID: ToRedisArgs>(
         keys: &'a [K],
         ids: &'a [ID]
-    ) -> Option<HashMap<String, Value>> {
+    ) -> Option<std::collections::HashMap<String, Value>> {
         cmd("XREAD").arg("STREAMS").arg(keys).arg(ids)
     }
 
@@ -2371,7 +2371,7 @@ implement_commands! {
         keys: &'a [K],
         ids: &'a [ID],
         options: &'a streams::StreamReadOptions
-    ) -> Option<HashMap<String, Value>> {
+    ) -> Option<std::collections::HashMap<String, Value>> {
         cmd(if options.read_only() {
             "XREAD"
         } else {

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -259,7 +259,7 @@ implement_commands! {
     }
 
     /// Get the absolute Unix expiration timestamp in milliseconds.
-	/// Returns `ExistsButNotRelevant` if key exists but has no expiration time,.
+	/// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
     fn pexpire_time<K: ToRedisArgs>(key: K) -> IntegerReplyOrNoOp {
         cmd("PEXPIRETIME").arg(key)
     }

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -253,13 +253,13 @@ implement_commands! {
     }
 
     /// Get the absolute Unix expiration timestamp in seconds.
-	/// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
+    /// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
     fn expire_time<K: ToRedisArgs>(key: K) -> IntegerReplyOrNoOp {
         cmd("EXPIRETIME").arg(key)
     }
 
     /// Get the absolute Unix expiration timestamp in milliseconds.
-	/// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
+    /// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
     fn pexpire_time<K: ToRedisArgs>(key: K) -> IntegerReplyOrNoOp {
         cmd("PEXPIRETIME").arg(key)
     }
@@ -271,13 +271,13 @@ implement_commands! {
     }
 
     /// Get the time to live for a key in seconds.
-	/// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
+    /// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
     fn ttl<K: ToRedisArgs>(key: K) -> IntegerReplyOrNoOp {
         cmd("TTL").arg(key)
     }
 
     /// Get the time to live for a key in milliseconds.
-	/// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
+    /// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
     fn pttl<K: ToRedisArgs>(key: K) -> isize {
         cmd("PTTL").arg(key)
     }

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -2395,6 +2395,8 @@ impl<T> Commands for T where T: ConnectionLike {}
 #[cfg(feature = "aio")]
 impl<T> AsyncCommands for T where T: crate::aio::ConnectionLike + Send + Sync + Sized {}
 
+impl<T> TypedCommands for T where T: ConnectionLike {}
+
 #[cfg(feature = "aio")]
 impl<T> AsyncTypedCommands for T where T: crate::aio::ConnectionLike + Send + Sync + Sized {}
 

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -140,7 +140,7 @@ implement_commands! {
     // most common operations
 
     /// Get the value of a key.  If key is a vec this becomes an `MGET`.
-    fn get<K: ToRedisArgs>(key: K) -> String {
+    fn get<K: ToRedisArgs>(key: K) -> Option<String> {
         cmd(if key.num_of_args() <= 1 { "GET" } else { "MGET" }).arg(key)
     }
 
@@ -212,7 +212,7 @@ implement_commands! {
     }
 
     /// Delete one or more keys.
-    fn del<K: ToRedisArgs>(key: K) {
+    fn del<K: ToRedisArgs>(key: K) -> usize {
         cmd("DEL").arg(key)
     }
 
@@ -222,7 +222,7 @@ implement_commands! {
     }
 
     /// Determine the type of a key.
-    fn key_type<K: ToRedisArgs>(key: K) {
+    fn key_type<K: ToRedisArgs>(key: K) -> crate::types::ValueType {
         cmd("TYPE").arg(key)
     }
 
@@ -305,7 +305,7 @@ implement_commands! {
 
     /// Increment the numeric value of a key by the given amount.  This
     /// issues a `INCRBY` or `INCRBYFLOAT` depending on the type.
-    fn incr<K: ToRedisArgs, V: ToRedisArgs>(key: K, delta: V) {
+    fn incr<K: ToRedisArgs, V: ToRedisArgs>(key: K, delta: V) -> isize {
         cmd(if delta.describe_numeric_behavior() == NumericBehavior::NumberIsFloat {
             "INCRBYFLOAT"
         } else {
@@ -575,7 +575,7 @@ implement_commands! {
     }
 
     /// Returns the specified elements of the list stored at key.
-    fn lrange<K: ToRedisArgs>(key: K, start: isize, stop: isize) {
+    fn lrange<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> Vec<String> {
         cmd("LRANGE").arg(key).arg(start).arg(stop)
     }
 

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -253,14 +253,14 @@ implement_commands! {
     }
 
     /// Get the absolute Unix expiration timestamp in seconds.
-    /// Returns -1 if key exists but has no expiration time, -2 if key does not exist.
-    fn expire_time<K: ToRedisArgs>(key: K) -> isize {
+	/// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
+    fn expire_time<K: ToRedisArgs>(key: K) -> IntegerReplyOrNoOp {
         cmd("EXPIRETIME").arg(key)
     }
 
     /// Get the absolute Unix expiration timestamp in milliseconds.
-    /// Returns -1 if key exists but has no expiration time, -2 if key does not exist.
-    fn pexpire_time<K: ToRedisArgs>(key: K) -> isize {
+	/// Returns `ExistsButNotRelevant` if key exists but has no expiration time,.
+    fn pexpire_time<K: ToRedisArgs>(key: K) -> IntegerReplyOrNoOp {
         cmd("PEXPIRETIME").arg(key)
     }
 
@@ -271,13 +271,13 @@ implement_commands! {
     }
 
     /// Get the time to live for a key in seconds.
-    /// Returns -1 if key exists but has no expiration time, -2 if key does not exist.
-    fn ttl<K: ToRedisArgs>(key: K) -> isize {
+	/// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
+    fn ttl<K: ToRedisArgs>(key: K) -> IntegerReplyOrNoOp {
         cmd("TTL").arg(key)
     }
 
     /// Get the time to live for a key in milliseconds.
-    /// Returns -1 if key exists but has no expiration time, -2 if key does not exist.
+	/// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
     fn pttl<K: ToRedisArgs>(key: K) -> isize {
         cmd("PTTL").arg(key)
     }

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -1,3 +1,5 @@
+#![allow(unused_parens)]
+
 use crate::cmd::{cmd, Cmd, Iter};
 use crate::connection::{Connection, ConnectionLike, Msg};
 use crate::pipeline::Pipeline;
@@ -136,37 +138,38 @@ pub(crate) fn is_readonly_cmd(cmd: &[u8]) -> bool {
     )
 }
 
+// Note - Brackets are needed around return types for purposes of macro branching.
 implement_commands! {
     'a
     // most common operations
 
-    /// Get the value of a key.  If key is a vec this becomes an `MGET`.
+    /// Get the value of a key.  If key is a vec this becomes an `MGET` (if using `TypedCommands`, you should specifically use `mget` to get the correct return type.
     /// [Redis Docs](https://redis.io/commands/get/)
-    fn get<K: ToRedisArgs>(key: K) -> Option<String> {
+    fn get<K: ToRedisArgs>(key: K) -> (Option<String>) {
         cmd(if key.num_of_args() <= 1 { "GET" } else { "MGET" }).arg(key)
     }
 
     /// Get values of keys
     /// [Redis Docs](https://redis.io/commands/MGET)
-    fn mget<K: ToRedisArgs>(key: K) -> Vec<Option<String>> {
+    fn mget<K: ToRedisArgs>(key: K) -> (Vec<Option<String>>) {
         cmd("MGET").arg(key)
     }
 
     /// Gets all keys matching pattern
     /// [Redis Docs](https://redis.io/commands/KEYS)
-    fn keys<K: ToRedisArgs>(key: K) -> Vec<String> {
+    fn keys<K: ToRedisArgs>(key: K) -> (Vec<String>) {
         cmd("KEYS").arg(key)
     }
 
     /// Set the string value of a key.
     /// [Redis Docs](https://redis.io/commands/SET)
-    fn set<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> () {
+    fn set<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> (()) {
         cmd("SET").arg(key).arg(value)
     }
 
     /// Set the string value of a key with options.
     /// [Redis Docs](https://redis.io/commands/SET)
-    fn set_options<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V, options: SetOptions) -> Generic {
+    fn set_options<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V, options: SetOptions) -> (Option<String>) {
         cmd("SET").arg(key).arg(value).arg(options)
     }
 
@@ -174,157 +177,157 @@ implement_commands! {
     #[allow(deprecated)]
     #[deprecated(since = "0.22.4", note = "Renamed to mset() to reflect Redis name")]
     /// [Redis Docs](https://redis.io/commands/MSET)
-    fn set_multiple<K: ToRedisArgs, V: ToRedisArgs>(items: &'a [(K, V)]) -> () {
+    fn set_multiple<K: ToRedisArgs, V: ToRedisArgs>(items: &'a [(K, V)]) -> (()) {
         cmd("MSET").arg(items)
     }
 
     /// Sets multiple keys to their values.
     /// [Redis Docs](https://redis.io/commands/MSET)
-    fn mset<K: ToRedisArgs, V: ToRedisArgs>(items: &'a [(K, V)]) -> () {
+    fn mset<K: ToRedisArgs, V: ToRedisArgs>(items: &'a [(K, V)]) -> (()) {
         cmd("MSET").arg(items)
     }
 
     /// Set the value and expiration of a key.
     /// [Redis Docs](https://redis.io/commands/SETEX)
-    fn set_ex<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V, seconds: u64) -> () {
+    fn set_ex<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V, seconds: u64) -> (()) {
         cmd("SETEX").arg(key).arg(seconds).arg(value)
     }
 
     /// Set the value and expiration in milliseconds of a key.
     /// [Redis Docs](https://redis.io/commands/PSETEX)
-    fn pset_ex<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V, milliseconds: u64) -> () {
+    fn pset_ex<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V, milliseconds: u64) -> (()) {
         cmd("PSETEX").arg(key).arg(milliseconds).arg(value)
     }
 
     /// Set the value of a key, only if the key does not exist
     /// [Redis Docs](https://redis.io/commands/SETNX)
-    fn set_nx<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> bool {
+    fn set_nx<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> (bool) {
         cmd("SETNX").arg(key).arg(value)
     }
 
     /// Sets multiple keys to their values failing if at least one already exists.
     /// [Redis Docs](https://redis.io/commands/MSETNX)
-    fn mset_nx<K: ToRedisArgs, V: ToRedisArgs>(items: &'a [(K, V)]) -> bool {
+    fn mset_nx<K: ToRedisArgs, V: ToRedisArgs>(items: &'a [(K, V)]) -> (bool) {
         cmd("MSETNX").arg(items)
     }
 
     /// Set the string value of a key and return its old value.
     /// [Redis Docs](https://redis.io/commands/GETSET)
-    fn getset<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> Option<String> {
+    fn getset<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> (Option<String>) {
         cmd("GETSET").arg(key).arg(value)
     }
 
     /// Get a range of bytes/substring from the value of a key. Negative values provide an offset from the end of the value.
     /// Redis returns an empty string if the key doesn't exist, not Nil
     /// [Redis Docs](https://redis.io/commands/GETRANGE)
-    fn getrange<K: ToRedisArgs>(key: K, from: isize, to: isize) -> String {
+    fn getrange<K: ToRedisArgs>(key: K, from: isize, to: isize) -> (String) {
         cmd("GETRANGE").arg(key).arg(from).arg(to)
     }
 
     /// Overwrite the part of the value stored in key at the specified offset.
     /// [Redis Docs](https://redis.io/commands/SETRANGE)
-    fn setrange<K: ToRedisArgs, V: ToRedisArgs>(key: K, offset: isize, value: V) -> usize {
+    fn setrange<K: ToRedisArgs, V: ToRedisArgs>(key: K, offset: isize, value: V) -> (usize) {
         cmd("SETRANGE").arg(key).arg(offset).arg(value)
     }
 
     /// Delete one or more keys.
     /// Returns the number of keys deleted.
     /// [Redis Docs](https://redis.io/commands/DEL)
-    fn del<K: ToRedisArgs>(key: K) -> usize {
+    fn del<K: ToRedisArgs>(key: K) -> (usize) {
         cmd("DEL").arg(key)
     }
 
     /// Determine if a key exists.
     /// [Redis Docs](https://redis.io/commands/EXISTS)
-    fn exists<K: ToRedisArgs>(key: K) -> bool {
+    fn exists<K: ToRedisArgs>(key: K) -> (bool) {
         cmd("EXISTS").arg(key)
     }
 
     /// Determine the type of key.
     /// [Redis Docs](https://redis.io/commands/TYPE)
-    fn key_type<K: ToRedisArgs>(key: K) -> crate::types::ValueType {
+    fn key_type<K: ToRedisArgs>(key: K) -> (crate::types::ValueType) {
         cmd("TYPE").arg(key)
     }
 
     /// Set a key's time to live in seconds.
     /// Returns whether expiration was set.
     /// [Redis Docs](https://redis.io/commands/EXPIRE)
-    fn expire<K: ToRedisArgs>(key: K, seconds: i64) -> bool {
+    fn expire<K: ToRedisArgs>(key: K, seconds: i64) -> (bool) {
         cmd("EXPIRE").arg(key).arg(seconds)
     }
 
     /// Set the expiration for a key as a UNIX timestamp.
     /// Returns whether expiration was set.
     /// [Redis Docs](https://redis.io/commands/EXPIREAT)
-    fn expire_at<K: ToRedisArgs>(key: K, ts: i64) -> bool {
+    fn expire_at<K: ToRedisArgs>(key: K, ts: i64) -> (bool) {
         cmd("EXPIREAT").arg(key).arg(ts)
     }
 
     /// Set a key's time to live in milliseconds.
     /// Returns whether expiration was set.
     /// [Redis Docs](https://redis.io/commands/PEXPIRE)
-    fn pexpire<K: ToRedisArgs>(key: K, ms: i64) -> bool {
+    fn pexpire<K: ToRedisArgs>(key: K, ms: i64) -> (bool) {
         cmd("PEXPIRE").arg(key).arg(ms)
     }
 
     /// Set the expiration for a key as a UNIX timestamp in milliseconds.
     /// Returns whether expiration was set.
     /// [Redis Docs](https://redis.io/commands/PEXPIREAT)
-    fn pexpire_at<K: ToRedisArgs>(key: K, ts: i64) -> bool {
+    fn pexpire_at<K: ToRedisArgs>(key: K, ts: i64) -> (bool) {
         cmd("PEXPIREAT").arg(key).arg(ts)
     }
 
     /// Get the absolute Unix expiration timestamp in seconds.
     /// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
     /// [Redis Docs](https://redis.io/commands/EXPIRETIME)
-    fn expire_time<K: ToRedisArgs>(key: K) -> IntegerReplyOrNoOp {
+    fn expire_time<K: ToRedisArgs>(key: K) -> (IntegerReplyOrNoOp) {
         cmd("EXPIRETIME").arg(key)
     }
 
     /// Get the absolute Unix expiration timestamp in milliseconds.
     /// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
     /// [Redis Docs](https://redis.io/commands/PEXPIRETIME)
-    fn pexpire_time<K: ToRedisArgs>(key: K) -> IntegerReplyOrNoOp {
+    fn pexpire_time<K: ToRedisArgs>(key: K) -> (IntegerReplyOrNoOp) {
         cmd("PEXPIRETIME").arg(key)
     }
 
     /// Remove the expiration from a key.
     /// Returns whether a timeout was removed.
     /// [Redis Docs](https://redis.io/commands/PERSIST)
-    fn persist<K: ToRedisArgs>(key: K) -> bool {
+    fn persist<K: ToRedisArgs>(key: K) -> (bool) {
         cmd("PERSIST").arg(key)
     }
 
     /// Get the time to live for a key in seconds.
     /// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
     /// [Redis Docs](https://redis.io/commands/TTL)
-    fn ttl<K: ToRedisArgs>(key: K) -> IntegerReplyOrNoOp {
+    fn ttl<K: ToRedisArgs>(key: K) -> (IntegerReplyOrNoOp) {
         cmd("TTL").arg(key)
     }
 
     /// Get the time to live for a key in milliseconds.
     /// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
     /// [Redis Docs](https://redis.io/commands/PTTL)
-    fn pttl<K: ToRedisArgs>(key: K) -> IntegerReplyOrNoOp {
+    fn pttl<K: ToRedisArgs>(key: K) -> (IntegerReplyOrNoOp) {
         cmd("PTTL").arg(key)
     }
 
     /// Get the value of a key and set expiration
     /// [Redis Docs](https://redis.io/commands/GETEX)
-    fn get_ex<K: ToRedisArgs>(key: K, expire_at: Expiry) -> Option<String> {
+    fn get_ex<K: ToRedisArgs>(key: K, expire_at: Expiry) -> (Option<String>) {
         cmd("GETEX").arg(key).arg(expire_at)
     }
 
     /// Get the value of a key and delete it
     /// [Redis Docs](https://redis.io/commands/GETDEL)
-    fn get_del<K: ToRedisArgs>(key: K) -> Option<String> {
+    fn get_del<K: ToRedisArgs>(key: K) -> (Option<String>) {
         cmd("GETDEL").arg(key)
     }
 
     /// Rename a key.
     /// Errors if key does not exist.
     /// [Redis Docs](https://redis.io/commands/RENAME)
-    fn rename<K: ToRedisArgs, N: ToRedisArgs>(key: K, new_key: N) -> () {
+    fn rename<K: ToRedisArgs, N: ToRedisArgs>(key: K, new_key: N) -> (()) {
         cmd("RENAME").arg(key).arg(new_key)
     }
 
@@ -332,14 +335,14 @@ implement_commands! {
     /// Errors if key does not exist.
     /// Returns whether the key was renamed, or false if the new key already exists.
     /// [Redis Docs](https://redis.io/commands/RENAMENX)
-    fn rename_nx<K: ToRedisArgs, N: ToRedisArgs>(key: K, new_key: N) -> bool {
+    fn rename_nx<K: ToRedisArgs, N: ToRedisArgs>(key: K, new_key: N) -> (bool) {
         cmd("RENAMENX").arg(key).arg(new_key)
     }
 
     /// Unlink one or more keys. This is a non-blocking version of `DEL`.
     /// Returns number of keys unlinked.
     /// [Redis Docs](https://redis.io/commands/UNLINK)
-    fn unlink<K: ToRedisArgs>(key: K) -> usize {
+    fn unlink<K: ToRedisArgs>(key: K) -> (usize) {
         cmd("UNLINK").arg(key)
     }
 
@@ -348,14 +351,14 @@ implement_commands! {
     /// Append a value to a key.
     /// Returns length of string after operation.
     /// [Redis Docs](https://redis.io/commands/APPEND)
-    fn append<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> usize {
+    fn append<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> (usize) {
         cmd("APPEND").arg(key).arg(value)
     }
 
     /// Increment the numeric value of a key by the given amount.  This
     /// issues a `INCRBY` or `INCRBYFLOAT` depending on the type.
     /// If the key does not exist, it is set to 0 before performing the operation.
-    fn incr<K: ToRedisArgs, V: ToRedisArgs>(key: K, delta: V) -> isize {
+    fn incr<K: ToRedisArgs, V: ToRedisArgs>(key: K, delta: V) -> (isize) {
         cmd(if delta.describe_numeric_behavior() == NumericBehavior::NumberIsFloat {
             "INCRBYFLOAT"
         } else {
@@ -366,34 +369,34 @@ implement_commands! {
     /// Decrement the numeric value of a key by the given amount.
     /// If the key does not exist, it is set to 0 before performing the operation.
     /// [Redis Docs](https://redis.io/commands/DECRBY)
-    fn decr<K: ToRedisArgs, V: ToRedisArgs>(key: K, delta: V) -> isize {
+    fn decr<K: ToRedisArgs, V: ToRedisArgs>(key: K, delta: V) -> (isize) {
         cmd("DECRBY").arg(key).arg(delta)
     }
 
     /// Sets or clears the bit at offset in the string value stored at key.
     /// Returns the original bit value stored at offset.
     /// [Redis Docs](https://redis.io/commands/SETBIT)
-    fn setbit<K: ToRedisArgs>(key: K, offset: usize, value: bool) -> u8 {
+    fn setbit<K: ToRedisArgs>(key: K, offset: usize, value: bool) -> (bool) {
         cmd("SETBIT").arg(key).arg(offset).arg(i32::from(value))
     }
 
     /// Returns the bit value at offset in the string value stored at key.
     /// [Redis Docs](https://redis.io/commands/GETBIT)
-    fn getbit<K: ToRedisArgs>(key: K, offset: usize) -> u8 {
+    fn getbit<K: ToRedisArgs>(key: K, offset: usize) -> (bool) {
         cmd("GETBIT").arg(key).arg(offset)
     }
 
     /// Count set bits in a string.
     /// Returns 0 if key does not exist.
     /// [Redis Docs](https://redis.io/commands/BITCOUNT)
-    fn bitcount<K: ToRedisArgs>(key: K) -> usize {
+    fn bitcount<K: ToRedisArgs>(key: K) -> (usize) {
         cmd("BITCOUNT").arg(key)
     }
 
     /// Count set bits in a string in a range.
     /// Returns 0 if key does not exist.
     /// [Redis Docs](https://redis.io/commands/BITCOUNT)
-    fn bitcount_range<K: ToRedisArgs>(key: K, start: usize, end: usize) -> usize {
+    fn bitcount_range<K: ToRedisArgs>(key: K, start: usize, end: usize) -> (usize) {
         cmd("BITCOUNT").arg(key).arg(start).arg(end)
     }
 
@@ -401,7 +404,7 @@ implement_commands! {
     /// and store the result in the destination key.
     /// Returns size of destination string after operation.
     /// [Redis Docs](https://redis.io/commands/BITOP").arg("AND)
-    fn bit_and<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) -> usize {
+    fn bit_and<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) -> (usize) {
         cmd("BITOP").arg("AND").arg(dstkey).arg(srckeys)
     }
 
@@ -409,7 +412,7 @@ implement_commands! {
     /// and store the result in the destination key.
     /// Returns size of destination string after operation.
     /// [Redis Docs](https://redis.io/commands/BITOP").arg("OR)
-    fn bit_or<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) -> usize {
+    fn bit_or<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) -> (usize) {
         cmd("BITOP").arg("OR").arg(dstkey).arg(srckeys)
     }
 
@@ -417,7 +420,7 @@ implement_commands! {
     /// and store the result in the destination key.
     /// Returns size of destination string after operation.
     /// [Redis Docs](https://redis.io/commands/BITOP").arg("XOR)
-    fn bit_xor<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) -> usize {
+    fn bit_xor<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) -> (usize) {
         cmd("BITOP").arg("XOR").arg(dstkey).arg(srckeys)
     }
 
@@ -425,72 +428,72 @@ implement_commands! {
     /// and store the result in the destination key.
     /// Returns size of destination string after operation.
     /// [Redis Docs](https://redis.io/commands/BITOP").arg("NOT)
-    fn bit_not<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckey: S) -> usize {
+    fn bit_not<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckey: S) -> (usize) {
         cmd("BITOP").arg("NOT").arg(dstkey).arg(srckey)
     }
 
     /// Get the length of the value stored in a key.
     /// 0 if key does not exist.
     /// [Redis Docs](https://redis.io/commands/STRLEN)
-    fn strlen<K: ToRedisArgs>(key: K) -> usize {
+    fn strlen<K: ToRedisArgs>(key: K) -> (usize) {
         cmd("STRLEN").arg(key)
     }
 
     // hash operations
 
     /// Gets a single (or multiple) fields from a hash.
-    fn hget<K: ToRedisArgs, F: ToRedisArgs>(key: K, field: F) -> Option<String> {
+    fn hget<K: ToRedisArgs, F: ToRedisArgs>(key: K, field: F) -> (Option<String>) {
         cmd(if field.num_of_args() <= 1 { "HGET" } else { "HMGET" }).arg(key).arg(field)
     }
 
     /// Get the value of one or more fields of a given hash key, and optionally set their expiration
     /// [Redis Docs](https://redis.io/commands/HGETEX").arg(key).arg(expire_at).arg("FIELDS)
-    fn hget_ex<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F, expire_at: Expiry) -> Vec<String> {
+    fn hget_ex<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F, expire_at: Expiry) -> (Vec<String>) {
         cmd("HGETEX").arg(key).arg(expire_at).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
 
     /// Deletes a single (or multiple) fields from a hash.
     /// Returns number of fields deleted.
     /// [Redis Docs](https://redis.io/commands/HDEL)
-    fn hdel<K: ToRedisArgs, F: ToRedisArgs>(key: K, field: F) -> usize {
+    fn hdel<K: ToRedisArgs, F: ToRedisArgs>(key: K, field: F) -> (usize) {
         cmd("HDEL").arg(key).arg(field)
     }
 
     /// Get and delete the value of one or more fields of a given hash key
     /// [Redis Docs](https://redis.io/commands/HGETDEL").arg(key).arg("FIELDS)
-    fn hget_del<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F) -> Vec<Option<String>> {
+    fn hget_del<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F) -> (Vec<Option<String>>) {
         cmd("HGETDEL").arg(key).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
 
     /// Sets a single field in a hash.
     /// Returns number of fields added.
     /// [Redis Docs](https://redis.io/commands/HSET)
-    fn hset<K: ToRedisArgs, F: ToRedisArgs, V: ToRedisArgs>(key: K, field: F, value: V) -> usize {
+    fn hset<K: ToRedisArgs, F: ToRedisArgs, V: ToRedisArgs>(key: K, field: F, value: V) -> (usize) {
         cmd("HSET").arg(key).arg(field).arg(value)
     }
 
     /// Set the value of one or more fields of a given hash key, and optionally set their expiration
     /// [Redis Docs](https://redis.io/commands/HSETEX").arg(key).arg(hash_field_expiration_options).arg("FIELDS)
-    fn hset_ex<K: ToRedisArgs, F: ToRedisArgs, V: ToRedisArgs>(key: K, hash_field_expiration_options: &'a HashFieldExpirationOptions, fields_values: &'a [(F, V)]) -> bool {
+    fn hset_ex<K: ToRedisArgs, F: ToRedisArgs, V: ToRedisArgs>(key: K, hash_field_expiration_options: &'a HashFieldExpirationOptions, fields_values: &'a [(F, V)]) -> (bool) {
         cmd("HSETEX").arg(key).arg(hash_field_expiration_options).arg("FIELDS").arg(fields_values.len()).arg(fields_values)
     }
 
     /// Sets a single field in a hash if it does not exist.
     /// Returns whether the field was added.
     /// [Redis Docs](https://redis.io/commands/HSETNX)
-    fn hset_nx<K: ToRedisArgs, F: ToRedisArgs, V: ToRedisArgs>(key: K, field: F, value: V) -> bool {
+    fn hset_nx<K: ToRedisArgs, F: ToRedisArgs, V: ToRedisArgs>(key: K, field: F, value: V) -> (bool) {
         cmd("HSETNX").arg(key).arg(field).arg(value)
     }
 
     /// Sets multiple fields in a hash.
     /// [Redis Docs](https://redis.io/commands/HMSET)
-    fn hset_multiple<K: ToRedisArgs, F: ToRedisArgs, V: ToRedisArgs>(key: K, items: &'a [(F, V)]) -> () {
+    fn hset_multiple<K: ToRedisArgs, F: ToRedisArgs, V: ToRedisArgs>(key: K, items: &'a [(F, V)]) -> (()) {
         cmd("HMSET").arg(key).arg(items)
     }
 
     /// Increments a value.
     /// Returns the new value of the field after incrementation.
-    fn hincr<K: ToRedisArgs, F: ToRedisArgs, D: ToRedisArgs>(key: K, field: F, delta: D) -> f64 {
+    fn hincr<K: ToRedisArgs, F: ToRedisArgs, D: ToRedisArgs>(key: K, field: F, delta: D) -> (f64) {
         cmd(if delta.describe_numeric_behavior() == NumericBehavior::NumberIsFloat {
             "HINCRBYFLOAT"
         } else {
@@ -500,19 +503,19 @@ implement_commands! {
 
     /// Checks if a field in a hash exists.
     /// [Redis Docs](https://redis.io/commands/HEXISTS)
-    fn hexists<K: ToRedisArgs, F: ToRedisArgs>(key: K, field: F) -> bool {
+    fn hexists<K: ToRedisArgs, F: ToRedisArgs>(key: K, field: F) -> (bool) {
         cmd("HEXISTS").arg(key).arg(field)
     }
 
     /// Get one or more fields' TTL in seconds.
     /// [Redis Docs](https://redis.io/commands/HTTL").arg(key).arg("FIELDS)
-    fn httl<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F) -> IntegerReplyOrNoOp {
+    fn httl<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F) -> (Vec<IntegerReplyOrNoOp>) {
         cmd("HTTL").arg(key).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
 
     /// Get one or more fields' TTL in milliseconds.
     /// [Redis Docs](https://redis.io/commands/HPTTL").arg(key).arg("FIELDS)
-    fn hpttl<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F) -> IntegerReplyOrNoOp {
+    fn hpttl<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F) -> (Vec<IntegerReplyOrNoOp>) {
         cmd("HPTTL").arg(key).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
 
@@ -524,7 +527,7 @@ implement_commands! {
     /// 2 if called with 0 seconds.
     /// Errors if provided key exists but is not a hash.
     /// [Redis Docs](https://redis.io/commands/HEXPIRE").arg(key).arg(seconds).arg(opt).arg("FIELDS)
-    fn hexpire<K: ToRedisArgs, F: ToRedisArgs>(key: K, seconds: i64, opt: ExpireOption, fields: F) -> Vec<IntegerReplyOrNoOp> {
+    fn hexpire<K: ToRedisArgs, F: ToRedisArgs>(key: K, seconds: i64, opt: ExpireOption, fields: F) -> (Vec<IntegerReplyOrNoOp>) {
        cmd("HEXPIRE").arg(key).arg(seconds).arg(opt).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
 
@@ -537,20 +540,20 @@ implement_commands! {
     /// 2 if called with a time in the past.
     /// Errors if provided key exists but is not a hash.
     /// [Redis Docs](https://redis.io/commands/HEXPIREAT").arg(key).arg(ts).arg(opt).arg("FIELDS)
-    fn hexpire_at<K: ToRedisArgs, F: ToRedisArgs>(key: K, ts: i64, opt: ExpireOption, fields: F) -> Vec<IntegerReplyOrNoOp>{
+    fn hexpire_at<K: ToRedisArgs, F: ToRedisArgs>(key: K, ts: i64, opt: ExpireOption, fields: F) -> (Vec<IntegerReplyOrNoOp>) {
         cmd("HEXPIREAT").arg(key).arg(ts).arg(opt).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
 
     /// Returns the absolute Unix expiration timestamp in seconds.
     /// [Redis Docs](https://redis.io/commands/HEXPIRETIME").arg(key).arg("FIELDS)
-    fn hexpire_time<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F) -> IntegerReplyOrNoOp {
+    fn hexpire_time<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F) -> (Vec<IntegerReplyOrNoOp>) {
         cmd("HEXPIRETIME").arg(key).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
 
     /// Remove the expiration from a key.
     /// Returns 1 if the expiration was removed.
     /// [Redis Docs](https://redis.io/commands/HPERSIST").arg(key).arg("FIELDS)
-    fn hpersist<K: ToRedisArgs, F :ToRedisArgs>(key: K, fields: F) -> IntegerReplyOrNoOp{
+    fn hpersist<K: ToRedisArgs, F :ToRedisArgs>(key: K, fields: F) -> (Vec<IntegerReplyOrNoOp>) {
         cmd("HPERSIST").arg(key).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
 
@@ -562,7 +565,7 @@ implement_commands! {
     /// 2 if called with 0 seconds.
     /// Errors if provided key exists but is not a hash.
     /// [Redis Docs](https://redis.io/commands/HPEXPIRE").arg(key).arg(milliseconds).arg(opt).arg("FIELDS)
-    fn hpexpire<K: ToRedisArgs, F: ToRedisArgs>(key: K, milliseconds: i64, opt: ExpireOption, fields: F) -> Vec<IntegerReplyOrNoOp>{
+    fn hpexpire<K: ToRedisArgs, F: ToRedisArgs>(key: K, milliseconds: i64, opt: ExpireOption, fields: F) -> (Vec<IntegerReplyOrNoOp>) {
         cmd("HPEXPIRE").arg(key).arg(milliseconds).arg(opt).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
 
@@ -574,38 +577,38 @@ implement_commands! {
     /// 2 if called with a time in the past.
     /// Errors if provided key exists but is not a hash.
     /// [Redis Docs](https://redis.io/commands/HPEXPIREAT").arg(key).arg(ts).arg(opt).arg("FIELDS)
-    fn hpexpire_at<K: ToRedisArgs, F: ToRedisArgs>(key: K, ts: i64,  opt: ExpireOption, fields: F) -> Vec<IntegerReplyOrNoOp>{
+    fn hpexpire_at<K: ToRedisArgs, F: ToRedisArgs>(key: K, ts: i64,  opt: ExpireOption, fields: F) -> (Vec<IntegerReplyOrNoOp>) {
         cmd("HPEXPIREAT").arg(key).arg(ts).arg(opt).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
 
     /// Returns the absolute Unix expiration timestamp in seconds.
     /// [Redis Docs](https://redis.io/commands/HPEXPIRETIME").arg(key).arg("FIELDS)
-    fn hpexpire_time<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F) -> IntegerReplyOrNoOp {
+    fn hpexpire_time<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F) -> (Vec<IntegerReplyOrNoOp>) {
         cmd("HPEXPIRETIME").arg(key).arg("FIELDS").arg(fields.num_of_args()).arg(fields)
     }
 
     /// Gets all the keys in a hash.
     /// [Redis Docs](https://redis.io/commands/HKEYS)
-    fn hkeys<K: ToRedisArgs>(key: K) -> Vec<String> {
+    fn hkeys<K: ToRedisArgs>(key: K) -> (Vec<String>) {
         cmd("HKEYS").arg(key)
     }
 
     /// Gets all the values in a hash.
     /// [Redis Docs](https://redis.io/commands/HVALS)
-    fn hvals<K: ToRedisArgs>(key: K) -> Vec<String> {
+    fn hvals<K: ToRedisArgs>(key: K) -> (Vec<String>) {
         cmd("HVALS").arg(key)
     }
 
     /// Gets all the fields and values in a hash.
     /// [Redis Docs](https://redis.io/commands/HGETALL)
-    fn hgetall<K: ToRedisArgs>(key: K) -> std::collections::HashMap<String, String> {
+    fn hgetall<K: ToRedisArgs>(key: K) -> (std::collections::HashMap<String, String>) {
         cmd("HGETALL").arg(key)
     }
 
     /// Gets the length of a hash.
     /// Returns 0 if key does not exist.
     /// [Redis Docs](https://redis.io/commands/HLEN)
-    fn hlen<K: ToRedisArgs>(key: K) -> usize {
+    fn hlen<K: ToRedisArgs>(key: K) -> (usize) {
         cmd("HLEN").arg(key)
     }
 
@@ -614,72 +617,72 @@ implement_commands! {
     /// Pop an element from a list, push it to another list
     /// and return it; or block until one is available
     /// [Redis Docs](https://redis.io/commands/BLMOVE)
-    fn blmove<S: ToRedisArgs, D: ToRedisArgs>(srckey: S, dstkey: D, src_dir: Direction, dst_dir: Direction, timeout: f64) -> Option<String> {
+    fn blmove<S: ToRedisArgs, D: ToRedisArgs>(srckey: S, dstkey: D, src_dir: Direction, dst_dir: Direction, timeout: f64) -> (Option<String>) {
         cmd("BLMOVE").arg(srckey).arg(dstkey).arg(src_dir).arg(dst_dir).arg(timeout)
     }
 
     /// Pops `count` elements from the first non-empty list key from the list of
     /// provided key names; or blocks until one is available.
     /// [Redis Docs](https://redis.io/commands/BLMPOP").arg(timeout).arg(numkeys).arg(key).arg(dir).arg("COUNT)
-    fn blmpop<K: ToRedisArgs>(timeout: f64, numkeys: usize, key: K, dir: Direction, count: usize) -> Option<[String; 2]> {
+    fn blmpop<K: ToRedisArgs>(timeout: f64, numkeys: usize, key: K, dir: Direction, count: usize) -> (Option<[String; 2]>) {
         cmd("BLMPOP").arg(timeout).arg(numkeys).arg(key).arg(dir).arg("COUNT").arg(count)
     }
 
     /// Remove and get the first element in a list, or block until one is available.
     /// [Redis Docs](https://redis.io/commands/BLPOP)
-    fn blpop<K: ToRedisArgs>(key: K, timeout: f64) -> Option<[String; 2]> {
+    fn blpop<K: ToRedisArgs>(key: K, timeout: f64) -> (Option<[String; 2]>) {
         cmd("BLPOP").arg(key).arg(timeout)
     }
 
     /// Remove and get the last element in a list, or block until one is available.
     /// [Redis Docs](https://redis.io/commands/BRPOP)
-    fn brpop<K: ToRedisArgs>(key: K, timeout: f64) -> Option<[String; 2]> {
+    fn brpop<K: ToRedisArgs>(key: K, timeout: f64) -> (Option<[String; 2]>) {
         cmd("BRPOP").arg(key).arg(timeout)
     }
 
     /// Pop a value from a list, push it to another list and return it;
     /// or block until one is available.
     /// [Redis Docs](https://redis.io/commands/BRPOPLPUSH)
-    fn brpoplpush<S: ToRedisArgs, D: ToRedisArgs>(srckey: S, dstkey: D, timeout: f64) -> Option<String> {
+    fn brpoplpush<S: ToRedisArgs, D: ToRedisArgs>(srckey: S, dstkey: D, timeout: f64) -> (Option<String>) {
         cmd("BRPOPLPUSH").arg(srckey).arg(dstkey).arg(timeout)
     }
 
     /// Get an element from a list by its index.
     /// [Redis Docs](https://redis.io/commands/LINDEX)
-    fn lindex<K: ToRedisArgs>(key: K, index: isize) -> Option<String> {
+    fn lindex<K: ToRedisArgs>(key: K, index: isize) -> (Option<String>) {
         cmd("LINDEX").arg(key).arg(index)
     }
 
     /// Insert an element before another element in a list.
     /// [Redis Docs](https://redis.io/commands/LINSERT)
     fn linsert_before<K: ToRedisArgs, P: ToRedisArgs, V: ToRedisArgs>(
-            key: K, pivot: P, value: V) -> isize {
+            key: K, pivot: P, value: V) -> (isize) {
         cmd("LINSERT").arg(key).arg("BEFORE").arg(pivot).arg(value)
     }
 
     /// Insert an element after another element in a list.
     /// [Redis Docs](https://redis.io/commands/LINSERT)
     fn linsert_after<K: ToRedisArgs, P: ToRedisArgs, V: ToRedisArgs>(
-            key: K, pivot: P, value: V) -> isize {
+            key: K, pivot: P, value: V) -> (isize) {
         cmd("LINSERT").arg(key).arg("AFTER").arg(pivot).arg(value)
     }
 
     /// Returns the length of the list stored at key.
     /// [Redis Docs](https://redis.io/commands/LLEN)
-    fn llen<K: ToRedisArgs>(key: K) -> usize {
+    fn llen<K: ToRedisArgs>(key: K) -> (usize) {
         cmd("LLEN").arg(key)
     }
 
     /// Pop an element a list, push it to another list and return it
     /// [Redis Docs](https://redis.io/commands/LMOVE)
-    fn lmove<S: ToRedisArgs, D: ToRedisArgs>(srckey: S, dstkey: D, src_dir: Direction, dst_dir: Direction) -> String {
+    fn lmove<S: ToRedisArgs, D: ToRedisArgs>(srckey: S, dstkey: D, src_dir: Direction, dst_dir: Direction) -> (String) {
         cmd("LMOVE").arg(srckey).arg(dstkey).arg(src_dir).arg(dst_dir)
     }
 
     /// Pops `count` elements from the first non-empty list key from the list of
     /// provided key names.
     /// [Redis Docs](https://redis.io/commands/LMPOP").arg(numkeys).arg(key).arg(dir).arg("COUNT)
-    fn lmpop<K: ToRedisArgs>( numkeys: usize, key: K, dir: Direction, count: usize) -> Option<(String, Vec<String>)> {
+    fn lmpop<K: ToRedisArgs>( numkeys: usize, key: K, dir: Direction, count: usize) -> (Option<(String, Vec<String>)>) {
         cmd("LMPOP").arg(numkeys).arg(key).arg(dir).arg("COUNT").arg(count)
     }
 
@@ -699,52 +702,52 @@ implement_commands! {
 
     /// Insert all the specified values at the head of the list stored at key.
     /// [Redis Docs](https://redis.io/commands/LPUSH)
-    fn lpush<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> usize {
+    fn lpush<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> (usize) {
         cmd("LPUSH").arg(key).arg(value)
     }
 
     /// Inserts a value at the head of the list stored at key, only if key
     /// already exists and holds a list.
     /// [Redis Docs](https://redis.io/commands/LPUSHX)
-    fn lpush_exists<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> usize {
+    fn lpush_exists<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> (usize) {
         cmd("LPUSHX").arg(key).arg(value)
     }
 
     /// Returns the specified elements of the list stored at key.
     /// [Redis Docs](https://redis.io/commands/LRANGE)
-    fn lrange<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> Vec<String> {
+    fn lrange<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> (Vec<String>) {
         cmd("LRANGE").arg(key).arg(start).arg(stop)
     }
 
     /// Removes the first count occurrences of elements equal to value
     /// from the list stored at key.
     /// [Redis Docs](https://redis.io/commands/LREM)
-    fn lrem<K: ToRedisArgs, V: ToRedisArgs>(key: K, count: isize, value: V) -> usize {
+    fn lrem<K: ToRedisArgs, V: ToRedisArgs>(key: K, count: isize, value: V) -> (usize) {
         cmd("LREM").arg(key).arg(count).arg(value)
     }
 
     /// Trim an existing list so that it will contain only the specified
     /// range of elements specified.
     /// [Redis Docs](https://redis.io/commands/LTRIM)
-    fn ltrim<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> () {
+    fn ltrim<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> (()) {
         cmd("LTRIM").arg(key).arg(start).arg(stop)
     }
 
     /// Sets the list element at index to value
     /// [Redis Docs](https://redis.io/commands/LSET)
-    fn lset<K: ToRedisArgs, V: ToRedisArgs>(key: K, index: isize, value: V) -> () {
+    fn lset<K: ToRedisArgs, V: ToRedisArgs>(key: K, index: isize, value: V) -> (()) {
         cmd("LSET").arg(key).arg(index).arg(value)
     }
 
     /// Sends a ping to the server
     /// [Redis Docs](https://redis.io/commands/PING)
-    fn ping<>() -> String {
+    fn ping<>() -> (String) {
          &mut cmd("PING")
     }
 
     /// Sends a ping with a message to the server
     /// [Redis Docs](https://redis.io/commands/PING)
-    fn ping_message<K: ToRedisArgs>(message: K) -> String {
+    fn ping_message<K: ToRedisArgs>(message: K) -> (String) {
          cmd("PING").arg(message)
     }
 
@@ -758,20 +761,20 @@ implement_commands! {
 
     /// Pop a value from a list, push it to another list and return it.
     /// [Redis Docs](https://redis.io/commands/RPOPLPUSH)
-    fn rpoplpush<K: ToRedisArgs, D: ToRedisArgs>(key: K, dstkey: D) -> Option<String> {
+    fn rpoplpush<K: ToRedisArgs, D: ToRedisArgs>(key: K, dstkey: D) -> (Option<String>) {
         cmd("RPOPLPUSH").arg(key).arg(dstkey)
     }
 
     /// Insert all the specified values at the tail of the list stored at key.
     /// [Redis Docs](https://redis.io/commands/RPUSH)
-    fn rpush<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> usize {
+    fn rpush<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> (usize) {
         cmd("RPUSH").arg(key).arg(value)
     }
 
     /// Inserts value at the tail of the list stored at key, only if key
     /// already exists and holds a list.
     /// [Redis Docs](https://redis.io/commands/RPUSHX)
-    fn rpush_exists<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> usize {
+    fn rpush_exists<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V) -> (usize) {
         cmd("RPUSHX").arg(key).arg(value)
     }
 
@@ -779,61 +782,61 @@ implement_commands! {
 
     /// Add one or more members to a set.
     /// [Redis Docs](https://redis.io/commands/SADD)
-    fn sadd<K: ToRedisArgs, M: ToRedisArgs>(key: K, member: M) -> usize {
+    fn sadd<K: ToRedisArgs, M: ToRedisArgs>(key: K, member: M) -> (usize) {
         cmd("SADD").arg(key).arg(member)
     }
 
     /// Get the number of members in a set.
     /// [Redis Docs](https://redis.io/commands/SCARD)
-    fn scard<K: ToRedisArgs>(key: K) -> usize {
+    fn scard<K: ToRedisArgs>(key: K) -> (usize) {
         cmd("SCARD").arg(key)
     }
 
     /// Subtract multiple sets.
     /// [Redis Docs](https://redis.io/commands/SDIFF)
-    fn sdiff<K: ToRedisArgs>(keys: K) -> HashSet<String> {
+    fn sdiff<K: ToRedisArgs>(keys: K) -> (HashSet<String>) {
         cmd("SDIFF").arg(keys)
     }
 
     /// Subtract multiple sets and store the resulting set in a key.
     /// [Redis Docs](https://redis.io/commands/SDIFFSTORE)
-    fn sdiffstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> usize {
+    fn sdiffstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> (usize) {
         cmd("SDIFFSTORE").arg(dstkey).arg(keys)
     }
 
     /// Intersect multiple sets.
     /// [Redis Docs](https://redis.io/commands/SINTER)
-    fn sinter<K: ToRedisArgs>(keys: K) -> HashSet<String> {
+    fn sinter<K: ToRedisArgs>(keys: K) -> (HashSet<String>) {
         cmd("SINTER").arg(keys)
     }
 
     /// Intersect multiple sets and store the resulting set in a key.
     /// [Redis Docs](https://redis.io/commands/SINTERSTORE)
-    fn sinterstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> usize {
+    fn sinterstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> (usize) {
         cmd("SINTERSTORE").arg(dstkey).arg(keys)
     }
 
     /// Determine if a given value is a member of a set.
     /// [Redis Docs](https://redis.io/commands/SISMEMBER)
-    fn sismember<K: ToRedisArgs, M: ToRedisArgs>(key: K, member: M) -> bool {
+    fn sismember<K: ToRedisArgs, M: ToRedisArgs>(key: K, member: M) -> (bool) {
         cmd("SISMEMBER").arg(key).arg(member)
     }
 
     /// Determine if given values are members of a set.
     /// [Redis Docs](https://redis.io/commands/SMISMEMBER)
-    fn smismember<K: ToRedisArgs, M: ToRedisArgs>(key: K, members: M) -> Vec<bool> {
+    fn smismember<K: ToRedisArgs, M: ToRedisArgs>(key: K, members: M) -> (Vec<bool>) {
         cmd("SMISMEMBER").arg(key).arg(members)
     }
 
     /// Get all the members in a set.
     /// [Redis Docs](https://redis.io/commands/SMEMBERS)
-    fn smembers<K: ToRedisArgs>(key: K) -> HashSet<String> {
+    fn smembers<K: ToRedisArgs>(key: K) -> (HashSet<String>) {
         cmd("SMEMBERS").arg(key)
     }
 
     /// Move a member from one set to another.
     /// [Redis Docs](https://redis.io/commands/SMOVE)
-    fn smove<S: ToRedisArgs, D: ToRedisArgs, M: ToRedisArgs>(srckey: S, dstkey: D, member: M) -> bool {
+    fn smove<S: ToRedisArgs, D: ToRedisArgs, M: ToRedisArgs>(srckey: S, dstkey: D, member: M) -> (bool) {
         cmd("SMOVE").arg(srckey).arg(dstkey).arg(member)
     }
 
@@ -845,31 +848,31 @@ implement_commands! {
 
     /// Get one random member from a set.
     /// [Redis Docs](https://redis.io/commands/SRANDMEMBER)
-    fn srandmember<K: ToRedisArgs>(key: K) -> Option<String> {
+    fn srandmember<K: ToRedisArgs>(key: K) -> (Option<String>) {
         cmd("SRANDMEMBER").arg(key)
     }
 
     /// Get multiple random members from a set.
     /// [Redis Docs](https://redis.io/commands/SRANDMEMBER)
-    fn srandmember_multiple<K: ToRedisArgs>(key: K, count: usize) -> Vec<String> {
+    fn srandmember_multiple<K: ToRedisArgs>(key: K, count: usize) -> (Vec<String>) {
         cmd("SRANDMEMBER").arg(key).arg(count)
     }
 
     /// Remove one or more members from a set.
     /// [Redis Docs](https://redis.io/commands/SREM)
-    fn srem<K: ToRedisArgs, M: ToRedisArgs>(key: K, member: M) -> usize {
+    fn srem<K: ToRedisArgs, M: ToRedisArgs>(key: K, member: M) -> (usize) {
         cmd("SREM").arg(key).arg(member)
     }
 
     /// Add multiple sets.
     /// [Redis Docs](https://redis.io/commands/SUNION)
-    fn sunion<K: ToRedisArgs>(keys: K) -> HashSet<String> {
+    fn sunion<K: ToRedisArgs>(keys: K) -> (HashSet<String>) {
         cmd("SUNION").arg(keys)
     }
 
     /// Add multiple sets and store the resulting set in a key.
     /// [Redis Docs](https://redis.io/commands/SUNIONSTORE)
-    fn sunionstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> usize {
+    fn sunionstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> (usize) {
         cmd("SUNIONSTORE").arg(dstkey).arg(keys)
     }
 
@@ -883,47 +886,47 @@ implement_commands! {
 
     /// Add multiple members to a sorted set, or update its score if it already exists.
     /// [Redis Docs](https://redis.io/commands/ZADD)
-    fn zadd_multiple<K: ToRedisArgs, S: ToRedisArgs, M: ToRedisArgs>(key: K, items: &'a [(S, M)]) -> usize {
+    fn zadd_multiple<K: ToRedisArgs, S: ToRedisArgs, M: ToRedisArgs>(key: K, items: &'a [(S, M)]) -> (usize) {
         cmd("ZADD").arg(key).arg(items)
     }
 
     /// Get the number of members in a sorted set.
     /// [Redis Docs](https://redis.io/commands/ZCARD)
-    fn zcard<K: ToRedisArgs>(key: K) -> usize {
+    fn zcard<K: ToRedisArgs>(key: K) -> (usize) {
         cmd("ZCARD").arg(key)
     }
 
     /// Count the members in a sorted set with scores within the given values.
     /// [Redis Docs](https://redis.io/commands/ZCOUNT)
-    fn zcount<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> usize {
+    fn zcount<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> (usize) {
         cmd("ZCOUNT").arg(key).arg(min).arg(max)
     }
 
     /// Increments the member in a sorted set at key by delta.
     /// If the member does not exist, it is added with delta as its score.
     /// [Redis Docs](https://redis.io/commands/ZINCRBY)
-    fn zincr<K: ToRedisArgs, M: ToRedisArgs, D: ToRedisArgs>(key: K, member: M, delta: D) -> f64 {
+    fn zincr<K: ToRedisArgs, M: ToRedisArgs, D: ToRedisArgs>(key: K, member: M, delta: D) -> (f64) {
         cmd("ZINCRBY").arg(key).arg(delta).arg(member)
     }
 
     /// Intersect multiple sorted sets and store the resulting sorted set in
     /// a new key using SUM as aggregation function.
     /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
-    fn zinterstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> usize {
+    fn zinterstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> (usize) {
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys)
     }
 
     /// Intersect multiple sorted sets and store the resulting sorted set in
     /// a new key using MIN as aggregation function.
     /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
-    fn zinterstore_min<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> usize {
+    fn zinterstore_min<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> (usize) {
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MIN")
     }
 
     /// Intersect multiple sorted sets and store the resulting sorted set in
     /// a new key using MAX as aggregation function.
     /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
-    fn zinterstore_max<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> usize {
+    fn zinterstore_max<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> (usize) {
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MAX")
     }
 
@@ -931,8 +934,8 @@ implement_commands! {
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
     /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
-    fn zinterstore_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> usize {
-        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> (&K, &W) {(key, weight)}).unzip();
+    fn zinterstore_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> (usize) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> ((&K, &W)) {(key, weight)}).unzip();
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights)
     }
 
@@ -940,8 +943,8 @@ implement_commands! {
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
     /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
-    fn zinterstore_min_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> usize {
-        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> (&K, &W) {(key, weight)}).unzip();
+    fn zinterstore_min_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> (usize) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> ((&K, &W)) {(key, weight)}).unzip();
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MIN").arg("WEIGHTS").arg(weights)
     }
 
@@ -949,40 +952,40 @@ implement_commands! {
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
     /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
-    fn zinterstore_max_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> usize {
-        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> (&K, &W) {(key, weight)}).unzip();
+    fn zinterstore_max_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> (usize) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> ((&K, &W)) {(key, weight)}).unzip();
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MAX").arg("WEIGHTS").arg(weights)
     }
 
     /// Count the number of members in a sorted set between a given lexicographical range.
     /// [Redis Docs](https://redis.io/commands/ZLEXCOUNT)
-    fn zlexcount<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> usize {
+    fn zlexcount<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> (usize) {
         cmd("ZLEXCOUNT").arg(key).arg(min).arg(max)
     }
 
     /// Removes and returns the member with the highest score in a sorted set.
     /// Blocks until a member is available otherwise.
     /// [Redis Docs](https://redis.io/commands/BZPOPMAX)
-    fn bzpopmax<K: ToRedisArgs>(key: K, timeout: f64) -> Option<(String, String, f64)> {
+    fn bzpopmax<K: ToRedisArgs>(key: K, timeout: f64) -> (Option<(String, String, f64)>) {
         cmd("BZPOPMAX").arg(key).arg(timeout)
     }
 
     /// Removes and returns up to count members with the highest scores in a sorted set
     /// [Redis Docs](https://redis.io/commands/ZPOPMAX)
-    fn zpopmax<K: ToRedisArgs>(key: K, count: isize) -> Vec<String> {
+    fn zpopmax<K: ToRedisArgs>(key: K, count: isize) -> (Vec<String>) {
         cmd("ZPOPMAX").arg(key).arg(count)
     }
 
     /// Removes and returns the member with the lowest score in a sorted set.
     /// Blocks until a member is available otherwise.
     /// [Redis Docs](https://redis.io/commands/BZPOPMIN)
-    fn bzpopmin<K: ToRedisArgs>(key: K, timeout: f64) -> Option<(String, String, f64)> {
+    fn bzpopmin<K: ToRedisArgs>(key: K, timeout: f64) -> (Option<(String, String, f64)>) {
         cmd("BZPOPMIN").arg(key).arg(timeout)
     }
 
     /// Removes and returns up to count members with the lowest scores in a sorted set
     /// [Redis Docs](https://redis.io/commands/ZPOPMIN)
-    fn zpopmin<K: ToRedisArgs>(key: K, count: isize) -> Vec<String> {
+    fn zpopmin<K: ToRedisArgs>(key: K, count: isize) -> (Vec<String>) {
         cmd("ZPOPMIN").arg(key).arg(count)
     }
 
@@ -990,14 +993,14 @@ implement_commands! {
     /// from the first non-empty sorted set in the provided list of key names.
     /// Blocks until a member is available otherwise.
     /// [Redis Docs](https://redis.io/commands/BZMPOP)
-    fn bzmpop_max<K: ToRedisArgs>(timeout: f64, keys: K, count: isize) -> Option<(String, Vec<(String, f64)>)> {
+    fn bzmpop_max<K: ToRedisArgs>(timeout: f64, keys: K, count: isize) -> (Option<(String, Vec<(String, f64)>)>) {
         cmd("BZMPOP").arg(timeout).arg(keys.num_of_args()).arg(keys).arg("MAX").arg("COUNT").arg(count)
     }
 
     /// Removes and returns up to count members with the highest scores,
     /// from the first non-empty sorted set in the provided list of key names.
     /// [Redis Docs](https://redis.io/commands/ZMPOP)
-    fn zmpop_max<K: ToRedisArgs>(keys: K, count: isize) -> Option<(String, Vec<(String, f64)>)> {
+    fn zmpop_max<K: ToRedisArgs>(keys: K, count: isize) -> (Option<(String, Vec<(String, f64)>)>) {
         cmd("ZMPOP").arg(keys.num_of_args()).arg(keys).arg("MAX").arg("COUNT").arg(count)
     }
 
@@ -1005,14 +1008,14 @@ implement_commands! {
     /// from the first non-empty sorted set in the provided list of key names.
     /// Blocks until a member is available otherwise.
     /// [Redis Docs](https://redis.io/commands/BZMPOP)
-    fn bzmpop_min<K: ToRedisArgs>(timeout: f64, keys: K, count: isize) -> Option<(String, Vec<(String, f64)>)> {
+    fn bzmpop_min<K: ToRedisArgs>(timeout: f64, keys: K, count: isize) -> (Option<(String, Vec<(String, f64)>)>) {
         cmd("BZMPOP").arg(timeout).arg(keys.num_of_args()).arg(keys).arg("MIN").arg("COUNT").arg(count)
     }
 
     /// Removes and returns up to count members with the lowest scores,
     /// from the first non-empty sorted set in the provided list of key names.
     /// [Redis Docs](https://redis.io/commands/ZMPOP)
-    fn zmpop_min<K: ToRedisArgs>(keys: K, count: isize) -> Option<(String, Vec<(String, f64)>)> {
+    fn zmpop_min<K: ToRedisArgs>(keys: K, count: isize) -> (Option<(String, Vec<(String, f64)>)>) {
         cmd("ZMPOP").arg(keys.num_of_args()).arg(keys).arg("MIN").arg("COUNT").arg(count)
     }
 
@@ -1030,19 +1033,19 @@ implement_commands! {
 
     /// Return a range of members in a sorted set, by index
     /// [Redis Docs](https://redis.io/commands/ZRANGE)
-    fn zrange<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> Vec<String> {
+    fn zrange<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> (Vec<String>) {
         cmd("ZRANGE").arg(key).arg(start).arg(stop)
     }
 
     /// Return a range of members in a sorted set, by index with scores.
     /// [Redis Docs](https://redis.io/commands/ZRANGE)
-    fn zrange_withscores<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> Vec<String> {
+    fn zrange_withscores<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> (Vec<(String, f64)>) {
         cmd("ZRANGE").arg(key).arg(start).arg(stop).arg("WITHSCORES")
     }
 
     /// Return a range of members in a sorted set, by lexicographical range.
     /// [Redis Docs](https://redis.io/commands/ZRANGEBYLEX)
-    fn zrangebylex<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> Vec<String> {
+    fn zrangebylex<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> (Vec<String>) {
         cmd("ZRANGEBYLEX").arg(key).arg(min).arg(max)
     }
 
@@ -1050,13 +1053,13 @@ implement_commands! {
     /// range with offset and limit.
     /// [Redis Docs](https://redis.io/commands/ZRANGEBYLEX)
     fn zrangebylex_limit<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(
-            key: K, min: M, max: MM, offset: isize, count: isize) -> Vec<String> {
+            key: K, min: M, max: MM, offset: isize, count: isize) -> (Vec<String>) {
         cmd("ZRANGEBYLEX").arg(key).arg(min).arg(max).arg("LIMIT").arg(offset).arg(count)
     }
 
     /// Return a range of members in a sorted set, by lexicographical range.
     /// [Redis Docs](https://redis.io/commands/ZREVRANGEBYLEX)
-    fn zrevrangebylex<K: ToRedisArgs, MM: ToRedisArgs, M: ToRedisArgs>(key: K, max: MM, min: M) -> Vec<String> {
+    fn zrevrangebylex<K: ToRedisArgs, MM: ToRedisArgs, M: ToRedisArgs>(key: K, max: MM, min: M) -> (Vec<String>) {
         cmd("ZREVRANGEBYLEX").arg(key).arg(max).arg(min)
     }
 
@@ -1064,144 +1067,144 @@ implement_commands! {
     /// range with offset and limit.
     /// [Redis Docs](https://redis.io/commands/ZREVRANGEBYLEX)
     fn zrevrangebylex_limit<K: ToRedisArgs, MM: ToRedisArgs, M: ToRedisArgs>(
-            key: K, max: MM, min: M, offset: isize, count: isize) -> Vec<String> {
+            key: K, max: MM, min: M, offset: isize, count: isize) -> (Vec<String>) {
         cmd("ZREVRANGEBYLEX").arg(key).arg(max).arg(min).arg("LIMIT").arg(offset).arg(count)
     }
 
     /// Return a range of members in a sorted set, by score.
     /// [Redis Docs](https://redis.io/commands/ZRANGEBYSCORE)
-    fn zrangebyscore<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> Vec<String> {
+    fn zrangebyscore<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> (Vec<String>) {
         cmd("ZRANGEBYSCORE").arg(key).arg(min).arg(max)
     }
 
     /// Return a range of members in a sorted set, by score with scores.
     /// [Redis Docs](https://redis.io/commands/ZRANGEBYSCORE)
-    fn zrangebyscore_withscores<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> Vec<String> {
+    fn zrangebyscore_withscores<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> (Vec<(String, usize)>) {
         cmd("ZRANGEBYSCORE").arg(key).arg(min).arg(max).arg("WITHSCORES")
     }
 
     /// Return a range of members in a sorted set, by score with limit.
     /// [Redis Docs](https://redis.io/commands/ZRANGEBYSCORE)
     fn zrangebyscore_limit<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>
-            (key: K, min: M, max: MM, offset: isize, count: isize) -> Vec<String> {
+            (key: K, min: M, max: MM, offset: isize, count: isize) -> (Vec<String>) {
         cmd("ZRANGEBYSCORE").arg(key).arg(min).arg(max).arg("LIMIT").arg(offset).arg(count)
     }
 
     /// Return a range of members in a sorted set, by score with limit with scores.
     /// [Redis Docs](https://redis.io/commands/ZRANGEBYSCORE)
     fn zrangebyscore_limit_withscores<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>
-            (key: K, min: M, max: MM, offset: isize, count: isize) -> Vec<String> {
+            (key: K, min: M, max: MM, offset: isize, count: isize) -> (Vec<(String, usize)>) {
         cmd("ZRANGEBYSCORE").arg(key).arg(min).arg(max).arg("WITHSCORES")
             .arg("LIMIT").arg(offset).arg(count)
     }
 
     /// Determine the index of a member in a sorted set.
     /// [Redis Docs](https://redis.io/commands/ZRANK)
-    fn zrank<K: ToRedisArgs, M: ToRedisArgs>(key: K, member: M) -> Option<usize> {
+    fn zrank<K: ToRedisArgs, M: ToRedisArgs>(key: K, member: M) -> (Option<usize>) {
         cmd("ZRANK").arg(key).arg(member)
     }
 
     /// Remove one or more members from a sorted set.
     /// [Redis Docs](https://redis.io/commands/ZREM)
-    fn zrem<K: ToRedisArgs, M: ToRedisArgs>(key: K, members: M) -> usize {
+    fn zrem<K: ToRedisArgs, M: ToRedisArgs>(key: K, members: M) -> (usize) {
         cmd("ZREM").arg(key).arg(members)
     }
 
     /// Remove all members in a sorted set between the given lexicographical range.
     /// [Redis Docs](https://redis.io/commands/ZREMRANGEBYLEX)
-    fn zrembylex<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> usize {
+    fn zrembylex<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> (usize) {
         cmd("ZREMRANGEBYLEX").arg(key).arg(min).arg(max)
     }
 
     /// Remove all members in a sorted set within the given indexes.
     /// [Redis Docs](https://redis.io/commands/ZREMRANGEBYRANK)
-    fn zremrangebyrank<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> usize {
+    fn zremrangebyrank<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> (usize) {
         cmd("ZREMRANGEBYRANK").arg(key).arg(start).arg(stop)
     }
 
     /// Remove all members in a sorted set within the given scores.
     /// [Redis Docs](https://redis.io/commands/ZREMRANGEBYSCORE)
-    fn zrembyscore<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> usize {
+    fn zrembyscore<K: ToRedisArgs, M: ToRedisArgs, MM: ToRedisArgs>(key: K, min: M, max: MM) -> (usize) {
         cmd("ZREMRANGEBYSCORE").arg(key).arg(min).arg(max)
     }
 
     /// Return a range of members in a sorted set, by index,
     /// ordered from high to low.
     /// [Redis Docs](https://redis.io/commands/ZREVRANGE)
-    fn zrevrange<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> Vec<String> {
+    fn zrevrange<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> (Vec<String>) {
         cmd("ZREVRANGE").arg(key).arg(start).arg(stop)
     }
 
     /// Return a range of members in a sorted set, by index, with scores
     /// ordered from high to low.
     /// [Redis Docs](https://redis.io/commands/ZREVRANGE)
-    fn zrevrange_withscores<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> Vec<String> {
+    fn zrevrange_withscores<K: ToRedisArgs>(key: K, start: isize, stop: isize) -> (Vec<String>) {
         cmd("ZREVRANGE").arg(key).arg(start).arg(stop).arg("WITHSCORES")
     }
 
     /// Return a range of members in a sorted set, by score.
     /// [Redis Docs](https://redis.io/commands/ZREVRANGEBYSCORE)
-    fn zrevrangebyscore<K: ToRedisArgs, MM: ToRedisArgs, M: ToRedisArgs>(key: K, max: MM, min: M) -> Vec<String> {
+    fn zrevrangebyscore<K: ToRedisArgs, MM: ToRedisArgs, M: ToRedisArgs>(key: K, max: MM, min: M) -> (Vec<String>) {
         cmd("ZREVRANGEBYSCORE").arg(key).arg(max).arg(min)
     }
 
     /// Return a range of members in a sorted set, by score with scores.
     /// [Redis Docs](https://redis.io/commands/ZREVRANGEBYSCORE)
-    fn zrevrangebyscore_withscores<K: ToRedisArgs, MM: ToRedisArgs, M: ToRedisArgs>(key: K, max: MM, min: M) -> Vec<String> {
+    fn zrevrangebyscore_withscores<K: ToRedisArgs, MM: ToRedisArgs, M: ToRedisArgs>(key: K, max: MM, min: M) -> (Vec<String>) {
         cmd("ZREVRANGEBYSCORE").arg(key).arg(max).arg(min).arg("WITHSCORES")
     }
 
     /// Return a range of members in a sorted set, by score with limit.
     /// [Redis Docs](https://redis.io/commands/ZREVRANGEBYSCORE)
     fn zrevrangebyscore_limit<K: ToRedisArgs, MM: ToRedisArgs, M: ToRedisArgs>
-            (key: K, max: MM, min: M, offset: isize, count: isize) -> Vec<String> {
+            (key: K, max: MM, min: M, offset: isize, count: isize) -> (Vec<String>) {
         cmd("ZREVRANGEBYSCORE").arg(key).arg(max).arg(min).arg("LIMIT").arg(offset).arg(count)
     }
 
     /// Return a range of members in a sorted set, by score with limit with scores.
     /// [Redis Docs](https://redis.io/commands/ZREVRANGEBYSCORE)
     fn zrevrangebyscore_limit_withscores<K: ToRedisArgs, MM: ToRedisArgs, M: ToRedisArgs>
-            (key: K, max: MM, min: M, offset: isize, count: isize) -> Vec<String> {
+            (key: K, max: MM, min: M, offset: isize, count: isize) -> (Vec<String>) {
         cmd("ZREVRANGEBYSCORE").arg(key).arg(max).arg(min).arg("WITHSCORES")
             .arg("LIMIT").arg(offset).arg(count)
     }
 
     /// Determine the index of a member in a sorted set, with scores ordered from high to low.
     /// [Redis Docs](https://redis.io/commands/ZREVRANK)
-    fn zrevrank<K: ToRedisArgs, M: ToRedisArgs>(key: K, member: M) -> Option<usize> {
+    fn zrevrank<K: ToRedisArgs, M: ToRedisArgs>(key: K, member: M) -> (Option<usize>) {
         cmd("ZREVRANK").arg(key).arg(member)
     }
 
     /// Get the score associated with the given member in a sorted set.
     /// [Redis Docs](https://redis.io/commands/ZSCORE)
-    fn zscore<K: ToRedisArgs, M: ToRedisArgs>(key: K, member: M) -> Option<f64> {
+    fn zscore<K: ToRedisArgs, M: ToRedisArgs>(key: K, member: M) -> (Option<f64>) {
         cmd("ZSCORE").arg(key).arg(member)
     }
 
     /// Get the scores associated with multiple members in a sorted set.
     /// [Redis Docs](https://redis.io/commands/ZMSCORE)
-    fn zscore_multiple<K: ToRedisArgs, M: ToRedisArgs>(key: K, members: &'a [M]) -> Option<Vec<f64>> {
+    fn zscore_multiple<K: ToRedisArgs, M: ToRedisArgs>(key: K, members: &'a [M]) -> (Option<Vec<f64>>) {
         cmd("ZMSCORE").arg(key).arg(members)
     }
 
     /// Unions multiple sorted sets and store the resulting sorted set in
     /// a new key using SUM as aggregation function.
     /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
-    fn zunionstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> usize {
+    fn zunionstore<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> (usize) {
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys)
     }
 
     /// Unions multiple sorted sets and store the resulting sorted set in
     /// a new key using MIN as aggregation function.
     /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
-    fn zunionstore_min<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> usize {
+    fn zunionstore_min<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> (usize) {
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MIN")
     }
 
     /// Unions multiple sorted sets and store the resulting sorted set in
     /// a new key using MAX as aggregation function.
     /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
-    fn zunionstore_max<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> usize {
+    fn zunionstore_max<D: ToRedisArgs, K: ToRedisArgs>(dstkey: D, keys: K) -> (usize) {
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MAX")
     }
 
@@ -1209,8 +1212,8 @@ implement_commands! {
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
     /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
-    fn zunionstore_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> usize {
-        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> (&K, &W) {(key, weight)}).unzip();
+    fn zunionstore_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> (usize) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> ((&K, &W)) {(key, weight)}).unzip();
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights)
     }
 
@@ -1218,8 +1221,8 @@ implement_commands! {
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
     /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
-    fn zunionstore_min_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> usize {
-        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> (&K, &W) {(key, weight)}).unzip();
+    fn zunionstore_min_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> (usize) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> ((&K, &W)) {(key, weight)}).unzip();
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MIN").arg("WEIGHTS").arg(weights)
     }
 
@@ -1227,8 +1230,8 @@ implement_commands! {
     /// multiplication factor for each sorted set by pairing one with each key
     /// in a tuple.
     /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
-    fn zunionstore_max_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> usize {
-        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> (&K, &W) {(key, weight)}).unzip();
+    fn zunionstore_max_weights<D: ToRedisArgs, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> (usize) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> ((&K, &W)) {(key, weight)}).unzip();
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MAX").arg("WEIGHTS").arg(weights)
     }
 
@@ -1236,32 +1239,32 @@ implement_commands! {
 
     /// Adds the specified elements to the specified HyperLogLog.
     /// [Redis Docs](https://redis.io/commands/PFADD)
-    fn pfadd<K: ToRedisArgs, E: ToRedisArgs>(key: K, element: E) -> bool {
+    fn pfadd<K: ToRedisArgs, E: ToRedisArgs>(key: K, element: E) -> (bool) {
         cmd("PFADD").arg(key).arg(element)
     }
 
     /// Return the approximated cardinality of the set(s) observed by the
     /// HyperLogLog at key(s).
     /// [Redis Docs](https://redis.io/commands/PFCOUNT)
-    fn pfcount<K: ToRedisArgs>(key: K) -> usize {
+    fn pfcount<K: ToRedisArgs>(key: K) -> (usize) {
         cmd("PFCOUNT").arg(key)
     }
 
     /// Merge N different HyperLogLogs into a single one.
     /// [Redis Docs](https://redis.io/commands/PFMERGE)
-    fn pfmerge<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) -> () {
+    fn pfmerge<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) -> (()) {
         cmd("PFMERGE").arg(dstkey).arg(srckeys)
     }
 
     /// Posts a message to the given channel.
     /// [Redis Docs](https://redis.io/commands/PUBLISH)
-    fn publish<K: ToRedisArgs, E: ToRedisArgs>(channel: K, message: E) -> usize {
+    fn publish<K: ToRedisArgs, E: ToRedisArgs>(channel: K, message: E) -> (usize) {
         cmd("PUBLISH").arg(channel).arg(message)
     }
 
     /// Posts a message to the given sharded channel.
     /// [Redis Docs](https://redis.io/commands/SPUBLISH)
-    fn spublish<K: ToRedisArgs, E: ToRedisArgs>(channel: K, message: E) -> usize {
+    fn spublish<K: ToRedisArgs, E: ToRedisArgs>(channel: K, message: E) -> (usize) {
         cmd("SPUBLISH").arg(channel).arg(message)
     }
 
@@ -1269,43 +1272,43 @@ implement_commands! {
 
     /// Returns the encoding of a key.
     /// [Redis Docs](https://redis.io/commands/OBJECT)
-    fn object_encoding<K: ToRedisArgs>(key: K) -> Option<String> {
+    fn object_encoding<K: ToRedisArgs>(key: K) -> (Option<String>) {
         cmd("OBJECT").arg("ENCODING").arg(key)
     }
 
     /// Returns the time in seconds since the last access of a key.
     /// [Redis Docs](https://redis.io/commands/OBJECT)
-    fn object_idletime<K: ToRedisArgs>(key: K) -> Option<usize> {
+    fn object_idletime<K: ToRedisArgs>(key: K) -> (Option<usize>) {
         cmd("OBJECT").arg("IDLETIME").arg(key)
     }
 
     /// Returns the logarithmic access frequency counter of a key.
     /// [Redis Docs](https://redis.io/commands/OBJECT)
-    fn object_freq<K: ToRedisArgs>(key: K) -> Option<usize> {
+    fn object_freq<K: ToRedisArgs>(key: K) -> (Option<usize>) {
         cmd("OBJECT").arg("FREQ").arg(key)
     }
 
     /// Returns the reference count of a key.
     /// [Redis Docs](https://redis.io/commands/OBJECT)
-    fn object_refcount<K: ToRedisArgs>(key: K) -> Option<usize> {
+    fn object_refcount<K: ToRedisArgs>(key: K) -> (Option<usize>) {
         cmd("OBJECT").arg("REFCOUNT").arg(key)
     }
 
     /// Returns the name of the current connection as set by CLIENT SETNAME.
     /// [Redis Docs](https://redis.io/commands/CLIENT)
-    fn client_getname<>() -> Option<String> {
+    fn client_getname<>() -> (Option<String>) {
         cmd("CLIENT").arg("GETNAME")
     }
 
     /// Returns the ID of the current connection.
     /// [Redis Docs](https://redis.io/commands/CLIENT)
-    fn client_id<>() -> usize {
+    fn client_id<>() -> (isize) {
         cmd("CLIENT").arg("ID")
     }
 
     /// Command assigns a name to the current connection.
     /// [Redis Docs](https://redis.io/commands/CLIENT)
-    fn client_setname<K: ToRedisArgs>(connection_name: K) -> () {
+    fn client_setname<K: ToRedisArgs>(connection_name: K) -> (()) {
         cmd("CLIENT").arg("SETNAME").arg(connection_name)
     }
 
@@ -1335,7 +1338,7 @@ implement_commands! {
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     /// [Redis Docs](https://redis.io/commands/ACL)
-    fn acl_list<>() -> Vec<String> {
+    fn acl_list<>() -> (Vec<String>) {
         cmd("ACL").arg("LIST")
     }
 
@@ -1344,7 +1347,7 @@ implement_commands! {
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     /// [Redis Docs](https://redis.io/commands/ACL)
-    fn acl_users<>() -> Vec<String> {
+    fn acl_users<>() -> (Vec<String>) {
         cmd("ACL").arg("USERS")
     }
 
@@ -1352,7 +1355,7 @@ implement_commands! {
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     /// [Redis Docs](https://redis.io/commands/ACL)
-    fn acl_getuser<K: ToRedisArgs>(username: K) -> Option<std::collections::HashMap<String, Value>> {
+    fn acl_getuser<K: ToRedisArgs>(username: K) -> (Option<std::collections::HashMap<String, Value>>) {
         cmd("ACL").arg("GETUSER").arg(username)
     }
 
@@ -1378,7 +1381,7 @@ implement_commands! {
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     /// [Redis Docs](https://redis.io/commands/ACL)
-    fn acl_deluser<K: ToRedisArgs>(usernames: &'a [K]) -> usize {
+    fn acl_deluser<K: ToRedisArgs>(usernames: &'a [K]) -> (usize) {
         cmd("ACL").arg("DELUSER").arg(usernames)
     }
 
@@ -1386,7 +1389,7 @@ implement_commands! {
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     /// [Redis Docs](https://redis.io/commands/ACL)
-    fn acl_dryrun<K: ToRedisArgs, C: ToRedisArgs, A: ToRedisArgs>(username: K, command: C, args: A) -> String {
+    fn acl_dryrun<K: ToRedisArgs, C: ToRedisArgs, A: ToRedisArgs>(username: K, command: C, args: A) -> (String) {
         cmd("ACL").arg("DRYRUN").arg(username).arg(command).arg(args)
     }
 
@@ -1394,7 +1397,7 @@ implement_commands! {
     /// [Redis Docs](https://redis.io/commands/ACL)
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
-    fn acl_cat<>() -> Vec<String> {
+    fn acl_cat<>() -> (Vec<String>) {
         cmd("ACL").arg("CAT")
     }
 
@@ -1402,7 +1405,7 @@ implement_commands! {
     /// [Redis Docs](https://redis.io/commands/ACL)
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
-    fn acl_cat_categoryname<K: ToRedisArgs>(categoryname: K) -> Vec<String> {
+    fn acl_cat_categoryname<K: ToRedisArgs>(categoryname: K) -> (Vec<String>) {
         cmd("ACL").arg("CAT").arg(categoryname)
     }
 
@@ -1410,7 +1413,7 @@ implement_commands! {
     /// [Redis Docs](https://redis.io/commands/ACL)
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
-    fn acl_genpass<>() -> String {
+    fn acl_genpass<>() -> (String) {
         cmd("ACL").arg("GENPASS")
     }
 
@@ -1418,7 +1421,7 @@ implement_commands! {
     /// [Redis Docs](https://redis.io/commands/ACL)
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
-    fn acl_genpass_bits<>(bits: isize) -> String {
+    fn acl_genpass_bits<>(bits: isize) -> (String) {
         cmd("ACL").arg("GENPASS").arg(bits)
     }
 
@@ -1426,7 +1429,7 @@ implement_commands! {
     /// [Redis Docs](https://redis.io/commands/ACL)
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
-    fn acl_whoami<>() -> String {
+    fn acl_whoami<>() -> (String) {
         cmd("ACL").arg("WHOAMI")
     }
 
@@ -1434,7 +1437,7 @@ implement_commands! {
     /// [Redis Docs](https://redis.io/commands/ACL)
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
-    fn acl_log<>(count: isize) -> Vec<String> {
+    fn acl_log<>(count: isize) -> (Vec<String>) {
         cmd("ACL").arg("LOG").arg(count)
 
     }
@@ -1451,7 +1454,7 @@ implement_commands! {
     /// [Redis Docs](https://redis.io/commands/ACL)
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
-    fn acl_help<>() -> String {
+    fn acl_help<>() -> (String) {
         cmd("ACL").arg("HELP")
     }
 
@@ -1477,15 +1480,15 @@ implement_commands! {
     /// use redis::{Commands, Connection, RedisResult};
     /// use redis::geo::Coord;
     ///
-    /// fn add_point(con: &mut Connection) -> RedisResult<isize> {
+    /// fn add_point(con: &mut Connection) -> (RedisResult<isize>) {
     ///     con.geo_add("my_gis", (Coord::lon_lat(13.361389, 38.115556), "Palermo"))
     /// }
     ///
-    /// fn add_point_with_tuples(con: &mut Connection) -> RedisResult<isize> {
+    /// fn add_point_with_tuples(con: &mut Connection) -> (RedisResult<isize>) {
     ///     con.geo_add("my_gis", ("13.361389", "38.115556", "Palermo"))
     /// }
     ///
-    /// fn add_many_points(con: &mut Connection) -> RedisResult<isize> {
+    /// fn add_many_points(con: &mut Connection) -> (RedisResult<isize>) {
     ///     con.geo_add("my_gis", &[
     ///         ("13.361389", "38.115556", "Palermo"),
     ///         ("15.087269", "37.502669", "Catania")
@@ -1495,7 +1498,7 @@ implement_commands! {
     /// [Redis Docs](https://redis.io/commands/GEOADD)
     #[cfg(feature = "geospatial")]
     #[cfg_attr(docsrs, doc(cfg(feature = "geospatial")))]
-    fn geo_add<K: ToRedisArgs, M: ToRedisArgs>(key: K, members: M) -> usize {
+    fn geo_add<K: ToRedisArgs, M: ToRedisArgs>(key: K, members: M) -> (usize) {
         cmd("GEOADD").arg(key).arg(members)
     }
 
@@ -1538,7 +1541,7 @@ implement_commands! {
         member1: M1,
         member2: M2,
         unit: geo::Unit
-    ) -> Option<String> {
+    ) -> (Option<String>) {
         cmd("GEODIST")
             .arg(key)
             .arg(member1)
@@ -1568,7 +1571,7 @@ implement_commands! {
     /// [Redis Docs](https://redis.io/commands/GEOHASH)
     #[cfg(feature = "geospatial")]
     #[cfg_attr(docsrs, doc(cfg(feature = "geospatial")))]
-    fn geo_hash<K: ToRedisArgs, M: ToRedisArgs>(key: K, members: M) -> Vec<String> {
+    fn geo_hash<K: ToRedisArgs, M: ToRedisArgs>(key: K, members: M) -> (Vec<String>) {
         cmd("GEOHASH").arg(key).arg(members)
     }
 
@@ -1598,7 +1601,7 @@ implement_commands! {
     /// [Redis Docs](https://redis.io/commands/GEOPOS)
     #[cfg(feature = "geospatial")]
     #[cfg_attr(docsrs, doc(cfg(feature = "geospatial")))]
-    fn geo_pos<K: ToRedisArgs, M: ToRedisArgs>(key: K, members: M) -> Vec<Option<(f64, f64)>> {
+    fn geo_pos<K: ToRedisArgs, M: ToRedisArgs>(key: K, members: M) -> (Vec<Option<(f64, f64)>>) {
         cmd("GEOPOS").arg(key).arg(members)
     }
 
@@ -1616,7 +1619,7 @@ implement_commands! {
     /// use redis::{Commands, RedisResult};
     /// use redis::geo::{RadiusOptions, RadiusSearchResult, RadiusOrder, Unit};
     ///
-    /// fn radius(con: &mut redis::Connection) -> Vec<RadiusSearchResult> {
+    /// fn radius(con: &mut redis::Connection) -> (Vec<RadiusSearchResult>) {
     ///     let opts = RadiusOptions::default().with_dist().order(RadiusOrder::Asc);
     ///     con.geo_radius("my_gis", 15.90, 37.21, 51.39, Unit::Kilometers, opts).unwrap()
     /// }
@@ -1676,7 +1679,7 @@ implement_commands! {
     fn xack<K: ToRedisArgs, G: ToRedisArgs, I: ToRedisArgs>(
         key: K,
         group: G,
-        ids: &'a [I]) -> usize {
+        ids: &'a [I]) -> (usize) {
         cmd("XACK")
             .arg(key)
             .arg(group)
@@ -1696,7 +1699,7 @@ implement_commands! {
         key: K,
         id: ID,
         items: &'a [(F, V)]
-    ) -> Option<String> {
+    ) -> (Option<String>) {
         cmd("XADD").arg(key).arg(id).arg(items)
     }
 
@@ -1714,7 +1717,7 @@ implement_commands! {
         key: K,
         id: ID,
         map: BTM
-    ) -> Option<String> {
+    ) -> (Option<String>) {
         cmd("XADD").arg(key).arg(id).arg(map)
     }
 
@@ -1746,7 +1749,7 @@ implement_commands! {
         id: ID,
         items: I,
         options: &'a streams::StreamAddOptions
-    ) -> Option<String> {
+    ) -> (Option<String>) {
         cmd("XADD")
             .arg(key)
             .arg(options)
@@ -1773,7 +1776,7 @@ implement_commands! {
         maxlen: streams::StreamMaxlen,
         id: ID,
         items: &'a [(F, V)]
-    ) -> Option<String> {
+    ) -> (Option<String>) {
         cmd("XADD")
             .arg(key)
             .arg(maxlen)
@@ -1795,7 +1798,7 @@ implement_commands! {
         maxlen: streams::StreamMaxlen,
         id: ID,
         map: BTM
-    ) -> Option<String> {
+    ) -> (Option<String>) {
         cmd("XADD")
             .arg(key)
             .arg(maxlen)
@@ -1862,7 +1865,7 @@ implement_commands! {
         consumer: C,
         min_idle_time: MIT,
         ids: &'a [ID]
-    ) -> Vec<(String, Value)>{
+    ) -> (Vec<(String, Value)>) {
         cmd("XCLAIM")
             .arg(key)
             .arg(group)
@@ -1942,7 +1945,7 @@ implement_commands! {
     fn xdel<K: ToRedisArgs, ID: ToRedisArgs>(
         key: K,
         ids: &'a [ID]
-    ) -> usize {
+    ) -> (usize) {
         cmd("XDEL").arg(key).arg(ids)
     }
 
@@ -2096,7 +2099,7 @@ implement_commands! {
     fn xinfo_consumers<K: ToRedisArgs, G: ToRedisArgs>(
         key: K,
         group: G
-    ) -> Vec<std::collections::HashMap<String, Value>> {
+    ) -> (Vec<std::collections::HashMap<String, Value>>) {
         cmd("XINFO")
             .arg("CONSUMERS")
             .arg(key)
@@ -2117,7 +2120,7 @@ implement_commands! {
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     /// [Redis Docs](https://redis.io/commands/XINFO").arg("GROUPS)
-    fn xinfo_groups<K: ToRedisArgs>(key: K) -> Vec<std::collections::HashMap<String, Value>> {
+    fn xinfo_groups<K: ToRedisArgs>(key: K) -> (Vec<std::collections::HashMap<String, Value>>) {
         cmd("XINFO").arg("GROUPS").arg(key)
     }
 
@@ -2324,7 +2327,7 @@ implement_commands! {
     fn xread<K: ToRedisArgs, ID: ToRedisArgs>(
         keys: &'a [K],
         ids: &'a [ID]
-    ) -> Option<std::collections::HashMap<String, Value>> {
+    ) -> (Option<std::collections::HashMap<String, Value>>) {
         cmd("XREAD").arg("STREAMS").arg(keys).arg(ids)
     }
 
@@ -2371,7 +2374,7 @@ implement_commands! {
         keys: &'a [K],
         ids: &'a [ID],
         options: &'a streams::StreamReadOptions
-    ) -> Option<std::collections::HashMap<String, Value>> {
+    ) -> (Option<std::collections::HashMap<String, Value>>) {
         cmd(if options.read_only() {
             "XREAD"
         } else {
@@ -2396,7 +2399,7 @@ implement_commands! {
         key: K,
         end: E,
         start: S
-    ) -> Vec<Value> {
+    ) -> (Vec<Value>) {
         cmd("XREVRANGE").arg(key).arg(end).arg(start)
     }
 
@@ -2407,7 +2410,7 @@ implement_commands! {
     /// XREVRANGE key + -
     /// ```
     /// [Redis Docs](https://redis.io/commands/XREVRANGE").arg(key).arg("+").arg("-)
-    fn xrevrange_all<K: ToRedisArgs>(key: K) -> Vec<Value> {
+    fn xrevrange_all<K: ToRedisArgs>(key: K) -> (Vec<Value>) {
         cmd("XREVRANGE").arg(key).arg("+").arg("-")
     }
 
@@ -2425,7 +2428,7 @@ implement_commands! {
         end: E,
         start: S,
         count: C
-    ) -> Vec<Value> {
+    ) -> (Vec<Value>) {
         cmd("XREVRANGE")
             .arg(key)
             .arg(end)
@@ -3084,6 +3087,3 @@ pub fn resp3_hello(connection_info: &RedisConnectionInfo) -> Cmd {
 
     hello_cmd
 }
-
-/// Dummy type used to indicate to the implement_commands macro that a command has a generic return type
-type Generic = ();

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -166,7 +166,7 @@ implement_commands! {
 
     /// Set the string value of a key with options.
     /// [Redis Docs](https://redis.io/commands/SET)
-    fn set_options<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V, options: SetOptions) -> GENERIC {
+    fn set_options<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V, options: SetOptions) -> Generic {
         cmd("SET").arg(key).arg(value).arg(options)
     }
 
@@ -687,13 +687,13 @@ implement_commands! {
     ///
     /// If `count` is not specified, then defaults to first element.
     /// [Redis Docs](https://redis.io/commands/LPOP)
-    fn lpop<K: ToRedisArgs>(key: K, count: Option<core::num::NonZeroUsize>) -> GENERIC {
+    fn lpop<K: ToRedisArgs>(key: K, count: Option<core::num::NonZeroUsize>) -> Generic {
         cmd("LPOP").arg(key).arg(count)
     }
 
     /// Returns the index of the first matching value of the list stored at key.
     /// [Redis Docs](https://redis.io/commands/LPOS)
-    fn lpos<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V, options: LposOptions) -> GENERIC {
+    fn lpos<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V, options: LposOptions) -> Generic {
         cmd("LPOS").arg(key).arg(value).arg(options)
     }
 
@@ -752,7 +752,7 @@ implement_commands! {
     ///
     /// If `count` is not specified, then defaults to last element.
     /// [Redis Docs](https://redis.io/commands/RPOP)
-    fn rpop<K: ToRedisArgs>(key: K, count: Option<core::num::NonZeroUsize>) -> GENERIC {
+    fn rpop<K: ToRedisArgs>(key: K, count: Option<core::num::NonZeroUsize>) -> Generic {
         cmd("RPOP").arg(key).arg(count)
     }
 
@@ -839,7 +839,7 @@ implement_commands! {
 
     /// Remove and return a random member from a set.
     /// [Redis Docs](https://redis.io/commands/SPOP)
-    fn spop<K: ToRedisArgs>(key: K) -> GENERIC {
+    fn spop<K: ToRedisArgs>(key: K) -> Generic {
         cmd("SPOP").arg(key)
     }
 
@@ -1018,13 +1018,13 @@ implement_commands! {
 
     /// Return up to count random members in a sorted set (or 1 if `count == None`)
     /// [Redis Docs](https://redis.io/commands/ZRANDMEMBER)
-    fn zrandmember<K: ToRedisArgs>(key: K, count: Option<isize>) -> GENERIC {
+    fn zrandmember<K: ToRedisArgs>(key: K, count: Option<isize>) -> Generic {
         cmd("ZRANDMEMBER").arg(key).arg(count)
     }
 
     /// Return up to count random members in a sorted set with scores
     /// [Redis Docs](https://redis.io/commands/ZRANDMEMBER)
-    fn zrandmember_withscores<K: ToRedisArgs>(key: K, count: isize) -> GENERIC {
+    fn zrandmember_withscores<K: ToRedisArgs>(key: K, count: isize) -> Generic {
         cmd("ZRANDMEMBER").arg(key).arg(count).arg("WITHSCORES")
     }
 
@@ -1631,7 +1631,7 @@ implement_commands! {
         radius: f64,
         unit: geo::Unit,
         options: geo::RadiusOptions
-    ) -> GENERIC {
+    ) -> Generic {
         cmd("GEORADIUS")
             .arg(key)
             .arg(longitude)
@@ -1652,7 +1652,7 @@ implement_commands! {
         radius: f64,
         unit: geo::Unit,
         options: geo::RadiusOptions
-    ) -> GENERIC {
+    ) -> Generic {
         cmd("GEORADIUSBYMEMBER")
             .arg(key)
             .arg(member)
@@ -1920,7 +1920,7 @@ implement_commands! {
         min_idle_time: MIT,
         ids: &'a [ID],
         options: streams::StreamClaimOptions
-    ) -> GENERIC {
+    ) -> Generic {
         cmd("XCLAIM")
             .arg(key)
             .arg(group)
@@ -2135,7 +2135,7 @@ implement_commands! {
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     /// [Redis Docs](https://redis.io/commands/XINFO").arg("STREAM)
-    fn xinfo_stream<K: ToRedisArgs>(key: K) -> GENERIC {
+    fn xinfo_stream<K: ToRedisArgs>(key: K) -> Generic {
         cmd("XINFO").arg("STREAM").arg(key)
     }
 
@@ -2172,7 +2172,7 @@ implement_commands! {
     fn xpending<K: ToRedisArgs, G: ToRedisArgs>(
         key: K,
         group: G
-    ) -> GENERIC {
+    ) -> Generic {
         cmd("XPENDING").arg(key).arg(group)
     }
 
@@ -2203,7 +2203,7 @@ implement_commands! {
         start: S,
         end: E,
         count: C
-    ) -> GENERIC {
+    ) -> Generic {
         cmd("XPENDING")
             .arg(key)
             .arg(group)
@@ -2240,7 +2240,7 @@ implement_commands! {
         end: E,
         count: C,
         consumer: CN
-    ) -> GENERIC {
+    ) -> Generic {
         cmd("XPENDING")
             .arg(key)
             .arg(group)
@@ -2268,7 +2268,7 @@ implement_commands! {
         key: K,
         start: S,
         end: E
-    ) -> GENERIC {
+    ) -> Generic {
         cmd("XRANGE").arg(key).arg(start).arg(end)
     }
 
@@ -2282,7 +2282,7 @@ implement_commands! {
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     /// [Redis Docs](https://redis.io/commands/XRANGE").arg(key).arg("-").arg("+)
-    fn xrange_all<K: ToRedisArgs>(key: K) -> GENERIC {
+    fn xrange_all<K: ToRedisArgs>(key: K) -> Generic {
         cmd("XRANGE").arg(key).arg("-").arg("+")
     }
 
@@ -2300,7 +2300,7 @@ implement_commands! {
         start: S,
         end: E,
         count: C
-    ) -> GENERIC {
+    ) -> Generic {
         cmd("XRANGE")
             .arg(key)
             .arg(start)
@@ -2495,7 +2495,7 @@ assert_eq!(b, 5);
 "##)]
     #[cfg(feature = "script")]
     #[cfg_attr(docsrs, doc(cfg(feature = "script")))]
-    fn invoke_script<>(invocation: &'a crate::ScriptInvocation<'a>) -> GENERIC {
+    fn invoke_script<>(invocation: &'a crate::ScriptInvocation<'a>) -> Generic {
         &mut invocation.eval_cmd()
     }
 
@@ -3086,4 +3086,4 @@ pub fn resp3_hello(connection_info: &RedisConnectionInfo) -> Cmd {
 }
 
 /// Dummy type used to indicate to the implement_commands macro that a command has a generic return type
-type GENERIC = ();
+type Generic = ();

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -603,7 +603,8 @@ pub use crate::types::{
     PushKind,
     VerbatimFormat,
     ProtocolVersion,
-    PushInfo
+    PushInfo,
+	ValueType
 };
 
 #[cfg(feature = "aio")]

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -234,8 +234,8 @@
 //!     let mut con = client.get_connection()?;
 //!     // `set` returns a `()`, so we don't need to specify the return type manually unlike in the previous example.
 //!     con.set("my_key", 42)?;
-//!     // `get_int` returns Option<isize>, as the key may not be found.
-//!     con.get_int("my_key").unwrap()
+//!     // `get_int` returns Result<Option<isize>>, as the key may not be found, or some error may occur.
+//!     Ok(con.get_int("my_key").unwrap().unwrap())
 //! }
 //! ```
 //!

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -591,6 +591,8 @@ pub use crate::types::{
     ExpireOption,
     Role,
     ReplicaInfo,
+    IntegerReplyOrNoOp,
+	ValueType,
 
     // error and result types
     RedisError,
@@ -604,7 +606,6 @@ pub use crate::types::{
     VerbatimFormat,
     ProtocolVersion,
     PushInfo,
-	ValueType
 };
 
 #[cfg(feature = "aio")]

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -610,7 +610,8 @@ pub use crate::types::{
 #[cfg(feature = "aio")]
 #[cfg_attr(docsrs, doc(cfg(feature = "aio")))]
 pub use crate::{
-    cmd::AsyncIter, commands::AsyncCommands, commands::AsyncTypedCommands, parser::parse_redis_value_async, types::RedisFuture,
+    cmd::AsyncIter, commands::AsyncCommands, commands::AsyncTypedCommands,
+    parser::parse_redis_value_async, types::RedisFuture,
 };
 
 mod macros;

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -609,7 +609,7 @@ pub use crate::types::{
 #[cfg(feature = "aio")]
 #[cfg_attr(docsrs, doc(cfg(feature = "aio")))]
 pub use crate::{
-    cmd::AsyncIter, commands::AsyncCommands, parser::parse_redis_value_async, types::RedisFuture,
+    cmd::AsyncIter, commands::AsyncCommands, commands::AsyncTypedCommands, parser::parse_redis_value_async, types::RedisFuture,
 };
 
 mod macros;

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -214,6 +214,31 @@
 //! # }
 //! ```
 //!
+//! ## Pre-typed Commands
+//!
+//! In some cases, you may not have a desired return type for a high-level command, and would
+//! instead like to use defaults provided by the library, to avoid the clutter and development overhead
+//! of specifying types for each command.
+//!
+//! The library facilitates this by providing the `TypedCommands` and `AsyncTypedCommands`
+//! as alternatives to `Commands` and `AsyncCommands` respectively. These traits provide functions
+//! with pre-defined and opinionated return types. For example, `set` returns `()`, avoiding the need
+//! for developers to explicitly type each call as returning `()`.
+//!
+//! ```rust,no_run
+//! use redis::TypedCommands;
+//!
+//! fn fetch_an_integer() -> redis::RedisResult<isize> {
+//!     // connect to redis
+//!     let client = redis::Client::open("redis://127.0.0.1/")?;
+//!     let mut con = client.get_connection()?;
+//!     // `set` returns a `()`, so we don't need to specify the return type manually unlike in the previous example.
+//!     con.set("my_key", 42)?;
+//!     // `get_int` returns Option<isize>, as the key may not be found.
+//!     con.get_int("my_key").unwrap()
+//! }
+//! ```
+//!
 //! # RESP3 support
 //! Since Redis / Valkey version 6, a newer communication protocol called RESP3 is supported.
 //! Using this protocol allows the user both to receive a more varied `Value` results, for users

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -553,7 +553,7 @@ pub use crate::cmd::CommandCacheConfig;
 pub use crate::cmd::{cmd, pack_command, pipe, Arg, Cmd, Iter};
 pub use crate::commands::{
     Commands, ControlFlow, Direction, FlushAllOptions, FlushDbOptions, HashFieldExpirationOptions,
-    LposOptions, PubSubCommands, ScanOptions, SetOptions,
+    LposOptions, PubSubCommands, ScanOptions, SetOptions, TypedCommands,
 };
 pub use crate::connection::{
     parse_redis_url, transaction, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike,

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -3010,13 +3010,13 @@ impl FromRedisValue for ValueType {
     }
 }
 
-/// Returned by typed commands which either return a positive integer, or some negative integer indicating some kind of no-op.
+/// Returned by typed commands which either return a positive integer or some negative integer indicating some kind of no-op.
 pub enum IntegerReplyOrNoOp {
     /// A positive integer reply indicating success of some kind.
     IntegerReply(u64),
     /// The field/key you are trying to operate on does not exist.
     NotExists,
-    /// The field/key you are trying to operate on exists, but is not of the correct type, or does not have some property you are trying to affect.
+    /// The field/key you are trying to operate on exists but is not of the correct type or does not have some property you are trying to affect.
     ExistsButNotRelevant,
 }
 

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -3013,7 +3013,6 @@ impl FromRedisValue for ValueType {
 /// Returned by typed commands which either return a positive integer, or some negative integer indicating some kind of no-op.
 pub enum IntegerReplyOrNoOp {
     /// A positive integer reply indicating success of some kind.
-    #[allow(dead_code)]
     IntegerReply(u64),
     /// The field/key you are trying to operate on does not exist.
     NotExists,

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2967,7 +2967,8 @@ pub enum ValueType {
 	Set,
 	ZSet,
 	Hash,
-	Stream
+	Stream,
+	Unknown(String)
 }
 
 impl FromRedisValue for ValueType {
@@ -2980,9 +2981,9 @@ impl FromRedisValue for ValueType {
 				"zset" => Ok(ValueType::ZSet),
 				"hash" => Ok(ValueType::Hash),
 				"stream" => Ok(ValueType::Stream),
-				_ => invalid_type_error!(v, "Unknown value type")
+				_ => Ok(ValueType::Unknown(s.clone()))
 			},
-			_ => invalid_type_error!(v, "Unknown value type")
+			_ => invalid_type_error!(v, "Value type should be a simple string")
 		}
 	}
 
@@ -2995,9 +2996,9 @@ impl FromRedisValue for ValueType {
 				"zset" => Ok(ValueType::ZSet),
 				"hash" => Ok(ValueType::Hash),
 				"stream" => Ok(ValueType::Stream),
-				_ => invalid_type_error!(s, "Unknown value type")
+				_ => Ok(ValueType::Unknown(s))
 			},
-			_ => invalid_type_error!(v, "Unknown value type")
+			_ => invalid_type_error!(v, "Value type should be a simple string")
 		}
 	}
 }

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2962,12 +2962,19 @@ pub(crate) fn closed_connection_error() -> RedisError {
 /// Possible types of value held in Redis, from https://redis.io/docs/latest/commands/type/
 #[derive(Debug, Clone, PartialEq)]
 pub enum ValueType {
+	/// Generally returned by anything that returns a single element. https://redis.io/docs/latest/develop/data-types/strings/
 	String,
+	/// A list of String values. https://redis.io/docs/latest/develop/data-types/lists/
 	List,
+	/// A set of unique String values. https://redis.io/docs/latest/develop/data-types/sets/
 	Set,
+	/// A sorted set of String values. https://redis.io/docs/latest/develop/data-types/sorted-sets/
 	ZSet,
+	/// A collection of field-value pairs. https://redis.io/docs/latest/develop/data-types/hashes/
 	Hash,
+	/// A Redis Stream. https://redis.io/docs/latest/develop/data-types/stream
 	Stream,
+	/// Any other value type not explicitly defined in https://redis.io/docs/latest/commands/type/
 	Unknown(String)
 }
 

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -3011,13 +3011,25 @@ impl FromRedisValue for ValueType {
 }
 
 /// Returned by typed commands which either return a positive integer or some negative integer indicating some kind of no-op.
+#[derive(Debug, PartialEq, Clone)]
 pub enum IntegerReplyOrNoOp {
     /// A positive integer reply indicating success of some kind.
-    IntegerReply(u64),
+    IntegerReply(usize),
     /// The field/key you are trying to operate on does not exist.
     NotExists,
     /// The field/key you are trying to operate on exists but is not of the correct type or does not have some property you are trying to affect.
     ExistsButNotRelevant,
+}
+
+impl IntegerReplyOrNoOp {
+    /// Returns the integer value of the reply.
+    pub fn raw(&self) -> isize {
+        match self {
+            IntegerReplyOrNoOp::IntegerReply(s) => *s as isize,
+            IntegerReplyOrNoOp::NotExists => -2,
+            IntegerReplyOrNoOp::ExistsButNotRelevant => -1,
+        }
+    }
 }
 
 impl FromRedisValue for IntegerReplyOrNoOp {
@@ -3026,7 +3038,7 @@ impl FromRedisValue for IntegerReplyOrNoOp {
             Value::Int(s) => match s {
                 -2 => Ok(IntegerReplyOrNoOp::NotExists),
                 -1 => Ok(IntegerReplyOrNoOp::ExistsButNotRelevant),
-                _ => Ok(IntegerReplyOrNoOp::IntegerReply(*s as u64)),
+                _ => Ok(IntegerReplyOrNoOp::IntegerReply(*s as usize)),
             },
             _ => invalid_type_error!(v, "Value should be an integer"),
         }
@@ -3037,9 +3049,47 @@ impl FromRedisValue for IntegerReplyOrNoOp {
             Value::Int(s) => match s {
                 -2 => Ok(IntegerReplyOrNoOp::NotExists),
                 -1 => Ok(IntegerReplyOrNoOp::ExistsButNotRelevant),
-                _ => Ok(IntegerReplyOrNoOp::IntegerReply(s as u64)),
+                _ => Ok(IntegerReplyOrNoOp::IntegerReply(s as usize)),
             },
             _ => invalid_type_error!(v, "Value should be an integer"),
+        }
+    }
+}
+
+impl PartialEq<isize> for IntegerReplyOrNoOp {
+    fn eq(&self, other: &isize) -> bool {
+        match self {
+            IntegerReplyOrNoOp::IntegerReply(s) => *s as isize == *other,
+            IntegerReplyOrNoOp::NotExists => *other == -2,
+            IntegerReplyOrNoOp::ExistsButNotRelevant => *other == -1,
+        }
+    }
+}
+
+impl PartialEq<usize> for IntegerReplyOrNoOp {
+    fn eq(&self, other: &usize) -> bool {
+        match self {
+            IntegerReplyOrNoOp::IntegerReply(s) => *s == *other,
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<i32> for IntegerReplyOrNoOp {
+    fn eq(&self, other: &i32) -> bool {
+        match self {
+            IntegerReplyOrNoOp::IntegerReply(s) => *s as i32 == *other,
+            IntegerReplyOrNoOp::NotExists => *other == -2,
+            IntegerReplyOrNoOp::ExistsButNotRelevant => *other == -1,
+        }
+    }
+}
+
+impl PartialEq<u32> for IntegerReplyOrNoOp {
+    fn eq(&self, other: &u32) -> bool {
+        match self {
+            IntegerReplyOrNoOp::IntegerReply(s) => *s as u32 == *other,
+            _ => false,
         }
     }
 }

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2962,85 +2962,85 @@ pub(crate) fn closed_connection_error() -> RedisError {
 /// Possible types of value held in Redis, from https://redis.io/docs/latest/commands/type/
 #[derive(Debug, Clone, PartialEq)]
 pub enum ValueType {
-	/// Generally returned by anything that returns a single element. https://redis.io/docs/latest/develop/data-types/strings/
-	String,
-	/// A list of String values. https://redis.io/docs/latest/develop/data-types/lists/
-	List,
-	/// A set of unique String values. https://redis.io/docs/latest/develop/data-types/sets/
-	Set,
-	/// A sorted set of String values. https://redis.io/docs/latest/develop/data-types/sorted-sets/
-	ZSet,
-	/// A collection of field-value pairs. https://redis.io/docs/latest/develop/data-types/hashes/
-	Hash,
-	/// A Redis Stream. https://redis.io/docs/latest/develop/data-types/stream
-	Stream,
-	/// Any other value type not explicitly defined in https://redis.io/docs/latest/commands/type/
-	Unknown(String)
+    /// Generally returned by anything that returns a single element. https://redis.io/docs/latest/develop/data-types/strings/
+    String,
+    /// A list of String values. https://redis.io/docs/latest/develop/data-types/lists/
+    List,
+    /// A set of unique String values. https://redis.io/docs/latest/develop/data-types/sets/
+    Set,
+    /// A sorted set of String values. https://redis.io/docs/latest/develop/data-types/sorted-sets/
+    ZSet,
+    /// A collection of field-value pairs. https://redis.io/docs/latest/develop/data-types/hashes/
+    Hash,
+    /// A Redis Stream. https://redis.io/docs/latest/develop/data-types/stream
+    Stream,
+    /// Any other value type not explicitly defined in https://redis.io/docs/latest/commands/type/
+    Unknown(String),
 }
 
 impl FromRedisValue for ValueType {
-	fn from_redis_value(v: &Value) -> RedisResult<Self> {
-		match v {
-			Value::SimpleString(s) => match s.as_str() {
-				"string" => Ok(ValueType::String),
-				"list" => Ok(ValueType::List),
-				"set" => Ok(ValueType::Set),
-				"zset" => Ok(ValueType::ZSet),
-				"hash" => Ok(ValueType::Hash),
-				"stream" => Ok(ValueType::Stream),
-				_ => Ok(ValueType::Unknown(s.clone()))
-			},
-			_ => invalid_type_error!(v, "Value type should be a simple string")
-		}
-	}
+    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+        match v {
+            Value::SimpleString(s) => match s.as_str() {
+                "string" => Ok(ValueType::String),
+                "list" => Ok(ValueType::List),
+                "set" => Ok(ValueType::Set),
+                "zset" => Ok(ValueType::ZSet),
+                "hash" => Ok(ValueType::Hash),
+                "stream" => Ok(ValueType::Stream),
+                _ => Ok(ValueType::Unknown(s.clone())),
+            },
+            _ => invalid_type_error!(v, "Value type should be a simple string"),
+        }
+    }
 
-	fn from_owned_redis_value(v: Value) -> RedisResult<Self> {
-		match v {
-			Value::SimpleString(s) => match s.as_str() {
-				"string" => Ok(ValueType::String),
-				"list" => Ok(ValueType::List),
-				"set" => Ok(ValueType::Set),
-				"zset" => Ok(ValueType::ZSet),
-				"hash" => Ok(ValueType::Hash),
-				"stream" => Ok(ValueType::Stream),
-				_ => Ok(ValueType::Unknown(s))
-			},
-			_ => invalid_type_error!(v, "Value type should be a simple string")
-		}
-	}
+    fn from_owned_redis_value(v: Value) -> RedisResult<Self> {
+        match v {
+            Value::SimpleString(s) => match s.as_str() {
+                "string" => Ok(ValueType::String),
+                "list" => Ok(ValueType::List),
+                "set" => Ok(ValueType::Set),
+                "zset" => Ok(ValueType::ZSet),
+                "hash" => Ok(ValueType::Hash),
+                "stream" => Ok(ValueType::Stream),
+                _ => Ok(ValueType::Unknown(s)),
+            },
+            _ => invalid_type_error!(v, "Value type should be a simple string"),
+        }
+    }
 }
 
 /// Returned by typed commands which either return a positive integer, or some negative integer indicating some kind of no-op.
 pub enum IntegerReplyOrNoOp {
-	/// A positive integer reply indicating success of some kind.
-	#[allow(dead_code)]
-	IntegerReply(u64),
-	/// The field/key you are trying to operate on does not exist.
-	NotExists,
-	/// The field/key you are trying to operate on exists, but is not of the correct type, or does not have some property you are trying to affect.
-	ExistsButNotRelevant
+    /// A positive integer reply indicating success of some kind.
+    #[allow(dead_code)]
+    IntegerReply(u64),
+    /// The field/key you are trying to operate on does not exist.
+    NotExists,
+    /// The field/key you are trying to operate on exists, but is not of the correct type, or does not have some property you are trying to affect.
+    ExistsButNotRelevant,
 }
 
 impl FromRedisValue for IntegerReplyOrNoOp {
-	fn from_redis_value(v: &Value) -> RedisResult<Self> {
-		match v {
-			Value::Int(s) => match s {
-				-2 => Ok(IntegerReplyOrNoOp::NotExists),
-				-1 => Ok(IntegerReplyOrNoOp::ExistsButNotRelevant),
-				_ => Ok(IntegerReplyOrNoOp::IntegerReply(*s as u64))
-			},
-			_ => invalid_type_error!(v, "Value should be an integer")
-		}
-	}
+    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+        match v {
+            Value::Int(s) => match s {
+                -2 => Ok(IntegerReplyOrNoOp::NotExists),
+                -1 => Ok(IntegerReplyOrNoOp::ExistsButNotRelevant),
+                _ => Ok(IntegerReplyOrNoOp::IntegerReply(*s as u64)),
+            },
+            _ => invalid_type_error!(v, "Value should be an integer"),
+        }
+    }
 
-	fn from_owned_redis_value(v: Value) -> RedisResult<Self> {
-		match v {
-			Value::Int(s) => match s {
-				-2 => Ok(IntegerReplyOrNoOp::NotExists),
-				-1 => Ok(IntegerReplyOrNoOp::ExistsButNotRelevant),
-				_ => Ok(IntegerReplyOrNoOp::IntegerReply(s as u64))
-			},
-			_ => invalid_type_error!(v, "Value should be an integer")
-		}
-	}
+    fn from_owned_redis_value(v: Value) -> RedisResult<Self> {
+        match v {
+            Value::Int(s) => match s {
+                -2 => Ok(IntegerReplyOrNoOp::NotExists),
+                -1 => Ok(IntegerReplyOrNoOp::ExistsButNotRelevant),
+                _ => Ok(IntegerReplyOrNoOp::IntegerReply(s as u64)),
+            },
+            _ => invalid_type_error!(v, "Value should be an integer"),
+        }
+    }
 }

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -3013,6 +3013,7 @@ impl FromRedisValue for ValueType {
 /// Returned by typed commands which either return a positive integer, or some negative integer indicating some kind of no-op.
 pub enum IntegerReplyOrNoOp {
 	/// A positive integer reply indicating success of some kind.
+	#[allow(dead_code)]
 	IntegerReply(u64),
 	/// The field/key you are trying to operate on does not exist.
 	NotExists,

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2959,22 +2959,22 @@ pub(crate) fn closed_connection_error() -> RedisError {
     RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe))
 }
 
-/// Possible types of value held in Redis, from https://redis.io/docs/latest/commands/type/
+/// Possible types of value held in Redis: [Redis Docs](https://redis.io/docs/latest/commands/type/)
 #[derive(Debug, Clone, PartialEq)]
 pub enum ValueType {
-    /// Generally returned by anything that returns a single element. https://redis.io/docs/latest/develop/data-types/strings/
+    /// Generally returned by anything that returns a single element. [Redis Docs](https://redis.io/docs/latest/develop/data-types/strings/)
     String,
-    /// A list of String values. https://redis.io/docs/latest/develop/data-types/lists/
+    /// A list of String values. [Redis Docs](https://redis.io/docs/latest/develop/data-types/lists/)
     List,
-    /// A set of unique String values. https://redis.io/docs/latest/develop/data-types/sets/
+    /// A set of unique String values. [Redis Docs](https://redis.io/docs/latest/develop/data-types/sets/)
     Set,
-    /// A sorted set of String values. https://redis.io/docs/latest/develop/data-types/sorted-sets/
+    /// A sorted set of String values. [Redis Docs](https://redis.io/docs/latest/develop/data-types/sorted-sets/)
     ZSet,
-    /// A collection of field-value pairs. https://redis.io/docs/latest/develop/data-types/hashes/
+    /// A collection of field-value pairs. [Redis Docs](https://redis.io/docs/latest/develop/data-types/hashes/)
     Hash,
-    /// A Redis Stream. https://redis.io/docs/latest/develop/data-types/stream
+    /// A Redis Stream. [Redis Docs](https://redis.io/docs/latest/develop/data-types/stream)
     Stream,
-    /// Any other value type not explicitly defined in https://redis.io/docs/latest/commands/type/
+    /// Any other value type not explicitly defined in [Redis Docs](https://redis.io/docs/latest/commands/type/)
     Unknown(String),
 }
 

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2958,3 +2958,46 @@ pub(crate) type SyncPushSender = std::sync::mpsc::Sender<PushInfo>;
 pub(crate) fn closed_connection_error() -> RedisError {
     RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe))
 }
+
+/// Possible types of value held in Redis, from https://redis.io/docs/latest/commands/type/
+#[derive(Debug, Clone, PartialEq)]
+pub enum ValueType {
+	String,
+	List,
+	Set,
+	ZSet,
+	Hash,
+	Stream
+}
+
+impl FromRedisValue for ValueType {
+	fn from_redis_value(v: &Value) -> RedisResult<Self> {
+		match v {
+			Value::SimpleString(s) => match s.as_str() {
+				"string" => Ok(ValueType::String),
+				"list" => Ok(ValueType::List),
+				"set" => Ok(ValueType::Set),
+				"zset" => Ok(ValueType::ZSet),
+				"hash" => Ok(ValueType::Hash),
+				"stream" => Ok(ValueType::Stream),
+				_ => invalid_type_error!(v, "Unknown value type")
+			},
+			_ => invalid_type_error!(v, "Unknown value type")
+		}
+	}
+
+	fn from_owned_redis_value(v: Value) -> RedisResult<Self> {
+		match v {
+			Value::SimpleString(s) => match s.as_str() {
+				"string" => Ok(ValueType::String),
+				"list" => Ok(ValueType::List),
+				"set" => Ok(ValueType::Set),
+				"zset" => Ok(ValueType::ZSet),
+				"hash" => Ok(ValueType::Hash),
+				"stream" => Ok(ValueType::Stream),
+				_ => invalid_type_error!(s, "Unknown value type")
+			},
+			_ => invalid_type_error!(v, "Unknown value type")
+		}
+	}
+}

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -2151,7 +2151,7 @@ mod basic {
         let map = HashMap::from([("one", 1), ("two", 2), ("three", 3)]);
 
         // Insert all pairs as entries of the hash `KEY`
-        assert_eq!(con.del(KEY), Ok(()));
+        assert!(con.del(KEY).is_ok());
         for kv in map.iter() {
             assert_eq!(con.hset(KEY, kv.0, kv.1), Ok(1));
         }

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -25,7 +25,7 @@ mod basic {
     use rand::{rng, Rng};
     use redis::IntegerReplyOrNoOp::{ExistsButNotRelevant, IntegerReply};
     use redis::{
-        cmd, Connection, ProtocolVersion, PushInfo, RedisConnectionInfo, Role, ScanOptions,
+        cmd, Client, Connection, ProtocolVersion, PushInfo, RedisConnectionInfo, Role, ScanOptions,
         ValueType,
     };
     use redis::{


### PR DESCRIPTION
A solution to #1228 and #1322 , as described by @nihohit.

Introduce two new traits `TypedCommands` and `AsyncTypedCommands` that behave like their non-typed counterparts, but return specifically opinionated types instead.

The return types are defined in the existing place in `commands/mod.rs` that defines the inputs for `Commands` and `AsyncCommands`. The existing macros for generating `Commands` and `AsyncCommands` will ignore the return type, while the new ones for the typed variants will include those types in the generated methods. Additionally, if a return type is omitted, it will default to `redis::Value`.