### PR TITLE
Add `transaction_async` function

### DIFF
--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -4,7 +4,8 @@
 use super::async_std;
 use super::ConnectionLike;
 use super::{setup_connection, AsyncStream, RedisRuntime};
-use crate::cmd::{cmd, Cmd};
+use crate::cmd::{cmd, pipe, Cmd};
+use crate::pipeline::Pipeline;
 use crate::connection::{
     resp2_is_pub_sub_state_cleared, resp3_is_pub_sub_state_cleared, ConnectionAddr, ConnectionInfo,
     Msg, RedisConnectionInfo,
@@ -24,6 +25,7 @@ use futures_util::{
     future::FutureExt,
     stream::{Stream, StreamExt},
 };
+use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
 #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
@@ -501,4 +503,36 @@ pub(crate) async fn connect_simple<T: RedisRuntime>(
             )))
         }
     })
+}
+
+/// This function, akin to `redis::transaction`, simplifies transaction management slightly, but asynchronously.
+pub async fn transaction_async<
+    C: ConnectionLike + Clone,
+    K: ToRedisArgs,
+    T: FromRedisValue,
+    F: Fn(C, Pipeline) -> Fut,
+    Fut: Future<Output = Result<Option<T>, RedisError>>,
+>(
+    mut connection: C,
+    keys: &[K],
+    func: F,
+) -> Result<T, RedisError> {
+    loop {
+        cmd("WATCH")
+            .arg(keys)
+            .exec_async(&mut connection)
+            .await?;
+
+        let mut p = pipe();
+        let response = func(connection.clone(), p.atomic().to_owned()).await?;
+
+        match response {
+            None => continue,
+            Some(response) => {
+                cmd("UNWATCH").exec_async(&mut connection).await?;
+
+                return Ok(response);
+            }
+        }
+    }
 }


### PR DESCRIPTION
# Description
This PR aims to add the asynchronous version of the `redis::transaction` function.
To do so, I duplicated the implementation of `redis::transaction` and adapted it with the asynchronous constraints:
The function takes a `redis::aio::ConnectionLike` instead of`redis::ConnectionLike` and requires this argument to be cloneable (and avoid any problem with lifetime). The underlying connection should be `MultiplexedConnection` or `ConnectionManager` which are both no costly to clone.
