### PR TITLE
feat(cluster): add `get(_async)?_connection_with_config`

### DIFF
--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -121,6 +121,18 @@ impl ClusterParams {
             async_push_sender: value.async_push_sender,
         })
     }
+    fn apply_config(&mut self, config: cluster::ClusterConfig) {
+        if let Some(connection_timeout) = config.connection_timeout {
+            self.connection_timeout = connection_timeout;
+        }
+        if let Some(response_timeout) = config.response_timeout {
+            self.response_timeout = response_timeout;
+        }
+        #[cfg(feature = "cluster-async")]
+        if let Some(async_push_sender) = config.async_push_sender {
+            self.async_push_sender = Some(async_push_sender);
+        }
+    }
 }
 
 /// Used to configure and build a [`ClusterClient`].
@@ -434,6 +446,21 @@ impl ClusterClient {
         cluster::ClusterConnection::new(self.cluster_params.clone(), self.initial_nodes.clone())
     }
 
+    /// Creates new connections to Redis Cluster nodes with a custom config and returns a
+    /// [`cluster_async::ClusterConnection`].
+    ///
+    /// # Errors
+    ///
+    /// An error is returned if there is a failure while creating connections or slots.
+    pub fn get_connection_with_config(
+        &self,
+        config: cluster::ClusterConfig,
+    ) -> RedisResult<cluster::ClusterConnection> {
+        let mut cluster_params = self.cluster_params.clone();
+        cluster_params.apply_config(config);
+        cluster::ClusterConnection::new(cluster_params, self.initial_nodes.clone())
+    }
+
     /// Creates new connections to Redis Cluster nodes and returns a
     /// [`cluster_async::ClusterConnection`].
     ///
@@ -444,6 +471,22 @@ impl ClusterClient {
     pub async fn get_async_connection(&self) -> RedisResult<cluster_async::ClusterConnection> {
         cluster_async::ClusterConnection::new(&self.initial_nodes, self.cluster_params.clone())
             .await
+    }
+
+    /// Creates new connections to Redis Cluster nodes with a custom config and returns a
+    /// [`cluster_async::ClusterConnection`].
+    ///
+    /// # Errors
+    ///
+    /// An error is returned if there is a failure while creating connections or slots.
+    #[cfg(feature = "cluster-async")]
+    pub async fn get_async_connection_with_config(
+        &self,
+        config: cluster::ClusterConfig,
+    ) -> RedisResult<cluster_async::ClusterConnection> {
+        let mut cluster_params = self.cluster_params.clone();
+        cluster_params.apply_config(config);
+        cluster_async::ClusterConnection::new(&self.initial_nodes, cluster_params).await
     }
 
     #[doc(hidden)]


### PR DESCRIPTION
This will allow to change some configuration fields based on the `ClusterConfig` type when creating the connection.
It is inspired from the `AsyncConnectionConfig` type for standalone async redis.

Here are the fields that can be set when calling `get_async_connection_with_config` and `get_connection_with_config`:
```rust
pub struct ClusterConfig {
    pub(crate) connection_timeout: Option<Duration>,
    pub(crate) response_timeout: Option<Duration>,
    #[cfg(feature = "cluster-async")]
    pub(crate) async_push_sender: Option<std::sync::Arc<dyn crate::aio::AsyncPushSender>>,
}
 ```

It a subset of the `ClusterParams` type and overwrite its fields if there are set on `ClusterConfig`.

* Fixes issue #1486 