### PR TITLE
Fix RetryMethod Import

### DIFF
--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -548,6 +548,7 @@ pub use crate::types::{
 
     // error kinds
     ErrorKind,
+    RetryMethod,
 
     // conversion traits
     FromRedisValue,


### PR DESCRIPTION
Noticed that while the `retry_method()` function was exported the type wasn't, this was due to it being missing from `lib.rs` it seems.

Could this be included in a minor release in version 28?