### PR TITLE
Hm/review fixes

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -127,7 +127,7 @@ cache-aio = ["aio", "dep:lru"]
 tls = ["tls-native-tls"] # use "tls-native-tls" instead
 async-std-tls-comp = ["async-std-native-tls-comp"] # use "async-std-native-tls-comp" instead
 # Instead of specifying "aio", use either "tokio-comp" or "async-std-comp".
-aio = ["bytes", "dep:pin-project-lite", "dep:futures-util", "dep:tokio", "tokio/io-util", "dep:tokio-util", "tokio-util/codec", "combine/tokio"]
+aio = ["bytes", "dep:pin-project-lite", "dep:futures-util", "dep:tokio", "tokio/io-util", "dep:tokio-util", "tokio-util/codec", "combine/tokio", "dep:log"]
 
 [dev-dependencies]
 assert_approx_eq = "1.0"

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -452,14 +452,9 @@ mod basic_async {
                     .get("x")
                     .get("y");
 
-                let res: Result<Vec<redis::Value>, RedisError> =
+                let res: Result<_, RedisError> =
                     redis::aio::transaction_async(con, &["x", "y"], &mut pipe).await;
-
-                let values = res.unwrap();
-                println!("RESULT value : {:?}", values);
-                let last_value: Vec<redis::Value> =
-                    redis::from_redis_value(values.last().expect("Error ?")).unwrap();
-
+                let last_value: Vec<redis::Value> = res.unwrap();
                 let x: i32 = redis::from_redis_value(&last_value[2]).unwrap();
                 let y: i32 = redis::from_redis_value(&last_value[3]).unwrap();
                 assert_eq!(x, 42);


### PR DESCRIPTION
Difference with previous work : 

- Updated F: Fn(C, Pipeline) -> Fut, to F: Fn(Pipeline) -> Pipeline like the maintainer asked
- Manually performed the wrapping the .atomic() function does, otherwise the DB will return an error of a conflicting MULTI / WATCH
- discard the intermediary potential outputs of the transaction
In more simple terms, this is the actual response : 
```
[ok, ok, simple-string("QUEUED"), simple-string("QUEUED"), simple-string("QUEUED"), simple-string("QUEUED"), array([ok, ok, bulk-string('"42"'), bulk-string('"21"')]), ok]
```

We only want that last array

- update docs, tests, etc