### PR TITLE
Allow users of async connections to set TCP settings.

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "redis"
 version = "0.28.2"
-keywords = ["redis",  "valkey", "cluster", "sentinel", "pubsub"]
+keywords = ["redis", "valkey", "cluster", "sentinel", "pubsub"]
 description = "Redis driver for Rust."
 homepage = "https://github.com/redis-rs/redis-rs"
 repository = "https://github.com/redis-rs/redis-rs"
@@ -38,11 +38,19 @@ combine = { version = "4.6", default-features = false, features = ["std"] }
 
 # Only needed for AIO
 bytes = { version = "1", optional = true }
-futures-util = { version = "0.3.31", default-features = false, features = ["std", "sink"], optional = true }
+futures-util = { version = "0.3.31", default-features = false, features = [
+  "std",
+  "sink",
+], optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 tokio-util = { version = "0.7", optional = true }
-tokio = { version = "1", features = ["rt", "net", "time", "sync"], optional = true }
-socket2 = { version = "0.5", default-features = false, optional = true }
+tokio = { version = "1", features = [
+  "rt",
+  "net",
+  "time",
+  "sync",
+], optional = true }
+socket2 = { version = "0.5", features = ["all"] }
 
 # Only needed for the connection manager
 arc-swap = { version = "1.7.1" }
@@ -94,7 +102,7 @@ uuid = { version = "1.12.1", optional = true }
 # Optional hashbrown support
 hashbrown = { version = "0.15", optional = true }
 
-lru = {version =  "0.12.3", optional = true}
+lru = { version = "0.12.3", optional = true }
 
 [features]
 default = ["acl", "streams", "geospatial", "script", "keep-alive"]
@@ -104,11 +112,20 @@ json = ["dep:serde", "serde/derive", "dep:serde_json"]
 cluster = ["dep:crc16", "dep:rand"]
 script = ["dep:sha1_smol"]
 tls-native-tls = ["dep:native-tls"]
-tls-rustls = ["dep:rustls","rustls/std", "rustls/ring", "dep:rustls-native-certs"]
+tls-rustls = [
+  "dep:rustls",
+  "rustls/std",
+  "rustls/ring",
+  "dep:rustls-native-certs",
+]
 tls-rustls-insecure = ["tls-rustls"]
 tls-rustls-webpki-roots = ["tls-rustls", "dep:webpki-roots"]
 async-std-comp = ["aio", "dep:async-std"]
-async-std-native-tls-comp = ["async-std-comp", "dep:async-native-tls", "tls-native-tls"]
+async-std-native-tls-comp = [
+  "async-std-comp",
+  "dep:async-native-tls",
+  "tls-native-tls",
+]
 async-std-rustls-comp = ["async-std-comp", "dep:futures-rustls", "tls-rustls"]
 tokio-comp = ["aio", "tokio/net"]
 tokio-native-tls-comp = ["tokio-comp", "tls-native-tls", "dep:tokio-native-tls"]
@@ -116,7 +133,7 @@ tokio-rustls-comp = ["tokio-comp", "tls-rustls", "dep:tokio-rustls"]
 connection-manager = ["dep:futures-channel", "aio", "dep:backon"]
 streams = []
 cluster-async = ["aio", "cluster", "dep:futures-sink", "dep:log"]
-keep-alive = ["dep:socket2"]
+keep-alive = []
 sentinel = ["dep:rand"]
 tcp_nodelay = []
 num-bigint = []
@@ -125,9 +142,20 @@ cache-aio = ["aio", "dep:lru"]
 
 # Deprecated features
 tls = ["tls-native-tls"] # use "tls-native-tls" instead
-async-std-tls-comp = ["async-std-native-tls-comp"] # use "async-std-native-tls-comp" instead
+async-std-tls-comp = [
+  "async-std-native-tls-comp",
+] # use "async-std-native-tls-comp" instead
 # Instead of specifying "aio", use either "tokio-comp" or "async-std-comp".
-aio = ["bytes", "dep:pin-project-lite", "dep:futures-util", "dep:tokio", "tokio/io-util", "dep:tokio-util", "tokio-util/codec", "combine/tokio"]
+aio = [
+  "bytes",
+  "dep:pin-project-lite",
+  "dep:futures-util",
+  "dep:tokio",
+  "tokio/io-util",
+  "dep:tokio-util",
+  "tokio-util/codec",
+  "combine/tokio",
+]
 
 [dev-dependencies]
 assert_approx_eq = "1.0"
@@ -137,7 +165,13 @@ futures-time = "3"
 criterion = "0.5"
 partial-io = { version = "0.5", features = ["tokio", "quickcheck1"] }
 quickcheck = "1.0.3"
-tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "test-util", "time"] }
+tokio = { version = "1", features = [
+  "rt",
+  "macros",
+  "rt-multi-thread",
+  "test-util",
+  "time",
+] }
 tempfile = "=3.16.0"
 once_cell = "1"
 anyhow = "1"

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -36,6 +36,7 @@ pub struct ConnectionManagerConfig {
     push_sender: Option<Arc<dyn AsyncPushSender>>,
     /// if true, the manager should resubscribe automatically to all pubsub channels after reconnect.
     resubscribe_automatically: bool,
+    tcp_settings: crate::io::tcp::TcpSettings,
 }
 
 impl std::fmt::Debug for ConnectionManagerConfig {
@@ -49,6 +50,7 @@ impl std::fmt::Debug for ConnectionManagerConfig {
             connection_timeout,
             push_sender,
             resubscribe_automatically,
+            tcp_settings,
         } = &self;
         f.debug_struct("ConnectionManagerConfig")
             .field("exponent_base", &exponent_base)
@@ -66,6 +68,7 @@ impl std::fmt::Debug for ConnectionManagerConfig {
                     &"not set"
                 },
             )
+            .field("tcp_settings", &tcp_settings)
             .finish()
     }
 }
@@ -165,6 +168,14 @@ impl ConnectionManagerConfig {
         self.resubscribe_automatically = true;
         self
     }
+
+    /// Set the behavior of the underlying TCP connection.
+    pub fn set_tcp_settings(self, tcp_settings: crate::io::tcp::TcpSettings) -> Self {
+        Self {
+            tcp_settings,
+            ..self
+        }
+    }
 }
 
 impl Default for ConnectionManagerConfig {
@@ -173,11 +184,12 @@ impl Default for ConnectionManagerConfig {
             exponent_base: Self::DEFAULT_CONNECTION_RETRY_EXPONENT_BASE,
             factor: Self::DEFAULT_CONNECTION_RETRY_FACTOR,
             number_of_retries: Self::DEFAULT_NUMBER_OF_CONNECTION_RETRIES,
-            max_delay: None,
             response_timeout: Self::DEFAULT_RESPONSE_TIMEOUT,
             connection_timeout: Self::DEFAULT_CONNECTION_TIMEOUT,
+            max_delay: None,
             push_sender: None,
             resubscribe_automatically: false,
+            tcp_settings: Default::default(),
         }
     }
 }
@@ -359,6 +371,7 @@ impl ConnectionManager {
         if let Some(response_timeout) = config.response_timeout {
             connection_config = connection_config.set_response_timeout(response_timeout);
         }
+        connection_config = connection_config.set_tcp_settings(config.tcp_settings);
 
         let (oneshot_sender, oneshot_receiver) = oneshot::channel();
         let _task_handle = HandleContainer::new(

--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -35,7 +35,10 @@ pub use pubsub::{PubSub, PubSubSink, PubSubStream};
 /// Represents the ability of connecting via TCP or via Unix socket
 pub(crate) trait RedisRuntime: AsyncStream + Send + Sync + Sized + 'static {
     /// Performs a TCP connection
-    async fn connect_tcp(socket_addr: SocketAddr) -> RedisResult<Self>;
+    async fn connect_tcp(
+        socket_addr: SocketAddr,
+        tcp_settings: &crate::io::tcp::TcpSettings,
+    ) -> RedisResult<Self>;
 
     // Performs a TCP TLS connection
     #[cfg(any(feature = "tls-native-tls", feature = "tls-rustls"))]
@@ -44,6 +47,7 @@ pub(crate) trait RedisRuntime: AsyncStream + Send + Sync + Sized + 'static {
         socket_addr: SocketAddr,
         insecure: bool,
         tls_params: &Option<TlsConnParams>,
+        tcp_settings: &crate::io::tcp::TcpSettings,
     ) -> RedisResult<Self>;
 
     /// Performs a UNIX connection

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -475,10 +475,7 @@ impl MultiplexedConnection {
             stream,
             AsyncConnectionConfig {
                 response_timeout,
-                connection_timeout: None,
-                push_sender: None,
-                #[cfg(feature = "cache-aio")]
-                cache_config: None,
+                ..Default::default()
             },
         )
         .await

--- a/redis/src/aio/tokio.rs
+++ b/redis/src/aio/tokio.rs
@@ -37,23 +37,11 @@ use super::Path;
 #[inline(always)]
 async fn connect_tcp(addr: &SocketAddr) -> io::Result<TcpStreamTokio> {
     let socket = TcpStreamTokio::connect(addr).await?;
-    #[cfg(feature = "tcp_nodelay")]
-    socket.set_nodelay(true)?;
-    #[cfg(feature = "keep-alive")]
-    {
-        //For now rely on system defaults
-        const KEEP_ALIVE: socket2::TcpKeepalive = socket2::TcpKeepalive::new();
-        //these are useless error that not going to happen
-        let std_socket = socket.into_std()?;
-        let socket2: socket2::Socket = std_socket.into();
-        socket2.set_tcp_keepalive(&KEEP_ALIVE)?;
-        TcpStreamTokio::from_std(socket2.into())
-    }
+    let std_socket = socket.into_std()?;
+    let std_socket =
+        crate::io::tcp::stream_with_settings(std_socket, &crate::io::tcp::TcpSettings::default())?;
 
-    #[cfg(not(feature = "keep-alive"))]
-    {
-        Ok(socket)
-    }
+    TcpStreamTokio::from_std(std_socket)
 }
 
 pub(crate) enum Tokio {

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -1350,10 +1350,12 @@ where
     let connection_timeout = params.connection_timeout;
     let response_timeout = params.response_timeout;
     let push_sender = params.async_push_sender.clone();
+    let tcp_settings = params.tcp_settings.clone();
     let info = get_connection_info(node, params)?;
     let mut config = AsyncConnectionConfig::default()
         .set_connection_timeout(connection_timeout)
-        .set_response_timeout(response_timeout);
+        .set_response_timeout(response_timeout)
+        .set_tcp_settings(tcp_settings);
     if let Some(push_sender) = push_sender {
         config = config.set_push_sender_internal(push_sender);
     }

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "cluster-async")]
 use crate::aio::AsyncPushSender;
 use crate::connection::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo};
+use crate::io::tcp::TcpSettings;
 use crate::types::{ErrorKind, ProtocolVersion, RedisError, RedisResult};
 use crate::{cluster, cluster::TlsMode};
 use rand::Rng;
@@ -37,6 +38,7 @@ struct BuilderParams {
     protocol: Option<ProtocolVersion>,
     #[cfg(feature = "cluster-async")]
     async_push_sender: Option<Arc<dyn AsyncPushSender>>,
+    pub(crate) tcp_settings: TcpSettings,
 }
 
 #[derive(Clone)]
@@ -93,6 +95,7 @@ pub(crate) struct ClusterParams {
     pub(crate) protocol: Option<ProtocolVersion>,
     #[cfg(feature = "cluster-async")]
     pub(crate) async_push_sender: Option<Arc<dyn AsyncPushSender>>,
+    pub(crate) tcp_settings: TcpSettings,
 }
 
 impl ClusterParams {
@@ -119,6 +122,7 @@ impl ClusterParams {
             protocol: value.protocol,
             #[cfg(feature = "cluster-async")]
             async_push_sender: value.async_push_sender,
+            tcp_settings: value.tcp_settings,
         })
     }
 
@@ -404,6 +408,13 @@ impl ClusterClientBuilder {
     /// ```
     pub fn push_sender(mut self, push_sender: impl AsyncPushSender) -> ClusterClientBuilder {
         self.builder_params.async_push_sender = Some(Arc::new(push_sender));
+        self
+    }
+
+    /// Set the behavior of the underlying TCP connection.
+    #[cfg(feature = "cluster-async")]
+    pub fn tcp_settings(mut self, tcp_settings: TcpSettings) -> ClusterClientBuilder {
+        self.builder_params.tcp_settings = tcp_settings;
         self
     }
 }

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -9,6 +9,7 @@ use std::str::{from_utf8, FromStr};
 use std::time::{Duration, Instant};
 
 use crate::cmd::{cmd, pipe, Cmd};
+use crate::io::tcp::{stream_with_settings, TcpSettings};
 use crate::parser::Parser;
 use crate::pipeline::Pipeline;
 use crate::types::{
@@ -52,41 +53,13 @@ static DEFAULT_PORT: u16 = 6379;
 #[inline(always)]
 fn connect_tcp(addr: (&str, u16)) -> io::Result<TcpStream> {
     let socket = TcpStream::connect(addr)?;
-    #[cfg(feature = "tcp_nodelay")]
-    socket.set_nodelay(true)?;
-    #[cfg(feature = "keep-alive")]
-    {
-        //For now rely on system defaults
-        const KEEP_ALIVE: socket2::TcpKeepalive = socket2::TcpKeepalive::new();
-        //these are useless error that not going to happen
-        let socket2: socket2::Socket = socket.into();
-        socket2.set_tcp_keepalive(&KEEP_ALIVE)?;
-        Ok(socket2.into())
-    }
-    #[cfg(not(feature = "keep-alive"))]
-    {
-        Ok(socket)
-    }
+    stream_with_settings(socket, &TcpSettings::default())
 }
 
 #[inline(always)]
 fn connect_tcp_timeout(addr: &SocketAddr, timeout: Duration) -> io::Result<TcpStream> {
     let socket = TcpStream::connect_timeout(addr, timeout)?;
-    #[cfg(feature = "tcp_nodelay")]
-    socket.set_nodelay(true)?;
-    #[cfg(feature = "keep-alive")]
-    {
-        //For now rely on system defaults
-        const KEEP_ALIVE: socket2::TcpKeepalive = socket2::TcpKeepalive::new();
-        //these are useless error that not going to happen
-        let socket2: socket2::Socket = socket.into();
-        socket2.set_tcp_keepalive(&KEEP_ALIVE)?;
-        Ok(socket2.into())
-    }
-    #[cfg(not(feature = "keep-alive"))]
-    {
-        Ok(socket)
-    }
+    stream_with_settings(socket, &TcpSettings::default())
 }
 
 /// This function takes a redis URL string and parses it into a URL

--- a/redis/src/io/mod.rs
+++ b/redis/src/io/mod.rs
@@ -1,0 +1,2 @@
+/// Module for defining the TCP settings and behavior.
+pub mod tcp;

--- a/redis/src/io/tcp.rs
+++ b/redis/src/io/tcp.rs
@@ -1,0 +1,57 @@
+use std::{io, net::TcpStream, time::Duration};
+
+/// Settings for a TCP stream.
+#[derive(Clone, Debug)]
+pub struct TcpSettings {
+    nodelay: bool,
+    keepalive: socket2::TcpKeepalive,
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    user_timeout: Option<Duration>,
+}
+
+impl TcpSettings {
+    /// Sets the value of the `TCP_NODELAY` option on this socket.
+    pub fn set_nodelay(self, nodelay: bool) -> Self {
+        Self { nodelay, ..self }
+    }
+
+    /// Set parameters configuring TCP keepalive probes for this socket.
+    pub fn set_keepalive(self, keepalive: socket2::TcpKeepalive) -> Self {
+        Self { keepalive, ..self }
+    }
+
+    /// Set the value of the `TCP_USER_TIMEOUT` option on this socket.
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    pub fn set_user_timeout(self, user_timeout: Option<Duration>) -> Self {
+        Self {
+            user_timeout,
+            ..self
+        }
+    }
+}
+
+impl Default for TcpSettings {
+    fn default() -> Self {
+        Self {
+            #[cfg(feature = "tcp_nodelay")]
+            nodelay: true,
+            #[cfg(not(feature = "tcp_nodelay"))]
+            nodelay: false,
+            keepalive: socket2::TcpKeepalive::new(),
+            #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+            user_timeout: Some(Duration::from_secs(5)),
+        }
+    }
+}
+
+pub(crate) fn stream_with_settings(
+    socket: TcpStream,
+    settings: &TcpSettings,
+) -> io::Result<TcpStream> {
+    socket.set_nodelay(settings.nodelay)?;
+    let socket2: socket2::Socket = socket.into();
+    socket2.set_tcp_keepalive(&settings.keepalive)?;
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    socket2.set_tcp_user_timeout(settings.user_timeout)?;
+    Ok(socket2.into())
+}

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -32,6 +32,12 @@
 //! `tokio-rustls-comp`, `async-std-native-tls-comp`, or `async-std-rustls-comp`. Additionally, the
 //! `tls-rustls-webpki-roots` allows usage of of webpki-roots for the root certificate store.
 //!
+//! # TCP settings
+//!
+//! The user can set parameters of the underlying TCP connection by using the `tcp_nodelay` and `keep-alive` features.
+//! Alternatively, users of async connections can set [crate::io::tcp::TcpSettings] on the connection configuration objects,
+//! and set the TCP parameters in a more specific manner there.
+//!
 //! ## Connection Handling
 //!
 //! For connecting to redis you can use a client object which then can produce

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -661,6 +661,8 @@ mod client;
 mod cmd;
 mod commands;
 mod connection;
+/// Module for defining I/O behavior.
+pub mod io;
 mod parser;
 mod script;
 mod types;


### PR DESCRIPTION
https://github.com/redis-rs/redis-rs/issues/1470
https://github.com/redis-rs/redis-rs/issues/1147

ATM this change is only for async connections, in order to get early feedback quickly. This can technically be added to sync connections too.