### PR TITLE
Cluster connect hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,6 +510,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "connect-hook-test"
+version = "0.1.0"
+dependencies = [
+ "redis",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["redis", "redis-test", "valkey", "afl/parser"]
+members = ["redis", "redis-test", "valkey", "afl/parser", "connect-hook-test"]
 resolver = "2"

--- a/connect-hook-test/Cargo.toml
+++ b/connect-hook-test/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "connect-hook-test"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+redis = { path = "../redis", features = ["cluster", "tls-native-tls"] }

--- a/connect-hook-test/src/main.rs
+++ b/connect-hook-test/src/main.rs
@@ -1,0 +1,37 @@
+//! This command demonstrates using a commit hook to bypass some network issues to reach a Redis
+//! cluster. It works without disabling SSL strict hostname checking or other security features.
+//!
+//! This program uses a `connect_hook` to rewrite addresses as we connect. I used this on my
+//! machine to make the client ignore the IP addresses the cluster tells it to use (which for
+//! networking reasons aren't reachable from my dev machine) and instead use a hostname that works.
+
+use redis::cluster::ClusterClient;
+use redis::Commands;
+
+fn main() -> redis::RedisResult<()> {
+    let password = std::env::var("REDISCLI_AUTH")
+        .expect("export REDISCLI_AUTH=<password> before running this");
+    let redis_ip =
+        std::env::var("REDIS_IP").expect("set REDIS_IP to an IP the cluster will tell us to use");
+    let redis_host =
+        std::env::var("REDIS_HOST").expect("set REDIS_HOST to the cluster host we should use");
+    let init_port = std::env::var("REDIS_PORT").unwrap_or("6380".to_string());
+    let key = std::env::var("KEY").expect("set KEY to a key to query");
+
+    // connect to redis
+    let client =
+        ClusterClient::builder([format!("rediss://:{password}@{redis_host}:{init_port}/")])
+            .connect_hook(move |mut host, port| {
+                if host == redis_ip {
+                    host = redis_host.to_string();
+                }
+                eprintln!("connecting to: {host}:{port}");
+                Ok((host, port))
+            })
+            .build()?;
+
+    let mut con = client.get_connection()?;
+    let result: redis::Value = con.get(key.as_str())?;
+    println!("ok: {result:#?}");
+    Ok(())
+}

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -1081,7 +1081,11 @@ pub(crate) fn get_connection_info(
     node: &str,
     cluster_params: ClusterParams,
 ) -> RedisResult<ConnectionInfo> {
-    let (host, port) = split_node_address(node)?;
+    let (mut host, mut port) = split_node_address(node)?;
+
+    if let Some(hook) = cluster_params.connect_hook {
+        (host, port) = hook(host, port)?;
+    }
 
     Ok(ConnectionInfo {
         addr: get_connection_addr(host, port, cluster_params.tls, cluster_params.tls_params),


### PR DESCRIPTION
I have a Redis 6 cluster. It unconditionally sends out node addresses as IPs. However, the nodes have certificates which only cover their hostnames, not their IPs. (I can't control the certificates.) So when I connect to the cluster with redis-rs, all non-initial connections fail with certificate errors.

Right now, I can connect by using `TlsMode::Insecure`, but I need a better solution.

The idea here is to add a hook that's called every time a ClusterClient connects to a node. It allows the client to rewrite the address and port used for the connection. This solves my problem: I can rewrite the IP addresses back to the hostnames that are in the certificates.

I'm sure this is not acceptable as-is (there aren't any tests and the connect hook API is not optimal), but consider it a proof of concept. Does the idea make sense?