### PR TITLE
Renaming tests the require the JSON module

### DIFF
--- a/redis/tests/test_cache.rs
+++ b/redis/tests/test_cache.rs
@@ -138,7 +138,7 @@ fn test_cache_mget(#[case] runtime: RuntimeType) {
 #[cfg(feature = "json")]
 #[case::tokio(RuntimeType::Tokio)]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
-fn test_cache_json_get_mget(#[case] runtime: RuntimeType) {
+fn test_module_cache_json_get_mget(#[case] runtime: RuntimeType) {
     let ctx = TestContext::with_modules(&[Module::Json], false);
     if ctx.protocol == ProtocolVersion::RESP2 {
         return;
@@ -211,7 +211,7 @@ fn test_cache_json_get_mget(#[case] runtime: RuntimeType) {
 #[cfg(feature = "json")]
 #[case::tokio(RuntimeType::Tokio)]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
-fn test_cache_json_get_mget_different_paths(#[case] runtime: RuntimeType) {
+fn test_module_cache_json_get_mget_different_paths(#[case] runtime: RuntimeType) {
     let ctx = TestContext::with_modules(&[Module::Json], false);
     if ctx.protocol == ProtocolVersion::RESP2 {
         return;


### PR DESCRIPTION
This will mean that they will be filtered in `make test`, which makes it easier to run local tests without having Redis JSON installed.