### PR TITLE
Implement `danger_accept_invalid_hostnames` option.

### DIFF
--- a/redis-test/src/cluster.rs
+++ b/redis-test/src/cluster.rs
@@ -4,7 +4,7 @@ use tempfile::TempDir;
 
 use crate::{
     server::{Module, RedisServer},
-    utils::{build_keys_and_certs_for_tls, get_random_available_port, TlsFilePaths},
+    utils::{build_keys_and_certs_for_tls_ext, get_random_available_port, TlsFilePaths},
 };
 
 pub struct RedisClusterConfiguration {
@@ -14,6 +14,7 @@ pub struct RedisClusterConfiguration {
     pub tls_insecure: bool,
     pub mtls_enabled: bool,
     pub ports: Vec<u16>,
+    pub certs_with_ip_alts: bool,
 }
 
 impl RedisClusterConfiguration {
@@ -35,6 +36,7 @@ impl Default for RedisClusterConfiguration {
             tls_insecure: true,
             mtls_enabled: false,
             ports: vec![],
+            certs_with_ip_alts: true,
         }
     }
 }
@@ -109,6 +111,7 @@ impl RedisCluster {
             tls_insecure,
             mtls_enabled,
             ports,
+            certs_with_ip_alts,
         } = configuration;
 
         let optional_ports = if ports.is_empty() {
@@ -131,7 +134,7 @@ impl RedisCluster {
                 .prefix("redis")
                 .tempdir()
                 .expect("failed to create tempdir");
-            let files = build_keys_and_certs_for_tls(&tempdir);
+            let files = build_keys_and_certs_for_tls_ext(&tempdir, certs_with_ip_alts);
             folders.push(tempdir);
             tls_paths = Some(files);
             is_tls = true;

--- a/redis-test/src/utils.rs
+++ b/redis-test/src/utils.rs
@@ -47,7 +47,7 @@ pub fn build_keys_and_certs_for_tls_ext(tempdir: &TempDir, with_ip_alts: bool) -
     make_key(&redis_key, 2048);
 
     // Build CA Cert
-    process::Command::new("openssl")
+    let status = process::Command::new("openssl")
         .arg("req")
         .arg("-x509")
         .arg("-new")
@@ -67,15 +67,38 @@ pub fn build_keys_and_certs_for_tls_ext(tempdir: &TempDir, with_ip_alts: bool) -
         .expect("failed to spawn openssl")
         .wait()
         .expect("failed to create CA cert");
+    assert!(
+        status.success(),
+        "`openssl req` failed to create CA cert: {status}"
+    );
 
     // Build x509v3 extensions file
-    let mut ext = "keyUsage = digitalSignature, keyEncipherment\n\
-                    subjectAltName = @alt_names\n"
-        .to_string();
-    if with_ip_alts {
-        ext += "[alt_names]\n";
-        ext += "IP.1 = 127.0.0.1\n";
-    }
+    let ext = if with_ip_alts {
+        "\
+            keyUsage = digitalSignature, keyEncipherment\n\
+            subjectAltName = @alt_names\n\
+            [alt_names]\n\
+            IP.1 = 127.0.0.1\n\
+            "
+    } else {
+        "\
+            [req]\n\
+            distinguished_name = req_distinguished_name\n\
+            x509_extensions = v3_req\n\
+            prompt = no\n\
+            \n\
+            [req_distinguished_name]\n\
+            CN = localhost.example.com\n\
+            \n\
+            [v3_req]\n\
+            basicConstraints = CA:FALSE\n\
+            keyUsage = nonRepudiation, digitalSignature, keyEncipherment\n\
+            subjectAltName = @alt_names\n\
+            \n\
+            [alt_names]\n\
+            DNS.1 = localhost.example.com\n\
+            "
+    };
     fs::write(&ext_file, ext).expect("failed to create x509v3 extensions file");
 
     // Read redis key
@@ -93,7 +116,8 @@ pub fn build_keys_and_certs_for_tls_ext(tempdir: &TempDir, with_ip_alts: bool) -
         .expect("failed to spawn openssl");
 
     // build redis cert
-    process::Command::new("openssl")
+    let mut command2 = process::Command::new("openssl");
+    command2
         .arg("x509")
         .arg("-req")
         .arg("-sha256")
@@ -107,18 +131,28 @@ pub fn build_keys_and_certs_for_tls_ext(tempdir: &TempDir, with_ip_alts: bool) -
         .arg("-days")
         .arg("365")
         .arg("-extfile")
-        .arg(&ext_file)
+        .arg(&ext_file);
+    if !with_ip_alts {
+        command2.arg("-extensions").arg("v3_req");
+    }
+    let status2 = command2
         .arg("-out")
         .arg(&redis_crt)
         .stdin(key_cmd.stdout.take().expect("should have stdout"))
-        .stdout(process::Stdio::piped())
-        .stderr(process::Stdio::piped())
         .spawn()
         .expect("failed to spawn openssl")
         .wait()
         .expect("failed to create redis cert");
 
-    key_cmd.wait().expect("failed to create redis key");
+    let status = key_cmd.wait().expect("failed to create redis key");
+    assert!(
+        status.success(),
+        "`openssl req` failed to create request for Redis cert: {status}"
+    );
+    assert!(
+        status2.success(),
+        "`openssl x509` failed to create Redis cert: {status2}"
+    );
 
     TlsFilePaths {
         redis_crt,

--- a/redis/src/aio/async_std.rs
+++ b/redis/src/aio/async_std.rs
@@ -195,7 +195,7 @@ impl RedisRuntime for AsyncStd {
         hostname: &str,
         socket_addr: SocketAddr,
         insecure: bool,
-        _tls_params: &Option<TlsConnParams>,
+        tls_params: &Option<TlsConnParams>,
         tcp_settings: &crate::io::tcp::TcpSettings,
     ) -> RedisResult<Self> {
         let tcp_stream = connect_tcp(&socket_addr, tcp_settings).await?;
@@ -204,6 +204,9 @@ impl RedisRuntime for AsyncStd {
                 .danger_accept_invalid_certs(true)
                 .danger_accept_invalid_hostnames(true)
                 .use_sni(false)
+        } else if let Some(params) = tls_params {
+            TlsConnector::new()
+                .danger_accept_invalid_hostnames(params.danger_accept_invalid_hostnames)
         } else {
             TlsConnector::new()
         };

--- a/redis/src/aio/async_std.rs
+++ b/redis/src/aio/async_std.rs
@@ -1,6 +1,6 @@
 #[cfg(unix)]
 use std::path::Path;
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "async-std-rustls-comp")]
 use std::sync::Arc;
 use std::{
     future::Future,
@@ -13,12 +13,15 @@ use std::{
 use crate::aio::{AsyncStream, RedisRuntime};
 use crate::types::RedisResult;
 
-#[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
+#[cfg(all(
+    feature = "async-std-native-tls-comp",
+    not(feature = "async-std-rustls-comp")
+))]
 use async_native_tls::{TlsConnector, TlsStream};
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "async-std-rustls-comp")]
 use crate::connection::create_rustls_config;
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "async-std-rustls-comp")]
 use futures_rustls::{client::TlsStream, TlsConnector};
 
 use super::TaskHandle;
@@ -40,7 +43,10 @@ async fn connect_tcp(
     Ok(std_socket.into())
 }
 
-#[cfg(any(feature = "tls-rustls", feature = "tls-native-tls"))]
+#[cfg(any(
+    feature = "async-std-rustls-comp",
+    feature = "async-std-native-tls-comp"
+))]
 use crate::connection::TlsConnParams;
 
 pin_project_lite::pin_project! {
@@ -190,7 +196,10 @@ impl RedisRuntime for AsyncStd {
             .map(|con| Self::Tcp(AsyncStdWrapped::new(con)))?)
     }
 
-    #[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
+    #[cfg(all(
+        feature = "async-std-native-tls-comp",
+        not(feature = "async-std-rustls-comp")
+    ))]
     async fn connect_tcp_tls(
         hostname: &str,
         socket_addr: SocketAddr,
@@ -216,7 +225,7 @@ impl RedisRuntime for AsyncStd {
             .map(|con| Self::TcpTls(AsyncStdWrapped::new(Box::new(con))))?)
     }
 
-    #[cfg(feature = "tls-rustls")]
+    #[cfg(feature = "async-std-rustls-comp")]
     async fn connect_tcp_tls(
         hostname: &str,
         socket_addr: SocketAddr,

--- a/redis/src/aio/async_std.rs
+++ b/redis/src/aio/async_std.rs
@@ -39,10 +39,8 @@ async fn connect_tcp(
 
     Ok(std_socket.into())
 }
-#[cfg(feature = "tls-rustls")]
-use crate::tls::TlsConnParams;
 
-#[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
+#[cfg(any(feature = "tls-rustls", feature = "tls-native-tls"))]
 use crate::connection::TlsConnParams;
 
 pin_project_lite::pin_project! {

--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -18,10 +18,7 @@ use std::pin::Pin;
 #[cfg_attr(docsrs, doc(cfg(feature = "async-std-comp")))]
 pub mod async_std;
 
-#[cfg(feature = "tls-rustls")]
-use crate::tls::TlsConnParams;
-
-#[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
+#[cfg(any(feature = "tls-rustls", feature = "tls-native-tls"))]
 use crate::connection::TlsConnParams;
 
 /// Enables the tokio compatibility

--- a/redis/src/aio/tokio.rs
+++ b/redis/src/aio/tokio.rs
@@ -12,14 +12,14 @@ use tokio::{
     net::TcpStream as TcpStreamTokio,
 };
 
-#[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
+#[cfg(all(feature = "tokio-native-tls-comp", not(feature = "tokio-rustls-comp")))]
 use native_tls::TlsConnector;
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tokio-rustls-comp")]
 use crate::connection::create_rustls_config;
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tokio-rustls-comp")]
 use std::sync::Arc;
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tokio-rustls-comp")]
 use tokio_rustls::{client::TlsStream, TlsConnector};
 
 #[cfg(all(feature = "tokio-native-tls-comp", not(feature = "tokio-rustls-comp")))]
@@ -116,7 +116,7 @@ impl RedisRuntime for Tokio {
             .map(Tokio::Tcp)?)
     }
 
-    #[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
+    #[cfg(all(feature = "tokio-native-tls-comp", not(feature = "tokio-rustls-comp")))]
     async fn connect_tcp_tls(
         hostname: &str,
         socket_addr: SocketAddr,
@@ -144,7 +144,7 @@ impl RedisRuntime for Tokio {
             .map(|con| Tokio::TcpTls(Box::new(con)))?)
     }
 
-    #[cfg(feature = "tls-rustls")]
+    #[cfg(feature = "tokio-rustls-comp")]
     async fn connect_tcp_tls(
         hostname: &str,
         socket_addr: SocketAddr,

--- a/redis/src/aio/tokio.rs
+++ b/redis/src/aio/tokio.rs
@@ -25,10 +25,7 @@ use tokio_rustls::{client::TlsStream, TlsConnector};
 #[cfg(all(feature = "tokio-native-tls-comp", not(feature = "tokio-rustls-comp")))]
 use tokio_native_tls::TlsStream;
 
-#[cfg(feature = "tokio-rustls-comp")]
-use crate::tls::TlsConnParams;
-
-#[cfg(all(feature = "tokio-native-tls-comp", not(feature = "tls-rustls")))]
+#[cfg(any(feature = "tokio-rustls-comp", feature = "tokio-native-tls-comp"))]
 use crate::connection::TlsConnParams;
 
 #[cfg(unix)]

--- a/redis/src/aio/tokio.rs
+++ b/redis/src/aio/tokio.rs
@@ -121,7 +121,7 @@ impl RedisRuntime for Tokio {
         hostname: &str,
         socket_addr: SocketAddr,
         insecure: bool,
-        _: &Option<TlsConnParams>,
+        params: &Option<TlsConnParams>,
         tcp_settings: &crate::io::tcp::TcpSettings,
     ) -> RedisResult<Self> {
         let tls_connector: tokio_native_tls::TlsConnector = if insecure {
@@ -129,6 +129,10 @@ impl RedisRuntime for Tokio {
                 .danger_accept_invalid_certs(true)
                 .danger_accept_invalid_hostnames(true)
                 .use_sni(false)
+                .build()?
+        } else if let Some(params) = params {
+            TlsConnector::builder()
+                .danger_accept_invalid_hostnames(params.danger_accept_invalid_hostnames)
                 .build()?
         } else {
             TlsConnector::new()?

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -90,10 +90,6 @@ use rand::{rng, seq::IteratorRandom, Rng};
 pub use crate::cluster_client::{ClusterClient, ClusterClientBuilder};
 pub use crate::cluster_pipeline::{cluster_pipe, ClusterPipeline};
 
-#[cfg(feature = "tls-rustls")]
-use crate::tls::TlsConnParams;
-
-#[cfg(not(feature = "tls-rustls"))]
 use crate::connection::TlsConnParams;
 
 #[derive(Clone)]

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -39,7 +39,7 @@ struct BuilderParams {
     pub(crate) tcp_settings: TcpSettings,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct RetryParams {
     pub(crate) number_of_retries: u32,
     max_wait_time: u64,

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -110,7 +110,13 @@ impl ClusterParams {
 
         #[cfg(any(feature = "tls-rustls-insecure", feature = "tls-native-tls"))]
         let tls_params = if value.danger_accept_invalid_hostnames {
-            let mut tls_params = tls_params.unwrap_or_default();
+            let mut tls_params = tls_params.unwrap_or(TlsConnParams {
+                #[cfg(feature = "tls-rustls")]
+                client_tls_params: None,
+                #[cfg(feature = "tls-rustls")]
+                root_cert_store: None,
+                danger_accept_invalid_hostnames: false,
+            });
             tls_params.danger_accept_invalid_hostnames = true;
             Some(tls_params)
         } else {

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -39,7 +39,7 @@ struct BuilderParams {
     pub(crate) tcp_settings: TcpSettings,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct RetryParams {
     pub(crate) number_of_retries: u32,
     max_wait_time: u64,

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -316,10 +316,9 @@ impl ClusterClientBuilder {
     /// Configure hostname verification when connecting with TLS.
     ///
     /// If `insecure` is true, this **disables** hostname verification, while
-    /// leaving other aspects of certificate checking enabled (but that isn't
-    /// worth much: without hostname verification, TLS as a whole is not
-    /// secure). This mode is similar to what `redis-cli` does: TLS connections
-    /// do check certificates, but hostname errors are ignored.
+    /// leaving other aspects of certificate checking enabled. This mode is
+    /// similar to what `redis-cli` does: TLS connections do check certificates,
+    /// but hostname errors are ignored.
     ///
     /// # Warning
     ///

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -28,6 +28,7 @@ struct BuilderParams {
     tls: Option<TlsMode>,
     #[cfg(feature = "tls-rustls")]
     certs: Option<TlsCertificates>,
+    #[cfg(any(feature = "tls-rustls-insecure", feature = "tls-native-tls"))]
     danger_accept_invalid_hostnames: bool,
     retries_configuration: RetryParams,
     connection_timeout: Option<Duration>,
@@ -107,7 +108,7 @@ impl ClusterParams {
             retrieved_tls_params.transpose()?
         };
 
-        #[cfg(any(feature = "tls-rustls", feature = "tls-native-tls"))]
+        #[cfg(any(feature = "tls-rustls-insecure", feature = "tls-native-tls"))]
         let tls_params = if value.danger_accept_invalid_hostnames {
             let mut tls_params = tls_params.unwrap_or_default();
             tls_params.danger_accept_invalid_hostnames = true;
@@ -326,7 +327,7 @@ impl ClusterClientBuilder {
     /// verification is not used, any valid certificate for any site will be
     /// trusted for use from any other. This introduces a significant
     /// vulnerability to man-in-the-middle attacks.
-    #[cfg(any(feature = "tls-native-tls", feature = "tls-rustls"))]
+    #[cfg(any(feature = "tls-rustls-insecure", feature = "tls-native-tls"))]
     pub fn danger_accept_invalid_hostnames(mut self, insecure: bool) -> ClusterClientBuilder {
         self.builder_params.danger_accept_invalid_hostnames = insecure;
         self

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -9,10 +9,6 @@ use rand::Rng;
 use std::sync::Arc;
 use std::time::Duration;
 
-#[cfg(feature = "tls-rustls")]
-use crate::tls::TlsConnParams;
-
-#[cfg(not(feature = "tls-rustls"))]
 use crate::connection::TlsConnParams;
 
 #[cfg(feature = "cluster-async")]

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -28,6 +28,7 @@ struct BuilderParams {
     tls: Option<TlsMode>,
     #[cfg(feature = "tls-rustls")]
     certs: Option<TlsCertificates>,
+    danger_accept_invalid_hostnames: bool,
     retries_configuration: RetryParams,
     connection_timeout: Option<Duration>,
     response_timeout: Option<Duration>,
@@ -97,13 +98,22 @@ pub(crate) struct ClusterParams {
 impl ClusterParams {
     fn from(value: BuilderParams) -> RedisResult<Self> {
         #[cfg(not(feature = "tls-rustls"))]
-        let tls_params = None;
+        let tls_params: Option<TlsConnParams> = None;
 
         #[cfg(feature = "tls-rustls")]
         let tls_params = {
             let retrieved_tls_params = value.certs.as_ref().map(retrieve_tls_certificates);
 
             retrieved_tls_params.transpose()?
+        };
+
+        #[cfg(any(feature = "tls-rustls", feature = "tls-native-tls"))]
+        let tls_params = if value.danger_accept_invalid_hostnames {
+            let mut tls_params = tls_params.unwrap_or_default();
+            tls_params.danger_accept_invalid_hostnames = true;
+            Some(tls_params)
+        } else {
+            tls_params
         };
 
         Ok(Self {
@@ -299,6 +309,26 @@ impl ClusterClientBuilder {
     #[cfg(any(feature = "tls-native-tls", feature = "tls-rustls"))]
     pub fn tls(mut self, tls: TlsMode) -> ClusterClientBuilder {
         self.builder_params.tls = Some(tls);
+        self
+    }
+
+    /// Configure hostname verification when connecting with TLS.
+    ///
+    /// If `insecure` is true, this **disables** hostname verification, while
+    /// leaving other aspects of certificate checking enabled (but that isn't
+    /// worth much: without hostname verification, TLS as a whole is not
+    /// secure). This mode is similar to what `redis-cli` does: TLS connections
+    /// do check certificates, but hostname errors are ignored.
+    ///
+    /// # Warning
+    ///
+    /// You should think very carefully before you use this method. If hostname
+    /// verification is not used, any valid certificate for any site will be
+    /// trusted for use from any other. This introduces a significant
+    /// vulnerability to man-in-the-middle attacks.
+    #[cfg(any(feature = "tls-native-tls", feature = "tls-rustls"))]
+    pub fn danger_accept_invalid_hostnames(mut self, insecure: bool) -> ClusterClientBuilder {
+        self.builder_params.danger_accept_invalid_hostnames = insecure;
         self
     }
 

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -43,7 +43,7 @@ use rustls_native_certs::load_native_certs;
 use crate::tls::ClientTlsParams;
 
 // Non-exhaustive to prevent construction outside this crate
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct TlsConnParams {
     #[cfg(feature = "tls-rustls")]
@@ -189,8 +189,11 @@ impl ConnectionAddr {
                 params.danger_accept_invalid_hostnames = insecure;
             } else if insecure {
                 *tls_params = Some(TlsConnParams {
+                    #[cfg(feature = "tls-rustls")]
+                    client_tls_params: None,
+                    #[cfg(feature = "tls-rustls")]
+                    root_cert_store: None,
                     danger_accept_invalid_hostnames: insecure,
-                    ..Default::default()
                 });
             }
         }

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -40,13 +40,17 @@ use crate::PushInfo;
 use rustls_native_certs::load_native_certs;
 
 #[cfg(feature = "tls-rustls")]
-use crate::tls::TlsConnParams;
+use crate::tls::ClientTlsParams;
 
 // Non-exhaustive to prevent construction outside this crate
-#[cfg(not(feature = "tls-rustls"))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
-pub struct TlsConnParams;
+pub struct TlsConnParams {
+    #[cfg(feature = "tls-rustls")]
+    pub(crate) client_tls_params: Option<ClientTlsParams>,
+    #[cfg(feature = "tls-rustls")]
+    pub(crate) root_cert_store: Option<RootCertStore>,
+}
 
 static DEFAULT_PORT: u16 = 6379;
 

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -994,6 +994,9 @@ pub(crate) fn create_rustls_config(
             config_builder.with_no_client_auth()
         };
 
+        // The cfg here matches the cfg on `danger_accept_invalid_hostnames`.
+        // This way adding `tls-rustls` on top of `tls-native-tls` does not
+        // remove the field or cause it to be silently ignored.
         #[cfg(any(feature = "tls-rustls-insecure", feature = "tls-native-tls"))]
         let config_builder = if !insecure && tls_params.danger_accept_invalid_hostnames {
             if !cfg!(feature = "tls-rustls-insecure") {

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -956,8 +956,6 @@ pub(crate) fn create_rustls_config(
     insecure: bool,
     tls_params: Option<TlsConnParams>,
 ) -> RedisResult<rustls::ClientConfig> {
-    use crate::tls::ClientTlsParams;
-
     #[allow(unused_mut)]
     let mut root_store = RootCertStore::empty();
     #[cfg(feature = "tls-rustls-webpki-roots")]

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -176,9 +176,14 @@ impl ConnectionAddr {
 
     /// Configure this address to connect without checking certificate hostnames.
     ///
-    /// This is slightly less insecure than full `insecure` mode.
+    /// # Warning
+    ///
+    /// You should think very carefully before you use this method. If hostname
+    /// verification is not used, any valid certificate for any site will be
+    /// trusted for use from any other. This introduces a significant
+    /// vulnerability to man-in-the-middle attacks.
     #[cfg(any(feature = "tls-rustls-insecure", feature = "tls-native-tls"))]
-    pub fn set_insecure_accept_invalid_hostnames(&mut self, insecure: bool) {
+    pub fn set_danger_accept_invalid_hostnames(&mut self, insecure: bool) {
         if let ConnectionAddr::TcpTls { tls_params, .. } = self {
             if let Some(ref mut params) = tls_params {
                 params.danger_accept_invalid_hostnames = insecure;

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -85,7 +85,7 @@ pub fn parse_redis_url(input: &str) -> Option<url::Url> {
 /// TlsMode indicates use or do not use verification of certification.
 ///
 /// Check [ConnectionAddr](ConnectionAddr::TcpTls::insecure) for more.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TlsMode {
     /// Secure verify certification.
     Secure,

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -85,7 +85,7 @@ pub fn parse_redis_url(input: &str) -> Option<url::Url> {
 /// TlsMode indicates use or do not use verification of certification.
 ///
 /// Check [ConnectionAddr](ConnectionAddr::TcpTls::insecure) for more.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum TlsMode {
     /// Secure verify certification.
     Secure,

--- a/redis/src/tls.rs
+++ b/redis/src/tls.rs
@@ -4,6 +4,7 @@ use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use rustls::RootCertStore;
 
+use crate::connection::TlsConnParams;
 use crate::{Client, ConnectionAddr, ConnectionInfo, ErrorKind, RedisError, RedisResult};
 
 /// Structure to hold mTLS client _certificate_ and _key_ binaries in PEM format
@@ -142,10 +143,4 @@ impl Clone for ClientTlsParams {
             },
         }
     }
-}
-
-#[derive(Debug, Clone)]
-pub struct TlsConnParams {
-    pub(crate) client_tls_params: Option<ClientTlsParams>,
-    pub(crate) root_cert_store: Option<RootCertStore>,
 }

--- a/redis/src/tls.rs
+++ b/redis/src/tls.rs
@@ -120,6 +120,7 @@ pub(crate) fn retrieve_tls_certificates(
     Ok(TlsConnParams {
         client_tls_params,
         root_cert_store,
+        danger_accept_invalid_hostnames: false,
     })
 }
 

--- a/redis/src/tls.rs
+++ b/redis/src/tls.rs
@@ -120,6 +120,7 @@ pub(crate) fn retrieve_tls_certificates(
     Ok(TlsConnParams {
         client_tls_params,
         root_cert_store,
+        #[cfg(any(feature = "tls-rustls-insecure", feature = "tls-native-tls"))]
         danger_accept_invalid_hostnames: false,
     })
 }

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -47,6 +47,17 @@ impl TestClusterContext {
         )
     }
 
+    pub fn new_with_mtls_no_ip_alts() -> TestClusterContext {
+        Self::new_with_config_and_builder(
+            RedisClusterConfiguration {
+                mtls_enabled: true,
+                certs_with_ip_alts: false,
+                ..Default::default()
+            },
+            identity,
+        )
+    }
+
     pub fn new_with_config(cluster_config: RedisClusterConfiguration) -> TestClusterContext {
         Self::new_with_config_and_builder(cluster_config, identity)
     }

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -47,10 +47,10 @@ impl TestClusterContext {
         )
     }
 
-    pub fn new_with_mtls_no_ip_alts() -> TestClusterContext {
+    pub fn new_without_ip_alts() -> TestClusterContext {
         Self::new_with_config_and_builder(
             RedisClusterConfiguration {
-                mtls_enabled: true,
+                tls_insecure: false,
                 certs_with_ip_alts: false,
                 ..Default::default()
             },

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -466,10 +466,7 @@ pub(crate) fn build_single_client<T: redis::IntoConnectionInfo>(
 #[cfg(feature = "tls-rustls")]
 pub(crate) mod mtls_test {
     use super::*;
-    use redis::{
-        cluster::{ClusterClient, ClusterClientBuilder},
-        ConnectionInfo, RedisError,
-    };
+    use redis::{cluster::ClusterClient, ConnectionInfo, RedisError};
 
     fn clean_node_info(nodes: &[ConnectionInfo]) -> Vec<ConnectionInfo> {
         let nodes = nodes
@@ -497,13 +494,6 @@ pub(crate) mod mtls_test {
         cluster: &TestClusterContext,
         mtls_enabled: bool,
     ) -> Result<ClusterClient, RedisError> {
-        create_cluster_client_builder_from_cluster(cluster, mtls_enabled).build()
-    }
-
-    pub(crate) fn create_cluster_client_builder_from_cluster(
-        cluster: &TestClusterContext,
-        mtls_enabled: bool,
-    ) -> ClusterClientBuilder {
         let server = cluster
             .cluster
             .servers
@@ -523,6 +513,7 @@ pub(crate) mod mtls_test {
             // server-side TLS NOT available
             builder
         }
+        .build()
     }
 }
 

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -466,7 +466,10 @@ pub(crate) fn build_single_client<T: redis::IntoConnectionInfo>(
 #[cfg(feature = "tls-rustls")]
 pub(crate) mod mtls_test {
     use super::*;
-    use redis::{cluster::ClusterClient, ConnectionInfo, RedisError};
+    use redis::{
+        cluster::{ClusterClient, ClusterClientBuilder},
+        ConnectionInfo, RedisError,
+    };
 
     fn clean_node_info(nodes: &[ConnectionInfo]) -> Vec<ConnectionInfo> {
         let nodes = nodes
@@ -494,6 +497,13 @@ pub(crate) mod mtls_test {
         cluster: &TestClusterContext,
         mtls_enabled: bool,
     ) -> Result<ClusterClient, RedisError> {
+        create_cluster_client_builder_from_cluster(cluster, mtls_enabled).build()
+    }
+
+    pub(crate) fn create_cluster_client_builder_from_cluster(
+        cluster: &TestClusterContext,
+        mtls_enabled: bool,
+    ) -> ClusterClientBuilder {
         let server = cluster
             .cluster
             .servers
@@ -513,7 +523,6 @@ pub(crate) mod mtls_test {
             // server-side TLS NOT available
             builder
         }
-        .build()
     }
 }
 


### PR DESCRIPTION
Fixes #1500.

This adds a new insecure connection mode between `TlsMode::Secure` and `TlsMode::Insecure`, called `danger_accept_invalid_hostnames` after the flag in `tls-native` that implements it. When this mode is enabled, certificate checking still happens, but the hostname in the certificate is not required to match the server we're trying to connect to.

**The new mode is not a new `TlsMode`** or a new field on `TlsMode::Insecure`. Either of those would be a better API, I think, but it'd be a breaking change. So this PR adds the new option as a `ClusterClientBuilder` method instead. When you use this, the `tls_mode` says `Secure` even though you've configured a hole in the TLS security. :-\

I don't actually need the rustls version, but I implemented the option for both `tls-rustls` and `tls-native-tls` to keep the features additive. That is, suppose we land this, and someone starts using it via the `tls-native-tls` feature. If they later add the `tls-rustls` feature, their project should keep building and working. (As implemented, it does keep building, but alas not working. They'll get a runtime error until they also add the `tls-rustls-insecure` feature. But I think that's already the case for the existing insecure mode. That should probably be fixed but it'll be a breaking change.)

This is an alternative to #1526.