### PR TITLE
Async cluster connection: Move response timeout out. 

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -1268,23 +1268,6 @@ pub trait Connect: Sized {
     /// Connect to a node, returning handle for command execution.
     fn connect_with_config<'a, T>(info: T, config: AsyncConnectionConfig) -> RedisFuture<'a, Self>
     where
-        T: IntoConnectionInfo + Send + 'a,
-    {
-        // default implementation, for backwards compatibility
-        Self::connect(
-            info,
-            config.response_timeout.unwrap_or(Duration::MAX),
-            config.connection_timeout.unwrap_or(Duration::MAX),
-        )
-    }
-
-    /// Connect to a node, returning handle for command execution.
-    fn connect<'a, T>(
-        info: T,
-        response_timeout: Duration,
-        connection_timeout: Duration,
-    ) -> RedisFuture<'a, Self>
-    where
         T: IntoConnectionInfo + Send + 'a;
 }
 
@@ -1296,27 +1279,6 @@ impl Connect for MultiplexedConnection {
         async move {
             let connection_info = info.into_connection_info()?;
             let client = crate::Client::open(connection_info)?;
-            client
-                .get_multiplexed_async_connection_with_config(&config)
-                .await
-        }
-        .boxed()
-    }
-
-    fn connect<'a, T>(
-        info: T,
-        response_timeout: Duration,
-        connection_timeout: Duration,
-    ) -> RedisFuture<'a, MultiplexedConnection>
-    where
-        T: IntoConnectionInfo + Send + 'a,
-    {
-        async move {
-            let connection_info = info.into_connection_info()?;
-            let client = crate::Client::open(connection_info)?;
-            let config = crate::AsyncConnectionConfig::new()
-                .set_connection_timeout(connection_timeout)
-                .set_response_timeout(response_timeout);
             client
                 .get_multiplexed_async_connection_with_config(&config)
                 .await

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -35,10 +35,9 @@ pub struct MockConnection {
 
 #[cfg(feature = "cluster-async")]
 impl cluster_async::Connect for MockConnection {
-    fn connect<'a, T>(
+    fn connect_with_config<'a, T>(
         info: T,
-        _response_timeout: Duration,
-        _connection_timeout: Duration,
+        _config: redis::AsyncConnectionConfig,
     ) -> RedisFuture<'a, Self>
     where
         T: IntoConnectionInfo + Send + 'a,

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -525,18 +525,15 @@ mod cluster_async {
     }
 
     impl Connect for ErrorConnection {
-        fn connect<'a, T>(
+        fn connect_with_config<'a, T>(
             info: T,
-            response_timeout: Duration,
-            connection_timeout: Duration,
+            config: redis::AsyncConnectionConfig,
         ) -> RedisFuture<'a, Self>
         where
             T: IntoConnectionInfo + Send + 'a,
         {
             Box::pin(async move {
-                let inner =
-                    MultiplexedConnection::connect(info, response_timeout, connection_timeout)
-                        .await?;
+                let inner = MultiplexedConnection::connect_with_config(info, config).await?;
                 Ok(ErrorConnection { inner })
             })
         }


### PR DESCRIPTION
Because the requests are retried internally, and might be delayed by reconnects, the timeout set by the users wasn't always enforced. Using it externally enforces it strongly.