### PR TITLE
Run most cluster tests in secure mode when rustls is enabled

### DIFF
--- a/redis/src/io/tcp.rs
+++ b/redis/src/io/tcp.rs
@@ -1,4 +1,7 @@
-use std::{io, net::TcpStream, time::Duration};
+use std::{io, net::TcpStream};
+
+#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+use std::time::Duration;
 
 /// Settings for a TCP stream.
 #[derive(Clone, Debug)]

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -1023,8 +1023,9 @@ mod cluster {
 
     #[test]
     fn test_cluster_reconnect_after_complete_server_disconnect() {
-        let cluster =
-            TestClusterContext::new_with_cluster_client_builder(|builder| builder.retries(3));
+        let cluster = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
+            builder.retries(3)
+        });
 
         let ports: Vec<_> = cluster
             .nodes
@@ -1064,8 +1065,9 @@ mod cluster {
 
     #[test]
     fn test_cluster_reconnect_after_complete_server_disconnect_route_to_many() {
-        let cluster =
-            TestClusterContext::new_with_cluster_client_builder(|builder| builder.retries(3));
+        let cluster = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
+            builder.retries(3)
+        });
 
         let ports: Vec<_> = cluster
             .nodes

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -1839,7 +1839,7 @@ mod cluster_async {
     #[case::tokio(RuntimeType::Tokio)]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     fn test_async_cluster_with_username_and_password(#[case] runtime: RuntimeType) {
-        let cluster = TestClusterContext::new_with_cluster_client_builder(|builder| {
+        let cluster = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
             builder
                 .username(RedisCluster::username().to_string())
                 .password(RedisCluster::password().to_string())
@@ -2016,8 +2016,9 @@ mod cluster_async {
     #[case::tokio(RuntimeType::Tokio)]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     fn test_async_cluster_reconnect_after_complete_server_disconnect(#[case] runtime: RuntimeType) {
-        let cluster =
-            TestClusterContext::new_with_cluster_client_builder(|builder| builder.retries(2));
+        let cluster = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
+            builder.retries(2)
+        });
 
         block_on_all(
             async move {
@@ -2070,8 +2071,9 @@ mod cluster_async {
     fn test_async_cluster_reconnect_after_complete_server_disconnect_route_to_many(
         #[case] runtime: RuntimeType,
     ) {
-        let cluster =
-            TestClusterContext::new_with_cluster_client_builder(|builder| builder.retries(3));
+        let cluster = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
+            builder.retries(3)
+        });
 
         block_on_all(
             async move {
@@ -2787,7 +2789,7 @@ mod cluster_async {
             // doesn't send disconnect message, but instead resubscribes automatically.
 
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-            let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
+            let ctx = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
                 builder
                     .use_protocol(ProtocolVersion::RESP3)
                     .push_sender(tx.clone())


### PR DESCRIPTION
In trying to add a test for a new security mode in https://github.com/redis-rs/redis-rs/pull/1529, I found out no existing cluster tests run in `TlsMode::Secure` mode. It seems like a good idea to get some coverage for that case first.

All but 6 tests pass with certificate checking enabled, so this PR transitions tests to run in `Secure` mode by default when `rustls` is used, and explicitly opts out those 6 tests.

This is `tls-rustls` only for now. TLS support in the cluster tests works by generating a one-off root cert (to sign the server cert), and it appears `redis-rs` doesn't support adding a root cert to the client in `tls-native-tls` builds, so certificate checking would always fail.