### PR TITLE
docs: added CLIENT SETINFO optional feature

### DIFF
--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -108,6 +108,7 @@
 //! * `sentinel`: enables high-level interfaces for communication with Redis sentinels (optional)
 //! * `json`: enables high-level interfaces for communication with the JSON module (optional)
 //! * `cache-aio`: enables **experimental** client side caching for MultiplexedConnection (optional)
+//! * `disable-client-setinfo`: disables the `CLIENT SETINFO` handshake during connection initialization
 //!
 //! ## Connection Parameters
 //!


### PR DESCRIPTION
I just added `disable-client-setinfo` optional feature in the documentation.

See #1535