### PR TITLE
Expose `Pipeline.len()` function as public

### DIFF
--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -97,7 +97,7 @@ async fn execute_connection_pipeline(
     rv: &mut impl ConnectionLike,
     (pipeline, instructions): (crate::Pipeline, ConnectionSetupComponents),
 ) -> RedisResult<AuthResult> {
-    if pipeline.len() == 0 {
+    if pipeline.is_empty() {
         return Ok(AuthResult::Succeeded);
     }
 

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -1184,7 +1184,7 @@ fn execute_connection_pipeline(
     rv: &mut Connection,
     (pipeline, instructions): (crate::Pipeline, ConnectionSetupComponents),
 ) -> RedisResult<AuthResult> {
-    if pipeline.len() == 0 {
+    if pipeline.is_empty() {
         return Ok(AuthResult::Succeeded);
     }
     let results = rv.req_packed_commands(&pipeline.get_packed_pipeline(), 0, pipeline.len())?;

--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -94,6 +94,11 @@ impl Pipeline {
         self.commands.len()
     }
 
+    /// Returns `true` is the pipeline contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.commands.is_empty()
+    }
+
     fn execute_pipelined(&self, con: &mut dyn ConnectionLike) -> RedisResult<Value> {
         self.make_pipeline_results(con.req_packed_commands(
             &encode_pipeline(&self.commands, false),

--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -87,7 +87,8 @@ impl Pipeline {
         write_pipeline(out, &self.commands, self.transaction_mode)
     }
 
-    pub(crate) fn len(&self) -> usize {
+    /// Returns the number of commands currently queued in the pipeline.
+    pub fn len(&self) -> usize {
         self.commands.len()
     }
 

--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -87,7 +87,9 @@ impl Pipeline {
         write_pipeline(out, &self.commands, self.transaction_mode)
     }
 
-    /// Returns the number of commands currently queued in the pipeline.
+    /// Returns the number of commands currently queued by the usr in the pipeline.
+    ///
+    /// Depending on its configuration (e.g. `atomic`), the pipeline may send more commands to the server than the returned length
     pub fn len(&self) -> usize {
         self.commands.len()
     }

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -770,6 +770,14 @@ mod basic {
     }
 
     #[test]
+    fn test_pipeline_len() {
+        let mut pl = redis::pipe();
+
+        pl.cmd("PING").cmd("SET").arg(1);
+        assert_eq!(pl.len(), 2);
+    }
+
+    #[test]
     fn test_real_transaction() {
         let ctx = TestContext::new();
         let mut con = ctx.connection();

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -778,6 +778,15 @@ mod basic {
     }
 
     #[test]
+    fn test_pipeline_is_empty() {
+        let mut pl = redis::pipe();
+
+        assert!(pl.is_empty());
+        pl.cmd("PING").cmd("SET").arg(1);
+        assert!(!pl.is_empty());
+    }
+
+    #[test]
     fn test_real_transaction() {
         let ctx = TestContext::new();
         let mut con = ctx.connection();


### PR DESCRIPTION
Closes #1538 

Exposes the `Pipeline.len()` function as discussed in #1538. Adds a simple test to ensure that the interface is constant.