### PR TITLE
perf: Run reconnection attempts concurrently

### DIFF
--- a/redis/src/cluster_async/routing.rs
+++ b/redis/src/cluster_async/routing.rs
@@ -6,8 +6,6 @@ use crate::{
     Cmd, ErrorKind, RedisResult,
 };
 
-use super::ConnectionFuture;
-
 #[derive(Clone)]
 pub(super) enum InternalRoutingInfo<C> {
     SingleNode(InternalSingleNodeRouting<C>),
@@ -40,7 +38,7 @@ pub(super) enum InternalSingleNodeRouting<C> {
     ByAddress(String),
     Connection {
         identifier: String,
-        conn: ConnectionFuture<C>,
+        conn: C,
     },
     Redirect {
         redirect: Redirect,


### PR DESCRIPTION
I don't think there is any reason not to do this concurrently? Each connection will be to a different node and they will mostly just wait for IO which is nice to do concurrently.

Also refactored a bit to remove `ConnectionFuture` as it does not seem to serve a purpose anymore.

(Looking over the implementation to try and debug a connection problem and spotted it).