### PR TITLE
Fix unreachable error when parsing a nested tuple. 

### DIFF
--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2546,12 +2546,11 @@ macro_rules! from_redis_value_for_tuple {
                     return Ok(rv)
                 }
                 //It's uglier then before!
-                for item in items.iter() {
+                for item in items.iter_mut() {
                     match item {
-                        Value::Array(ch) => {
-                            // TODO - this copies when we could've used the owned value. need to find out how to do this.
-                        if  let [$($name),*] = &ch[..] {
-                            rv.push(($(from_redis_value($name)?),*),)
+                        Value::Array(ref mut ch) => {
+                        if  let [$($name),*] = &mut ch[..] {
+                            rv.push(($(from_owned_redis_value(std::mem::replace($name, Value::Nil))?),*),);
                            };
                         },
                         _ => {},

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2512,9 +2512,7 @@ macro_rules! from_redis_value_for_tuple {
                         Value::Array(ch) => {
                            if  let [$($name),*] = &ch[..] {
                             rv.push(($(from_redis_value(&$name)?),*),)
-                           } else {
-                                unreachable!()
-                            };
+                           };
                         },
                         _ => {},
 
@@ -2554,9 +2552,7 @@ macro_rules! from_redis_value_for_tuple {
                             // TODO - this copies when we could've used the owned value. need to find out how to do this.
                         if  let [$($name),*] = &ch[..] {
                             rv.push(($(from_redis_value($name)?),*),)
-                           } else {
-                                unreachable!()
-                            };
+                           };
                         },
                         _ => {},
                     }


### PR DESCRIPTION
The unreachable code assumed that a nested array has to be able to converted to the target tuple, and so panicked when when the array is larger. Instead, we should just fallback to the next piece of code, and allow the array to be split into multiple returns of the target tuple.

https://github.com/redis-rs/redis-rs/issues/1561