### PR TITLE
feat: Add bb8 support for async client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bb8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d8b8e1a22743d9241575c6ba822cf9c8fef34771c86ab7e477a4fbfd254e5"
+dependencies = [
+ "futures-util",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1705,6 +1716,7 @@ dependencies = [
  "async-native-tls",
  "async-std",
  "backon",
+ "bb8",
  "bigdecimal",
  "bytes",
  "combine",
@@ -2298,6 +2310,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "socket2 0.5.8",
  "tokio-macros",

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -60,6 +60,9 @@ backon = { version = "1.4.0", optional = true, default-features = false }
 # Only needed for the r2d2 feature
 r2d2 = { version = "0.8.10", optional = true }
 
+# Only needed for the bb8 feature
+bb8 = { version = "0.9.0", optional = true }
+
 # Only needed for cluster
 crc16 = { version = "0.4", optional = true }
 rand = { version = "0.9", optional = true }

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -142,6 +142,8 @@ tcp_nodelay = []
 num-bigint = []
 disable-client-setinfo = []
 cache-aio = ["aio", "dep:lru"]
+r2d2 = ["dep:r2d2"]
+bb8 = ["dep:bb8"]
 
 # Deprecated features
 tls = ["tls-native-tls"] # use "tls-native-tls" instead

--- a/redis/src/bb8.rs
+++ b/redis/src/bb8.rs
@@ -1,0 +1,23 @@
+use crate::{aio::MultiplexedConnection, ErrorKind};
+use crate::{Client, RedisError};
+
+impl bb8::ManageConnection for Client {
+    type Connection = MultiplexedConnection;
+    type Error = RedisError;
+
+    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
+        self.get_multiplexed_async_connection().await
+    }
+
+    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+        let pong: String = crate::cmd("PING").query_async(conn).await?;
+        match pong.as_str() {
+            "PONG" => Ok(()),
+            _ => Err((ErrorKind::ResponseError, "ping request").into()),
+        }
+    }
+
+    fn has_broken(&self, _: &mut Self::Connection) -> bool {
+        false
+    }
+}

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -641,6 +641,10 @@ pub mod cluster_routing;
 #[cfg_attr(docsrs, doc(cfg(feature = "r2d2")))]
 mod r2d2;
 
+#[cfg(all(feature = "bb8", feature = "aio"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "bb8", feature = "aio"))))]
+mod bb8;
+
 #[cfg(feature = "streams")]
 #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
 pub mod streams;


### PR DESCRIPTION
Part of https://github.com/redis-rs/redis-rs/issues/1563

---

My original plan was to use the bb8 code directly, but I decided to follow the same pattern as r2d2 instead.