### PR TITLE
Remove PFCOUNT from the list of illegal cluster pipeline commands (#1565)

### DIFF
--- a/redis/src/cluster_pipeline.rs
+++ b/redis/src/cluster_pipeline.rs
@@ -24,7 +24,7 @@ fn is_illegal_cmd(cmd: &str) -> bool {
         "KEYS" |
         "LASTSAVE" |
         "MGET" | "MOVE" | "MSET" | "MSETNX" |
-        "PFMERGE" | "PFCOUNT" | "PING" | "PUBLISH" |
+        "PFMERGE" | "PING" | "PUBLISH" |
         "RANDOMKEY" | "RENAME" | "RENAMENX" | "RPOPLPUSH" |
         "SAVE" | "SCAN" |
         // All commands that start with "SCRIPT"
@@ -62,7 +62,7 @@ pub struct ClusterPipeline {
 /// KEYS
 /// LASTSAVE
 /// MGET, MOVE, MSET, MSETNX
-/// PFMERGE, PFCOUNT, PING, PUBLISH
+/// PFMERGE, PING, PUBLISH
 /// RANDOMKEY, RENAME, RENAMENX, RPOPLPUSH
 /// SAVE, SCAN, SCRIPT EXISTS, SCRIPT FLUSH, SCRIPT KILL, SCRIPT LOAD, SDIFF, SDIFFSTORE,
 /// SENTINEL GET MASTER ADDR BY NAME, SENTINEL MASTER, SENTINEL MASTERS, SENTINEL MONITOR,


### PR DESCRIPTION
Related to the issue https://github.com/redis-rs/redis-rs/issues/1565.

As long as all keys in PFCOUNT command are hashed to the same slot, there should be no problem using the command in the cluster pipeline.