### PR TITLE
Remove EVALSHA from the list of illegal cluster pipeline commands

### DIFF
--- a/redis/src/cluster_pipeline.rs
+++ b/redis/src/cluster_pipeline.rs
@@ -18,7 +18,7 @@ fn is_illegal_cmd(cmd: &str) -> bool {
         // All commands that start with "CONFIG"
         "CONFIG" | "CONFIG GET" | "CONFIG RESETSTAT" | "CONFIG REWRITE" | "CONFIG SET" |
         "DBSIZE" |
-        "ECHO" | "EVALSHA" |
+        "ECHO" |
         "FLUSHALL" | "FLUSHDB" |
         "INFO" |
         "KEYS" |


### PR DESCRIPTION
For both EVAL and EVALSHA we check that all referenced keys are hashed to the same slot.

related to #1266.