### PR TITLE
Fix valkey(s) url schemes not able to be converted to connection infos; Add valkey+unix url scheme

### DIFF
--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -75,7 +75,7 @@ fn connect_tcp_timeout(addr: &SocketAddr, timeout: Duration) -> io::Result<TcpSt
 pub fn parse_redis_url(input: &str) -> Option<url::Url> {
     match url::Url::parse(input) {
         Ok(result) => match result.scheme() {
-            "redis" | "rediss" | "valkey" | "valkeys" | "redis+unix" | "unix" => Some(result),
+            "redis" | "rediss" | "valkey" | "valkeys" | "redis+unix" | "valkey+unix" | "unix" => Some(result),
             _ => None,
         },
         Err(_) => None,
@@ -270,7 +270,7 @@ impl IntoConnectionInfo for ConnectionInfo {
     }
 }
 
-/// URL format: `{redis|rediss}://[<username>][:<password>@]<hostname>[:port][/<db>]`
+/// URL format: `{redis|rediss|valkey|valkeys}://[<username>][:<password>@]<hostname>[:port][/<db>]`
 ///
 /// - Basic: `redis://127.0.0.1:6379`
 /// - Username & Password: `redis://user:password@127.0.0.1:6379`
@@ -300,7 +300,7 @@ where
     }
 }
 
-/// URL format: `{redis|rediss}://[<username>][:<password>@]<hostname>[:port][/<db>]`
+/// URL format: `{redis|rediss|valkey|valkeys}://[<username>][:<password>@]<hostname>[:port][/<db>]`
 ///
 /// - Basic: `redis://127.0.0.1:6379`
 /// - Username & Password: `redis://user:password@127.0.0.1:6379`
@@ -360,7 +360,7 @@ fn url_to_tcp_connection_info(url: url::Url) -> RedisResult<ConnectionInfo> {
         None => fail!((ErrorKind::InvalidClientConfig, "Missing hostname")),
     };
     let port = url.port().unwrap_or(DEFAULT_PORT);
-    let addr = if url.scheme() == "rediss" {
+    let addr = if url.scheme() == "rediss" || url.scheme() == "valkeys" {
         #[cfg(any(feature = "tls-native-tls", feature = "tls-rustls"))]
         {
             match url.fragment() {
@@ -460,8 +460,8 @@ fn url_to_unix_connection_info(_: url::Url) -> RedisResult<ConnectionInfo> {
 impl IntoConnectionInfo for url::Url {
     fn into_connection_info(self) -> RedisResult<ConnectionInfo> {
         match self.scheme() {
-            "redis" | "rediss" => url_to_tcp_connection_info(self),
-            "unix" | "redis+unix" => url_to_unix_connection_info(self),
+            "redis" | "rediss" | "valkey" | "valkeys" => url_to_tcp_connection_info(self),
+            "unix" | "redis+unix" | "valkey+unix" => url_to_unix_connection_info(self),
             _ => fail!((
                 ErrorKind::InvalidClientConfig,
                 "URL provided is not a redis URL"
@@ -2220,6 +2220,7 @@ mod tests {
             ("valkey://127.0.0.1", true),
             ("valkey://[::1]", true),
             ("redis+unix:///run/redis.sock", true),
+            ("valkey+unix:///run/valkey.sock", true),
             ("unix:///run/redis.sock", true),
             ("http://127.0.0.1", false),
             ("tcp://127.0.0.1", false),

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -75,7 +75,9 @@ fn connect_tcp_timeout(addr: &SocketAddr, timeout: Duration) -> io::Result<TcpSt
 pub fn parse_redis_url(input: &str) -> Option<url::Url> {
     match url::Url::parse(input) {
         Ok(result) => match result.scheme() {
-            "redis" | "rediss" | "valkey" | "valkeys" | "redis+unix" | "valkey+unix" | "unix" => Some(result),
+            "redis" | "rediss" | "valkey" | "valkeys" | "redis+unix" | "valkey+unix" | "unix" => {
+                Some(result)
+            }
             _ => None,
         },
         Err(_) => None,
@@ -2217,8 +2219,12 @@ mod tests {
         let cases = vec![
             ("redis://127.0.0.1", true),
             ("redis://[::1]", true),
+            ("rediss://127.0.0.1", true),
+            ("rediss://[::1]", true),
             ("valkey://127.0.0.1", true),
             ("valkey://[::1]", true),
+            ("valkeys://127.0.0.1", true),
+            ("valkeys://[::1]", true),
             ("redis+unix:///run/redis.sock", true),
             ("valkey+unix:///run/valkey.sock", true),
             ("unix:///run/redis.sock", true),


### PR DESCRIPTION
This adds some changes, that (I assume) were forgotten in https://github.com/redis-rs/redis-rs/pull/1558.

- "valkey" and "valkeys" were not able to be converted to a connection info https://github.com/redis-rs/redis-rs/blob/8db06bf4e67c526a0604c8d3bc15ae7acf281a0e/redis/src/connection.rs#L463-L464
- "valkeys" did not get treated the same as "rediss" https://github.com/redis-rs/redis-rs/blob/8db06bf4e67c526a0604c8d3bc15ae7acf281a0e/redis/src/connection.rs#L363-L393
- "valkey+unix" protocol scheme was missing (equivalent to "redis+unix")