### PR TITLE
Add commands to flush database(s)

### DIFF
--- a/redis/src/cluster_async/routing.rs
+++ b/redis/src/cluster_async/routing.rs
@@ -114,7 +114,7 @@ mod pipeline_routing_tests {
         let mut pipeline = crate::Pipeline::new();
 
         pipeline
-            .add_command(cmd("FLUSHALL")) // route to all masters
+            .flushall() // route to all masters
             .get("foo") // route to slot 12182
             .add_command(cmd("EVAL")); // route randomly
 
@@ -129,7 +129,7 @@ mod pipeline_routing_tests {
         let mut pipeline = crate::Pipeline::new();
 
         pipeline
-            .add_command(cmd("FLUSHALL")) // route to all masters
+            .flushall() // route to all masters
             .add_command(cmd("EVAL")); // route randomly
 
         assert_eq!(route_for_pipeline(&pipeline), Ok(None));
@@ -141,7 +141,7 @@ mod pipeline_routing_tests {
 
         pipeline
             .get("foo") // route to replica of slot 12182
-            .add_command(cmd("FLUSHALL")) // route to all masters
+            .flushall() // route to all masters
             .add_command(cmd("EVAL"))// route randomly
             .cmd("CONFIG").arg("GET").arg("timeout") // unkeyed command
             .set("foo", "bar"); // route to primary of slot 12182
@@ -157,7 +157,7 @@ mod pipeline_routing_tests {
         let mut pipeline = crate::Pipeline::new();
 
         pipeline
-            .add_command(cmd("FLUSHALL")) // route to all masters
+            .flushall() // route to all masters
             .set("baz", "bar") // route to slot 4813
             .get("foo"); // route to slot 12182
 

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -534,7 +534,8 @@ pub use crate::client::Client;
 pub use crate::cmd::CommandCacheConfig;
 pub use crate::cmd::{cmd, pack_command, pipe, Arg, Cmd, Iter};
 pub use crate::commands::{
-    Commands, ControlFlow, Direction, LposOptions, PubSubCommands, ScanOptions, SetOptions,
+    Commands, ControlFlow, Direction, FlushAllOptions, FlushDbOptions, LposOptions, PubSubCommands,
+    ScanOptions, SetOptions,
 };
 pub use crate::connection::{
     parse_redis_url, transaction, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike,

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -4,7 +4,7 @@
 use futures::Future;
 #[cfg(feature = "aio")]
 use redis::{aio, cmd};
-use redis::{ConnectionAddr, InfoDict, Pipeline, ProtocolVersion, RedisResult, Value};
+use redis::{Commands, ConnectionAddr, InfoDict, Pipeline, ProtocolVersion, RedisResult, Value};
 use redis_test::server::{use_protocol, Module, RedisServer};
 use redis_test::utils::{get_random_available_port, TlsFilePaths};
 #[cfg(feature = "tls-rustls")]
@@ -232,7 +232,7 @@ impl TestContext {
                 }
             }
         }
-        redis::cmd("FLUSHDB").exec(&mut con).unwrap();
+        con.flushdb::<()>().unwrap();
 
         TestContext {
             server,

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -508,15 +508,10 @@ mod cluster_async {
                     let role: String = info.get("role").expect("cluster role");
 
                     if role == "master" {
-                        async {
-                            Ok(redis::Cmd::new()
-                                .arg("FLUSHALL")
-                                .exec_async(&mut conn)
-                                .await?)
-                        }
-                        .timeout(futures_time::time::Duration::from_secs(3))
-                        .await
-                        .unwrap_or_else(|err| Err(anyhow::Error::from(err)))?;
+                        async { Ok(conn.flushall::<()>().await?) }
+                            .timeout(futures_time::time::Duration::from_secs(3))
+                            .await
+                            .unwrap_or_else(|err| Err(anyhow::Error::from(err)))?;
                     }
 
                     node_conns.push(conn);


### PR DESCRIPTION
We tend to run flushing commands in our tests, and it would be great to be able to do that directly on the connection, like

```
conn.flushdb().await?;
```