### PR TITLE
Support bb8 for cluster client

### DIFF
--- a/redis/src/bb8.rs
+++ b/redis/src/bb8.rs
@@ -1,23 +1,47 @@
-use crate::{aio::MultiplexedConnection, ErrorKind};
-use crate::{Client, RedisError};
+use crate::aio::MultiplexedConnection;
+use crate::{Client, Cmd, ErrorKind, RedisError};
 
-impl bb8::ManageConnection for Client {
-    type Connection = MultiplexedConnection;
-    type Error = RedisError;
+#[cfg(feature = "cluster-async")]
+use crate::{cluster::ClusterClient, cluster_async::ClusterConnection};
 
-    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
-        self.get_multiplexed_async_connection().await
-    }
+macro_rules! impl_bb8_manage_connection {
+    ($client:ty, $connectioin:ty, $get_conn:expr) => {
+        impl bb8::ManageConnection for $client {
+            type Connection = $connectioin;
+            type Error = RedisError;
 
-    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
-        let pong: String = crate::cmd("PING").query_async(conn).await?;
-        match pong.as_str() {
-            "PONG" => Ok(()),
-            _ => Err((ErrorKind::ResponseError, "ping request").into()),
+            async fn connect(&self) -> Result<Self::Connection, Self::Error> {
+                $get_conn(self).await
+            }
+
+            async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+                let pong: String = Cmd::ping().query_async(conn).await?;
+                match pong.as_str() {
+                    "PONG" => Ok(()),
+                    _ => Err((ErrorKind::ResponseError, "ping request").into()),
+                }
+            }
+
+            fn has_broken(&self, _: &mut Self::Connection) -> bool {
+                false
+            }
         }
-    }
-
-    fn has_broken(&self, _: &mut Self::Connection) -> bool {
-        false
-    }
+    };
 }
+
+impl_bb8_manage_connection!(
+    Client,
+    MultiplexedConnection,
+    Client::get_multiplexed_async_connection
+);
+
+#[cfg(feature = "cluster-async")]
+impl_bb8_manage_connection!(
+    ClusterClient,
+    ClusterConnection,
+    ClusterClient::get_async_connection
+);
+
+// TODO: support bb8 for sentinel client which required
+// [`crate::sentinel::LockedSentinelClient`] implement async method of
+// `get_multiplexed_async_connection`.


### PR DESCRIPTION
Hi, this PR add support bb8 for `redis::cluster::ClusterClient` inspired by the #1564.

Thank you for these work, any feedback is appreciated.