### PR TITLE
Update danger_accept_invalid_hostnames for rustls 0.23.24

### DIFF
--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -564,7 +564,10 @@ struct AcceptInvalidHostnamesCertVerifier {
 fn is_hostname_error(err: &rustls::Error) -> bool {
     matches!(
         err,
-        rustls::Error::InvalidCertificate(rustls::CertificateError::NotValidForName)
+        rustls::Error::InvalidCertificate(
+            rustls::CertificateError::NotValidForName
+                | rustls::CertificateError::NotValidForNameContext { .. }
+        )
     )
 }
 


### PR DESCRIPTION
Rustls 0.23.24 introduced some new variants in `CertificateError`, to improve their error messages:

[0.23.23](https://docs.rs/rustls/0.23.23/rustls/enum.CertificateError.html)

[0.23.24](https://docs.rs/rustls/0.23.24/rustls/enum.CertificateError.html)

The new variants (including `NotValidForNameContext`) express the same kinds of errors as the old ones (`NotValidForName`), but with extra fields for information... which, incidentally, would have been incredibly handy while I was implementing this in the first place, so I can't object to the change, even if they probably should have waited for a non-compatible release.

Anyway, the code where we match on this enum must now accept both the old and new variants.