### PR TITLE
Fix compiling on windows

### DIFF
--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -13,6 +13,7 @@ use crate::io::tcp::TcpSettings;
 #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
 use crate::parser::ValueCodec;
 use crate::types::{FromRedisValue, RedisFuture, RedisResult, Value};
+use crate::RedisError;
 use crate::{from_owned_redis_value, ProtocolVersion, ToRedisArgs};
 use ::tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use combine::{parser::combinator::AnySendSyncPartialState, stream::PointerOffset};


### PR DESCRIPTION
This sample program builds + runs for me on Windows with this simple band-aid fix.

use anyhow::Result;
use redis::AsyncCommands;

```
#[tokio::main]
async fn main() -> Result<()> {
    // Connect to Redis using a connection string
    let client = redis::Client::open("redis://127.0.0.1/")?;
    let mut con = client.get_multiplexed_async_connection().await?;

    println!("Connected to Redis server successfully!");

    let _: () = con.set_ex("key", "value", 10).await?;

    let result: Option<String> = con.get("key").await?;
    println!("{result:?}");

    let result: Option<String> = con.get("notakey").await?;
    println!("{result:?}");

    Ok(())
}
```

```
[package]
name = "redis-test"
version = "0.1.0"
edition = "2021"

[dependencies]
anyhow = "1.0.97"
redis = { git = "https://github.com/BMorinBlitz/redis-rs", branch = "bmorin-hotfix-windows", features = ["tokio-comp"] }
tokio = { version = "1.44.0", features = [
    "macros",
    "rt-multi-thread",
    "signal",
    "sync"
] }
```