### PR TITLE
Add support for the Smol runtime.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,17 +318,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
-name = "async-trait"
-version = "0.1.88"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1798,7 +1787,6 @@ dependencies = [
  "async-io 2.4.0",
  "async-native-tls",
  "async-std",
- "async-trait",
  "backon",
  "bb8",
  "bigdecimal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
  "futures-core",
- "pin-project-lite",
+ "pin-project-lite 0.2.16",
 ]
 
 [[package]]
@@ -138,6 +138,17 @@ dependencies = [
  "fastrand 2.3.0",
  "futures-lite 2.6.0",
  "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
+dependencies = [
+ "async-lock 3.4.0",
+ "blocking",
+ "futures-lite 2.6.0",
 ]
 
 [[package]]
@@ -211,7 +222,7 @@ checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
  "event-listener 5.4.0",
  "event-listener-strategy",
- "pin-project-lite",
+ "pin-project-lite 0.2.16",
 ]
 
 [[package]]
@@ -224,6 +235,54 @@ dependencies = [
  "native-tls",
  "thiserror",
  "url",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io 2.4.0",
+ "blocking",
+ "futures-lite 2.6.0",
+]
+
+[[package]]
+name = "async-process"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-io 2.4.0",
+ "async-lock 3.4.0",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.0",
+ "futures-lite 2.6.0",
+ "rustix 0.38.44",
+ "tracing",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfb3634b73397aa844481f814fad23bbf07fdb0eabec10f2eb95e58944b1ec32"
+dependencies = [
+ "async-io 2.4.0",
+ "async-lock 3.4.0",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 0.38.44",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -246,7 +305,7 @@ dependencies = [
  "log",
  "memchr",
  "once_cell",
- "pin-project-lite",
+ "pin-project-lite 0.2.16",
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
@@ -257,6 +316,17 @@ name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -506,7 +576,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "memchr",
- "pin-project-lite",
+ "pin-project-lite 0.2.16",
  "tokio",
  "tokio-util",
 ]
@@ -676,7 +746,7 @@ checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite",
+ "pin-project-lite 0.2.16",
 ]
 
 [[package]]
@@ -686,7 +756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
  "event-listener 5.4.0",
- "pin-project-lite",
+ "pin-project-lite 0.2.16",
 ]
 
 [[package]]
@@ -805,7 +875,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite",
+ "pin-project-lite 0.2.16",
  "waker-fn",
 ]
 
@@ -819,7 +889,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "parking",
- "pin-project-lite",
+ "pin-project-lite 0.2.16",
 ]
 
 [[package]]
@@ -865,7 +935,7 @@ dependencies = [
  "async-channel 1.9.0",
  "async-io 1.13.0",
  "futures-core",
- "pin-project-lite",
+ "pin-project-lite 0.2.16",
 ]
 
 [[package]]
@@ -887,7 +957,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite",
+ "pin-project-lite 0.2.16",
  "pin-utils",
  "slab",
 ]
@@ -1460,6 +1530,12 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
+
+[[package]]
+name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
@@ -1527,7 +1603,7 @@ dependencies = [
  "concurrent-queue",
  "libc",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.2.16",
  "windows-sys 0.48.0",
 ]
 
@@ -1540,7 +1616,7 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi 0.4.0",
- "pin-project-lite",
+ "pin-project-lite 0.2.16",
  "rustix 0.38.44",
  "tracing",
  "windows-sys 0.59.0",
@@ -1719,12 +1795,15 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "assert_approx_eq",
+ "async-io 2.4.0",
  "async-native-tls",
  "async-std",
+ "async-trait",
  "backon",
  "bb8",
  "bigdecimal",
  "bytes",
+ "cfg-if",
  "combine",
  "crc16",
  "criterion",
@@ -1744,7 +1823,7 @@ dependencies = [
  "once_cell",
  "partial-io",
  "percent-encoding",
- "pin-project-lite",
+ "pin-project-lite 0.2.16",
  "quickcheck",
  "r2d2",
  "rand 0.9.0",
@@ -1757,6 +1836,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1_smol",
+ "smol",
+ "smol-timeout",
  "socket2 0.5.9",
  "tempfile",
  "tokio",
@@ -2159,6 +2240,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,6 +2268,33 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "smol"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-executor",
+ "async-fs",
+ "async-io 2.4.0",
+ "async-lock 3.4.0",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite 2.6.0",
+]
+
+[[package]]
+name = "smol-timeout"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847d777e2c6c166bad26264479e80a9820f3d364fcb4a0e23cd57bbfa8e94961"
+dependencies = [
+ "async-io 1.13.0",
+ "pin-project-lite 0.1.12",
+]
 
 [[package]]
 name = "socket2"
@@ -2329,7 +2446,7 @@ dependencies = [
  "libc",
  "mio",
  "parking_lot",
- "pin-project-lite",
+ "pin-project-lite 0.2.16",
  "socket2 0.5.9",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -2375,7 +2492,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "pin-project-lite",
+ "pin-project-lite 0.2.16",
  "tokio",
 ]
 
@@ -2402,7 +2519,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "pin-project-lite",
+ "pin-project-lite 0.2.16",
  "tracing-core",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test:
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with native-TLS support"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo nextest run --locked -p redis --features=json,tokio-native-tls-comp,async-std-native-tls-comp,connection-manager,cluster-async -E 'not test(test_module)'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo nextest run --locked -p redis --features=json,tokio-native-tls-comp,async-std-native-tls-comp,smol-native-tls-comp,connection-manager,cluster-async -E 'not test(test_module)'
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type UNIX"

--- a/config/redis.toml
+++ b/config/redis.toml
@@ -1,10 +1,10 @@
 [[rule]]
 when = "cluster-async"
-require = ["tokio-comp", "OR", "async-std-comp"]
+require = ["tokio-comp", "OR", "smol-comp"]
 
 [[rule]]
 when = "connection-manager"
-require = ["tokio-comp", "OR", "async-std-comp"]
+require = ["tokio-comp", "OR", "smol-comp"]
 
 [[rule]]
 when = ["tls-rustls", "tokio-comp"]
@@ -15,12 +15,12 @@ when = ["tls-native-tls", "tokio-comp"]
 require = ["tokio-native-tls-comp"]
 
 [[rule]]
-when = ["tls-rustls", "async-std-comp"]
-require = ["async-std-rustls-comp"]
+when = ["tls-rustls", "smol-comp"]
+require = ["smol-rustls-comp"]
 
 [[rule]]
-when = ["tls-native-tls", "async-std-comp"]
-require = ["async-std-native-tls-comp"]
+when = ["tls-native-tls", "smol-comp"]
+require = ["smol-native-tls-comp"]
 
 [[rule]]
 when = "tls-rustls-insecure"
@@ -31,7 +31,7 @@ require = ["tls-rustls"]
 when = [
   "tokio-native-tls-comp",
   "OR",
-  "async-std-native-tls-comp",
+  "smol-native-tls-comp",
   "OR",
   "tls-native-tls",
 ]
@@ -44,17 +44,17 @@ forbid = [
   "OR",
   "tls-rustls-insecure",
   "OR",
-  "async-std-rustls-comp",
+  "smol-rustls-comp",
 ]
 
-# we don't need to check whether the async-std features are working with the tokio features
+# we don't need to check whether the smol features are working with the tokio features
 [[rule]]
 when = [
-  "async-std-native-tls-comp",
+  "smol-native-tls-comp",
   "OR",
-  "async-std-comp",
+  "smol-comp",
   "OR",
-  "async-std-rustls-comp",
+  "smol-rustls-comp",
 ]
 forbid = [
   "tokio-rustls-comp",
@@ -65,12 +65,12 @@ forbid = [
 ]
 
 [[rule]]
-when = ["async-std-native-tls-comp"]
-forbid = ["async-std-rustls-comp"]
+when = ["smol-native-tls-comp"]
+forbid = ["smol-rustls-comp"]
 
 [[rule]]
-when = ["tls-rustls-webpki-roots", "async-std-comp"]
-require = ["async-std-rustls-comp"]
+when = ["tls-rustls-webpki-roots", "smol-comp"]
+require = ["smol-rustls-comp"]
 
 [[rule]]
 when = ["tls-rustls-webpki-roots", "tokio-comp"]
@@ -94,7 +94,15 @@ forbid = "tls"
 # deprecated
 [[rule]]
 when = true
-forbid = "async-std-tls-comp"
+forbid = [
+  "async-std-tls-comp",
+  "OR",
+  "async-std-comp",
+  "OR",
+  "async-std-native-tls-comp",
+  "OR",
+  "async-std-rustls-comp",
+]
 
 # these are all included in the `default` feature, so in order to reduce combinatoric explosion, we don't check them individually.
 [[rule]]
@@ -113,4 +121,4 @@ forbid = [
 
 [[rule]]
 when = "cache-aio"
-require = ["tokio-comp", "OR", "async-std-comp"]
+require = ["tokio-comp", "OR", "smol-comp"]

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -150,7 +150,6 @@ disable-client-setinfo = []
 cache-aio = ["aio", "dep:lru"]
 r2d2 = ["dep:r2d2"]
 bb8 = ["dep:bb8"]
-hashbrown = ["dep:hashbrown"]
 
 # Deprecated features
 tls = ["tls-native-tls"] # use "tls-native-tls" instead

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -38,6 +38,7 @@ combine = { version = "4.6", default-features = false, features = ["std"] }
 
 # Only needed for AIO
 bytes = { version = "1", optional = true }
+cfg-if = { version = "1", optional = true }
 futures-util = { version = "0.3.31", default-features = false, features = [
   "std",
   "sink",
@@ -72,6 +73,12 @@ futures-sink = { version = "0.3.31", optional = true }
 
 # Only needed for async_std support
 async-std = { version = "1.13.0", optional = true }
+async-trait = { version = "0.1.83", optional = true }
+
+#only needed for smol support
+smol = { version = "2", optional = true }
+async-io = { version = "2", optional = true }
+smol-timeout = { version = "0.6", optional = true }
 
 # Only needed for native tls
 native-tls = { version = "0.2", optional = true }
@@ -123,13 +130,13 @@ tls-rustls = [
 ]
 tls-rustls-insecure = ["tls-rustls"]
 tls-rustls-webpki-roots = ["tls-rustls", "dep:webpki-roots"]
-async-std-comp = ["aio", "dep:async-std"]
-async-std-native-tls-comp = [
-  "async-std-comp",
+smol-comp = ["aio", "dep:smol", "dep:smol-timeout", "dep:async-io"]
+smol-native-tls-comp = [
+  "smol-comp",
   "dep:async-native-tls",
   "tls-native-tls",
 ]
-async-std-rustls-comp = ["async-std-comp", "dep:futures-rustls", "tls-rustls"]
+smol-rustls-comp = ["smol-comp", "dep:futures-rustls", "tls-rustls"]
 tokio-comp = ["aio", "tokio/net"]
 tokio-native-tls-comp = ["tokio-comp", "tls-native-tls", "dep:tokio-native-tls"]
 tokio-rustls-comp = ["tokio-comp", "tls-rustls", "dep:tokio-rustls"]
@@ -144,12 +151,20 @@ disable-client-setinfo = []
 cache-aio = ["aio", "dep:lru"]
 r2d2 = ["dep:r2d2"]
 bb8 = ["dep:bb8"]
+hashbrown = ["dep:hashbrown"]
 
 # Deprecated features
 tls = ["tls-native-tls"] # use "tls-native-tls" instead
 async-std-tls-comp = [
   "async-std-native-tls-comp",
 ] # use "async-std-native-tls-comp" instead
+async-std-comp = ["aio", "dep:async-std"]
+async-std-native-tls-comp = [
+  "async-std-comp",
+  "dep:async-native-tls",
+  "tls-native-tls",
+]
+async-std-rustls-comp = ["async-std-comp", "dep:futures-rustls", "tls-rustls"]
 # Instead of specifying "aio", use either "tokio-comp" or "async-std-comp".
 aio = [
   "bytes",
@@ -160,6 +175,7 @@ aio = [
   "dep:tokio-util",
   "tokio-util/codec",
   "combine/tokio",
+  "dep:cfg-if",
 ]
 
 [dev-dependencies]

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -73,7 +73,6 @@ futures-sink = { version = "0.3.31", optional = true }
 
 # Only needed for async_std support
 async-std = { version = "1.13.0", optional = true }
-async-trait = { version = "0.1.83", optional = true }
 
 #only needed for smol support
 smol = { version = "2", optional = true }

--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -2,7 +2,9 @@
 
 #[cfg(feature = "async-std-comp")]
 use super::async_std;
-use super::{setup_connection, AsyncStream, DefaultAsyncDNSResolver, RedisRuntime};
+#[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
+use super::DefaultAsyncDNSResolver;
+use super::{setup_connection, AsyncStream, RedisRuntime};
 use super::{AsyncDNSResolver, ConnectionLike};
 use crate::cmd::{cmd, Cmd};
 use crate::connection::{
@@ -10,7 +12,7 @@ use crate::connection::{
     Msg, RedisConnectionInfo,
 };
 use crate::io::tcp::TcpSettings;
-#[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
+#[cfg(feature = "aio")]
 use crate::parser::ValueCodec;
 use crate::types::{FromRedisValue, RedisFuture, RedisResult, Value};
 use crate::{from_owned_redis_value, ProtocolVersion, ToRedisArgs};
@@ -22,7 +24,7 @@ use futures_util::{
     stream::{Stream, StreamExt},
 };
 use std::pin::Pin;
-#[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
+#[cfg(feature = "aio")]
 use tokio_util::codec::Decoder;
 
 /// Represents a stateful redis TCP connection.
@@ -50,6 +52,7 @@ fn test() {
     assert_sync::<Connection>();
 }
 
+#[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
 impl<C> Connection<C> {
     pub(crate) fn map<D>(self, f: impl FnOnce(C) -> D) -> Connection<D> {
         let Self {
@@ -210,6 +213,7 @@ where
     }
 }
 
+#[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
 pub(crate) async fn connect<C>(connection_info: &ConnectionInfo) -> RedisResult<Connection<C>>
 where
     C: Unpin + RedisRuntime + AsyncRead + AsyncWrite + Send,

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -3,7 +3,6 @@ use crate::aio::{check_resp3, setup_connection};
 #[cfg(feature = "cache-aio")]
 use crate::caching::{CacheManager, CacheStatistics, PrepareCacheResult};
 use crate::cmd::Cmd;
-#[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
 use crate::parser::ValueCodec;
 use crate::types::{closed_connection_error, RedisError, RedisFuture, RedisResult, Value};
 use crate::{
@@ -27,7 +26,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{self, Poll};
 use std::time::Duration;
-#[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
 use tokio_util::codec::Decoder;
 
 // Senders which the result of a single request are sent through
@@ -496,9 +494,6 @@ impl MultiplexedConnection {
     where
         C: Unpin + AsyncRead + AsyncWrite + Send + 'static,
     {
-        #[cfg(all(not(feature = "tokio-comp"), not(feature = "async-std-comp")))]
-        compile_error!("tokio-comp or async-std-comp features required for aio feature");
-
         let codec = ValueCodec::default().framed(stream);
         if config.push_sender.is_some() {
             check_resp3!(

--- a/redis/src/aio/pubsub.rs
+++ b/redis/src/aio/pubsub.rs
@@ -2,7 +2,6 @@ use crate::aio::Runtime;
 use crate::connection::{
     check_connection_setup, connection_setup_pipeline, AuthResult, ConnectionSetupComponents,
 };
-#[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
 use crate::parser::ValueCodec;
 use crate::types::{closed_connection_error, RedisError, RedisResult, Value};
 use crate::{cmd, from_owned_redis_value, FromRedisValue, Msg, RedisConnectionInfo, ToRedisArgs};
@@ -22,7 +21,6 @@ use std::pin::Pin;
 use std::task::{self, Poll};
 use tokio::sync::mpsc::unbounded_channel;
 use tokio::sync::mpsc::UnboundedSender;
-#[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
 use tokio_util::codec::Decoder;
 
 use super::SharedHandleContainer;
@@ -456,9 +454,6 @@ impl PubSub {
     where
         C: Unpin + AsyncRead + AsyncWrite + Send + 'static,
     {
-        #[cfg(all(not(feature = "tokio-comp"), not(feature = "async-std-comp")))]
-        compile_error!("tokio-comp or async-std-comp features required for aio feature");
-
         let mut codec = ValueCodec::default().framed(stream);
         setup_connection(&mut codec, connection_info).await?;
         let (sender, receiver) = unbounded_channel();

--- a/redis/src/aio/runtime.rs
+++ b/redis/src/aio/runtime.rs
@@ -2,19 +2,41 @@ use std::{io, sync::Arc, time::Duration};
 
 use futures_util::Future;
 
+#[cfg(any(
+    all(
+        feature = "tokio-comp",
+        any(feature = "async-std-comp", feature = "smol-comp")
+    ),
+    all(
+        feature = "smol-comp",
+        any(feature = "async-std-comp", feature = "tokio-comp")
+    ),
+    all(
+        feature = "async-std-comp",
+        any(feature = "tokio-comp", feature = "smol-comp")
+    )
+))]
+use std::sync::OnceLock;
+
 #[cfg(feature = "async-std-comp")]
 use super::async_std as crate_async_std;
+#[cfg(feature = "smol-comp")]
+use super::smol as crate_smol;
 #[cfg(feature = "tokio-comp")]
 use super::tokio as crate_tokio;
 use super::RedisRuntime;
 use crate::types::RedisError;
+#[cfg(feature = "smol-comp")]
+use smol_timeout::TimeoutExt;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub(crate) enum Runtime {
     #[cfg(feature = "tokio-comp")]
     Tokio,
     #[cfg(feature = "async-std-comp")]
     AsyncStd,
+    #[cfg(feature = "smol-comp")]
+    Smol,
 }
 
 pub(crate) enum TaskHandle {
@@ -22,6 +44,8 @@ pub(crate) enum TaskHandle {
     Tokio(tokio::task::JoinHandle<()>),
     #[cfg(feature = "async-std-comp")]
     AsyncStd(async_std::task::JoinHandle<()>),
+    #[cfg(feature = "smol-comp")]
+    Smol(smol::Task<()>),
 }
 
 pub(crate) struct HandleContainer(Option<TaskHandle>);
@@ -41,8 +65,11 @@ impl Drop for HandleContainer {
             #[cfg(feature = "async-std-comp")]
             Some(TaskHandle::AsyncStd(handle)) => {
                 // schedule for cancellation without waiting for result.
+                // TODO - can we cancel the task without awaiting its completion?
                 Runtime::locate().spawn(async move { handle.cancel().await.unwrap_or_default() });
             }
+            #[cfg(feature = "smol-comp")]
+            Some(TaskHandle::Smol(task)) => drop(task),
         }
     }
 }
@@ -58,30 +85,159 @@ impl SharedHandleContainer {
     }
 }
 
+#[cfg(any(
+    all(
+        feature = "tokio-comp",
+        any(feature = "async-std-comp", feature = "smol-comp")
+    ),
+    all(
+        feature = "smol-comp",
+        any(feature = "async-std-comp", feature = "tokio-comp")
+    ),
+    all(
+        feature = "async-std-comp",
+        any(feature = "tokio-comp", feature = "smol-comp")
+    )
+))]
+static CHOSEN_RUNTIME: OnceLock<Runtime> = const { OnceLock::new() };
+
+#[cfg(any(
+    all(
+        feature = "tokio-comp",
+        any(feature = "async-std-comp", feature = "smol-comp")
+    ),
+    all(
+        feature = "smol-comp",
+        any(feature = "async-std-comp", feature = "tokio-comp")
+    ),
+    all(
+        feature = "async-std-comp",
+        any(feature = "tokio-comp", feature = "smol-comp")
+    )
+))]
+fn set_runtime(runtime: Runtime) -> Result<(), RedisError> {
+    const PREFER_RUNTIME_ERROR: &str =
+    "Another runtime preference was already set. Please call this function before any other runtime preference is set.";
+
+    CHOSEN_RUNTIME
+        .set(runtime)
+        .map_err(|_| RedisError::from((crate::ErrorKind::ClientError, PREFER_RUNTIME_ERROR)))
+}
+
+/// Mark Smol as the preferred runtime.
+///
+/// If the function returns `Err`, another runtime preference was already set, and won't be changed.
+/// Call this function if the application doesn't use multiple runtimes,
+/// but the crate is compiled with multiple runtimes enabled, which is a bad pattern that should be avoided.
+#[cfg(all(
+    feature = "smol-comp",
+    any(feature = "async-std-comp", feature = "tokio-comp")
+))]
+pub fn prefer_smol() -> Result<(), RedisError> {
+    set_runtime(Runtime::Smol)
+}
+
+/// Mark async-std compliant runtimes, such as smol, as the preferred runtime.
+///
+/// If the function returns `Err`, another runtime preference was already set, and won't be changed.
+/// Call this function if the application doesn't use multiple runtimes,
+/// but the crate is compiled with multiple runtimes enabled, which is a bad pattern that should be avoided.
+#[cfg(all(
+    feature = "async-std-comp",
+    any(feature = "tokio-comp", feature = "smol-comp")
+))]
+pub fn prefer_async_std() -> Result<(), RedisError> {
+    set_runtime(Runtime::AsyncStd)
+}
+
+/// Mark Tokio as the preferred runtime.
+///
+/// If the function returns `Err`, another runtime preference was already set, and won't be changed.
+/// Call this function if the application doesn't use multiple runtimes,
+/// but the crate is compiled with multiple runtimes enabled, which is a bad pattern that should be avoided.
+#[cfg(all(
+    feature = "tokio-comp",
+    any(feature = "async-std-comp", feature = "smol-comp")
+))]
+pub fn prefer_tokio() -> Result<(), RedisError> {
+    set_runtime(Runtime::Tokio)
+}
+
 impl Runtime {
     pub(crate) fn locate() -> Self {
-        #[cfg(all(feature = "tokio-comp", not(feature = "async-std-comp")))]
+        #[cfg(any(
+            all(
+                feature = "tokio-comp",
+                any(feature = "async-std-comp", feature = "smol-comp")
+            ),
+            all(
+                feature = "smol-comp",
+                any(feature = "async-std-comp", feature = "tokio-comp")
+            ),
+            all(
+                feature = "async-std-comp",
+                any(feature = "tokio-comp", feature = "smol-comp")
+            )
+        ))]
+        if let Some(runtime) = CHOSEN_RUNTIME.get() {
+            return *runtime;
+        }
+
+        #[cfg(all(
+            feature = "tokio-comp",
+            not(feature = "async-std-comp"),
+            not(feature = "smol-comp")
+        ))]
         {
             Runtime::Tokio
         }
 
-        #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
+        #[cfg(all(
+            not(feature = "tokio-comp"),
+            not(feature = "smol-comp"),
+            feature = "async-std-comp"
+        ))]
         {
             Runtime::AsyncStd
         }
 
-        #[cfg(all(feature = "tokio-comp", feature = "async-std-comp"))]
+        #[cfg(all(
+            not(feature = "tokio-comp"),
+            feature = "smol-comp",
+            not(feature = "async-std-comp")
+        ))]
         {
+            Runtime::Smol
+        }
+
+        cfg_if::cfg_if! {
+        if #[cfg(all(feature = "tokio-comp", feature = "async-std-comp"))] {
             if ::tokio::runtime::Handle::try_current().is_ok() {
                 Runtime::Tokio
             } else {
                 Runtime::AsyncStd
             }
+        } else if         #[cfg(all(feature = "tokio-comp", feature = "smol-comp"))] {
+            if ::tokio::runtime::Handle::try_current().is_ok() {
+                Runtime::Tokio
+            } else {
+                Runtime::Smol
+            }
+        } else if                 #[cfg(all(feature = "smol-comp", feature = "async-std-comp"))]
+            {
+                Runtime::AsyncStd
+            }
         }
 
-        #[cfg(all(not(feature = "tokio-comp"), not(feature = "async-std-comp")))]
+        #[cfg(all(
+            not(feature = "tokio-comp"),
+            not(feature = "async-std-comp"),
+            not(feature = "smol-comp")
+        ))]
         {
-            compile_error!("tokio-comp or async-std-comp features required for aio feature")
+            compile_error!(
+                "tokio-comp, async-std-comp, or smol-comp features required for aio feature"
+            )
         }
     }
 
@@ -92,6 +248,8 @@ impl Runtime {
             Runtime::Tokio => crate_tokio::Tokio::spawn(f),
             #[cfg(feature = "async-std-comp")]
             Runtime::AsyncStd => crate_async_std::AsyncStd::spawn(f),
+            #[cfg(feature = "smol-comp")]
+            Runtime::Smol => crate_smol::Smol::spawn(f),
         }
     }
 
@@ -109,6 +267,8 @@ impl Runtime {
             Runtime::AsyncStd => async_std::future::timeout(duration, future)
                 .await
                 .map_err(|_| Elapsed(())),
+            #[cfg(feature = "smol-comp")]
+            Runtime::Smol => future.timeout(duration).await.ok_or(Elapsed(())),
         }
     }
 
@@ -122,6 +282,10 @@ impl Runtime {
             #[cfg(feature = "async-std-comp")]
             Runtime::AsyncStd => {
                 async_std::task::sleep(duration).await;
+            }
+            #[cfg(feature = "smol-comp")]
+            Runtime::Smol => {
+                smol::Timer::after(duration).await;
             }
         }
     }

--- a/redis/src/aio/runtime.rs
+++ b/redis/src/aio/runtime.rs
@@ -217,13 +217,13 @@ impl Runtime {
             } else {
                 Runtime::AsyncStd
             }
-        } else if         #[cfg(all(feature = "tokio-comp", feature = "smol-comp"))] {
+        } else if #[cfg(all(feature = "tokio-comp", feature = "smol-comp"))] {
             if ::tokio::runtime::Handle::try_current().is_ok() {
                 Runtime::Tokio
             } else {
                 Runtime::Smol
             }
-        } else if                 #[cfg(all(feature = "smol-comp", feature = "async-std-comp"))]
+        } else if #[cfg(all(feature = "smol-comp", feature = "async-std-comp"))]
             {
                 Runtime::AsyncStd
             }

--- a/redis/src/aio/runtime.rs
+++ b/redis/src/aio/runtime.rs
@@ -99,7 +99,7 @@ impl SharedHandleContainer {
         any(feature = "tokio-comp", feature = "smol-comp")
     )
 ))]
-static CHOSEN_RUNTIME: OnceLock<Runtime> = const { OnceLock::new() };
+static CHOSEN_RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
 #[cfg(any(
     all(

--- a/redis/src/aio/smol.rs
+++ b/redis/src/aio/smol.rs
@@ -1,0 +1,247 @@
+#[cfg(unix)]
+use std::path::Path;
+use std::sync::Arc;
+use std::{
+    future::Future,
+    io,
+    net::SocketAddr,
+    pin::Pin,
+    task::{self, Poll},
+};
+
+use crate::aio::{AsyncStream, RedisRuntime};
+use crate::types::RedisResult;
+
+#[cfg(all(feature = "smol-native-tls-comp", not(feature = "smol-rustls-comp")))]
+use async_native_tls::{TlsConnector, TlsStream};
+
+#[cfg(feature = "smol-rustls-comp")]
+use crate::connection::create_rustls_config;
+#[cfg(feature = "smol-rustls-comp")]
+use futures_rustls::{client::TlsStream, TlsConnector};
+
+use super::TaskHandle;
+use futures_util::ready;
+#[cfg(unix)]
+use smol::net::unix::UnixStream;
+use smol::net::TcpStream;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+#[inline(always)]
+async fn connect_tcp(
+    addr: &SocketAddr,
+    tcp_settings: &crate::io::tcp::TcpSettings,
+) -> io::Result<TcpStream> {
+    let socket = TcpStream::connect(addr).await?;
+    let socket_inner: Arc<async_io::Async<std::net::TcpStream>> = socket.into();
+    let async_socket_inner = Arc::into_inner(socket_inner).unwrap();
+    let std_socket = async_socket_inner.into_inner()?;
+    let std_socket = crate::io::tcp::stream_with_settings(std_socket, tcp_settings)?;
+
+    std_socket.try_into()
+}
+
+#[cfg(any(feature = "smol-rustls-comp", feature = "smol-native-tls-comp"))]
+use crate::connection::TlsConnParams;
+
+pin_project_lite::pin_project! {
+    /// Wraps the smol `AsyncRead/AsyncWrite` in order to implement the required the tokio traits
+    /// for it
+    pub struct SmolWrapped<T> {  #[pin] inner: T }
+}
+
+impl<T> SmolWrapped<T> {
+    pub(super) fn new(inner: T) -> Self {
+        Self { inner }
+    }
+}
+
+impl<T> AsyncWrite for SmolWrapped<T>
+where
+    T: smol::io::AsyncWrite,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut core::task::Context,
+        buf: &[u8],
+    ) -> std::task::Poll<Result<usize, tokio::io::Error>> {
+        smol::io::AsyncWrite::poll_write(self.project().inner, cx, buf)
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut core::task::Context,
+    ) -> std::task::Poll<Result<(), tokio::io::Error>> {
+        smol::io::AsyncWrite::poll_flush(self.project().inner, cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut core::task::Context,
+    ) -> std::task::Poll<Result<(), tokio::io::Error>> {
+        smol::io::AsyncWrite::poll_close(self.project().inner, cx)
+    }
+}
+
+impl<T> AsyncRead for SmolWrapped<T>
+where
+    T: smol::prelude::AsyncRead,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut core::task::Context,
+        buf: &mut ReadBuf<'_>,
+    ) -> std::task::Poll<Result<(), tokio::io::Error>> {
+        let n = ready!(smol::prelude::AsyncRead::poll_read(
+            self.project().inner,
+            cx,
+            buf.initialize_unfilled()
+        ))?;
+        buf.advance(n);
+        std::task::Poll::Ready(Ok(()))
+    }
+}
+
+/// Represents an Smol connectable
+pub enum Smol {
+    /// Represents aa TCP connection.
+    Tcp(SmolWrapped<TcpStream>),
+    /// Represents a TLS encrypted TCP connection.
+    #[cfg(any(feature = "smol-native-tls-comp", feature = "smol-rustls-comp"))]
+    TcpTls(SmolWrapped<Box<TlsStream<TcpStream>>>),
+    /// Represents an Unix connection.
+    #[cfg(unix)]
+    Unix(SmolWrapped<UnixStream>),
+}
+
+impl AsyncWrite for Smol {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match &mut *self {
+            Smol::Tcp(r) => Pin::new(r).poll_write(cx, buf),
+            #[cfg(any(feature = "smol-native-tls-comp", feature = "smol-rustls-comp"))]
+            Smol::TcpTls(r) => Pin::new(r).poll_write(cx, buf),
+            #[cfg(unix)]
+            Smol::Unix(r) => Pin::new(r).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<io::Result<()>> {
+        match &mut *self {
+            Smol::Tcp(r) => Pin::new(r).poll_flush(cx),
+            #[cfg(any(feature = "smol-native-tls-comp", feature = "smol-rustls-comp"))]
+            Smol::TcpTls(r) => Pin::new(r).poll_flush(cx),
+            #[cfg(unix)]
+            Smol::Unix(r) => Pin::new(r).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<io::Result<()>> {
+        match &mut *self {
+            Smol::Tcp(r) => Pin::new(r).poll_shutdown(cx),
+            #[cfg(any(feature = "smol-native-tls-comp", feature = "smol-rustls-comp"))]
+            Smol::TcpTls(r) => Pin::new(r).poll_shutdown(cx),
+            #[cfg(unix)]
+            Smol::Unix(r) => Pin::new(r).poll_shutdown(cx),
+        }
+    }
+}
+
+impl AsyncRead for Smol {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        match &mut *self {
+            Smol::Tcp(r) => Pin::new(r).poll_read(cx, buf),
+            #[cfg(any(feature = "smol-native-tls-comp", feature = "smol-rustls-comp"))]
+            Smol::TcpTls(r) => Pin::new(r).poll_read(cx, buf),
+            #[cfg(unix)]
+            Smol::Unix(r) => Pin::new(r).poll_read(cx, buf),
+        }
+    }
+}
+
+impl RedisRuntime for Smol {
+    async fn connect_tcp(
+        socket_addr: SocketAddr,
+        tcp_settings: &crate::io::tcp::TcpSettings,
+    ) -> RedisResult<Self> {
+        Ok(connect_tcp(&socket_addr, tcp_settings)
+            .await
+            .map(|con| Self::Tcp(SmolWrapped::new(con)))?)
+    }
+
+    #[cfg(all(feature = "smol-native-tls-comp", not(feature = "smol-rustls-comp")))]
+    async fn connect_tcp_tls(
+        hostname: &str,
+        socket_addr: SocketAddr,
+        insecure: bool,
+        tls_params: &Option<TlsConnParams>,
+        tcp_settings: &crate::io::tcp::TcpSettings,
+    ) -> RedisResult<Self> {
+        let tcp_stream = connect_tcp(&socket_addr, tcp_settings).await?;
+        let tls_connector = if insecure {
+            TlsConnector::new()
+                .danger_accept_invalid_certs(true)
+                .danger_accept_invalid_hostnames(true)
+                .use_sni(false)
+        } else if let Some(params) = tls_params {
+            TlsConnector::new()
+                .danger_accept_invalid_hostnames(params.danger_accept_invalid_hostnames)
+        } else {
+            TlsConnector::new()
+        };
+        Ok(tls_connector
+            .connect(hostname, tcp_stream)
+            .await
+            .map(|con| Self::TcpTls(SmolWrapped::new(Box::new(con))))?)
+    }
+
+    #[cfg(feature = "smol-rustls-comp")]
+    async fn connect_tcp_tls(
+        hostname: &str,
+        socket_addr: SocketAddr,
+        insecure: bool,
+        tls_params: &Option<TlsConnParams>,
+        tcp_settings: &crate::io::tcp::TcpSettings,
+    ) -> RedisResult<Self> {
+        let tcp_stream = connect_tcp(&socket_addr, tcp_settings).await?;
+
+        let config = create_rustls_config(insecure, tls_params.clone())?;
+        let tls_connector = TlsConnector::from(Arc::new(config));
+
+        Ok(tls_connector
+            .connect(
+                rustls::pki_types::ServerName::try_from(hostname)?.to_owned(),
+                tcp_stream,
+            )
+            .await
+            .map(|con| Self::TcpTls(SmolWrapped::new(Box::new(con))))?)
+    }
+
+    #[cfg(unix)]
+    async fn connect_unix(path: &Path) -> RedisResult<Self> {
+        Ok(UnixStream::connect(path)
+            .await
+            .map(|con| Self::Unix(SmolWrapped::new(con)))?)
+    }
+
+    fn spawn(f: impl Future<Output = ()> + Send + 'static) -> TaskHandle {
+        TaskHandle::Smol(smol::spawn(f))
+    }
+
+    fn boxed(self) -> Pin<Box<dyn AsyncStream + Send + Sync>> {
+        match self {
+            Smol::Tcp(x) => Box::pin(x),
+            #[cfg(any(feature = "smol-native-tls-comp", feature = "smol-rustls-comp"))]
+            Smol::TcpTls(x) => Box::pin(x),
+            #[cfg(unix)]
+            Smol::Unix(x) => Box::pin(x),
+        }
+    }
+}

--- a/redis/src/aio/tokio.rs
+++ b/redis/src/aio/tokio.rs
@@ -169,14 +169,8 @@ impl RedisRuntime for Tokio {
         Ok(UnixStreamTokio::connect(path).await.map(Tokio::Unix)?)
     }
 
-    #[cfg(feature = "tokio-comp")]
     fn spawn(f: impl Future<Output = ()> + Send + 'static) -> TaskHandle {
         TaskHandle::Tokio(tokio::spawn(f))
-    }
-
-    #[cfg(not(feature = "tokio-comp"))]
-    fn spawn(_: impl Future<Output = ()> + Send + 'static) -> TokioTaskHandle {
-        unreachable!()
     }
 
     fn boxed(self) -> Pin<Box<dyn AsyncStream + Send + Sync>> {

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -285,7 +285,7 @@ impl AsyncConnectionConfig {
 #[cfg_attr(docsrs, doc(cfg(feature = "aio")))]
 impl Client {
     /// Returns an async connection from the client.
-    #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
+    #[cfg(feature = "aio")]
     #[deprecated(
         note = "aio::Connection is deprecated. Use client::get_multiplexed_async_connection instead."
     )]
@@ -334,11 +334,8 @@ impl Client {
     }
 
     /// Returns an async connection from the client.
-    #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(any(feature = "tokio-comp", feature = "async-std-comp")))
-    )]
+    #[cfg(feature = "aio")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "aio")))]
     pub async fn get_multiplexed_async_connection(
         &self,
     ) -> RedisResult<crate::aio::MultiplexedConnection> {
@@ -347,11 +344,8 @@ impl Client {
     }
 
     /// Returns an async connection from the client.
-    #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(any(feature = "tokio-comp", feature = "async-std-comp")))
-    )]
+    #[cfg(feature = "aio")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "aio")))]
     #[deprecated(note = "Use `get_multiplexed_async_connection_with_config` instead")]
     pub async fn get_multiplexed_async_connection_with_timeouts(
         &self,
@@ -367,11 +361,8 @@ impl Client {
     }
 
     /// Returns an async connection from the client.
-    #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(any(feature = "tokio-comp", feature = "async-std-comp")))
-    )]
+    #[cfg(feature = "aio")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "aio")))]
     pub async fn get_multiplexed_async_connection_with_config(
         &self,
         config: &AsyncConnectionConfig,
@@ -383,9 +374,16 @@ impl Client {
                     config, rt,
                 )
                 .await,
+
             #[cfg(feature = "async-std-comp")]
             rt @ Runtime::AsyncStd => self.get_multiplexed_async_connection_inner_with_timeout::<
                 crate::aio::async_std::AsyncStd,
+            >(config, rt)
+            .await,
+
+            #[cfg(feature = "smol-comp")]
+            rt @ Runtime::Smol => self.get_multiplexed_async_connection_inner_with_timeout::<
+                crate::aio::smol::Smol,
             >(config, rt)
             .await,
         }
@@ -866,6 +864,15 @@ impl Client {
                 )
                 .await
             }
+
+            #[cfg(feature = "smol-comp")]
+            Runtime::Smol => {
+                self.get_simple_async_connection::<crate::aio::smol::Smol>(
+                    dns_resolver,
+                    tcp_settings,
+                )
+                .await
+            }
         }
     }
 
@@ -890,7 +897,7 @@ impl Client {
     }
 
     /// Returns an async receiver for pub-sub messages.
-    #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
+    #[cfg(feature = "aio")]
     // TODO - do we want to type-erase pubsub using a trait, to allow us to replace it with a different implementation later?
     pub async fn get_async_pubsub(&self) -> RedisResult<crate::aio::PubSub> {
         let connection = self
@@ -904,7 +911,7 @@ impl Client {
     }
 
     /// Returns an async receiver for monitor messages.
-    #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
+    #[cfg(feature = "aio")]
     // TODO - do we want to type-erase monitor using a trait, to allow us to replace it with a different implementation later?
     pub async fn get_async_monitor(&self) -> RedisResult<crate::aio::Monitor> {
         #[allow(deprecated)]

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -438,7 +438,7 @@ it will not automatically be loaded and retried. The script can be loaded using 
 # Async
 
 In addition to the synchronous interface that's been explained above there also exists an
-asynchronous interface based on [`futures`][] and [`tokio`][], [`smol`][], or [`async-std`][].
+asynchronous interface based on [`futures`][] and [`tokio`][], [`smol`](https://docs.rs/smol/latest/smol/), or [`async-std`][].
 
 This interface exists under the `aio` (async io) module (which requires that the `aio` feature
 is enabled) and largely mirrors the synchronous with a few concessions to make it fit the
@@ -468,8 +468,9 @@ assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
 ## Runtime support
 The crate supports multiple runtimes, including `tokio`, `async-std`, and `smol`. For Tokio, the crate will
 spawn tasks on the current thread runtime. For async-std & smol, the crate will spawn tasks on the the global runtime.
-It is recommended that the crate be used with support only for a single runtime. If
-the crate is compiled with multiple runtimes, 
+It is recommended that the crate be used with support only for a single runtime. If the crate is compiled with multiple runtimes, 
+the user should call [`crate::aio::prefer_tokio`], [`crate::aio::prefer_async_std`] or [`crate::aio::prefer_smol`] to set the preferred runtime.
+These functions set global state which automatically chooses the correct runtime for the async connection.
 
 "##
 )]

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -92,7 +92,8 @@
 //!
 //! * `acl`: enables acl support (enabled by default)
 //! * `tokio-comp`: enables support for async usage with the Tokio runtime (optional)
-//! * `async-std-comp`: enables support for async usage with any runtime which is async-std compliant, such as Smol. (optional)
+//! * `async-std-comp`: enables support for async usage with any runtime which is async-std compliant. (optional)
+//! * `smol-comp`: enables support for async usage with the Smol runtime (optional)
 //! * `geospatial`: enables geospatial support (enabled by default)
 //! * `script`: enables script support (enabled by default)
 //! * `streams`: enables high-level interface for interaction with Redis streams (enabled by default)
@@ -437,7 +438,7 @@ it will not automatically be loaded and retried. The script can be loaded using 
 # Async
 
 In addition to the synchronous interface that's been explained above there also exists an
-asynchronous interface based on [`futures`][] and [`tokio`][], or [`async-std`][].
+asynchronous interface based on [`futures`][] and [`tokio`][], [`smol`][], or [`async-std`][].
 
 This interface exists under the `aio` (async io) module (which requires that the `aio` feature
 is enabled) and largely mirrors the synchronous with a few concessions to make it fit the
@@ -463,6 +464,13 @@ let result = redis::cmd("MGET")
 assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
 # Ok(()) }
 ```
+
+## Runtime support
+The crate supports multiple runtimes, including `tokio`, `async-std`, and `smol`. For Tokio, the crate will
+spawn tasks on the current thread runtime. For async-std & smol, the crate will spawn tasks on the the global runtime.
+It is recommended that the crate be used with support only for a single runtime. If
+the crate is compiled with multiple runtimes, 
+
 "##
 )]
 //!

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -1100,7 +1100,7 @@ impl SentinelClient {
 
     /// Returns an async connection from the client, using the same logic from
     /// `SentinelClient::get_connection`.
-    #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
+    #[cfg(feature = "aio")]
     pub async fn get_async_connection(&mut self) -> RedisResult<AsyncConnection> {
         self.get_async_connection_with_config(&AsyncConnectionConfig::new())
             .await
@@ -1108,7 +1108,7 @@ impl SentinelClient {
 
     /// Returns an async connection from the client with options, using the same logic from
     /// `SentinelClient::get_connection`.
-    #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
+    #[cfg(feature = "aio")]
     pub async fn get_async_connection_with_config(
         &mut self,
         config: &AsyncConnectionConfig,

--- a/redis/tests/parser.rs
+++ b/redis/tests/parser.rs
@@ -12,7 +12,7 @@ use {
 };
 
 mod support;
-use crate::support::{block_on_all, encode_value};
+use crate::support::{current_thread_runtime, encode_value};
 
 #[derive(Clone, Debug)]
 struct ArbitraryValue(Value);
@@ -188,7 +188,7 @@ quickcheck! {
         let mut partial_reader = PartialAsyncRead { inner: &mut reader, ops: Box::new(seq.into_iter()) };
         let mut decoder = combine::stream::Decoder::new();
 
-        let result = block_on_all(redis::parse_redis_value_async(&mut decoder, &mut partial_reader), support::RuntimeType::Tokio);
+        let result =  current_thread_runtime().block_on(redis::parse_redis_value_async(&mut decoder, &mut partial_reader));
         assert!(result.as_ref().is_ok(), "{}", result.unwrap_err());
         assert_eq!(
             result.unwrap(),

--- a/redis/tests/parser.rs
+++ b/redis/tests/parser.rs
@@ -188,7 +188,7 @@ quickcheck! {
         let mut partial_reader = PartialAsyncRead { inner: &mut reader, ops: Box::new(seq.into_iter()) };
         let mut decoder = combine::stream::Decoder::new();
 
-        let result =  current_thread_runtime().block_on(redis::parse_redis_value_async(&mut decoder, &mut partial_reader));
+        let result = current_thread_runtime().block_on(redis::parse_redis_value_async(&mut decoder, &mut partial_reader));
         assert!(result.as_ref().is_ok(), "{}", result.unwrap_err());
         assert_eq!(
             result.unwrap(),

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -93,7 +93,7 @@ where
 
 #[cfg(feature = "aio")]
 #[rstest::rstest]
-#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+#[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
 #[should_panic(expected = "Internal thread panicked")]

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -32,9 +32,12 @@ pub fn current_thread_runtime() -> tokio::runtime::Runtime {
 
 #[cfg(feature = "aio")]
 pub enum RuntimeType {
+    #[cfg(feature = "tokio-comp")]
     Tokio,
     #[cfg(feature = "async-std-comp")]
     AsyncStd,
+    #[cfg(feature = "smol-comp")]
+    Smol,
 }
 
 #[cfg(feature = "aio")]
@@ -67,14 +70,17 @@ where
     let f = futures_util::FutureExt::fuse(f);
     futures::pin_mut!(f, check_future);
 
+    let f = async move {
+        futures::select! {res = f => res, err = check_future => err}
+    };
+
     let res = match runtime {
-        RuntimeType::Tokio => current_thread_runtime().block_on(async {
-            futures::select! {res = f => res, err = check_future => err}
-        }),
+        #[cfg(feature = "tokio-comp")]
+        RuntimeType::Tokio => block_on_all_using_tokio(f),
         #[cfg(feature = "async-std-comp")]
-        RuntimeType::AsyncStd => block_on_all_using_async_std(async move {
-            futures::select! {res = f => res, err = check_future => err}
-        }),
+        RuntimeType::AsyncStd => block_on_all_using_async_std(f),
+        #[cfg(feature = "smol-comp")]
+        RuntimeType::Smol => block_on_all_using_smol(f),
     };
 
     let _ = panic::take_hook();
@@ -87,8 +93,9 @@ where
 
 #[cfg(feature = "aio")]
 #[rstest::rstest]
-#[case::tokio(RuntimeType::Tokio)]
+#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+#[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
 #[should_panic(expected = "Internal thread panicked")]
 fn test_block_on_all_panics_from_spawns(#[case] runtime: RuntimeType) {
     let _ = block_on_all(
@@ -104,12 +111,34 @@ fn test_block_on_all_panics_from_spawns(#[case] runtime: RuntimeType) {
     );
 }
 
+#[cfg(feature = "tokio-comp")]
+fn block_on_all_using_tokio<F>(f: F) -> F::Output
+where
+    F: Future,
+{
+    #[cfg(any(feature = "async-std-comp", feature = "smol-comp"))]
+    redis::aio::prefer_tokio().unwrap();
+    current_thread_runtime().block_on(f)
+}
+
 #[cfg(feature = "async-std-comp")]
 fn block_on_all_using_async_std<F>(f: F) -> F::Output
 where
     F: Future,
 {
+    #[cfg(any(feature = "tokio-comp", feature = "smol-comp"))]
+    redis::aio::prefer_async_std().unwrap();
     async_std::task::block_on(f)
+}
+
+#[cfg(feature = "smol-comp")]
+fn block_on_all_using_smol<F>(f: F) -> F::Output
+where
+    F: Future,
+{
+    #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
+    redis::aio::prefer_smol().unwrap();
+    smol::block_on(f)
 }
 
 #[cfg(any(feature = "cluster", feature = "cluster-async"))]

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -137,8 +137,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_args(#[case] runtime: RuntimeType) {
         test_with_all_connection_types(
             |mut con| async move {
@@ -163,7 +164,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     fn test_works_with_paused_time(#[case] runtime: RuntimeType) {
         test_with_all_connection_types_with_setup(
             || tokio::time::pause(),
@@ -193,8 +194,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_can_authenticate_with_username_and_password(#[case] runtime: RuntimeType) {
         let ctx = TestContext::new();
         block_on_all(
@@ -242,8 +244,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_nice_hash_api(#[case] runtime: RuntimeType) {
         test_with_all_connection_types(
             |mut connection| async move {
@@ -267,8 +270,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_nice_hash_api_in_pipe(#[case] runtime: RuntimeType) {
         test_with_all_connection_types(
             |mut connection| async move {
@@ -298,8 +302,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn dont_panic_on_closed_multiplexed_connection(#[case] runtime: RuntimeType) {
         let ctx = TestContext::new();
         let client = ctx.client.clone();
@@ -346,8 +351,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_pipeline_transaction(#[case] runtime: RuntimeType) {
         test_with_all_connection_types(
             |mut con| async move {
@@ -375,8 +381,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_client_tracking_doesnt_block_execution(#[case] runtime: RuntimeType) {
         //It checks if the library distinguish a push-type message from the others and continues its normal operation.
         test_with_all_connection_types(
@@ -403,8 +410,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_pipeline_transaction_with_errors(#[case] runtime: RuntimeType) {
         test_with_all_connection_types(
             |mut con| async move {
@@ -469,8 +477,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_pipe_over_multiplexed_connection(#[case] runtime: RuntimeType) {
         test_with_all_connection_types(
             |mut con| async move {
@@ -488,8 +497,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_running_multiple_commands(#[case] runtime: RuntimeType) {
         test_with_all_connection_types(
             |con| async move {
@@ -506,8 +516,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_transaction_multiplexed_connection(#[case] runtime: RuntimeType) {
         test_with_all_connection_types(
             |con| async move {
@@ -549,8 +560,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_scanning(#[values(2, 1000)] batch_size: usize, #[case] runtime: RuntimeType) {
         test_with_all_connection_types(
             |mut con| async move {
@@ -586,8 +598,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_scanning_iterative(
         #[values(2, 1000)] batch_size: usize,
         #[case] runtime: RuntimeType,
@@ -630,8 +643,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_scanning_stream(
         #[values(2, 1000)] batch_size: usize,
         #[case] runtime: RuntimeType,
@@ -675,8 +689,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_response_timeout_multiplexed_connection(#[case] runtime: RuntimeType) {
         let ctx = TestContext::new();
         block_on_all(
@@ -696,8 +711,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     #[cfg(feature = "script")]
     fn test_script(#[case] runtime: RuntimeType) {
         test_with_all_connection_types(
@@ -732,8 +748,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     #[cfg(feature = "script")]
     fn test_script_load(#[case] runtime: RuntimeType) {
         test_with_all_connection_types(
@@ -749,8 +766,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     #[cfg(feature = "script")]
     fn test_script_returning_complex_type(#[case] runtime: RuntimeType) {
         test_with_all_connection_types(
@@ -773,8 +791,9 @@ mod basic_async {
     // Allowing `let ()` as `query_async` requires the type it converts the result to.
     #[allow(clippy::let_unit_value, clippy::iter_nth_zero)]
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn io_error_on_kill_issue_320(#[case] runtime: RuntimeType) {
         let ctx = TestContext::new();
         block_on_all(
@@ -801,8 +820,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn invalid_password_issue_343(#[case] runtime: RuntimeType) {
         let ctx = TestContext::new();
         block_on_all(
@@ -834,8 +854,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_scan_with_options_works(#[case] runtime: RuntimeType) {
         test_with_all_connection_types(
             |mut con| async move {
@@ -871,8 +892,9 @@ mod basic_async {
     // Test issue of Stream trait blocking if we try to iterate more than 10 items
     // https://github.com/mitsuhiko/redis-rs/issues/537 and https://github.com/mitsuhiko/redis-rs/issues/583
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_issue_stream_blocks(#[case] runtime: RuntimeType) {
         test_with_all_connection_types(
             |mut con| async move {
@@ -896,8 +918,9 @@ mod basic_async {
     #[rstest]
     // Test issue of AsyncCommands::scan returning the wrong number of keys
     // https://github.com/redis-rs/redis-rs/issues/759
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_issue_async_commands_scan_broken(#[case] runtime: RuntimeType) {
         test_with_all_connection_types(
             |mut con| async move {
@@ -924,8 +947,9 @@ mod basic_async {
         use super::*;
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn pub_sub_subscription(#[case] runtime: RuntimeType) {
             let ctx = TestContext::new();
             block_on_all(
@@ -956,8 +980,9 @@ mod basic_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn pub_sub_subscription_to_multiple_channels(#[case] runtime: RuntimeType) {
             use redis::RedisError;
 
@@ -985,8 +1010,9 @@ mod basic_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn pub_sub_unsubscription(#[case] runtime: RuntimeType) {
             const SUBSCRIPTION_KEY: &str = "phonewave-pub-sub-unsubscription";
 
@@ -1014,8 +1040,9 @@ mod basic_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn can_receive_messages_while_sending_requests_from_split_pub_sub(
             #[case] runtime: RuntimeType,
         ) {
@@ -1045,8 +1072,9 @@ mod basic_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn can_send_ping_on_split_pubsub(#[case] runtime: RuntimeType) {
             let ctx = TestContext::new();
             block_on_all(
@@ -1097,8 +1125,9 @@ mod basic_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn can_receive_messages_from_split_pub_sub_after_sink_was_dropped(
             #[case] runtime: RuntimeType,
         ) {
@@ -1129,8 +1158,9 @@ mod basic_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn can_receive_messages_from_split_pub_sub_after_into_on_message(
             #[case] runtime: RuntimeType,
         ) {
@@ -1163,8 +1193,9 @@ mod basic_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn cannot_subscribe_on_split_pub_sub_after_stream_was_dropped(
             #[case] runtime: RuntimeType,
         ) {
@@ -1184,8 +1215,9 @@ mod basic_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn automatic_unsubscription(#[case] runtime: RuntimeType) {
             const SUBSCRIPTION_KEY: &str = "phonewave-automatic-unsubscription";
 
@@ -1222,8 +1254,9 @@ mod basic_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn automatic_unsubscription_on_split(#[case] runtime: RuntimeType) {
             const SUBSCRIPTION_KEY: &str = "phonewave-automatic-unsubscription-on-split";
 
@@ -1274,8 +1307,9 @@ mod basic_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn pub_sub_conn_reuse(#[case] runtime: RuntimeType) {
             let ctx = TestContext::new();
             block_on_all(
@@ -1304,8 +1338,9 @@ mod basic_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn pipe_errors_do_not_affect_subsequent_commands(#[case] runtime: RuntimeType) {
             test_with_all_connection_types(
                 |mut conn| async move {
@@ -1328,8 +1363,9 @@ mod basic_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn multiplexed_pub_sub_subscribe_on_multiple_channels(#[case] runtime: RuntimeType) {
             let ctx = TestContext::new();
             if ctx.protocol == ProtocolVersion::RESP2 {
@@ -1366,8 +1402,9 @@ mod basic_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn non_transaction_errors_do_not_affect_other_results_in_pipeline(
             #[case] runtime: RuntimeType,
         ) {
@@ -1396,8 +1433,9 @@ mod basic_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn pub_sub_multiple(#[case] runtime: RuntimeType) {
             use redis::RedisError;
 
@@ -1471,8 +1509,9 @@ mod basic_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn pub_sub_requires_resp3(#[case] runtime: RuntimeType) {
             if use_protocol() != ProtocolVersion::RESP2 {
                 return;
@@ -1493,8 +1532,9 @@ mod basic_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn push_sender_send_on_disconnect(#[case] runtime: RuntimeType) {
             use redis::RedisError;
 
@@ -1526,7 +1566,7 @@ mod basic_async {
 
         #[cfg(feature = "connection-manager")]
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[case::async_std(RuntimeType::AsyncStd)]
         fn manager_should_resubscribe_to_pubsub_channels_after_disconnect(
             #[case] runtime: RuntimeType,
@@ -1657,8 +1697,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_basic_pipe_with_parsing_error(#[case] runtime: RuntimeType) {
         // Tests a specific case involving repeated errors in transactions.
         test_with_all_connection_types(
@@ -1694,8 +1735,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     #[cfg(feature = "connection-manager")]
     fn test_connection_manager_reconnect_after_delay(#[case] runtime: RuntimeType) {
         let max_delay_between_attempts = 2;
@@ -1754,7 +1796,7 @@ mod basic_async {
 
     #[cfg(feature = "connection-manager")]
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[case::async_std(RuntimeType::AsyncStd)]
     fn manager_should_reconnect_without_actions_if_push_sender_is_set(
         #[case] runtime: RuntimeType,
@@ -1795,8 +1837,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_multiplexed_connection_kills_connection_on_drop_even_when_blocking(
         #[case] runtime: RuntimeType,
     ) {
@@ -1849,8 +1892,9 @@ mod basic_async {
         use super::*;
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn test_should_connect_mtls(#[case] runtime: RuntimeType) {
             let ctx = TestContext::new_with_mtls();
 
@@ -1875,8 +1919,9 @@ mod basic_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn test_should_not_connect_if_tls_active(#[case] runtime: RuntimeType) {
             let ctx = TestContext::new_with_mtls();
 
@@ -1918,8 +1963,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     #[cfg(feature = "connection-manager")]
     fn test_resp3_pushes_connection_manager(#[case] runtime: RuntimeType) {
         let ctx = TestContext::new();
@@ -1960,8 +2006,9 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_select_db(#[case] runtime: RuntimeType) {
         let ctx = TestContext::new();
         let mut connection_info = ctx.client.get_connection_info().clone();
@@ -1986,7 +2033,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     fn test_multiplexed_connection_send_single_disconnect_on_connection_failure(
         #[case] runtime: RuntimeType,

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -137,7 +137,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_args(#[case] runtime: RuntimeType) {
@@ -164,7 +164,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     fn test_works_with_paused_time(#[case] runtime: RuntimeType) {
         test_with_all_connection_types_with_setup(
             || tokio::time::pause(),
@@ -194,7 +194,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_can_authenticate_with_username_and_password(#[case] runtime: RuntimeType) {
@@ -244,7 +244,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_nice_hash_api(#[case] runtime: RuntimeType) {
@@ -270,7 +270,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_nice_hash_api_in_pipe(#[case] runtime: RuntimeType) {
@@ -302,7 +302,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn dont_panic_on_closed_multiplexed_connection(#[case] runtime: RuntimeType) {
@@ -351,7 +351,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_pipeline_transaction(#[case] runtime: RuntimeType) {
@@ -381,7 +381,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_client_tracking_doesnt_block_execution(#[case] runtime: RuntimeType) {
@@ -410,7 +410,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_pipeline_transaction_with_errors(#[case] runtime: RuntimeType) {
@@ -477,7 +477,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_pipe_over_multiplexed_connection(#[case] runtime: RuntimeType) {
@@ -497,7 +497,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_running_multiple_commands(#[case] runtime: RuntimeType) {
@@ -516,7 +516,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_transaction_multiplexed_connection(#[case] runtime: RuntimeType) {
@@ -560,7 +560,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_scanning(#[values(2, 1000)] batch_size: usize, #[case] runtime: RuntimeType) {
@@ -598,7 +598,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_scanning_iterative(
@@ -643,7 +643,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_scanning_stream(
@@ -689,7 +689,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_response_timeout_multiplexed_connection(#[case] runtime: RuntimeType) {
@@ -711,7 +711,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     #[cfg(feature = "script")]
@@ -748,7 +748,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     #[cfg(feature = "script")]
@@ -766,7 +766,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     #[cfg(feature = "script")]
@@ -791,7 +791,7 @@ mod basic_async {
     // Allowing `let ()` as `query_async` requires the type it converts the result to.
     #[allow(clippy::let_unit_value, clippy::iter_nth_zero)]
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn io_error_on_kill_issue_320(#[case] runtime: RuntimeType) {
@@ -820,7 +820,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn invalid_password_issue_343(#[case] runtime: RuntimeType) {
@@ -854,7 +854,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_scan_with_options_works(#[case] runtime: RuntimeType) {
@@ -892,7 +892,7 @@ mod basic_async {
     // Test issue of Stream trait blocking if we try to iterate more than 10 items
     // https://github.com/mitsuhiko/redis-rs/issues/537 and https://github.com/mitsuhiko/redis-rs/issues/583
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_issue_stream_blocks(#[case] runtime: RuntimeType) {
@@ -918,7 +918,7 @@ mod basic_async {
     #[rstest]
     // Test issue of AsyncCommands::scan returning the wrong number of keys
     // https://github.com/redis-rs/redis-rs/issues/759
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_issue_async_commands_scan_broken(#[case] runtime: RuntimeType) {
@@ -947,7 +947,7 @@ mod basic_async {
         use super::*;
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn pub_sub_subscription(#[case] runtime: RuntimeType) {
@@ -980,7 +980,7 @@ mod basic_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn pub_sub_subscription_to_multiple_channels(#[case] runtime: RuntimeType) {
@@ -1010,7 +1010,7 @@ mod basic_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn pub_sub_unsubscription(#[case] runtime: RuntimeType) {
@@ -1040,7 +1040,7 @@ mod basic_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn can_receive_messages_while_sending_requests_from_split_pub_sub(
@@ -1072,7 +1072,7 @@ mod basic_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn can_send_ping_on_split_pubsub(#[case] runtime: RuntimeType) {
@@ -1125,7 +1125,7 @@ mod basic_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn can_receive_messages_from_split_pub_sub_after_sink_was_dropped(
@@ -1158,7 +1158,7 @@ mod basic_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn can_receive_messages_from_split_pub_sub_after_into_on_message(
@@ -1193,7 +1193,7 @@ mod basic_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn cannot_subscribe_on_split_pub_sub_after_stream_was_dropped(
@@ -1215,7 +1215,7 @@ mod basic_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn automatic_unsubscription(#[case] runtime: RuntimeType) {
@@ -1254,7 +1254,7 @@ mod basic_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn automatic_unsubscription_on_split(#[case] runtime: RuntimeType) {
@@ -1307,7 +1307,7 @@ mod basic_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn pub_sub_conn_reuse(#[case] runtime: RuntimeType) {
@@ -1338,7 +1338,7 @@ mod basic_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn pipe_errors_do_not_affect_subsequent_commands(#[case] runtime: RuntimeType) {
@@ -1363,7 +1363,7 @@ mod basic_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn multiplexed_pub_sub_subscribe_on_multiple_channels(#[case] runtime: RuntimeType) {
@@ -1402,7 +1402,7 @@ mod basic_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn non_transaction_errors_do_not_affect_other_results_in_pipeline(
@@ -1433,7 +1433,7 @@ mod basic_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn pub_sub_multiple(#[case] runtime: RuntimeType) {
@@ -1509,7 +1509,7 @@ mod basic_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn pub_sub_requires_resp3(#[case] runtime: RuntimeType) {
@@ -1532,7 +1532,7 @@ mod basic_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn push_sender_send_on_disconnect(#[case] runtime: RuntimeType) {
@@ -1566,7 +1566,7 @@ mod basic_async {
 
         #[cfg(feature = "connection-manager")]
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[case::async_std(RuntimeType::AsyncStd)]
         fn manager_should_resubscribe_to_pubsub_channels_after_disconnect(
             #[case] runtime: RuntimeType,
@@ -1697,7 +1697,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_basic_pipe_with_parsing_error(#[case] runtime: RuntimeType) {
@@ -1735,7 +1735,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     #[cfg(feature = "connection-manager")]
@@ -1796,7 +1796,7 @@ mod basic_async {
 
     #[cfg(feature = "connection-manager")]
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[case::async_std(RuntimeType::AsyncStd)]
     fn manager_should_reconnect_without_actions_if_push_sender_is_set(
         #[case] runtime: RuntimeType,
@@ -1837,7 +1837,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_multiplexed_connection_kills_connection_on_drop_even_when_blocking(
@@ -1892,7 +1892,7 @@ mod basic_async {
         use super::*;
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn test_should_connect_mtls(#[case] runtime: RuntimeType) {
@@ -1919,7 +1919,7 @@ mod basic_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn test_should_not_connect_if_tls_active(#[case] runtime: RuntimeType) {
@@ -1963,7 +1963,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     #[cfg(feature = "connection-manager")]
@@ -2006,7 +2006,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_select_db(#[case] runtime: RuntimeType) {
@@ -2033,7 +2033,7 @@ mod basic_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     fn test_multiplexed_connection_send_single_disconnect_on_connection_failure(
         #[case] runtime: RuntimeType,

--- a/redis/tests/test_cache.rs
+++ b/redis/tests/test_cache.rs
@@ -32,7 +32,7 @@ macro_rules! assert_invalidate {
 
 // Basic testing should work with both CacheMode::All and CacheMode::OptIn if commands has called cache()
 #[rstest]
-#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+#[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 fn test_cache_basic(#[case] runtime: RuntimeType, #[values(true, false)] test_with_optin: bool) {
     let ctx = TestContext::new();
@@ -95,7 +95,7 @@ fn test_cache_basic(#[case] runtime: RuntimeType, #[values(true, false)] test_wi
 }
 
 #[rstest]
-#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+#[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 fn test_cache_mget(#[case] runtime: RuntimeType) {
     let ctx = TestContext::new();
@@ -153,7 +153,7 @@ fn test_cache_mget(#[case] runtime: RuntimeType) {
 
 #[rstest]
 #[cfg(feature = "json")]
-#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+#[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 fn test_module_cache_json_get_mget(#[case] runtime: RuntimeType) {
     let ctx = TestContext::with_modules(&[Module::Json], false);
@@ -226,7 +226,7 @@ fn test_module_cache_json_get_mget(#[case] runtime: RuntimeType) {
 
 #[rstest]
 #[cfg(feature = "json")]
-#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+#[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 fn test_module_cache_json_get_mget_different_paths(#[case] runtime: RuntimeType) {
     let ctx = TestContext::with_modules(&[Module::Json], false);
@@ -338,7 +338,7 @@ fn test_module_cache_json_get_mget_different_paths(#[case] runtime: RuntimeType)
 }
 
 #[rstest]
-#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+#[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 fn test_cache_is_not_target_type_dependent(#[case] runtime: RuntimeType) {
     let ctx = TestContext::new();
@@ -366,7 +366,7 @@ fn test_cache_is_not_target_type_dependent(#[case] runtime: RuntimeType) {
 }
 
 #[rstest]
-#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+#[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 fn test_cache_with_pipeline(#[case] runtime: RuntimeType, #[values(true, false)] atomic: bool) {
     let ctx = TestContext::new();
@@ -420,7 +420,7 @@ fn test_cache_with_pipeline(#[case] runtime: RuntimeType, #[values(true, false)]
 }
 
 #[rstest]
-#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+#[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 fn test_cache_basic_partial_opt_in(#[case] runtime: RuntimeType) {
     // In OptIn mode cache must not be utilized without explicit per command configuration.
@@ -491,7 +491,7 @@ fn test_cache_basic_partial_opt_in(#[case] runtime: RuntimeType) {
 }
 
 #[rstest]
-#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+#[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 fn test_cache_pipeline_partial_opt_in(
     #[case] runtime: RuntimeType,
@@ -554,7 +554,7 @@ fn test_cache_pipeline_partial_opt_in(
 }
 
 #[rstest]
-#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+#[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 fn test_cache_different_commands(
     #[case] runtime: RuntimeType,
@@ -625,7 +625,7 @@ fn test_cache_different_commands(
 }
 
 #[rstest]
-#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+#[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 #[cfg(feature = "connection-manager")]
 fn test_connection_manager_maintains_statistics_after_crashes(

--- a/redis/tests/test_cache.rs
+++ b/redis/tests/test_cache.rs
@@ -32,7 +32,7 @@ macro_rules! assert_invalidate {
 
 // Basic testing should work with both CacheMode::All and CacheMode::OptIn if commands has called cache()
 #[rstest]
-#[case::tokio(RuntimeType::Tokio)]
+#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 fn test_cache_basic(#[case] runtime: RuntimeType, #[values(true, false)] test_with_optin: bool) {
     let ctx = TestContext::new();
@@ -95,7 +95,7 @@ fn test_cache_basic(#[case] runtime: RuntimeType, #[values(true, false)] test_wi
 }
 
 #[rstest]
-#[case::tokio(RuntimeType::Tokio)]
+#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 fn test_cache_mget(#[case] runtime: RuntimeType) {
     let ctx = TestContext::new();
@@ -153,7 +153,7 @@ fn test_cache_mget(#[case] runtime: RuntimeType) {
 
 #[rstest]
 #[cfg(feature = "json")]
-#[case::tokio(RuntimeType::Tokio)]
+#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 fn test_module_cache_json_get_mget(#[case] runtime: RuntimeType) {
     let ctx = TestContext::with_modules(&[Module::Json], false);
@@ -226,7 +226,7 @@ fn test_module_cache_json_get_mget(#[case] runtime: RuntimeType) {
 
 #[rstest]
 #[cfg(feature = "json")]
-#[case::tokio(RuntimeType::Tokio)]
+#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 fn test_module_cache_json_get_mget_different_paths(#[case] runtime: RuntimeType) {
     let ctx = TestContext::with_modules(&[Module::Json], false);
@@ -338,7 +338,7 @@ fn test_module_cache_json_get_mget_different_paths(#[case] runtime: RuntimeType)
 }
 
 #[rstest]
-#[case::tokio(RuntimeType::Tokio)]
+#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 fn test_cache_is_not_target_type_dependent(#[case] runtime: RuntimeType) {
     let ctx = TestContext::new();
@@ -366,7 +366,7 @@ fn test_cache_is_not_target_type_dependent(#[case] runtime: RuntimeType) {
 }
 
 #[rstest]
-#[case::tokio(RuntimeType::Tokio)]
+#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 fn test_cache_with_pipeline(#[case] runtime: RuntimeType, #[values(true, false)] atomic: bool) {
     let ctx = TestContext::new();
@@ -420,7 +420,7 @@ fn test_cache_with_pipeline(#[case] runtime: RuntimeType, #[values(true, false)]
 }
 
 #[rstest]
-#[case::tokio(RuntimeType::Tokio)]
+#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 fn test_cache_basic_partial_opt_in(#[case] runtime: RuntimeType) {
     // In OptIn mode cache must not be utilized without explicit per command configuration.
@@ -491,7 +491,7 @@ fn test_cache_basic_partial_opt_in(#[case] runtime: RuntimeType) {
 }
 
 #[rstest]
-#[case::tokio(RuntimeType::Tokio)]
+#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 fn test_cache_pipeline_partial_opt_in(
     #[case] runtime: RuntimeType,
@@ -554,7 +554,7 @@ fn test_cache_pipeline_partial_opt_in(
 }
 
 #[rstest]
-#[case::tokio(RuntimeType::Tokio)]
+#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 fn test_cache_different_commands(
     #[case] runtime: RuntimeType,
@@ -625,7 +625,7 @@ fn test_cache_different_commands(
 }
 
 #[rstest]
-#[case::tokio(RuntimeType::Tokio)]
+#[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
 #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
 #[cfg(feature = "connection-manager")]
 fn test_connection_manager_maintains_statistics_after_crashes(

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -55,7 +55,7 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_basic_cmd(#[case] runtime: RuntimeType) {
@@ -73,7 +73,7 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_basic_eval(#[case] runtime: RuntimeType) {
@@ -100,7 +100,7 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_basic_script(#[case] runtime: RuntimeType) {
@@ -125,7 +125,7 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_route_flush_to_specific_node(#[case] runtime: RuntimeType) {
@@ -166,7 +166,7 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_route_flush_to_node_by_address(#[case] runtime: RuntimeType) {
@@ -213,7 +213,7 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_route_info_to_nodes(#[case] runtime: RuntimeType) {
@@ -302,7 +302,7 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_cluster_resp3(#[case] runtime: RuntimeType) {
@@ -341,7 +341,7 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_basic_pipe(#[case] runtime: RuntimeType) {
@@ -366,7 +366,7 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_multi_shard_commands(#[case] runtime: RuntimeType) {
@@ -391,7 +391,7 @@ mod cluster_async {
 
     #[cfg(feature = "tls-rustls")]
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     fn test_async_cluster_default_reject_invalid_hostnames(#[case] runtime: RuntimeType) {
         use redis_test::cluster::ClusterType;
@@ -419,7 +419,7 @@ mod cluster_async {
 
     #[cfg(feature = "tls-rustls-insecure")]
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     fn test_async_cluster_danger_accept_invalid_hostnames(#[case] runtime: RuntimeType) {
         use redis_test::cluster::ClusterType;
@@ -450,7 +450,7 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_basic_failover(#[case] runtime: RuntimeType) {
@@ -1904,7 +1904,7 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_with_username_and_password(#[case] runtime: RuntimeType) {
@@ -2051,7 +2051,7 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_handle_complete_server_disconnect_without_panicking(
@@ -2083,7 +2083,7 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_reconnect_after_complete_server_disconnect(#[case] runtime: RuntimeType) {
@@ -2137,7 +2137,7 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_reconnect_after_complete_server_disconnect_route_to_many(
@@ -2261,7 +2261,7 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_kill_connection_on_drop_even_when_blocking(#[case] runtime: RuntimeType) {
@@ -2482,7 +2482,7 @@ mod cluster_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         fn pub_sub_subscription(#[case] runtime: RuntimeType) {
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -2510,7 +2510,7 @@ mod cluster_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         fn pub_sub_subscription_with_config(#[case] runtime: RuntimeType) {
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -2538,7 +2538,7 @@ mod cluster_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         fn pub_sub_shardnumsub(#[case] runtime: RuntimeType) {
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
@@ -2570,7 +2570,7 @@ mod cluster_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         fn pub_sub_unsubscription(#[case] runtime: RuntimeType) {
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -2676,7 +2676,7 @@ mod cluster_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         fn connection_is_still_usable_if_pubsub_receiver_is_dropped(#[case] runtime: RuntimeType) {
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -2711,7 +2711,7 @@ mod cluster_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         fn multiple_subscribes_and_unsubscribes_work(#[case] runtime: RuntimeType) {
             // In this test we subscribe on all subscription variations to 3 channels in a single call, then unsubscribe from 2 channels.
@@ -2855,7 +2855,7 @@ mod cluster_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         fn pub_sub_reconnect_after_disconnect(#[case] runtime: RuntimeType) {
             // in this test we will subscribe to channels, then restart the server, and check that the connection
@@ -2973,7 +2973,7 @@ mod cluster_async {
         use super::*;
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn test_async_cluster_basic_cmd_with_mtls(#[case] runtime: RuntimeType) {
@@ -3001,7 +3001,7 @@ mod cluster_async {
         }
 
         #[rstest]
-        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn test_async_cluster_should_not_connect_without_mtls_enabled(

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -55,8 +55,9 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_basic_cmd(#[case] runtime: RuntimeType) {
         let cluster = TestClusterContext::new();
 
@@ -72,8 +73,9 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_basic_eval(#[case] runtime: RuntimeType) {
         let cluster = TestClusterContext::new();
 
@@ -98,8 +100,9 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_basic_script(#[case] runtime: RuntimeType) {
         let cluster = TestClusterContext::new();
 
@@ -122,8 +125,9 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_route_flush_to_specific_node(#[case] runtime: RuntimeType) {
         let cluster = TestClusterContext::new();
 
@@ -162,8 +166,9 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_route_flush_to_node_by_address(#[case] runtime: RuntimeType) {
         let cluster = TestClusterContext::new();
 
@@ -208,8 +213,9 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_route_info_to_nodes(#[case] runtime: RuntimeType) {
         let cluster = TestClusterContext::new_with_config(RedisClusterConfiguration {
             num_nodes: 12,
@@ -296,8 +302,9 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_cluster_resp3(#[case] runtime: RuntimeType) {
         if use_protocol() == ProtocolVersion::RESP2 {
             return;
@@ -334,8 +341,9 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_basic_pipe(#[case] runtime: RuntimeType) {
         let cluster = TestClusterContext::new();
 
@@ -358,8 +366,9 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_multi_shard_commands(#[case] runtime: RuntimeType) {
         let cluster = TestClusterContext::new();
 
@@ -382,7 +391,7 @@ mod cluster_async {
 
     #[cfg(feature = "tls-rustls")]
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     fn test_async_cluster_default_reject_invalid_hostnames(#[case] runtime: RuntimeType) {
         use redis_test::cluster::ClusterType;
@@ -410,7 +419,7 @@ mod cluster_async {
 
     #[cfg(feature = "tls-rustls-insecure")]
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     fn test_async_cluster_danger_accept_invalid_hostnames(#[case] runtime: RuntimeType) {
         use redis_test::cluster::ClusterType;
@@ -441,8 +450,9 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_basic_failover(#[case] runtime: RuntimeType) {
         block_on_all(
             async move {
@@ -1894,8 +1904,9 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_with_username_and_password(#[case] runtime: RuntimeType) {
         let cluster = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
             builder
@@ -2040,8 +2051,9 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_handle_complete_server_disconnect_without_panicking(
         #[case] runtime: RuntimeType,
     ) {
@@ -2071,8 +2083,9 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_reconnect_after_complete_server_disconnect(#[case] runtime: RuntimeType) {
         let cluster = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
             builder.retries(2)
@@ -2124,8 +2137,9 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_async_cluster_reconnect_after_complete_server_disconnect_route_to_many(
         #[case] runtime: RuntimeType,
     ) {
@@ -2247,8 +2261,9 @@ mod cluster_async {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_kill_connection_on_drop_even_when_blocking(#[case] runtime: RuntimeType) {
         let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| builder.retries(3));
 
@@ -2467,7 +2482,7 @@ mod cluster_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         fn pub_sub_subscription(#[case] runtime: RuntimeType) {
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -2495,7 +2510,7 @@ mod cluster_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         fn pub_sub_subscription_with_config(#[case] runtime: RuntimeType) {
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -2523,7 +2538,7 @@ mod cluster_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         fn pub_sub_shardnumsub(#[case] runtime: RuntimeType) {
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
@@ -2555,7 +2570,7 @@ mod cluster_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         fn pub_sub_unsubscription(#[case] runtime: RuntimeType) {
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -2661,7 +2676,7 @@ mod cluster_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         fn connection_is_still_usable_if_pubsub_receiver_is_dropped(#[case] runtime: RuntimeType) {
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -2696,7 +2711,7 @@ mod cluster_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         fn multiple_subscribes_and_unsubscribes_work(#[case] runtime: RuntimeType) {
             // In this test we subscribe on all subscription variations to 3 channels in a single call, then unsubscribe from 2 channels.
@@ -2840,7 +2855,7 @@ mod cluster_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
         fn pub_sub_reconnect_after_disconnect(#[case] runtime: RuntimeType) {
             // in this test we will subscribe to channels, then restart the server, and check that the connection
@@ -2958,8 +2973,9 @@ mod cluster_async {
         use super::*;
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn test_async_cluster_basic_cmd_with_mtls(#[case] runtime: RuntimeType) {
             let cluster = TestClusterContext::new_with_mtls();
             block_on_all(
@@ -2985,8 +3001,9 @@ mod cluster_async {
         }
 
         #[rstest]
-        #[case::tokio(RuntimeType::Tokio)]
+        #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
         #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn test_async_cluster_should_not_connect_without_mtls_enabled(
             #[case] runtime: RuntimeType,
         ) {

--- a/redis/tests/test_sentinel.rs
+++ b/redis/tests/test_sentinel.rs
@@ -465,7 +465,7 @@ pub mod async_tests {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_sentinel_connect_to_random_replica_async(#[case] runtime: RuntimeType) {
@@ -502,7 +502,7 @@ pub mod async_tests {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_sentinel_connect_to_multiple_replicas_async(#[case] runtime: RuntimeType) {
@@ -548,7 +548,7 @@ pub mod async_tests {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_sentinel_server_down_async(#[case] runtime: RuntimeType) {
@@ -600,7 +600,7 @@ pub mod async_tests {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_sentinel_client_async(#[case] runtime: RuntimeType) {
@@ -653,7 +653,7 @@ pub mod async_tests {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_sentinel_client_async_with_connection_timeout(#[case] runtime: RuntimeType) {
@@ -713,7 +713,7 @@ pub mod async_tests {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_sentinel_client_async_with_response_timeout(#[case] runtime: RuntimeType) {
@@ -773,7 +773,7 @@ pub mod async_tests {
     }
 
     #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_sentinel_client_async_with_timeouts(#[case] runtime: RuntimeType) {

--- a/redis/tests/test_sentinel.rs
+++ b/redis/tests/test_sentinel.rs
@@ -465,8 +465,9 @@ pub mod async_tests {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_sentinel_connect_to_random_replica_async(#[case] runtime: RuntimeType) {
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, 3, 3);
@@ -501,8 +502,9 @@ pub mod async_tests {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_sentinel_connect_to_multiple_replicas_async(#[case] runtime: RuntimeType) {
         let number_of_replicas = 3;
         let master_name = "master1";
@@ -546,8 +548,9 @@ pub mod async_tests {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_sentinel_server_down_async(#[case] runtime: RuntimeType) {
         let number_of_replicas = 3;
         let master_name = "master1";
@@ -597,8 +600,9 @@ pub mod async_tests {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_sentinel_client_async(#[case] runtime: RuntimeType) {
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, 3, 3);
@@ -649,8 +653,9 @@ pub mod async_tests {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_sentinel_client_async_with_connection_timeout(#[case] runtime: RuntimeType) {
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, 3, 3);
@@ -708,8 +713,9 @@ pub mod async_tests {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_sentinel_client_async_with_response_timeout(#[case] runtime: RuntimeType) {
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, 3, 3);
@@ -767,8 +773,9 @@ pub mod async_tests {
     }
 
     #[rstest]
-    #[case::tokio(RuntimeType::Tokio)]
+    #[cfg_attr(feature = "tokio-comp", case::smol(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
     fn test_sentinel_client_async_with_timeouts(#[case] runtime: RuntimeType) {
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, 3, 3);


### PR DESCRIPTION
Since async-std is [officially deprecated](https://www.reddit.com/r/rust/comments/1jc6gis/psa_asyncstd_has_been_officially_discontinued_use/), this change adds explicit support for the Smol runtime. In the future the async-std features will be removed - in the meanwhile, since AFAIS there's no way to trigger a compile warning by feature.