### PR TITLE
Fix `make docs`

### DIFF
--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -666,7 +666,7 @@ impl ConnectionManager {
         Ok(())
     }
 
-    /// Gets [`CacheStatistics`] for current connection if caching is enabled.
+    /// Gets [`crate::caching::CacheStatistics`] for current connection if caching is enabled.
     #[cfg(feature = "cache-aio")]
     #[cfg_attr(docsrs, doc(cfg(feature = "cache-aio")))]
     pub fn get_cache_statistics(&self) -> Option<crate::caching::CacheStatistics> {

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -698,6 +698,7 @@ impl MultiplexedConnection {
     ///
     /// This method is only available when the connection is using RESP3 protocol, and will return an error otherwise.
     ///
+    /// ```rust,no_run
     /// # async fn func() -> redis::RedisResult<()> {
     /// let client = redis::Client::open("redis://127.0.0.1/?protocol=resp3").unwrap();
     /// let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -705,7 +706,7 @@ impl MultiplexedConnection {
     /// let mut con = client.get_multiplexed_async_connection_with_config(&config).await?;
     /// con.subscribe(&["channel_1", "channel_2"]).await?;
     /// # Ok(()) }
-    /// # }
+    /// ```
     pub async fn subscribe(&mut self, channel_name: impl ToRedisArgs) -> RedisResult<()> {
         check_resp3!(self.protocol);
         let mut cmd = cmd("SUBSCRIBE");
@@ -718,6 +719,7 @@ impl MultiplexedConnection {
     ///
     /// This method is only available when the connection is using RESP3 protocol, and will return an error otherwise.
     ///
+    /// ```rust,no_run
     /// # async fn func() -> redis::RedisResult<()> {
     /// let client = redis::Client::open("redis://127.0.0.1/?protocol=resp3").unwrap();
     /// let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -726,7 +728,7 @@ impl MultiplexedConnection {
     /// con.subscribe(&["channel_1", "channel_2"]).await?;
     /// con.unsubscribe(&["channel_1", "channel_2"]).await?;
     /// # Ok(()) }
-    /// # }
+    /// ```
     pub async fn unsubscribe(&mut self, channel_name: impl ToRedisArgs) -> RedisResult<()> {
         check_resp3!(self.protocol);
         let mut cmd = cmd("UNSUBSCRIBE");
@@ -742,6 +744,7 @@ impl MultiplexedConnection {
     ///
     /// This method is only available when the connection is using RESP3 protocol, and will return an error otherwise.
     ///
+    /// ```rust,no_run
     /// # async fn func() -> redis::RedisResult<()> {
     /// let client = redis::Client::open("redis://127.0.0.1/?protocol=resp3").unwrap();
     /// let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -750,7 +753,7 @@ impl MultiplexedConnection {
     /// con.subscribe(&["channel_1", "channel_2"]).await?;
     /// con.unsubscribe(&["channel_1", "channel_2"]).await?;
     /// # Ok(()) }
-    /// # }
+    /// ```
     pub async fn psubscribe(&mut self, channel_pattern: impl ToRedisArgs) -> RedisResult<()> {
         check_resp3!(self.protocol);
         let mut cmd = cmd("PSUBSCRIBE");

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -265,7 +265,7 @@ impl AsyncConnectionConfig {
 
     /// Set the DNS resolver for the underlying TCP connection.
     ///
-    /// The parameter resolver must implement the [`crate::aio::DNSResolver`] trait.
+    /// The parameter resolver must implement the [`crate::io::AsyncDNSResolver`] trait.
     pub fn set_dns_resolver(self, dns_resolver: impl AsyncDNSResolver) -> Self {
         self.set_dns_resolver_internal(std::sync::Arc::new(dns_resolver))
     }

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -270,7 +270,7 @@ where
     ///
     /// This method is only available when the connection is using RESP3 protocol, and will return an error otherwise.
     /// It should be noted that the subscription will be automatically resubscribed after disconnections, so the user might
-    /// receive additional pushes with [crate::PushKind::Subcribe], later after the subscription completed.
+    /// receive additional pushes with [crate::PushKind::Subscribe], later after the subscription completed.
     pub async fn subscribe(&mut self, channel_name: impl ToRedisArgs) -> RedisResult<()> {
         check_resp3!(self.state.protocol);
         let mut cmd = cmd("SUBSCRIBE");
@@ -297,7 +297,7 @@ where
     ///
     /// This method is only available when the connection is using RESP3 protocol, and will return an error otherwise.
     /// It should be noted that the subscription will be automatically resubscribed after disconnections, so the user might
-    /// receive additional pushes with [crate::PushKind::PSubcribe], later after the subscription completed.
+    /// receive additional pushes with [crate::PushKind::PSubscribe], later after the subscription completed.
     pub async fn psubscribe(&mut self, channel_pattern: impl ToRedisArgs) -> RedisResult<()> {
         check_resp3!(self.state.protocol);
         let mut cmd = cmd("PSUBSCRIBE");
@@ -324,7 +324,7 @@ where
     ///
     /// This method is only available when the connection is using RESP3 protocol, and will return an error otherwise.
     /// It should be noted that the subscription will be automatically resubscribed after disconnections, so the user might
-    /// receive additional pushes with [crate::PushKind::SSubcribe], later after the subscription completed.
+    /// receive additional pushes with [crate::PushKind::SSubscribe], later after the subscription completed.
     pub async fn ssubscribe(&mut self, channel_name: impl ToRedisArgs) -> RedisResult<()> {
         check_resp3!(self.state.protocol);
         let mut cmd = cmd("SSUBSCRIBE");


### PR DESCRIPTION
This PR tries to fix the warnings of running `make docs`

The only missing issue is `redis/src/aio/connection.rs:99`

There, the `PubSub` link in the documentation

```
    /// Converts this [`Connection`] into [`PubSub`].
    #[deprecated(note = "aio::Connection is deprecated. Use [Client::get_async_pubsub] instead")]
    pub fn into_pubsub(self) -> PubSub<C> {
        PubSub::new(self)
    }
```

does not work. The warning I get is:

```
warning: public documentation for `into_pubsub` links to private item `PubSub`
  --> redis/src/aio/connection.rs:99:45
   |
99 |     /// Converts this [`Connection`] into [`PubSub`].
   |                                             ^^^^^^ this item is private
   |
   = note: this link will resolve properly if you pass `--document-private-items`
   = note: `#[warn(rustdoc::private_intra_doc_links)]` on by default
```

But in contrast to rustdoc's warning, PubSub there is not private. It's public.

The issue seems to be the wildcard import in `redis/src/aio/mod.rs` getting in the way of the `pub use` of `pubsub::PubSub` (`redis/src/aio/mod.rs:34`). Hence, the wildcard import cannot match the `PubSub` from `redis/src/aio/connection.rs:99`

Is there a simple way to make that link work?

(I put together a minimal example of the situation at https://github.com/somechris/rustdoc-wildcard-hiding-names )
