### PR TITLE
Add an optional bytes::BufMut function to RedisWrite

### DIFF
--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -354,6 +354,13 @@ impl RedisWrite for Cmd {
         CmdBufferedArgGuard(self)
     }
 
+    fn reserve_space_for_args(&mut self, additional: &[usize]) {
+        // Reserve space for the sum of the data size of all the arguments
+        self.data.reserve(additional.iter().sum());
+        // Reserve space for the argument markers
+        self.args.reserve(additional.len());
+    }
+
     #[cfg(feature = "bytes")]
     fn bufmut_for_next_arg(&mut self, capacity: usize) -> impl bytes::BufMut + '_ {
         self.data.reserve(capacity);


### PR DESCRIPTION
I'm dealing with some legacy stuff where I need to serialize some data as ProtoBuf and send it via Redis. Currently this requires creating an extra buffer where I serialize the data, and then copy that data to the writer. This PR allows serializing directly into the writer.

This function is gated behind the "bytes" feature, which is automatically enabled with any of the async features.

A default implementation is provided, so that this is not a breaking change for upstream.