### PR TITLE
Reorganize flag-frenzy comnfiguration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
 dependencies = [
  "hashbrown 0.15.2",
 ]
@@ -1948,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
 dependencies = [
  "futures-timer",
  "futures-util",
@@ -1960,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
 dependencies = [
  "cfg-if",
  "glob",

--- a/config/redis.toml
+++ b/config/redis.toml
@@ -110,12 +110,9 @@ forbid = "aio"
 # deprecated
 [[rule]]
 when = true
-forbid = "tls"
-
-# deprecated
-[[rule]]
-when = true
 forbid = [
+  "tls",
+  "OR",
   "async-std-tls-comp",
   "OR",
   "async-std-comp",
@@ -138,4 +135,6 @@ forbid = [
   "script",
   "OR",
   "keep-alive",
+  "OR",
+  "num-bigint",
 ]

--- a/config/redis.toml
+++ b/config/redis.toml
@@ -90,10 +90,6 @@ forbid = [
 ]
 
 [[rule]]
-when = ["smol-native-tls-comp"]
-forbid = ["smol-rustls-comp"]
-
-[[rule]]
 when = ["tls-rustls-webpki-roots", "smol-comp"]
 require = ["smol-rustls-comp"]
 

--- a/config/redis.toml
+++ b/config/redis.toml
@@ -1,9 +1,5 @@
 [[rule]]
-when = "cluster-async"
-require = ["tokio-comp", "OR", "smol-comp"]
-
-[[rule]]
-when = "connection-manager"
+when = ["cache-aio", "OR", "connection-manager", "OR", "cluster-async"]
 require = ["tokio-comp", "OR", "smol-comp"]
 
 [[rule]]
@@ -135,7 +131,3 @@ forbid = [
   "OR",
   "keep-alive",
 ]
-
-[[rule]]
-when = "cache-aio"
-require = ["tokio-comp", "OR", "smol-comp"]

--- a/config/redis.toml
+++ b/config/redis.toml
@@ -1,6 +1,18 @@
 [[rule]]
 when = ["cache-aio", "OR", "connection-manager", "OR", "cluster-async"]
-require = ["tokio-comp", "OR", "smol-comp"]
+require = [
+  "tokio-comp",
+  "OR",
+  "smol-comp",
+  "OR",
+  "tokio-rustls-comp",
+  "OR",
+  "tokio-native-tls-comp",
+  "OR",
+  "smol-native-tls-comp",
+  "OR",
+  "smol-rustls-comp",
+]
 
 [[rule]]
 when = ["tls-rustls", "tokio-comp"]

--- a/config/redis.toml
+++ b/config/redis.toml
@@ -64,6 +64,23 @@ forbid = [
   "tokio-comp",
 ]
 
+# cluster-async is the feature for async work. We don't need to check cluster with async.
+[[rule]]
+when = ["cluster"]
+forbid = [
+  "tokio-rustls-comp",
+  "OR",
+  "tokio-native-tls-comp",
+  "OR",
+  "tokio-comp",
+  "OR",
+  "smol-native-tls-comp",
+  "OR",
+  "smol-comp",
+  "OR",
+  "smol-rustls-comp",
+]
+
 [[rule]]
 when = ["smol-native-tls-comp"]
 forbid = ["smol-rustls-comp"]

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -54,7 +54,7 @@ tokio = { version = "1", features = [
 socket2 = { version = "0.5", features = ["all"] }
 
 # Only needed for the connection manager
-arc-swap = { version = "1.7.1" }
+arc-swap = { version = "1.7.1", optional = true }
 futures-channel = { version = "0.3.31", optional = true }
 backon = { version = "1.4.1", optional = true, default-features = false }
 
@@ -111,7 +111,7 @@ uuid = { version = "1.15.1", optional = true }
 # Optional hashbrown support
 hashbrown = { version = "0.15", optional = true }
 
-lru = { version = "0.13", optional = true }
+lru = { version = "0.14", optional = true }
 
 [features]
 default = ["acl", "streams", "geospatial", "script", "keep-alive", "num-bigint"]
@@ -139,7 +139,7 @@ smol-rustls-comp = ["smol-comp", "dep:futures-rustls", "tls-rustls"]
 tokio-comp = ["aio", "tokio/net"]
 tokio-native-tls-comp = ["tokio-comp", "tls-native-tls", "dep:tokio-native-tls"]
 tokio-rustls-comp = ["tokio-comp", "tls-rustls", "dep:tokio-rustls"]
-connection-manager = ["dep:futures-channel", "aio", "dep:backon"]
+connection-manager = ["dep:arc-swap", "dep:futures-channel", "aio", "dep:backon"]
 streams = []
 cluster-async = ["aio", "cluster", "dep:futures-sink", "dep:log"]
 keep-alive = []
@@ -195,7 +195,7 @@ tempfile = "=3.19.1"
 once_cell = "1"
 anyhow = "1"
 redis-test = { path = "../redis-test" }
-rstest = "0.24"
+rstest = "0.25"
 rand = "0.9"
 
 [[test]]

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -114,7 +114,7 @@ hashbrown = { version = "0.15", optional = true }
 lru = { version = "0.13", optional = true }
 
 [features]
-default = ["acl", "streams", "geospatial", "script", "keep-alive"]
+default = ["acl", "streams", "geospatial", "script", "keep-alive", "num-bigint"]
 acl = []
 geospatial = []
 json = ["dep:serde", "serde/derive", "dep:serde_json"]


### PR DESCRIPTION
Somewhat reduce the number of checks, and organize it to be more coherent with less redundant rules.