### PR TITLE
Make `reserve_space_for_args` take a `IntoIterator`

### DIFF
--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -354,7 +354,7 @@ impl RedisWrite for Cmd {
         CmdBufferedArgGuard(self)
     }
 
-    fn reserve_space_for_args(&mut self, additional: impl Iterator<Item = usize>) {
+    fn reserve_space_for_args(&mut self, additional: impl IntoIterator<Item = usize>) {
         let mut capacity = 0;
         let mut args = 0;
         for add in additional {

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1371,8 +1371,7 @@ pub trait RedisWrite {
     /// let mut cmd = Cmd::new();
     ///
     /// // Calculate and reserve the space for the args
-    /// let needed_space: Vec<usize> = to_send.iter().map(Message::encoded_len).collect();
-    /// cmd.reserve_space_for_args(&needed_space);
+    /// cmd.reserve_space_for_args(to_send.iter().map(Message::encoded_len));
     ///
     /// // Write the args to the buffer
     /// for arg in to_send {
@@ -1386,11 +1385,11 @@ pub trait RedisWrite {
     ///
     /// # Implementation note
     /// The default implementation provided by this trait is a no-op. It's therefore strongly
-    /// recommend to implement this function. Depending on the internal buffer it might only
+    /// recommended to implement this function. Depending on the internal buffer it might only
     /// be possible to use the numbers of arguments (`additional.len()`) or the total expected
     /// capacity (`additional.iter().sum()`). Implementors should assume that the caller will
     /// be wrong and might over or under specify the amount of arguments and space required.
-    fn reserve_space_for_args(&mut self, additional: impl Iterator<Item = usize>) {
+    fn reserve_space_for_args(&mut self, additional: impl IntoIterator<Item = usize>) {
         // _additional would show up in the documentation, so we assign it
         // to make it used.
         let _do_nothing = additional;
@@ -1479,12 +1478,12 @@ impl RedisWrite for Vec<Vec<u8>> {
         self.last_mut().unwrap()
     }
 
-    fn reserve_space_for_args(&mut self, additional: impl Iterator<Item = usize>) {
+    fn reserve_space_for_args(&mut self, additional: impl IntoIterator<Item = usize>) {
         // It would be nice to do this, but there's no way to store where we currently are.
         // Checking for the first empty Vec is not possible, as it's valid to write empty args.
         // self.extend(additional.iter().copied().map(Vec::with_capacity));
         // So we just reserve space for the extra args and have to forgo the extra optimisation
-        self.reserve(additional.count());
+        self.reserve(additional.into_iter().count());
     }
 
     #[cfg(feature = "bytes")]


### PR DESCRIPTION
With `IntoIterator` a Vec or array can be provided without the user needing to call `.into_iter()`. As this trait also has a default implementation for all traits (a no-op that returns the same iterator) this also works with iterators.

Also simplifies the example in the documentation and fixed a typo.