### PR TITLE
Implement Error::source for the RedisError struct

### DIFF
--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -427,7 +427,7 @@ assert_eq!(b, 5);
 ```
 
 Note: unlike a call to [`invoke`](ScriptInvocation::invoke), if the script isn't loaded during the pipeline operation,
-it will not automatically be loaded and retried. The script can be loaded using the 
+it will not automatically be loaded and retried. The script can be loaded using the
 [`load`](ScriptInvocation::load) operation.
 "##
 )]
@@ -468,7 +468,7 @@ assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
 ## Runtime support
 The crate supports multiple runtimes, including `tokio`, `async-std`, and `smol`. For Tokio, the crate will
 spawn tasks on the current thread runtime. For async-std & smol, the crate will spawn tasks on the the global runtime.
-It is recommended that the crate be used with support only for a single runtime. If the crate is compiled with multiple runtimes, 
+It is recommended that the crate be used with support only for a single runtime. If the crate is compiled with multiple runtimes,
 the user should call [`crate::aio::prefer_tokio`], [`crate::aio::prefer_async_std`] or [`crate::aio::prefer_smol`] to set the preferred runtime.
 These functions set global state which automatically chooses the correct runtime for the async connection.
 
@@ -572,6 +572,7 @@ pub use crate::types::{
     // utility functions
     from_redis_value,
     from_owned_redis_value,
+    make_extension_error,
 
     // error kinds
     ErrorKind,

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -766,6 +766,13 @@ impl error::Error for RedisError {
             _ => None,
         }
     }
+
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self.repr {
+            ErrorRepr::IoError(ref err) => Some(err),
+            _ => None,
+        }
+    }
 }
 
 impl fmt::Display for RedisError {
@@ -1087,6 +1094,19 @@ impl RedisError {
     }
 }
 
+/// Creates a new Redis error with the `ExtensionError` kind.
+///
+/// This function is used to create Redis errors for extension error codes
+/// that are not directly understood by the library.
+///
+/// # Arguments
+///
+/// * `code` - The error code string returned by the Redis server
+/// * `detail` - Optional detailed error message. If None, a default message is used.
+///
+/// # Returns
+///
+/// A `RedisError` with the `ExtensionError` kind.
 pub fn make_extension_error(code: String, detail: Option<String>) -> RedisError {
     RedisError {
         repr: ErrorRepr::ExtensionError(

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -3,6 +3,7 @@ mod support;
 mod types {
     use std::{
         collections::{HashMap, HashSet},
+        error::Error,
         rc::Rc,
         sync::Arc,
     };
@@ -16,6 +17,46 @@ mod types {
             "Multiplexed connection driver unexpectedly terminated",
         ));
         assert!(err.is_io_error());
+    }
+
+    #[test]
+    fn test_redis_error_source_presence_for_io_wrapped_errors() {
+        let io_error = RedisError::from(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "I/O failure",
+        ));
+        let source = io_error.source();
+        assert_eq!(io_error.kind(), redis::ErrorKind::IoError);
+
+        assert!(source.is_some());
+        assert_eq!(source.unwrap().to_string(), "I/O failure");
+    }
+
+    #[test]
+    fn test_redis_error_source_absence_for_non_io_wrapped_errors() {
+        // Even though the ErrorKind is IoError, no actual I/O error is wrapped, so the source should be None.
+        let simulated_io_error = RedisError::from((ErrorKind::IoError, "Simulated I/O error"));
+        // Similarly this error is not an Extension error, even though it's ErrorKind is ExtensionError
+        let simulated_extension_error =
+            RedisError::from((ErrorKind::ExtensionError, "Simulated extension error"));
+        let simulated_type_error_with_details = RedisError::from((
+            ErrorKind::TypeError,
+            "Simulated type error",
+            "Type error details".to_string(),
+        ));
+
+        let an_extension_error =
+            redis::make_extension_error("A true extension error".to_string(), None);
+        assert_eq!(an_extension_error.kind(), redis::ErrorKind::ExtensionError);
+
+        for error in [
+            simulated_io_error,
+            simulated_extension_error,
+            simulated_type_error_with_details,
+            an_extension_error,
+        ] {
+            assert!(error.source().is_none());
+        }
     }
 
     #[test]


### PR DESCRIPTION
# Implement the `source` method of the `error::Error` _trait_ for the `RedisError` struct.

### Description
`Error::source()` is the recommended method for accessing the error chain, and it should be used instead of `cause()` in modern Rust code.

### Testing
Add unit tests that cover cases with and without an underlying source error.