### PR TITLE
feat: extend sentinel api to be a bit more flexible

### DIFF
--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -1058,7 +1058,7 @@ impl SentinelClient {
         })
     }
 
-    /// Returns a `redis::Client` considering the server type.
+    /// Returns a [`Client`] considering the server type.
     pub fn get_client(&mut self) -> RedisResult<Client> {
         match self.server_type {
             SentinelServerType::Master => self
@@ -1070,13 +1070,13 @@ impl SentinelClient {
         }
     }
 
-    /// Returns a [`redis::Client`] connected to **the first Sentinel node that
+    /// Returns a [`Client`] connected to **the first Sentinel node that
     /// responds successfully to `ROLE` with the expected value**.
     ///
     /// The function walks through the list supplied in
     /// `Sentinel::sentinels_connection_info`, trying each address in order:
     ///
-    /// 1. `Client::open` attempts to build a client for that Sentinel.
+    /// 1. [Client::open] attempts to build a client for that Sentinel.
     /// 2. We immediately issue `ROLE` to confirm the node is reachable and is a Setinel node.
     /// 3. The **first** node that passes both checks, the client is returned.
     ///
@@ -1133,7 +1133,7 @@ impl SentinelClient {
 #[cfg(feature = "aio")]
 #[cfg_attr(docsrs, doc(cfg(feature = "aio")))]
 impl SentinelClient {
-    /// Returns a `redis::Client` considering the server type.
+    /// Returns a [`Client`] considering the server type.
     pub async fn async_get_client(&mut self) -> RedisResult<Client> {
         match self.server_type {
             SentinelServerType::Master => {
@@ -1149,13 +1149,13 @@ impl SentinelClient {
         }
     }
 
-    /// Returns a [`redis::Client`] connected to **the first Sentinel node that
+    /// Returns a [`Client`] connected to **the first Sentinel node that
     /// responds successfully to `ROLE` with the expected value**.
     ///
     /// The function walks through the list supplied in
     /// `Sentinel::sentinels_connection_info`, trying each address in order:
     ///
-    /// 1. `Client::open` attempts to build a client for that Sentinel.
+    /// 1. [`Client::open`] attempts to build a client for that Sentinel.
     /// 2. We immediately issue `ROLE` to confirm the node is reachable and is a Setinel node.
     /// 3. The **first** node that passes both checks, the client is returned.
     ///

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -143,7 +143,7 @@ use crate::tls::retrieve_tls_certificates;
 #[cfg(feature = "tls-rustls")]
 use crate::TlsCertificates;
 use crate::{
-    connection::ConnectionInfo, types::RedisResult, Client, Cmd, Connection, ConnectionAddr,
+    cmd, connection::ConnectionInfo, types::RedisResult, Client, Cmd, Connection, ConnectionAddr,
     ErrorKind, FromRedisValue, IntoConnectionInfo, ProtocolVersion, RedisConnectionInfo,
     RedisError, Role, TlsMode,
 };
@@ -1058,7 +1058,8 @@ impl SentinelClient {
         })
     }
 
-    fn get_client(&mut self) -> RedisResult<Client> {
+    /// Returns a `redis::Client` considering the server type.
+    pub fn get_client(&mut self) -> RedisResult<Client> {
         match self.server_type {
             SentinelServerType::Master => self
                 .sentinel
@@ -1067,6 +1068,55 @@ impl SentinelClient {
                 .sentinel
                 .replica_for(self.service_name.as_str(), Some(&self.node_connection_info)),
         }
+    }
+
+    /// Returns a [`redis::Client`] connected to **the first Sentinel node that
+    /// responds successfully to `ROLE` with the expected value**.
+    ///
+    /// The function walks through the list supplied in
+    /// `Sentinel::sentinels_connection_info`, trying each address in order:
+    ///
+    /// 1. `Client::open` attempts to build a client for that Sentinel.
+    /// 2. We immediately issue `ROLE` to confirm the node is reachable and is a Setinel node.
+    /// 3. The **first** node that passes both checks, the client is returned.
+    ///
+    /// If **none** of the Sentinel addresses respond successfully or, an error occurs when
+    /// establishing a connection, the method returns the appropriate error.
+    ///
+    /// Use this client when you need Sentinel-specific features—e.g.
+    /// subscribing to `+switch-master` Pub/Sub events or running topology
+    /// queries—rather than talking to the Redis master itself.
+    pub fn get_sentinel_client(&mut self) -> RedisResult<Client> {
+        let mut err = Err(RedisError::from((
+            ErrorKind::InvalidClientConfig,
+            "Couldn't open connection to a sentinel node.",
+        )));
+
+        for connection_info in &self.sentinel.sentinels_connection_info {
+            if let Ok(client) = Client::open(connection_info.clone()) {
+                match try_single_sentinel::<Role>(
+                    cmd::cmd("ROLE"),
+                    connection_info,
+                    self.sentinel
+                        .connections_cache
+                        .first_mut()
+                        .unwrap_or(&mut None),
+                ) {
+                    Ok(role) if matches!(role, Role::Sentinel { .. }) => {
+                        return Ok(client);
+                    }
+                    Ok(_) => {
+                        // Do nothing, the node is not a sentinel node. If no Sentinel node is found
+                        // the client will receive the appropriate error
+                    }
+                    Err(e) => {
+                        err = Err(e);
+                    }
+                }
+            }
+        }
+
+        err
     }
 
     /// Creates a new connection to the desired type of server (based on the
@@ -1083,7 +1133,8 @@ impl SentinelClient {
 #[cfg(feature = "aio")]
 #[cfg_attr(docsrs, doc(cfg(feature = "aio")))]
 impl SentinelClient {
-    async fn async_get_client(&mut self) -> RedisResult<Client> {
+    /// Returns a `redis::Client` considering the server type.
+    pub async fn async_get_client(&mut self) -> RedisResult<Client> {
         match self.server_type {
             SentinelServerType::Master => {
                 self.sentinel
@@ -1096,6 +1147,57 @@ impl SentinelClient {
                     .await
             }
         }
+    }
+
+    /// Returns a [`redis::Client`] connected to **the first Sentinel node that
+    /// responds successfully to `ROLE` with the expected value**.
+    ///
+    /// The function walks through the list supplied in
+    /// `Sentinel::sentinels_connection_info`, trying each address in order:
+    ///
+    /// 1. `Client::open` attempts to build a client for that Sentinel.
+    /// 2. We immediately issue `ROLE` to confirm the node is reachable and is a Setinel node.
+    /// 3. The **first** node that passes both checks, the client is returned.
+    ///
+    /// If **none** of the Sentinel addresses respond successfully or, an error occurs when
+    /// establishing a connection, the method returns the appropriate error.
+    ///
+    /// Use this client when you need Sentinel-specific features—e.g.
+    /// subscribing to `+switch-master` Pub/Sub events or running topology
+    /// queries—rather than talking to the Redis master itself.
+    pub async fn async_get_sentinel_client(&mut self) -> RedisResult<Client> {
+        let mut err = Err(RedisError::from((
+            ErrorKind::InvalidClientConfig,
+            "Couldn't open connection to a sentinel node.",
+        )));
+
+        for connection_info in &self.sentinel.sentinels_connection_info {
+            if let Ok(client) = Client::open(connection_info.clone()) {
+                match async_try_single_sentinel::<Role>(
+                    cmd::cmd("ROLE"),
+                    connection_info,
+                    self.sentinel
+                        .async_connections_cache
+                        .first_mut()
+                        .unwrap_or(&mut None),
+                )
+                .await
+                {
+                    Ok(role) if matches!(role, Role::Sentinel { .. }) => {
+                        return Ok(client);
+                    }
+                    Ok(_) => {
+                        // Do nothing, the node is not a sentinel node. If no Sentinel node is found
+                        // the client will receive the appropriate error
+                    }
+                    Err(e) => {
+                        err = Err(e);
+                    }
+                }
+            }
+        }
+
+        err
     }
 
     /// Returns an async connection from the client, using the same logic from

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -1102,7 +1102,7 @@ impl SentinelClient {
                         .first_mut()
                         .unwrap_or(&mut None),
                 ) {
-                    Ok(role) if matches!(role, Role::Sentinel { .. }) => {
+                    Ok(Role::Sentinel { .. }) => {
                         return Ok(client);
                     }
                     Ok(_) => {
@@ -1183,7 +1183,7 @@ impl SentinelClient {
                 )
                 .await
                 {
-                    Ok(role) if matches!(role, Role::Sentinel { .. }) => {
+                    Ok(Role::Sentinel { .. }) => {
                         return Ok(client);
                     }
                     Ok(_) => {

--- a/redis/tests/test_sentinel.rs
+++ b/redis/tests/test_sentinel.rs
@@ -343,7 +343,7 @@ fn test_sentinel_client_io_error() {
     .unwrap();
 
     let sentinel_client = master_client.get_sentinel_client();
-    let err = sentinel_client.err().expect("Expected an error");
+    let err = sentinel_client.expect_err("Expected an error");
     assert!(err.is_io_error());
 }
 
@@ -367,7 +367,7 @@ fn test_sentinel_client_not_sentinel_error() {
     .unwrap();
 
     let sentinel_client = master_client.get_sentinel_client();
-    let err = sentinel_client.err().expect("Expected an error");
+    let err = sentinel_client.expect_err("Expected an error");
     assert_eq!(
         err,
         RedisError::from((
@@ -806,7 +806,7 @@ pub mod async_tests {
         block_on_all(
             async move {
                 let sentinel_client = master_client.async_get_sentinel_client().await;
-                let err = sentinel_client.err().expect("Expected an error");
+                let err = sentinel_client.expect_err("Expected an error");
                 assert_eq!(
                     err,
                     RedisError::from((
@@ -839,7 +839,7 @@ pub mod async_tests {
         block_on_all(
             async move {
                 let sentinel_client = master_client.async_get_sentinel_client().await;
-                let err = sentinel_client.err().expect("Expected an error");
+                let err = sentinel_client.expect_err("Expected an error");
                 assert!(err.is_io_error());
                 Ok::<(), RedisError>(())
             },

--- a/redis/tests/test_sentinel.rs
+++ b/redis/tests/test_sentinel.rs
@@ -296,7 +296,7 @@ fn test_sentinel_redis_client() {
 }
 
 #[test]
-fn test_sentinel_client_async() {
+fn test_sentinel_client() {
     let master_name = "master1";
     let context = TestSentinelContext::new(2, 3, 3);
     let mut master_client = SentinelClient::build(
@@ -331,7 +331,7 @@ fn test_sentinel_client_async() {
 }
 
 #[test]
-fn test_sentinel_client_async_io_error() {
+fn test_sentinel_client_io_error() {
     let master_name = "master1";
 
     let mut master_client = SentinelClient::build(

--- a/redis/tests/test_sentinel.rs
+++ b/redis/tests/test_sentinel.rs
@@ -7,7 +7,7 @@ use crate::support::*;
 use redis::sentinel::SentinelClientBuilder;
 use redis::{
     sentinel::{Sentinel, SentinelClient, SentinelNodeConnectionInfo},
-    Client, Connection, ConnectionAddr, ConnectionInfo, Role,
+    Client, Connection, ConnectionAddr, ConnectionInfo, ErrorKind, RedisError, Role,
 };
 
 fn parse_replication_info(value: &str) -> HashMap<&str, &str> {
@@ -246,7 +246,7 @@ fn test_sentinel_server_down() {
 }
 
 #[test]
-fn test_sentinel_client() {
+fn test_sentinel_redis_client() {
     let master_name = "master1";
     let mut context = TestSentinelContext::new(2, 3, 3);
     for sentinel in context.sentinels_connection_info() {
@@ -293,6 +293,91 @@ fn test_sentinel_client() {
 
         assert_connection_is_replica_of_correct_master(&mut replica_con, &master_client);
     }
+}
+
+#[test]
+fn test_sentinel_client_async() {
+    let master_name = "master1";
+    let context = TestSentinelContext::new(2, 3, 3);
+    let mut master_client = SentinelClient::build(
+        context.sentinels_connection_info().clone(),
+        String::from(master_name),
+        Some(context.sentinel_node_connection_info()),
+        redis::sentinel::SentinelServerType::Master,
+    )
+    .unwrap();
+
+    let mut replica_client = SentinelClient::build(
+        context.sentinels_connection_info().clone(),
+        String::from(master_name),
+        Some(context.sentinel_node_connection_info()),
+        redis::sentinel::SentinelServerType::Replica,
+    )
+    .unwrap();
+
+    let sentinel_client_1 = master_client.get_sentinel_client().unwrap();
+    let sentinel_client_2 = replica_client.get_sentinel_client().unwrap();
+    let first_configured_sentinel = context.sentinels_connection_info.first().unwrap();
+
+    assert_eq!(
+        sentinel_client_1.get_connection_info().addr,
+        sentinel_client_2.get_connection_info().addr
+    );
+
+    assert_eq!(
+        first_configured_sentinel.addr,
+        sentinel_client_2.get_connection_info().addr
+    );
+}
+
+#[test]
+fn test_sentinel_client_async_io_error() {
+    let master_name = "master1";
+
+    let mut master_client = SentinelClient::build(
+        vec!["redis://test:6379"],
+        String::from(master_name),
+        None,
+        redis::sentinel::SentinelServerType::Master,
+    )
+    .unwrap();
+
+    let sentinel_client = master_client.get_sentinel_client();
+    let err = sentinel_client.err().expect("Expected an error");
+    assert_eq!(
+        err.to_string(),
+        "failed to lookup address information: nodename nor servname provided, or not known"
+    );
+}
+
+#[test]
+fn test_sentinel_client_not_sentinel_error() {
+    let master_name = "master1";
+    let mut context = TestSentinelContext::new(2, 3, 3);
+    // Change the context with incorrect sentinel servers
+    context.sentinels_connection_info = context
+        .cluster
+        .servers
+        .iter()
+        .map(|redis_server| redis_server.connection_info().clone())
+        .collect::<Vec<_>>();
+    let mut master_client = SentinelClient::build(
+        context.sentinels_connection_info().clone(),
+        String::from(master_name),
+        None,
+        redis::sentinel::SentinelServerType::Master,
+    )
+    .unwrap();
+
+    let sentinel_client = master_client.get_sentinel_client();
+    let err = sentinel_client.err().expect("Expected an error");
+    assert_eq!(
+        err,
+        RedisError::from((
+            ErrorKind::InvalidClientConfig,
+            "Couldn't open connection to a sentinel node."
+        ))
+    );
 }
 
 #[test]
@@ -375,7 +460,7 @@ pub mod async_tests {
     use redis::{
         aio::MultiplexedConnection,
         sentinel::{Sentinel, SentinelClient, SentinelNodeConnectionInfo},
-        AsyncConnectionConfig, Client, ConnectionAddr, RedisError,
+        AsyncConnectionConfig, Client, ConnectionAddr, ErrorKind, RedisError,
     };
     use rstest::rstest;
 
@@ -603,7 +688,7 @@ pub mod async_tests {
     #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
     #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
     #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
-    fn test_sentinel_client_async(#[case] runtime: RuntimeType) {
+    fn test_sentinel_redis_client_async(#[case] runtime: RuntimeType) {
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, 3, 3);
         let mut master_client = SentinelClient::build(
@@ -645,6 +730,123 @@ pub mod async_tests {
                     .await;
                 }
 
+                Ok::<(), RedisError>(())
+            },
+            runtime,
+        )
+        .unwrap();
+    }
+
+    #[rstest]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
+    fn test_sentinel_client_async(#[case] runtime: RuntimeType) {
+        let master_name = "master1";
+        let context = TestSentinelContext::new(2, 3, 3);
+        let mut master_client = SentinelClient::build(
+            context.sentinels_connection_info().clone(),
+            String::from(master_name),
+            Some(context.sentinel_node_connection_info()),
+            redis::sentinel::SentinelServerType::Master,
+        )
+        .unwrap();
+
+        let mut replica_client = SentinelClient::build(
+            context.sentinels_connection_info().clone(),
+            String::from(master_name),
+            Some(context.sentinel_node_connection_info()),
+            redis::sentinel::SentinelServerType::Replica,
+        )
+        .unwrap();
+
+        block_on_all(
+            async move {
+                let sentinel_client_1 = master_client.async_get_sentinel_client().await?;
+                let sentinel_client_2 = replica_client.async_get_sentinel_client().await?;
+                let first_configured_sentinel = context.sentinels_connection_info.first().unwrap();
+
+                assert_eq!(
+                    sentinel_client_1.get_connection_info().addr,
+                    sentinel_client_2.get_connection_info().addr
+                );
+
+                assert_eq!(
+                    first_configured_sentinel.addr,
+                    sentinel_client_2.get_connection_info().addr
+                );
+
+                Ok::<(), RedisError>(())
+            },
+            runtime,
+        )
+        .unwrap();
+    }
+
+    #[rstest]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
+    fn test_sentinel_client_async_not_sentinel_error(#[case] runtime: RuntimeType) {
+        let master_name = "master1";
+
+        let mut context = TestSentinelContext::new(2, 3, 3);
+        // Change the context with incorrect sentinel servers
+        context.sentinels_connection_info = context
+            .cluster
+            .servers
+            .iter()
+            .map(|redis_server| redis_server.connection_info().clone())
+            .collect::<Vec<_>>();
+        let mut master_client = SentinelClient::build(
+            context.sentinels_connection_info().clone(),
+            String::from(master_name),
+            Some(context.sentinel_node_connection_info()),
+            redis::sentinel::SentinelServerType::Master,
+        )
+        .unwrap();
+
+        block_on_all(
+            async move {
+                let sentinel_client = master_client.async_get_sentinel_client().await;
+                let err = sentinel_client.err().expect("Expected an error");
+                assert_eq!(
+                    err,
+                    RedisError::from((
+                        ErrorKind::InvalidClientConfig,
+                        "Couldn't open connection to a sentinel node."
+                    ))
+                );
+                Ok::<(), RedisError>(())
+            },
+            runtime,
+        )
+        .unwrap();
+    }
+
+    #[rstest]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
+    fn test_sentinel_client_async_io_error(#[case] runtime: RuntimeType) {
+        let master_name = "master1";
+
+        let mut master_client = SentinelClient::build(
+            vec!["redis://test:6379"],
+            String::from(master_name),
+            None,
+            redis::sentinel::SentinelServerType::Master,
+        )
+        .unwrap();
+
+        block_on_all(
+            async move {
+                let sentinel_client = master_client.async_get_sentinel_client().await;
+                let err = sentinel_client.err().expect("Expected an error");
+                assert_eq!(
+                    err.to_string(),
+                    "failed to lookup address information: nodename nor servname provided, or not known"
+                );
                 Ok::<(), RedisError>(())
             },
             runtime,

--- a/redis/tests/test_sentinel.rs
+++ b/redis/tests/test_sentinel.rs
@@ -344,10 +344,7 @@ fn test_sentinel_client_async_io_error() {
 
     let sentinel_client = master_client.get_sentinel_client();
     let err = sentinel_client.err().expect("Expected an error");
-    assert_eq!(
-        err.to_string(),
-        "failed to lookup address information: nodename nor servname provided, or not known"
-    );
+    assert!(err.is_io_error());
 }
 
 #[test]
@@ -843,10 +840,7 @@ pub mod async_tests {
             async move {
                 let sentinel_client = master_client.async_get_sentinel_client().await;
                 let err = sentinel_client.err().expect("Expected an error");
-                assert_eq!(
-                    err.to_string(),
-                    "failed to lookup address information: nodename nor servname provided, or not known"
-                );
+                assert!(err.is_io_error());
                 Ok::<(), RedisError>(())
             },
             runtime,


### PR DESCRIPTION
The current `redis::sentinel::SentinelClient` api is limited to `get_connection` and `async_get_connection`. In order to establish connections to the correct (master/replica) Redis instance, it will first attempt to find the master/replica and create a `redis::Client` pointing at it. 

This PR makes `get_client` and `async_get_client` publicly available so users have the ability of getting such `redis::Client` and use it directly without going through sentinel facade.

Additionally, I'm adding a method that allows a user to obtain a `redis::Client` that points to one of the provided Sentinel instances. Having such a client allows, for instance, to leverage `pubsub` to subscribe to Sentinel events.