### PR TITLE
Add Client Side Caching for async Cluster Connections

### DIFF
--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -503,7 +503,7 @@ impl MultiplexedConnection {
         #[cfg(feature = "cache-aio")]
         let cache_config = config.cache.as_ref().map(|cache| match cache {
             crate::client::Cache::Config(cache_config) => *cache_config,
-            #[cfg(feature = "connection-manager")]
+            #[cfg(any(feature = "connection-manager", feature = "cluster-async"))]
             crate::client::Cache::Manager(cache_manager) => cache_manager.cache_config,
         });
         #[cfg(feature = "cache-aio")]
@@ -518,7 +518,7 @@ impl MultiplexedConnection {
                     crate::client::Cache::Config(cache_config) => {
                         Ok(CacheManager::new(cache_config))
                     }
-                    #[cfg(feature = "connection-manager")]
+                    #[cfg(any(feature = "connection-manager", feature = "cluster-async"))]
                     crate::client::Cache::Manager(cache_manager) => Ok(cache_manager),
                 }
             })

--- a/redis/src/caching/cache_manager.rs
+++ b/redis/src/caching/cache_manager.rs
@@ -37,7 +37,7 @@ impl CacheManager {
     // Clone the CacheManager and increase epoch from LRU,
     // this will eventually remove all keys created with previous
     // CacheManager's epoch.
-    #[cfg(feature = "connection-manager")]
+    #[cfg(any(feature = "connection-manager", feature = "cluster-async"))]
     pub(crate) fn clone_and_increase_epoch(&self) -> CacheManager {
         CacheManager {
             lru: self.lru.clone(),

--- a/redis/src/caching/mod.rs
+++ b/redis/src/caching/mod.rs
@@ -9,6 +9,9 @@
 //! TTL is for key and not per command, when TTL of redis key gets updated, all command pairs of that redis key will use the new one.
 //!
 //! For more information please read <https://redis.io/docs/manual/client-side-caching/>
+//!
+//! **Note:** ClusterConnection usage with Redis instances using 6.x version might give stale duration when resharding happens,
+//! therefore it's recommended to use version 7.x and above.
 
 mod cache_manager;
 pub(crate) mod cmd;

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -16,7 +16,10 @@ use crate::tls::{inner_build_with_tls, TlsCertificates};
 
 #[cfg(feature = "cache-aio")]
 use crate::caching::CacheConfig;
-#[cfg(all(feature = "cache-aio", feature = "connection-manager"))]
+#[cfg(all(
+    feature = "cache-aio",
+    any(feature = "connection-manager", feature = "cluster-async")
+))]
 use crate::caching::CacheManager;
 
 /// The client type.
@@ -167,7 +170,7 @@ impl Client {
 #[derive(Clone)]
 pub(crate) enum Cache {
     Config(CacheConfig),
-    #[cfg(feature = "connection-manager")]
+    #[cfg(any(feature = "connection-manager", feature = "cluster-async"))]
     Manager(CacheManager),
 }
 
@@ -249,7 +252,10 @@ impl AsyncConnectionConfig {
         self
     }
 
-    #[cfg(all(feature = "cache-aio", feature = "connection-manager"))]
+    #[cfg(all(
+        feature = "cache-aio",
+        any(feature = "connection-manager", feature = "cluster-async")
+    ))]
     pub(crate) fn set_cache_manager(mut self, cache_manager: CacheManager) -> Self {
         self.cache = Some(Cache::Manager(cache_manager));
         self

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -108,7 +108,7 @@
 //! * `uuid`: enables type conversion to UUID (optional)
 //! * `sentinel`: enables high-level interfaces for communication with Redis sentinels (optional)
 //! * `json`: enables high-level interfaces for communication with the JSON module (optional)
-//! * `cache-aio`: enables **experimental** client side caching for MultiplexedConnection (optional)
+//! * `cache-aio`: enables **experimental** client side caching for MultiplexedConnection, ConnectionManager and async ClusterConnection (optional)
 //! * `disable-client-setinfo`: disables the `CLIENT SETINFO` handshake during connection initialization
 //!
 //! ## Connection Parameters


### PR DESCRIPTION
This is quite a small change because most of the logic is already implemented in other modules used by ClusterConnection.

I wanted to consolidate cache tests nicely across mpx,cm and cluster connections but so far failed to do so.

With that reason patch adds two new tests.

Also I have tested slot change on Redis 8, when there is a slot change redis will send invalidation but couldn't write a simple test for it.