### PR TITLE
Fix AsyncIter implementation of stream.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ test:
 	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run --locked -p redis --no-default-features -F safe_iterators -E 'not test(test_module)'
 
 	@echo "===================================================================="
+	@echo "Testing Connection Type TCP without safe_iterators, but with async"
+	@echo "===================================================================="
+	@RUSTFLAGS="-D warnings -A deprecated" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run --locked -p redis --no-default-features -F tokio-comp -E 'not test(test_module)'
+
+	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features and RESP2"
 	@echo "===================================================================="
 	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features -E 'not test(test_module)'

--- a/redis/examples/async-scan.rs
+++ b/redis/examples/async-scan.rs
@@ -10,6 +10,9 @@ async fn main() -> redis::RedisResult<()> {
     let _: () = con.set("async-key2", b"foo").await?;
 
     let iter: AsyncIter<String> = con.scan().await?;
+    #[cfg(not(feature = "safe_iterators"))]
+    let mut keys: Vec<String> = iter.collect().await;
+    #[cfg(feature = "safe_iterators")]
     let mut keys: Vec<_> = iter.map(std::result::Result::unwrap).collect().await;
 
     keys.sort();

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -939,6 +939,9 @@ mod basic_async {
                 }
 
                 let iter: redis::AsyncIter<String> = con.scan().await.unwrap();
+                #[cfg(not(feature = "safe_iterators"))]
+                let mut keys_from_redis: Vec<String> = iter.collect().await;
+                #[cfg(feature = "safe_iterators")]
                 let mut keys_from_redis: Vec<_> =
                     iter.map(std::result::Result::unwrap).collect().await;
                 keys_from_redis.sort();


### PR DESCRIPTION
When the `safe_iterators` feature isn't implemented, the `Stream` implementation of AsyncIter should return T, not `RedisResult<T>`.