### PR TITLE
Minimize the lifetime of mutex lock guards

### DIFF
--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -607,11 +607,14 @@ impl ConnectionManager {
         let Some(subscription_tracker) = &self.0.subscription_tracker else {
             return;
         };
-        let mut guard = subscription_tracker.lock().await;
-        guard.update_with_request(action, args.to_redis_args().into_iter());
+        let args = args.to_redis_args().into_iter();
+        subscription_tracker
+            .lock()
+            .await
+            .update_with_request(action, args);
     }
 
-    /// Subscribes to a new channel(s).    
+    /// Subscribes to a new channel(s).
     ///
     /// Updates from the sender will be sent on the push sender that was passed to the manager.
     /// If the manager was configured without a push sender, the connection won't be able to pass messages back to the user.


### PR DESCRIPTION
We've been investigating some tokio poll latency spikes that then lead to timeouts in some redis accesses. One of the theories going around is that it might be bug in this library. I have audited `Mutex` and `RwLock` uses and found some lock guards that are being kept alive a little longer than necessary, so here's a PR to fix that (though it seems very unlikely that any of these changes are related to our issue - the bug hunt continues).