### PR TITLE
feat: Make transaction status of pipelines public

### DIFF
--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -72,8 +72,9 @@ impl Pipeline {
         self
     }
 
+    /// Returns `true` if the pipeline is in transaction mode (aka atomic mode).
     #[cfg(feature = "aio")]
-    pub(crate) fn is_transaction(&self) -> bool {
+    pub fn is_transaction(&self) -> bool {
         self.transaction_mode
     }
 


### PR DESCRIPTION
When trying to mock Redis connections, the `ConnectionLike`'s `req_packed_commands` expects a different response shape on `transactional` and non-`transactional` pipelines.

(Vec with single entry of Redis array of results, resp. Vec of results)

In order to hide this difference from users, it would be helpful to check if a pipeline is in transaction mode or not.

To allow this, we make the accessor function public.