### PR TITLE
Fix handling of nested tuples.

### DIFF
--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2598,8 +2598,7 @@ macro_rules! from_redis_value_for_tuple {
                             invalid_type_error!(v, "Array response of wrong dimension")
                         }
 
-                        // this is pretty ugly too.  The { i += 1; i - 1} is rust's
-                        // postfix increment :)
+                        // The { i += 1; i - 1} is rust's postfix increment :)
                         let mut i = 0;
                         Ok(($({let $name = (); from_redis_value(
                              &items[{ i += 1; i - 1 }])?},)*))
@@ -2610,29 +2609,21 @@ macro_rules! from_redis_value_for_tuple {
                             invalid_type_error!(v, "Set response of wrong dimension")
                         }
 
-                        // this is pretty ugly too.  The { i += 1; i - 1} is rust's
-                        // postfix increment :)
+                        // The { i += 1; i - 1} is rust's postfix increment :)
                         let mut i = 0;
                         Ok(($({let $name = (); from_redis_value(
                              &items[{ i += 1; i - 1 }])?},)*))
                     }
 
                     Value::Map(ref items) => {
-                        if n != 2 {
+                        if n != items.len() * 2 {
                             invalid_type_error!(v, "Map response of wrong dimension")
                         }
 
-                        let mut flatten_items = vec![];
-                        for (k,v) in items {
-                            flatten_items.push(k);
-                            flatten_items.push(v);
-                        }
+                        let mut flatten_items = items.iter().map(|(a,b)|[a,b]).flatten();
 
-                        // this is pretty ugly too.  The { i += 1; i - 1} is rust's
-                        // postfix increment :)
-                        let mut i = 0;
                         Ok(($({let $name = (); from_redis_value(
-                             &flatten_items[{ i += 1; i - 1 }])?},)*))
+                             &flatten_items.next().unwrap())?},)*))
                     }
 
                     _ => invalid_type_error!(v, "Not a Array response")
@@ -2653,8 +2644,7 @@ macro_rules! from_redis_value_for_tuple {
                             invalid_type_error!(Value::Array(items), "Array response of wrong dimension")
                         }
 
-                        // this is pretty ugly too.  The { i += 1; i - 1} is rust's
-                        // postfix increment :)
+                        // The { i += 1; i - 1} is rust's postfix increment :)
                         let mut i = 0;
                         Ok(($({let $name = (); from_owned_redis_value(
                             ::std::mem::replace(&mut items[{ i += 1; i - 1 }], Value::Nil)
@@ -2666,8 +2656,7 @@ macro_rules! from_redis_value_for_tuple {
                             invalid_type_error!(Value::Array(items), "Set response of wrong dimension")
                         }
 
-                        // this is pretty ugly too.  The { i += 1; i - 1} is rust's
-                        // postfix increment :)
+                        // The { i += 1; i - 1} is rust's postfix increment :)
                         let mut i = 0;
                         Ok(($({let $name = (); from_owned_redis_value(
                             ::std::mem::replace(&mut items[{ i += 1; i - 1 }], Value::Nil)
@@ -2675,21 +2664,15 @@ macro_rules! from_redis_value_for_tuple {
                     }
 
                     Value::Map(items) => {
-                        if n != 2 {
+                        if n != items.len() * 2 {
                             invalid_type_error!(Value::Map(items), "Map response of wrong dimension")
                         }
 
-                        let mut flatten_items = vec![];
-                        for (k,v) in items {
-                            flatten_items.push(k);
-                            flatten_items.push(v);
-                        }
+                        let mut flatten_items = items.into_iter().map(|(a,b)|[a,b]).flatten();
 
-                        // this is pretty ugly too.  The { i += 1; i - 1} is rust's
-                        // postfix increment :)
-                        let mut i = 0;
-                        Ok(($({let $name = (); from_redis_value(
-                             &flatten_items[{ i += 1; i - 1 }])?},)*))
+                        Ok(($({let $name = (); from_owned_redis_value(
+                            ::std::mem::replace(&mut flatten_items.next().unwrap(), Value::Nil)
+                        )?},)*))
                     }
 
                     _ => invalid_type_error!(v, "Not a Array response")

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -889,6 +889,31 @@ mod types {
     }
 
     #[test]
+    fn arrays_to_tuples() {
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            let value = Value::Array(vec![
+                Value::Array(vec![
+                    Value::BulkString(b"Hi1".to_vec()),
+                    Value::BulkString(b"Bye1".to_vec()),
+                ]),
+                Value::Array(vec![
+                    Value::BulkString(b"Hi2".to_vec()),
+                    Value::BulkString(b"Bye2".to_vec()),
+                ]),
+            ]);
+            let res: Vec<(String, String)> = parse_mode.parse_redis_value(value).unwrap();
+
+            assert_eq!(
+                res,
+                vec![
+                    ("Hi1".to_string(), "Bye1".to_string()),
+                    ("Hi2".to_string(), "Bye2".to_string()),
+                ]
+            );
+        }
+    }
+
+    #[test]
     fn test_complex_nested_tuples() {
         for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
             let value = Value::Array(vec![
@@ -908,12 +933,18 @@ mod types {
                     Value::BulkString(b"Bye3".to_vec()),
                     Value::BulkString(b"Hi4".to_vec()),
                     Value::BulkString(b"Bye4".to_vec()),
+                    Value::BulkString(b"Hi5".to_vec()),
+                    Value::BulkString(b"Bye5".to_vec()),
                 ]),
                 Value::Array(vec![
                     Value::BulkString(b"S4".to_vec()),
                     Value::BulkString(b"S5".to_vec()),
-                    Value::BulkString(b"S6".to_vec()),
                 ]),
+                Value::Array(vec![
+                    Value::BulkString(b"Hi6".to_vec()),
+                    Value::BulkString(b"Bye6".to_vec()),
+                ]),
+                Value::Array(vec![Value::BulkString(b"S6".to_vec())]),
             ]);
             let res: Vec<(HashMap<String, String>, Vec<String>)> =
                 parse_mode.parse_redis_value(value).unwrap();
@@ -925,6 +956,10 @@ mod types {
             let mut expected_map2 = HashMap::new();
             expected_map2.insert("Hi3".to_string(), "Bye3".to_string());
             expected_map2.insert("Hi4".to_string(), "Bye4".to_string());
+            expected_map2.insert("Hi5".to_string(), "Bye5".to_string());
+
+            let mut expected_map3 = HashMap::new();
+            expected_map3.insert("Hi6".to_string(), "Bye6".to_string());
 
             assert_eq!(
                 res,
@@ -933,10 +968,8 @@ mod types {
                         expected_map1,
                         vec!["S1".to_string(), "S2".to_string(), "S3".to_string()]
                     ),
-                    (
-                        expected_map2,
-                        vec!["S4".to_string(), "S5".to_string(), "S6".to_string()]
-                    )
+                    (expected_map2, vec!["S4".to_string(), "S5".to_string()]),
+                    (expected_map3, vec!["S6".to_string()])
                 ]
             );
         }


### PR DESCRIPTION
The blocks that tried to convert internal collections to tuples caused bad results if some of the values in the items array could be converted to tuples and others couldn't.
```rs
for item in items {
    match item {
        Value::Array(ch) => {
            if  let [$($name),*] = &ch[..] {
            rv.push(($(from_redis_value(&$name)?),*),)
            };
        },
        _ => {},

    }
}
if !rv.is_empty(){
    return Ok(rv);
}
```
So it was replaced with a block that first verifies that all of the values in the collection can be converted to the tuple.
```rs
if items.iter().all(|item|item.is_collection_of_len(n)) {
    return items.iter().map(|item|from_redis_value(item)).collect();
}
```

Fixes https://github.com/redis-rs/redis-rs/issues/1674