### PR TITLE
Propagate connection error when failing to connect to clustered redis

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -439,7 +439,7 @@ where
                         formatted_detail += "; ";
                     }
                     use std::fmt::Write;
-                    let _ = write!(&mut formatted_detail, "{}: {}", addr, conn_err);
+                    let _ = write!(&mut formatted_detail, "{addr}: {conn_err}");
                 }
                 formatted_detail += ")";
                 formatted_detail


### PR DESCRIPTION
When attempting to connect to a clustered Redis instance, if there is some kind of network misconfiguration, the only error message you get back is `It failed to check startup nodes.` which doesn't help to diagnose the connection problem.

This PR formats and combines the individual reasons for failing to connect to each initial node in the cluster, and concatenates them into the "details" of the error message.