### PR TITLE
add method hget_multiple to explicitly call HMGET

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -496,7 +496,7 @@ implement_commands! {
 
     /// Gets multiple fields from a hash.
     /// [Redis Docs](https://redis.io/commands/HMGET)
-    fn hget_multiple<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F) -> (Vec<String>) {
+    fn hmget<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F) -> (Vec<String>) {
         cmd("HMGET").arg(key).arg(fields)
     }
 

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -494,6 +494,12 @@ implement_commands! {
         cmd(if field.num_of_args() <= 1 { "HGET" } else { "HMGET" }).arg(key).arg(field)
     }
 
+    /// Gets multiple fields from a hash.
+    /// [Redis Docs](https://redis.io/commands/HMGET)
+    fn hget_multiple<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F) -> (Vec<String>) {
+        cmd("HMGET").arg(key).arg(fields)
+    }
+
     /// Get the value of one or more fields of a given hash key, and optionally set their expiration
     /// [Redis Docs](https://redis.io/commands/HGETEX)
     fn hget_ex<K: ToRedisArgs, F: ToRedisArgs>(key: K, fields: F, expire_at: Expiry) -> (Vec<String>) {

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -2084,7 +2084,7 @@ mod basic {
             Ok((2, 8))
         );
         assert_eq!(
-            redis::Commands::hget_multiple(&mut con, "my_hash", &["f2", "f4"]),
+            redis::Commands::hmget(&mut con, "my_hash", &["f2", "f4"]),
             Ok((2, 8))
         );
         assert_eq!(con.hincr("my_hash", "f1", 1), Ok(2.0));

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -2083,6 +2083,10 @@ mod basic {
             redis::Commands::hget(&mut con, "my_hash", &["f2", "f4"]),
             Ok((2, 8))
         );
+        assert_eq!(
+            redis::Commands::hget_multiple(&mut con, "my_hash", &["f2", "f4"]),
+            Ok((2, 8))
+        );
         assert_eq!(con.hincr("my_hash", "f1", 1), Ok(2.0));
         assert_eq!(con.hincr("my_hash", "f2", 1.5), Ok(3.5));
         assert_eq!(con.hexists("my_hash", "f2"), Ok(true));


### PR DESCRIPTION
fixes #1720
creates a method to call HMGET explcitly
I named the method `hget_multiple` to be consistent with `hset_multiple`