### PR TITLE
Make `Script`'s `load_cmd` public

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -2700,11 +2700,12 @@ implement_commands! {
 
     // script commands
 
-    /// Adds a prepared script command to the pipeline.
+    /// Invoke a prepared script.
     ///
-    /// Note: unlike a call to [`invoke`](crate::ScriptInvocation::invoke), if the script isn't loaded during the pipeline operation,
-    /// it will not automatically be loaded and retried. The script can be loaded using the
-    /// [`load`](crate::ScriptInvocation::load) operation.
+    /// Note: Unlike[`ScriptInvocation::invoke`](crate::ScriptInvocation::invoke), this function
+    /// does _not_ automatically load the script. If the invoked script did not get loaded beforehand, you
+    /// need to manually load it (e.g.: using [`ScriptInvocation::load`](crate::ScriptInvocation::load))
+    /// or this command will fail.
     #[cfg_attr(feature = "script", doc = r##"
 
 # Examples:

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -2717,7 +2717,7 @@ implement_commands! {
 let script = redis::Script::new(r"
     return tonumber(ARGV[1]) + tonumber(ARGV[2]);
 ");
-script.prepare_invoke().load(&mut con)?;
+script.load(&mut con)?;
 let (a, b): (isize, isize) = redis::pipe()
     .invoke_script(script.arg(1).arg(2))
     .invoke_script(script.arg(2).arg(3))

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -2700,12 +2700,9 @@ implement_commands! {
 
     // script commands
 
-    /// Invoke a prepared script.
+    /// Load a script.
     ///
-    /// Note: Unlike[`ScriptInvocation::invoke`](crate::ScriptInvocation::invoke), this function
-    /// does _not_ automatically load the script. If the invoked script did not get loaded beforehand, you
-    /// need to manually load it (e.g.: using [`ScriptInvocation::load`](crate::ScriptInvocation::load))
-    /// or this command will fail.
+    /// See [`invoke_script`](Self::invoke_script) to actually run the scripts.
     #[cfg_attr(feature = "script", doc = r##"
 
 # Examples:
@@ -2717,14 +2714,48 @@ implement_commands! {
 let script = redis::Script::new(r"
     return tonumber(ARGV[1]) + tonumber(ARGV[2]);
 ");
-script.load(&mut con)?;
-let (a, b): (isize, isize) = redis::pipe()
+let (load_res, invok_res): (String, isize) = redis::pipe()
+    .load_script(&script)
+    .invoke_script(script.arg(1).arg(2))
+    .query(&mut con)?;
+
+assert_eq!(load_res, "1ca80f2366c125a7c43519ce241d5c24c2b64023");
+assert_eq!(invok_res, 3);
+# Ok(()) }
+```
+"##)]
+    #[cfg(feature = "script")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "script")))]
+    fn load_script<>(script: &'a crate::Script) -> Generic {
+        &mut script.load_cmd()
+    }
+
+    /// Invoke a prepared script.
+    ///
+    /// Note: Unlike[`ScriptInvocation::invoke`](crate::ScriptInvocation::invoke), this function
+    /// does _not_ automatically load the script. If the invoked script did not get loaded beforehand, you
+    /// need to manually load it (e.g.: using [`load_script`](Self::load_script) or
+    /// [`ScriptInvocation::load`](crate::ScriptInvocation::load)). Otherwise this command will fail.
+    #[cfg_attr(feature = "script", doc = r##"
+
+# Examples:
+
+```rust,no_run
+# fn do_something() -> redis::RedisResult<()> {
+# let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+# let mut con = client.get_connection().unwrap();
+let script = redis::Script::new(r"
+    return tonumber(ARGV[1]) + tonumber(ARGV[2]);
+");
+let (load_res, invok_1_res, invok_2_res): (String, isize, isize) = redis::pipe()
+    .load_script(&script)
     .invoke_script(script.arg(1).arg(2))
     .invoke_script(script.arg(2).arg(3))
     .query(&mut con)?;
 
-assert_eq!(a, 3);
-assert_eq!(b, 5);
+assert_eq!(load_res, "1ca80f2366c125a7c43519ce241d5c24c2b64023");
+assert_eq!(invok_1_res, 3);
+assert_eq!(invok_2_res, 5);
 # Ok(()) }
 ```
 "##)]

--- a/redis/src/script.rs
+++ b/redis/src/script.rs
@@ -45,7 +45,7 @@ impl Script {
     }
 
     /// Returns a command to load the script.
-    fn load_cmd(&self) -> Cmd {
+    pub(crate) fn load_cmd(&self) -> Cmd {
         let mut cmd = cmd("SCRIPT");
         cmd.arg("LOAD").arg(self.code.as_bytes());
         cmd

--- a/redis/src/script.rs
+++ b/redis/src/script.rs
@@ -147,7 +147,7 @@ impl<'a> ScriptInvocation<'a> {
             Ok(val) => Ok(val),
             Err(err) => {
                 if err.kind() == ErrorKind::NoScriptError {
-                    self.load_cmd().exec(con)?;
+                    self.load(con)?;
                     eval_cmd.query(con)
                 } else {
                     Err(err)
@@ -172,7 +172,7 @@ impl<'a> ScriptInvocation<'a> {
             Err(err) => {
                 // Load the script into Redis if the script hash wasn't there already
                 if err.kind() == ErrorKind::NoScriptError {
-                    self.load_cmd().exec_async(con).await?;
+                    self.load_async(con).await?;
                     eval_cmd.query_async(con).await
                 } else {
                     Err(err)

--- a/redis/tests/test_script.rs
+++ b/redis/tests/test_script.rs
@@ -66,15 +66,16 @@ mod script {
         let mut con = ctx.connection();
 
         let script = redis::Script::new(r"return tonumber(ARGV[1]) + tonumber(ARGV[2]);");
-        script.load(&mut con).unwrap();
 
-        let (a, b): (isize, isize) = redis::pipe()
+        let (load_res, invok_1_res, invok_2_res): (String, isize, isize) = redis::pipe()
+            .load_script(&script)
             .invoke_script(script.arg(1).arg(2))
             .invoke_script(script.arg(2).arg(3))
             .query(&mut con)
             .unwrap();
 
-        assert_eq!(a, 3);
-        assert_eq!(b, 5);
+        assert_eq!(load_res, "1ca80f2366c125a7c43519ce241d5c24c2b64023");
+        assert_eq!(invok_1_res, 3);
+        assert_eq!(invok_2_res, 5);
     }
 }

--- a/redis/tests/test_script.rs
+++ b/redis/tests/test_script.rs
@@ -31,6 +31,18 @@ mod script {
 
         let script = redis::Script::new("return 'Hello World'");
 
+        let hash = script.load(&mut con);
+
+        assert_eq!(hash, Ok(script.get_hash().to_string()));
+    }
+
+    #[test]
+    fn test_script_load_through_invocation() {
+        let ctx = TestContext::new();
+        let mut con = ctx.connection();
+
+        let script = redis::Script::new("return 'Hello World'");
+
         let hash = script.prepare_invoke().load(&mut con);
 
         assert_eq!(hash, Ok(script.get_hash().to_string()));
@@ -54,7 +66,7 @@ mod script {
         let mut con = ctx.connection();
 
         let script = redis::Script::new(r"return tonumber(ARGV[1]) + tonumber(ARGV[2]);");
-        script.prepare_invoke().load(&mut con).unwrap();
+        script.load(&mut con).unwrap();
 
         let (a, b): (isize, isize) = redis::pipe()
             .invoke_script(script.arg(1).arg(2))


### PR DESCRIPTION
Having the `load_cmd` public allows to re-use it when loading scripts in pipelines.