### PR TITLE
Support Redis 8.2 stream command extensions and new deletion commands

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
               rust: stable,
               db-org: redis,
               db-name: redis,
-              db-version: 8.2-m01
+              db-version: 8.2.0
             },
 
             # Different rust cases

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -1954,7 +1954,7 @@ implement_commands! {
     /// ```
     ///
     /// ```text
-    /// XADD key [NOMKSTREAM] [<MAXLEN|MINID> [~|=] threshold [LIMIT count]] <* | ID> field value [field value] ...
+    /// XADD key [NOMKSTREAM] [<MAXLEN|MINID> [~|=] threshold [LIMIT count]] <* | ID> field value [field value] [KEEPREF | DELREF | ACKED] ...
     /// ```
     /// [Redis Docs](https://redis.io/commands/XADD)
     #[cfg(feature = "streams")]
@@ -2166,6 +2166,19 @@ implement_commands! {
         cmd("XDEL").arg(key).arg(ids)
     }
 
+    /// An extension of the Streams `XDEL` command that provides finer control over how message entries are deleted with respect to consumer groups.
+    #[cfg(feature = "streams")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
+    fn xdel_ex<K: ToRedisArgs, ID: ToRedisArgs>(key: K, ids: &'a [ID], options: streams::StreamDeletionPolicy) -> (Vec<streams::XDelExStatusCode>) {
+        cmd("XDELEX").arg(key).arg(options).arg("IDS").arg(ids.len()).arg(ids)
+    }
+
+    /// A combination of `XACK` and `XDEL` that acknowledges and attempts to delete a list of `ids` for a given stream `key` and consumer `group`.
+    #[cfg(feature = "streams")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
+    fn xack_del<K: ToRedisArgs, G: ToRedisArgs, ID: ToRedisArgs>(key: K, group: G, ids: &'a [ID], options: streams::StreamDeletionPolicy) -> (Vec<streams::XAckDelStatusCode>) {
+        cmd("XACKDEL").arg(key).arg(group).arg(options).arg("IDS").arg(ids.len()).arg(ids)
+    }
 
     /// This command is used for creating a consumer `group`. It expects the stream key
     /// to already exist. Otherwise, use `xgroup_create_mkstream` if it doesn't.
@@ -2673,7 +2686,7 @@ implement_commands! {
      /// Trim a stream `key` with full options
      ///
      /// ```text
-     /// XTRIM <key> <MAXLEN|MINID> [~|=] <threshold> [LIMIT <count>]  (Same as XADD MAXID|MINID options)
+     /// XTRIM <key> <MAXLEN|MINID> [~|=] <threshold> [LIMIT <count>]  (Same as XADD MAXID|MINID options) [KEEPREF | DELREF | ACKED]
      /// ```
      /// [Redis Docs](https://redis.io/commands/XTRIM)
     #[cfg(feature = "streams")]

--- a/redis/src/streams.rs
+++ b/redis/src/streams.rs
@@ -1058,10 +1058,11 @@ define_stream_response_status_enum! {
     XDelExStatusCode,
     /// No entry with the given id exists in the stream
     IdNotFound = -1,
-    /// Entry was deleted from the stream
+    /// The entry was deleted from the stream
     Deleted = 1,
-    /// Entry was not deleted because it has references in consumer groups' PEL
-    NotDeletedStillReferenced = 2
+    /// The entry was not deleted because it has either not been delivered to any consumer
+    /// or still has references in the consumer groups' Pending Entries List (PEL)
+    NotDeletedUnacknowledgedOrStillReferenced = 2
 }
 
 define_stream_response_status_enum! {
@@ -1069,9 +1070,9 @@ define_stream_response_status_enum! {
     XAckDelStatusCode,
     /// No entry with the given id exists in the stream
     IdNotFound = -1,
-    /// Entry was acknowledged and deleted from the stream
+    /// The entry was acknowledged and deleted from the stream
     AcknowledgedAndDeleted = 1,
-    /// Entry was acknowledged but not deleted because it has references in consumer groups' PEL
+    /// The entry was acknowledged but not deleted because it has references in the consumer groups' Pending Entries List (PEL)
     AcknowledgedNotDeletedStillReferenced = 2
 }
 

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -442,8 +442,6 @@ pub fn is_version(expected_major_minor: (u16, u16), version: Version) -> bool {
 }
 
 // Redis version constants for version-gated tests
-pub const REDIS_VERSION_CE_8_0_RC1: Version = (7, 9, 240);
-#[cfg(feature = "vector-sets")]
 pub const REDIS_VERSION_CE_8_0: Version = (8, 0, 0);
 pub const REDIS_VERSION_CE_8_2: Version = (8, 1, 240);
 

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -441,6 +441,30 @@ pub fn is_version(expected_major_minor: (u16, u16), version: Version) -> bool {
         || (expected_major_minor.0 == version.0 && expected_major_minor.1 <= version.1)
 }
 
+// Redis version constants for version-gated tests
+pub const REDIS_VERSION_CE_8_0_RC1: Version = (7, 9, 240);
+#[cfg(feature = "vector-sets")]
+pub const REDIS_VERSION_CE_8_0: Version = (8, 0, 0);
+pub const REDIS_VERSION_CE_8_2: Version = (8, 1, 240);
+
+/// Macro to run tests only if the Redis version meets the minimum requirement.
+/// If the version is insufficient, the test is skipped with a message.
+#[macro_export]
+macro_rules! run_test_if_version_supported {
+    ($minimum_required_version:expr) => {{
+        let ctx = $crate::support::TestContext::new();
+        let redis_version = ctx.get_version();
+
+        if redis_version < *$minimum_required_version {
+            eprintln!("Skipping the test because the current version of Redis {:?} doesn't match the minimum required version {:?}.",
+            redis_version, $minimum_required_version);
+            return;
+        }
+
+        ctx
+    }};
+}
+
 #[cfg(feature = "tls-rustls")]
 fn load_certs_from_file(tls_file_paths: &TlsFilePaths) -> TlsCertificates {
     let ca_file = File::open(&tls_file_paths.ca_crt).expect("Cannot open CA cert file");

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -1,21 +1,7 @@
 #![allow(clippy::let_unit_value)]
 
+#[macro_use]
 mod support;
-
-macro_rules! run_test_if_version_supported {
-    ($minimum_required_version:expr) => {{
-        let ctx = TestContext::new();
-        let redis_version = ctx.get_version();
-
-        if redis_version < *$minimum_required_version {
-            eprintln!("Skipping the test because the current version of Redis {:?} doesn't match the minimum required version {:?}.",
-            redis_version, $minimum_required_version);
-            return;
-        }
-
-        ctx
-    }};
-}
 
 #[cfg(test)]
 mod basic {
@@ -50,12 +36,6 @@ mod basic {
     use std::thread::{self, sleep, spawn};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
     use std::vec;
-
-    const REDIS_VERSION_CE_8_0_RC1: (u16, u16, u16) = (7, 9, 240);
-    #[cfg(feature = "vector-sets")]
-    const REDIS_VERSION_CE_8_0: (u16, u16, u16) = (8, 0, 0);
-
-    const REDIS_VERSION_CE_8_2: (u16, u16, u16) = (8, 1, 240);
 
     const HASH_KEY: &str = "testing_hash";
     const HASH_FIELDS_AND_VALUES: [(&str, u8); 5] =

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -483,7 +483,7 @@ mod basic {
     /// 5. Attempting to delete a field from a non-existing hash results in a NIL response.
     #[test]
     fn test_hget_del() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0_RC1);
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
@@ -560,7 +560,7 @@ mod basic {
     /// 6. Attempting to retrieve a field from a non-existing hash returns in a NIL response.
     #[test]
     fn test_hget_ex() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0_RC1);
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
@@ -679,7 +679,7 @@ mod basic {
     /// as well as removing an existing expiration using the PERSIST option.
     #[test]
     fn test_hget_ex_field_expiration_options() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0_RC1);
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
@@ -774,7 +774,7 @@ mod basic {
     ///        and verifies that their values have been modified and the fields are set to expire.
     #[test]
     fn test_hset_ex() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0_RC1);
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0);
         let mut con = ctx.connection();
 
         let generated_hash_key = generate_random_testing_hash_key(&mut con);
@@ -960,7 +960,7 @@ mod basic {
     /// as well as keeping an existing expiration using the KEEPTTL option.
     #[test]
     fn test_hsetex_field_expiration_options() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0_RC1);
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
@@ -1022,7 +1022,7 @@ mod basic {
 
     #[test]
     fn test_hsetex_can_update_the_expiration_of_a_field_that_has_already_been_set_to_expire() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0_RC1);
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));

--- a/redis/tests/test_streams.rs
+++ b/redis/tests/test_streams.rs
@@ -1275,7 +1275,7 @@ fn test_xtrim_options_deletion_policy_acked() {
     let info = con.xinfo_stream(stream_name).unwrap();
     assert_eq!(info.length, initial_stream_entries.len());
     assert_eq!(info.first_entry.id, id1);
-    // Check that the PEL entry for the first entry has been removed.
+    // PEL entries should remain unchanged because no stream trimming was performed.
     let reply = con
         .xpending_consumer_count(
             stream_name,


### PR DESCRIPTION
# Add support for new stream commands and extensions introduced in Redis 8.2

## Overview
This Pull Request introduces new Redis Streams commands (`XDELEX` and `XACKDEL`) that provide enhanced control over message deletion and acknowledgment operations, specifically targeting **Redis 8.2+** features. The implementation adds support for fine-grained deletion policies that control how stream entries are handled with respect to consumer group Pending Entries Lists (PELs). It also extends the `XADD` and `XTRIM` commands with the same capabilities.

## New commands:

### `XDELEX` - an extension to the `XDEL` command that provides more control over when entry references are deleted.

#### Syntax
`XDELEX key [KEEPREF | DELREF | ACKED] IDS numids id [id ...]`

`XDELEX` accepts one of the following options: `KEEPREF` (default), `DELREF` or `ACKED`.
- Using the `KEEPREF` deletion policy deletes entries from the stream, but preserves existing references to those entries in all consumer groups' PELs. This behavior is similar to that of `XDEL`.
- Using the `XDELEX` deletion policy deletes entries from the stream and also removes all references to those entries from all consumer groups' PELs, effectively cleaning up all traces of the entries.
- Using the `ACKED` deletion policy deletes only those entries that have been read and acknowledged by **all** consumer groups. If an entry has not yet been read or acknowledged by some group, it will not be deleted.

### `XACKDEL` - combines the functionality of `XACK` and `XDEL` in Redis Streams. 
It acknowledges the specified entry IDs in the given consumer group and conditionally deletes the corresponding entries from the stream.

#### Syntax
`XACKDEL key group [KEEPREF | DELREF | ACKED] IDS numids id [id ...]`

`XACKDEL` accepts one of the following options: `KEEPREF` (default), `DELREF` or `ACKED`.
- `KEEPREF` acknowledges the entries in the specified consumer group and deletes them from the stream, but preserves any existing references to those entries in all consumer groups' PELs.
- `DELREF` acknowledges the entries in the specified consumer group, deletes them from the stream, and also removes all references to those entries from all consumer groups' PELs - effectively cleaning up all traces. If an entry ID is no longer in the stream but still has dangling references, `XDELEX` with `DELREF` would still remove those references.
- `ACKED` acknowledges the entries in the specified consumer group and deletes only those entries that have been read and acknowledged by **all** consumer groups. If an entry has not yet been read or acknowledged by any consumer group, it will not be deleted.

## Altered commands
Since `XADD` and `XTRIM` can delete entries, they were both extended with the `[KEEPREF | DELREF | ACKED]` deletion policies as well.
`KEEPREF` - 
Removes entries from the stream according to the specified strategy (`MAXLEN` or `MINID`), regardless of whether they are still referenced by any consumer groups. However, it **preserves** existing references to those entries in all consumer groups’ PELs.
This is the **default behavior** of these commands, so it introduces **no breaking change**.
`DELREF` –
Removes entries from the stream based on the specified strategy (`MAXLEN` or `MINID`), and also removes **all** references to those entries from all consumer groups’ PELs — effectively cleaning up all traces of the entries.
`ACKED` –
Only removes entries that have been **read and acknowledged by all consumer groups**. If an entry has not been read or acknowledged by some group, it will not be deleted. When `MAXLEN` is specified, **no more than** `MAXLEN` entries will be deleted.

### `XTRIM` - library function xtrim_options

#### Syntax
`XTRIM key <MAXLEN | MINID> [= | ~] threshold [LIMIT count] [KEEPREF | DELREF | ACKED]`

### `XADD` - library function xadd_options

#### Syntax
`XADD key [NOMKSTREAM] [<MAXLEN | MINID> [= | ~] threshold [LIMIT count]] [KEEPREF | DELREF | ACKED] <* | id> field value [field value ...]`

---

## 🧪 Tests

- Each of the deletion policies in the `XADD` and `XTRIM` commands has its own individual test.
- The `XDELEX` and `XACKDEL` commands each have separate tests that showcase and verify various use cases.

---

### 📚 References

- [Pull Request](https://github.com/redis/redis/pull/14130) that introduces the commands in Redis
