### PR TITLE
test: Fix clippy warnings about `ref instead of clone` in stream tests

### DIFF
--- a/redis/tests/test_streams.rs
+++ b/redis/tests/test_streams.rs
@@ -8,6 +8,7 @@ mod support;
 use crate::support::*;
 
 use std::collections::BTreeMap;
+use std::slice;
 use std::str;
 use std::thread::sleep;
 use std::time::Duration;
@@ -673,7 +674,7 @@ fn test_xclaim() {
 
     // grab this id if > 4ms
     let reply = con
-        .xclaim("k1", "g1", "c2", 4, &[claim.id.clone()])
+        .xclaim("k1", "g1", "c2", 4, slice::from_ref(&claim.id))
         .unwrap();
     assert_eq!(reply.ids.len(), 1);
     assert_eq!(reply.ids[0].id, claim.id);
@@ -699,7 +700,7 @@ fn test_xclaim() {
             "g1",
             "c3",
             4,
-            &[claim.id.clone()],
+            slice::from_ref(&claim.id),
             StreamClaimOptions::default().with_force(),
         )
         .unwrap();
@@ -773,7 +774,7 @@ fn test_xclaim_last_id() {
             "g1",
             "c2",
             4,
-            &[claim_middle_id.id.clone()],
+            slice::from_ref(&claim_middle_id.id),
             StreamClaimOptions::default()
                 .with_justid()
                 .with_lastid(claim_early_id.id.as_str()),
@@ -793,7 +794,7 @@ fn test_xclaim_last_id() {
             "g1",
             "c1",
             4,
-            &[claim_middle_id.id.clone()],
+            slice::from_ref(&claim_middle_id.id),
             StreamClaimOptions::default()
                 .with_justid()
                 .with_lastid(claim_late_id.id.as_str()),


### PR DESCRIPTION
Clippy complained that `std::slice::from_ref` should get used instead of cloning when calling `xclaim_options`. So we switch.

An example of a failed CI run is at:

  https://github.com/redis-rs/redis-rs/actions/runs/16804997078/job/47595063961?pr=1731