### PR TITLE
Align async resubscribe behavior.

### DIFF
--- a/redis/src/subscription_tracker.rs
+++ b/redis/src/subscription_tracker.rs
@@ -98,12 +98,6 @@ impl SubscriptionTracker {
         self.update_with_request(action, args);
     }
 
-    pub(crate) fn update_with_pipeline<'a>(&'a mut self, pipe: &'a Pipeline) {
-        for cmd in pipe.cmd_iter() {
-            self.update_with_cmd(cmd);
-        }
-    }
-
     pub(crate) fn get_subscription_pipeline(&self) -> Pipeline {
         let mut pipeline = crate::pipe();
         if !self.subscriptions.is_empty() {
@@ -177,47 +171,6 @@ mod tests {
         let result = tracker.get_subscription_pipeline();
         let mut expected = pipe();
         expected.cmd("PSUBSCRIBE").arg("b*ar");
-        assert_eq!(
-            result.get_packed_pipeline(),
-            expected.get_packed_pipeline(),
-            "{}",
-            String::from_utf8(result.get_packed_pipeline()).unwrap()
-        );
-    }
-
-    #[test]
-    fn test_add_and_remove_subscriptions_with_pipeline() {
-        let mut tracker = SubscriptionTracker::default();
-
-        tracker.update_with_pipeline(
-            pipe()
-                .cmd("subscribe")
-                .arg("foo")
-                .arg("bar")
-                .cmd("PSUBSCRIBE")
-                .arg("fo*o")
-                .arg("b*ar")
-                .cmd("SSUBSCRIBE")
-                .arg("sfoo")
-                .arg("sbar")
-                .cmd("unsubscribe")
-                .arg("foo")
-                .cmd("Punsubscribe")
-                .arg("b*ar")
-                .cmd("Sunsubscribe")
-                .arg("sfoo")
-                .arg("SBAR"),
-        );
-
-        let result = tracker.get_subscription_pipeline();
-        let mut expected = pipe();
-        expected
-            .cmd("SUBSCRIBE")
-            .arg("bar")
-            .cmd("SSUBSCRIBE")
-            .arg("sbar")
-            .cmd("PSUBSCRIBE")
-            .arg("fo*o");
         assert_eq!(
             result.get_packed_pipeline(),
             expected.get_packed_pipeline(),

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -2987,7 +2987,7 @@ mod cluster_async {
         #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn pub_sub_should_not_reconnect_if_subscription_failed(#[case] runtime: RuntimeType) {
-            // in this test we will try to subscribe to a disconnected cluster, fail, and check that once the connection reconnects it won't try and reconnect.
+            // in this test we will try to subscribe to a disconnected cluster, fail, and check that once the connection reconnects it won't try and resubscribe.
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
             let ctx = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
                 builder

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -2982,6 +2982,85 @@ mod cluster_async {
             )
             .unwrap();
         }
+
+        #[rstest]
+        #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+        #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
+        fn pub_sub_should_not_reconnect_if_subscription_failed(#[case] runtime: RuntimeType) {
+            // in this test we will try to subscribe to a disconnected cluster, fail, and check that once the connection reconnects it won't try and reconnect.
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+            let ctx = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
+                builder
+                    .use_protocol(ProtocolVersion::RESP3)
+                    .push_sender(tx.clone())
+            });
+
+            block_on_all(
+                async move {
+                    let ports: Vec<_> = ctx.get_ports();
+
+                    let mut pubsub_conn = ctx.async_connection().await;
+
+                    drop(ctx);
+
+                    let err = pubsub_conn
+                        .subscribe("regular-phonewave")
+                        .await
+                        .unwrap_err();
+                    assert!(err.is_unrecoverable_error(), "{err:?}");
+
+                    // we expect 1 disconnect per connection to node.
+                    for _ in 0..3 {
+                        let push = rx
+                            .recv()
+                            .timeout(futures_time::time::Duration::from_millis(5))
+                            .await
+                            .unwrap();
+                        assert_eq!(
+                            push,
+                            Some(PushInfo {
+                                kind: PushKind::Disconnection,
+                                data: vec![]
+                            })
+                        );
+                    }
+
+                    // recreate cluster
+                    let _cluster = RedisCluster::new(RedisClusterConfiguration {
+                        ports: ports.clone(),
+                        ..Default::default()
+                    });
+
+                    // verify that we didn't get any disconnect notices.
+                    assert_eq!(
+                        rx.try_recv(),
+                        Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+                    );
+
+                    // send request to trigger reconnection.
+                    let cmd = cmd("PING");
+                    let _ = pubsub_conn
+                        .route_command(
+                            &cmd,
+                            RoutingInfo::MultiNode((
+                                MultipleNodeRoutingInfo::AllMasters,
+                                Some(redis::cluster_routing::ResponsePolicy::AllSucceeded),
+                            )),
+                        )
+                        .await?;
+
+                    // verify that we didn't get any subscription notices.
+                    assert_eq!(
+                        rx.try_recv(),
+                        Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+                    );
+
+                    Ok::<_, RedisError>(())
+                },
+                runtime,
+            )
+            .unwrap();
+        }
     }
 
     #[cfg(feature = "tls-rustls")]


### PR DESCRIPTION
This changes the behavior of the cluster connection and the connection manager re: resubscribing on subscription that failed. The connection manager only registers successful subscription and unsubscription - which makes sense. It would be peculiar for the user if a connection that failed subscription would suddenly be subscribed after reconnection to the node.