### PR TITLE
fix: Reject wildcard addresses in client and cluster connections

### DIFF
--- a/redis/src/cluster_topology.rs
+++ b/redis/src/cluster_topology.rs
@@ -46,7 +46,9 @@ pub(crate) fn parse_slots(
                         // However, if the received hostname is "?", it should be regarded as an indication of an unknown node.
                         let hostname = if let Value::BulkString(ref ip) = node[0] {
                             let hostname = String::from_utf8_lossy(ip);
-                            if hostname.is_empty() {
+                            let is_wildcard = hostname == "0.0.0.0" || hostname == "::";
+                            if hostname.is_empty() || is_wildcard {
+                                // Treat wildcard addresses like empty per practicality: use the responding node's hostname
                                 addr_of_answering_node.into()
                             } else if hostname == "?" {
                                 return None;
@@ -117,5 +119,22 @@ mod tests {
 
         let slots = parse_slots(view, None, "node").unwrap();
         assert_eq!(slots[0].master, "node:6379");
+    }
+
+    #[test]
+    fn parse_slots_treats_wildcard_hostnames_as_answering_node() {
+        // Master advertised as 0.0.0.0 should be treated as the answering node's host
+        let view = Value::Array(vec![slot_value_with_replicas(
+            0,
+            100,
+            vec![("0.0.0.0", 7000)],
+        )]);
+        let slots = parse_slots(view, None, "answer.host").unwrap();
+        assert_eq!(slots[0].master, "answer.host:7000");
+
+        // IPv6 wildcard :: similarly falls back to answering node
+        let view_v6 = Value::Array(vec![slot_value_with_replicas(200, 300, vec![("::", 7001)])]);
+        let slots_v6 = parse_slots(view_v6, None, "answer6.host").unwrap();
+        assert_eq!(slots_v6[0].master, "answer6.host:7001");
     }
 }


### PR DESCRIPTION
Rejects wildcard addresses like '0.0.0.0' and '::' in connection URLs to prevent connection timeouts, providing a clearer error message. Additionally, when parsing cluster slots, treat wildcard addresses advertised by nodes as the address of the responding node, improving robustness against misconfigured clusters. Fixes #1492