### PR TITLE
chore(ci/tests): fix test matrix and lints (refs #1727)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,7 +84,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Cache RedisJSON
       id: cache-redisjson
@@ -119,7 +119,7 @@ jobs:
 
     - name: Checkout RedisJSON
       if: steps.cache-redisjson.outputs.cache-hit != 'true' && matrix.config.db-version != '6.2.13'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: "RedisJSON/RedisJSON"
         path: "./__ci/redis-json"
@@ -203,7 +203,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install DB
         uses: ./.github/actions/install-db
@@ -250,7 +250,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain/@master
         with:
           toolchain: stable
@@ -277,7 +277,7 @@ jobs:
       rust_ver: stable
     steps:
       
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Install DB
       uses: ./.github/actions/install-db
@@ -303,12 +303,12 @@ jobs:
         critcmp base changes
 
     # We check out again, because we switched branches in the last step.
-    - uses: actions/checkout@v4        
+    - uses: actions/checkout@v5        
 
   flag-frenzy:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
         - uses: dtolnay/rust-toolchain/@master
           with:
             toolchain: stable
@@ -322,7 +322,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain/@master

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730294c1c08c2e0f85759590518f6333f0d5a0a766a27d519c1b244c3dfd8a24"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
 dependencies = [
  "async-channel 1.9.0",
  "async-global-executor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2625,9 +2625,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2707,9 +2707,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,6 +856,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,13 +1119,24 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.4",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1289,7 +1306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1458,7 +1475,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86ea4e65087ff52f3862caff188d489f1fab49a0cb09e01b2e3f1a617b10aaed"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1947,7 +1964,7 @@ dependencies = [
  "futures-sink",
  "futures-time",
  "futures-util",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.0",
  "itoa",
  "log",
  "lru",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "afl"
-version = "0.15.19"
+version = "0.15.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e868a49dcc54f7edcec970721ba68c4b5cc5f1e478393ae2dd2d475efd752e"
+checksum = "e3d197cb6a514b7dffadc7ccab0d1215bed207bcd7532306fe433678541bc3a9"
 dependencies = [
  "home",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
- "bytes",
  "io-uring",
  "libc",
  "mio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "redis-test"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,9 +2509,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand 2.3.0",
  "getrandom 0.3.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,9 +2361,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "backon"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302eaff5357a264a2c42f127ecb8bac761cf99749fc3dc95677e2743991f99e7"
+checksum = "592277618714fbcecda9a02ba7a8781f319d26532a88553bbacc77ba5d2b3a8d"
 dependencies = [
  "fastrand 2.3.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,9 +82,9 @@ checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "arc-swap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,6 +1313,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags 2.8.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2438,16 +2449,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
@@ -2577,19 +2578,21 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
- "socket2 0.5.9",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cfg_aliases"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "afl"
@@ -35,22 +35,22 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
 ]
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.3.3",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -76,9 +76,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anyhow"
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -129,26 +129,27 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.1"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
+checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
 dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand 2.3.0",
- "futures-lite 2.6.0",
+ "futures-lite 2.6.1",
+ "pin-project-lite",
  "slab",
 ]
 
 [[package]]
 name = "async-fs"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
 dependencies = [
- "async-lock 3.4.0",
+ "async-lock 3.4.1",
  "blocking",
- "futures-lite 2.6.0",
+ "futures-lite 2.6.1",
 ]
 
 [[package]]
@@ -157,12 +158,12 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "async-executor",
- "async-io 2.4.0",
- "async-lock 3.4.0",
+ "async-io 2.6.0",
+ "async-lock 3.4.1",
  "blocking",
- "futures-lite 2.6.0",
+ "futures-lite 2.6.1",
  "once_cell",
 ]
 
@@ -188,21 +189,20 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
- "async-lock 3.4.0",
+ "autocfg",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.6.0",
+ "futures-lite 2.6.1",
  "parking",
- "polling 3.7.4",
- "rustix 0.38.44",
+ "polling 3.11.0",
+ "rustix 1.1.2",
  "slab",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -216,11 +216,11 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -243,46 +243,45 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
 dependencies = [
- "async-io 2.4.0",
+ "async-io 2.6.0",
  "blocking",
- "futures-lite 2.6.0",
+ "futures-lite 2.6.1",
 ]
 
 [[package]]
 name = "async-process"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
- "async-channel 2.3.1",
- "async-io 2.4.0",
- "async-lock 3.4.0",
+ "async-channel 2.5.0",
+ "async-io 2.6.0",
+ "async-lock 3.4.1",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.4.0",
- "futures-lite 2.6.0",
- "rustix 0.38.44",
- "tracing",
+ "event-listener 5.4.1",
+ "futures-lite 2.6.1",
+ "rustix 1.1.2",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb3634b73397aa844481f814fad23bbf07fdb0eabec10f2eb95e58944b1ec32"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
 dependencies = [
- "async-io 2.4.0",
- "async-lock 3.4.0",
+ "async-io 2.6.0",
+ "async-lock 3.4.1",
  "atomic-waker",
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.44",
+ "rustix 1.1.2",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -293,13 +292,13 @@ checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
 dependencies = [
  "async-channel 1.9.0",
  "async-global-executor",
- "async-io 2.4.0",
- "async-lock 3.4.0",
+ "async-io 2.6.0",
+ "async-lock 3.4.1",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
  "futures-io",
- "futures-lite 2.6.0",
+ "futures-lite 2.6.1",
  "gloo-timers",
  "kv-log-macro",
  "log",
@@ -325,15 +324,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b756939cb2f8dc900aa6dcd505e6e2428e9cae7ff7b028c49e3946efa70878"
+checksum = "94b8ff6c09cd57b16da53641caa860168b88c172a5ee163b0288d3d6eea12786"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -341,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.28.2"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa9b6986f250236c27e5a204062434a773a13243d2ffc2955f37bdba4c5c6a1"
+checksum = "0e44d16778acaf6a9ec9899b92cebd65580b83f685446bf2e1f5d3d732f99dcd"
 dependencies = [
  "bindgen",
  "cc",
@@ -363,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -402,16 +401,14 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
- "lazy_static",
- "lazycell",
+ "itertools",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -419,8 +416,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.98",
- "which",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -431,9 +427,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bitvec"
@@ -449,22 +445,22 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "async-task",
  "futures-io",
- "futures-lite 2.6.0",
+ "futures-lite 2.6.1",
  "piper",
 ]
 
 [[package]]
 name = "borsh"
-version = "1.5.5"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5430e3be710b68d984d1391c854eb431a9d548640711faa54eecb1df93db91cc"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -472,22 +468,22 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.5"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b668d39970baad5356d7c83a86fee3a539e6f93bf6764c97368243e17a0487"
+checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytecheck"
@@ -512,12 +508,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,10 +521,11 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -601,18 +592,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.29"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.29"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -620,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cmake"
@@ -668,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -699,7 +690,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools 0.13.0",
+ "itertools",
  "num-traits",
  "oorandom",
  "plotters",
@@ -718,7 +709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
- "itertools 0.13.0",
+ "itertools",
 ]
 
 [[package]]
@@ -748,9 +739,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "displaydoc"
@@ -760,7 +751,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -771,9 +762,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_logger"
@@ -787,18 +778,18 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -809,9 +800,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -820,11 +811,11 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener 5.4.1",
  "pin-project-lite",
 ]
 
@@ -844,6 +835,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,9 +848,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -962,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "futures-lite"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "fastrand 2.3.0",
  "futures-core",
@@ -981,7 +978,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1053,25 +1050,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "r-efi",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1082,9 +1079,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gloo-timers"
@@ -1100,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -1125,7 +1122,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.1.4",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1147,9 +1144,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "home"
@@ -1162,21 +1159,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1186,30 +1184,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -1217,65 +1195,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -1291,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1301,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "92119844f513ffa41556430369ab02c295a3578af21cf945caa3e9e0c2481ac3"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -1335,18 +1300,9 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.4",
  "cfg-if",
  "libc",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -1366,18 +1322,19 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
+ "getrandom 0.3.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1393,38 +1350,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1434,27 +1379,21 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1462,27 +1401,27 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 dependencies = [
  "value-bag",
 ]
 
 [[package]]
 name = "lru"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ea4e65087ff52f3862caff188d489f1fab49a0cb09e01b2e3f1a617b10aaed"
+checksum = "bfe949189f46fabb938b3a9a0be30fdd93fd8a09260da863399a8cf3db756ec8"
 dependencies = [
  "hashbrown 0.15.5",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "minimal-lexical"
@@ -1492,29 +1431,29 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.4"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "native-tls"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -1582,17 +1521,17 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
-version = "11.1.4"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.4",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1609,7 +1548,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1620,9 +1559,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -1638,9 +1577,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1648,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1701,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -1751,52 +1690,60 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.4"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.4.0",
+ "hermit-abi 0.5.2",
  "pin-project-lite",
- "rustix 0.38.44",
- "tracing",
- "windows-sys 0.59.0",
+ "rustix 1.1.2",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.98",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -1834,12 +1781,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r2d2"
@@ -1876,7 +1829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1896,7 +1849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1905,24 +1858,23 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.1",
- "zerocopy 0.8.17",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -1930,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1942,11 +1894,11 @@ dependencies = [
 name = "redis"
 version = "0.32.5"
 dependencies = [
- "ahash 0.8.11",
+ "ahash 0.8.12",
  "anyhow",
  "arc-swap",
  "assert_approx_eq",
- "async-io 2.4.0",
+ "async-io 2.6.0",
  "async-native-tls",
  "async-std",
  "backon",
@@ -2014,18 +1966,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2035,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2046,9 +1998,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "relative-path"
@@ -2067,13 +2019,13 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -2133,15 +2085,15 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.98",
+ "syn 2.0.106",
  "unicode-ident",
 ]
 
 [[package]]
 name = "rust_decimal"
-version = "1.37.2"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b203a6425500a03e0919c42d3c47caca51e79f1132046626d2c8871c5092035d"
+checksum = "c8975fc98059f365204d635119cf9c5a60ae67b841ed49b5422a9a7e56cdfac0"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -2155,15 +2107,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -2190,28 +2142,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04a32fb43fcdef85b977ce7f77a150805e4b2ea1f2656898d4a547dde78df6"
-dependencies = [
- "bitflags 2.8.0",
- "errno",
- "libc",
- "linux-raw-sys 0.9.3",
- "windows-sys 0.59.0",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2239,7 +2178,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.1.0",
+ "security-framework 3.4.0",
 ]
 
 [[package]]
@@ -2253,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2265,9 +2204,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -2286,11 +2225,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2320,7 +2259,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.4",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -2329,12 +2268,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.1.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d3f8c9bfcc3cbb6b0179eb57042d75b1582bdc65c3cb95f3fa999509c03cbc"
+checksum = "60b369d18893388b345804dc0007963c99b7d665ae71d275812d828c6f089640"
 dependencies = [
- "bitflags 2.8.0",
- "core-foundation 0.10.0",
+ "bitflags 2.9.4",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2342,9 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.13.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2352,40 +2291,51 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2402,9 +2352,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -2417,18 +2367,15 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smol"
@@ -2436,15 +2383,15 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "async-executor",
  "async-fs",
- "async-io 2.4.0",
- "async-lock 3.4.0",
+ "async-io 2.6.0",
+ "async-lock 3.4.1",
  "async-net",
  "async-process",
  "blocking",
- "futures-lite 2.6.0",
+ "futures-lite 2.6.1",
 ]
 
 [[package]]
@@ -2453,7 +2400,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7859830574b98cb971aa80d150d8920d28a75df5ed7b0c0d6bd4b50fa0b0cf1f"
 dependencies = [
- "async-io 2.4.0",
+ "async-io 2.6.0",
  "pin-project-lite",
 ]
 
@@ -2502,9 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2513,13 +2460,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2535,10 +2482,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand 2.3.0",
- "getrandom 0.3.1",
+ "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.4",
- "windows-sys 0.59.0",
+ "rustix 1.1.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2558,14 +2505,14 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2583,9 +2530,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2622,7 +2569,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2660,15 +2607,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2676,26 +2623,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing"
-version = "0.1.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
-dependencies = [
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
-
-[[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "untrusted"
@@ -2716,12 +2647,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2729,9 +2654,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2743,9 +2668,9 @@ version = "0.0.2"
 
 [[package]]
 name = "value-bag"
-version = "1.10.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
+checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
 
 [[package]]
 name = "vcpkg"
@@ -2777,50 +2702,60 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
- "wit-bindgen-rt",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2831,9 +2766,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2841,31 +2776,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2878,18 +2813,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
 ]
 
 [[package]]
@@ -2910,11 +2833,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2922,6 +2845,18 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-sys"
@@ -2951,6 +2886,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2974,11 +2927,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -2994,6 +2964,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3004,6 +2980,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3018,10 +3000,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3036,6 +3030,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3046,6 +3046,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3060,6 +3066,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3072,34 +3084,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.2"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.33.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
-dependencies = [
- "bitflags 2.8.0",
-]
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "wyz"
@@ -3118,9 +3127,9 @@ checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -3130,75 +3139,54 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.106",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
-dependencies = [
- "zerocopy-derive 0.8.17",
+ "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -3209,10 +3197,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3221,11 +3220,11 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.106",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2227,15 +2227,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1871,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.0",
@@ -1976,7 +1976,7 @@ dependencies = [
  "pin-project-lite",
  "quickcheck",
  "r2d2",
- "rand 0.9.1",
+ "rand 0.9.2",
  "redis-test",
  "rstest",
  "rust_decimal",
@@ -2005,7 +2005,7 @@ version = "0.12.0"
 dependencies = [
  "bytes",
  "futures",
- "rand 0.9.1",
+ "rand 0.9.2",
  "redis",
  "socket2 0.6.0",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,9 +872,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -1263,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -1644,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -2683,13 +2683,14 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test:
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP without features except safe_iterators"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run --locked -p redis --no-default-features -F safe_iterators -E 'not test(test_module)'
+	@RUSTFLAGS="-D warnings -A deprecated" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run --locked -p redis --no-default-features -F safe_iterators -E 'not test(test_module)'
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP without safe_iterators, but with async"

--- a/redis-test/Cargo.toml
+++ b/redis-test/Cargo.toml
@@ -16,7 +16,7 @@ bench = false
 redis = { version = "0.32", path = "../redis" }
 bytes = { version = "1", optional = true }
 futures = { version = "0.3", optional = true }
-tempfile = "=3.20.0"
+tempfile = "=3.21.0"
 socket2 = "0.6"
 rand = "0.9"
 

--- a/redis-test/Cargo.toml
+++ b/redis-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-test"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Testing helpers for the `redis` crate"
 homepage = "https://github.com/redis-rs/redis-rs"

--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -1,3 +1,14 @@
+### Unreleased
+
+#### Added
+
+* ConnectionManager: initialization configuration supporting CLIENT SETNAME and CLIENT SETINFO; optional user-provided initialization pipeline with safe-by-default behavior (arbitrary commands require explicit opt-in); await_ready() gating to ensure post-connect usage only after init completes; and per-init command timeout configuration.
+
+#### Fixed
+
+* Sync connection: Mark connection as closed on additional OS-level read errors (ConnectionReset, BrokenPipe, NotConnected, ConnectionAborted) in addition to UnexpectedEof. This resolves macOS "Connection reset by peer (os error 54)" causing is_open() to remain true after server shutdown.
+
+
 ### 0.32.5 (2025-08-10)
 
 #### Changes & Bug fixes
@@ -183,9 +194,9 @@
 
 #### Changes & Bug fixes
 
-* feat(cluster): add `get(_async)?_connection_with_config` ([#1487](https://github\.com/redis-rs/redis-rs/pull/1487) by @Totodore) 
-* Fix connection creation timeout. ([#1490](https://github\.com/redis-rs/redis-rs/pull/1490)) 
-* Fix RetryMethod Import ([#1494](https://github\.com/redis-rs/redis-rs/pull/1494) by @Braedon-Wooding-Displayr) 
+* feat(cluster): add `get(_async)?_connection_with_config` ([#1487](https://github\.com/redis-rs/redis-rs/pull/1487) by @Totodore)
+* Fix connection creation timeout. ([#1490](https://github\.com/redis-rs/redis-rs/pull/1490))
+* Fix RetryMethod Import ([#1494](https://github\.com/redis-rs/redis-rs/pull/1494) by @Braedon-Wooding-Displayr)
 
 ### 0.28.1 (2025-01-11)
 
@@ -522,7 +533,7 @@ have been pushed to 0.24.0.
 ### 0.23.3 (2023-09-01)
 
 Note that this release fixes a small regression in async Redis Cluster handling of the `PING` command.
-Based on updated response aggregation logic in [#888](https://github.com/redis-rs/redis-rs/pull/888), it 
+Based on updated response aggregation logic in [#888](https://github.com/redis-rs/redis-rs/pull/888), it
 will again return a single response instead of an array.
 
 #### Features
@@ -597,9 +608,9 @@ sought feature. Thanks to @rharish101 and @LeoRowan for getting this in!
 This release adds the `cluster_async` module, which introduces async Redis Cluster support. The code therein
 is largely taken from @Marwes's [redis-cluster-async crate](https://github.com/redis-rs/redis-cluster-async), which itself
 appears to have started from a sync Redis Cluster implementation started by @atuk721. In any case, thanks to @Marwes and @atuk721
-for the great work, and we hope to keep development moving forward in `redis-rs`. 
+for the great work, and we hope to keep development moving forward in `redis-rs`.
 
-Though async Redis Cluster functionality for the time being has been kept as close to the originating crate as possible, previous users of 
+Though async Redis Cluster functionality for the time being has been kept as close to the originating crate as possible, previous users of
 `redis-cluster-async` should note the following changes:
 * Retries, while still configurable, can no longer be set to `None`/infinite retries
 * Routing and slot parsing logic has been removed and merged with existing `redis-rs` functionality
@@ -647,7 +658,7 @@ This release adds various incremental improvements and fixes a few long-standing
 contributors for making this release happen.
 
 #### Features
-*   Implement ToRedisArgs for HashMap ([#722](https://github.com/redis-rs/redis-rs/pull/722) @gibranamparan) 
+*   Implement ToRedisArgs for HashMap ([#722](https://github.com/redis-rs/redis-rs/pull/722) @gibranamparan)
 *   Add explicit `MGET` command ([#729](https://github.com/redis-rs/redis-rs/pull/729) @vamshiaruru-virgodesigns)
 
 #### Bug fixes
@@ -658,8 +669,8 @@ contributors for making this release happen.
 
 #### Changes
 *   Add test case for atomic pipeline ([#702](https://github.com/redis-rs/redis-rs/pull/702) @CNLHC)
-*   Capture subscribe result error in PubSub doc example ([#739](https://github.com/redis-rs/redis-rs/pull/739) @baoyachi) 
-*   Use async-std name resolution when necessary ([#701](https://github.com/redis-rs/redis-rs/pull/701) @UgnilJoZ) 
+*   Capture subscribe result error in PubSub doc example ([#739](https://github.com/redis-rs/redis-rs/pull/739) @baoyachi)
+*   Use async-std name resolution when necessary ([#701](https://github.com/redis-rs/redis-rs/pull/701) @UgnilJoZ)
 *   Add Script::invoke_async method ([#711](https://github.com/redis-rs/redis-rs/pull/711) @r-bk)
 *   Cluster Refactorings ([#717](https://github.com/redis-rs/redis-rs/pull/717), [#716](https://github.com/redis-rs/redis-rs/pull/716), [#709](https://github.com/redis-rs/redis-rs/pull/709), [#707](https://github.com/redis-rs/redis-rs/pull/707), [#706](https://github.com/redis-rs/redis-rs/pull/706) @0xWOF, @utkarshgupta137)
 *   Fix intermittent test failure ([#714](https://github.com/redis-rs/redis-rs/pull/714) @0xWOF, @utkarshgupta137)
@@ -681,10 +692,10 @@ This release adds various incremental improvements, including
 additional convenience commands, improved Cluster APIs, and various other bug
 fixes/library improvements.
 
-Although the changes here are incremental, this is a major release due to the 
+Although the changes here are incremental, this is a major release due to the
 breaking changes listed below.
 
-This release would not be possible without our many wonderful 
+This release would not be possible without our many wonderful
 contributors -- thank you!
 
 #### Breaking changes

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -106,7 +106,7 @@ ahash = { version = "0.8.11", optional = true }
 log = { version = "0.4", optional = true }
 
 # Optional uuid support
-uuid = { version = "1.17.0", optional = true }
+uuid = { version = "1.18.0", optional = true }
 
 # Optional hashbrown support
 hashbrown = { version = "0.15", optional = true }

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -26,7 +26,7 @@ ryu = "1.0"
 itoa = "1.0"
 
 # This is a dependency that already exists in url
-percent-encoding = "2.1"
+percent-encoding = "2.3"
 
 # We need this for redis url parsing
 url = "2.5"

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -10,6 +10,7 @@ license = "BSD-3-Clause"
 edition = "2021"
 rust-version = "1.80"
 readme = "../README.md"
+autoexamples = false
 
 [package.metadata.docs.rs]
 all-features = true
@@ -248,43 +249,4 @@ required-features = ["cluster-async", "tokio-comp"]
 [[bench]]
 name = "bench_cache"
 harness = false
-required-features = ["tokio-comp", "cache-aio"]
-
-[[example]]
-name = "async-multiplexed"
-required-features = ["tokio-comp"]
-
-[[example]]
-name = "async-await"
-required-features = ["aio"]
-
-[[example]]
-name = "async-resp2-pub-sub"
-required-features = ["aio"]
-
-[[example]]
-name = "async-resp3-pub-sub"
-required-features = ["aio", "connection-manager"]
-
-[[example]]
-name = "async-scan"
-required-features = ["aio"]
-
-[[example]]
-name = "async-connection-loss"
-required-features = ["connection-manager"]
-
-[[example]]
-name = "streams"
-required-features = ["streams"]
-
-[[example]]
-name = "async-typed"
-required-features = ["aio"]
-
-[[example]]
-name = "typed"
-
-[[example]]
-name = "async-caching"
 required-features = ["tokio-comp", "cache-aio"]

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -175,7 +175,6 @@ aio = [
   "dep:pin-project-lite",
   "dep:futures-util",
   "dep:tokio",
-  "tokio/io-util",
   "dep:tokio-util",
   "tokio-util/codec",
   "combine/tokio",

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -109,7 +109,7 @@ log = { version = "0.4", optional = true }
 uuid = { version = "1.18.0", optional = true }
 
 # Optional hashbrown support
-hashbrown = { version = "0.15", optional = true }
+hashbrown = { version = "0.16", optional = true }
 
 lru = { version = "0.16", optional = true }
 

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -56,7 +56,7 @@ socket2 = { version = "0.6", features = ["all"] }
 # Only needed for the connection manager
 arc-swap = { version = "1.7.1", optional = true }
 futures-channel = { version = "0.3.31", optional = true }
-backon = { version = "1.5.1", optional = true, default-features = false }
+backon = { version = "1.5.2", optional = true, default-features = false }
 
 # Only needed for the r2d2 feature
 r2d2 = { version = "0.8.10", optional = true }

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -72,7 +72,7 @@ rand = { version = "0.9", optional = true }
 futures-sink = { version = "0.3.31", optional = true }
 
 # Only needed for async_std support
-async-std = { version = "1.13.1", optional = true }
+async-std = { version = "1.13.2", optional = true }
 
 #only needed for smol support
 smol = { version = "2", optional = true }

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -93,7 +93,7 @@ futures-rustls = { version = "0.26", optional = true, default-features = false }
 
 # Needed for modules Support
 serde = { version = "1.0.219", optional = true }
-serde_json = { version = "1.0.142", optional = true }
+serde_json = { version = "1.0.143", optional = true }
 
 # Only needed for bignum Support
 rust_decimal = { version = "1.37.2", optional = true }

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -197,7 +197,7 @@ tokio = { version = "1", features = [
   "test-util",
   "time",
 ] }
-tempfile = "=3.20.0"
+tempfile = "=3.21.0"
 once_cell = "1"
 anyhow = "1"
 redis-test = { path = "../redis-test" }

--- a/redis/docs/SECURITY.md
+++ b/redis/docs/SECURITY.md
@@ -1,0 +1,241 @@
+# Redis-rs Security Guide
+
+## ConnectionManager Security Configuration
+
+The `ConnectionManager` provides several security features to protect against common vulnerabilities and attacks during connection initialization.
+
+### Security Configuration
+
+```rust
+use redis::aio::{ConnectionManagerConfig, SecurityConfig};
+
+let security_config = SecurityConfig::new()
+    .set_max_client_name_size(32768)  // 32KB limit instead of default 64KB
+    .set_validate_utf8(true)          // Enable UTF-8 validation
+    .set_init_timeout(Duration::from_secs(10))  // Shorter timeout
+    .set_enable_resource_monitoring(true);
+
+let config = ConnectionManagerConfig::new()
+    .set_security_config(security_config);
+
+let manager = client.get_connection_manager_with_config(config).await?;
+```
+
+## Security Features
+
+### 1. Client Name Size Limits
+
+**Risk**: Large client names can cause memory exhaustion or DoS attacks.
+
+**Mitigation**: Configure maximum client name size (default: 64KB).
+
+```rust
+let security_config = SecurityConfig::new()
+    .set_max_client_name_size(1024); // 1KB limit
+```
+
+### 2. UTF-8 Validation
+
+**Risk**: Invalid UTF-8 in client names can cause encoding issues in monitoring tools.
+
+**Mitigation**: Enable UTF-8 validation for client names.
+
+```rust
+let security_config = SecurityConfig::new()
+    .set_validate_utf8(true);
+```
+
+### 3. Initialization Timeouts
+
+**Risk**: Hanging initialization commands can cause resource exhaustion.
+
+**Mitigation**: Set reasonable timeouts for initialization pipeline.
+
+```rust
+let security_config = SecurityConfig::new()
+    .set_init_timeout(Duration::from_secs(10));
+```
+
+### 4. Resource Monitoring
+
+**Risk**: Memory leaks or resource exhaustion during initialization.
+
+**Mitigation**: Enable resource monitoring with custom callbacks.
+
+```rust
+struct MyResourceMonitor;
+
+impl ResourceMonitor for MyResourceMonitor {
+    fn on_init_start(&self, client_info: &str) {
+        log::info!("Starting initialization for: {}", client_info);
+    }
+    
+    fn on_command_executed(&self, command: &str, duration: Duration, memory_delta: Option<i64>) {
+        log::debug!("Command {} took {:?}, memory delta: {:?}", command, duration, memory_delta);
+    }
+    
+    fn on_init_complete(&self, total_duration: Duration, final_memory: Option<u64>) {
+        log::info!("Initialization completed in {:?}, final memory: {:?}", total_duration, final_memory);
+    }
+    
+    fn on_init_failed(&self, error: &InitializationError, total_duration: Duration) {
+        log::error!("Initialization failed after {:?}: {}", total_duration, error);
+    }
+}
+
+let security_config = SecurityConfig::new()
+    .set_resource_monitor(MyResourceMonitor);
+```
+
+## Redis CONFIG Command Security
+
+### ⚠️ Critical Security Warning
+
+The Redis `CONFIG` command can modify server configuration at runtime, including security settings. **Never allow untrusted clients to execute CONFIG commands.**
+
+### Dangerous CONFIG Commands
+
+```rust
+// DANGEROUS - Can disable authentication
+redis::cmd("CONFIG").arg("SET").arg("requirepass").arg("").exec(&mut conn)?;
+
+// DANGEROUS - Can change memory limits
+redis::cmd("CONFIG").arg("SET").arg("maxmemory").arg("0").exec(&mut conn)?;
+
+// DANGEROUS - Can disable persistence
+redis::cmd("CONFIG").arg("SET").arg("save").arg("").exec(&mut conn)?;
+```
+
+### Best Practices
+
+1. **Restrict CONFIG access**: Use Redis ACLs to prevent CONFIG command access:
+   ```
+   ACL SETUSER myapp -config +@all
+   ```
+
+2. **Use configuration files**: Set critical settings in `redis.conf` instead of runtime CONFIG:
+   ```
+   requirepass mypassword
+   maxmemory 100mb
+   save 900 1
+   ```
+
+3. **Monitor CONFIG usage**: Log all CONFIG commands for security auditing.
+
+4. **Validate configuration**: Always validate configuration changes before applying.
+
+### Safe CONFIG Usage
+
+If you must use CONFIG commands, validate inputs and use allowlists:
+
+```rust
+fn safe_config_set(conn: &mut Connection, key: &str, value: &str) -> RedisResult<()> {
+    // Allowlist of safe configuration keys
+    const SAFE_KEYS: &[&str] = &[
+        "timeout",
+        "tcp-keepalive", 
+        "slowlog-log-slower-than",
+        "slowlog-max-len"
+    ];
+    
+    if !SAFE_KEYS.contains(&key) {
+        return Err(RedisError::from((
+            ErrorKind::ClientError,
+            format!("Configuration key '{}' is not allowed", key)
+        )));
+    }
+    
+    redis::cmd("CONFIG").arg("SET").arg(key).arg(value).exec(conn)
+}
+```
+
+## Error Handling Security
+
+### Enhanced Error Handling
+
+The ConnectionManager provides enhanced error handling for initialization failures:
+
+```rust
+use redis::aio::InitializationError;
+
+match manager.send_packed_command(&cmd).await {
+    Ok(result) => result,
+    Err(e) => {
+        if let Some(init_error) = e.downcast_ref::<InitializationError>() {
+            if init_error.is_recoverable {
+                // Retry logic for recoverable errors
+                log::warn!("Recoverable initialization error: {}", init_error);
+            } else {
+                // Fail fast for non-recoverable errors
+                log::error!("Non-recoverable initialization error: {}", init_error);
+                return Err(e);
+            }
+        }
+        Err(e)
+    }
+}
+```
+
+## Protocol Security
+
+### RESP Protocol Validation
+
+Redis-rs automatically handles malformed RESP protocol, but be aware of these security considerations:
+
+1. **Large payloads**: Redis may accept very large command arguments. Use size limits.
+2. **Protocol errors**: Malformed RESP is handled gracefully by Redis server.
+3. **Connection drops**: Network interruptions are handled with automatic reconnection.
+
+### Memory Safety
+
+Redis server is memory-safe regarding protocol handling:
+- Invalid UTF-8 sequences are accepted as binary data
+- Large commands are processed but may hit memory limits
+- Protocol violations return clear error messages
+
+## Deployment Security Checklist
+
+- [ ] Set `requirepass` in Redis configuration
+- [ ] Configure Redis ACLs for fine-grained access control
+- [ ] Use TLS for network connections (`rediss://` URLs)
+- [ ] Set appropriate `maxmemory` limits
+- [ ] Disable dangerous commands: `CONFIG`, `FLUSHALL`, `SHUTDOWN`
+- [ ] Configure connection limits with `maxclients`
+- [ ] Enable Redis logging for security monitoring
+- [ ] Use ConnectionManager security configuration
+- [ ] Implement resource monitoring
+- [ ] Set appropriate timeouts
+- [ ] Validate all user inputs before Redis commands
+
+## Example Secure Configuration
+
+```rust
+use redis::aio::{ConnectionManagerConfig, SecurityConfig, ResourceMonitor};
+use std::time::Duration;
+
+// Security configuration
+let security_config = SecurityConfig::new()
+    .set_max_client_name_size(1024)           // 1KB limit
+    .set_validate_utf8(true)                  // Validate UTF-8
+    .set_init_timeout(Duration::from_secs(5)) // 5 second timeout
+    .set_resource_monitor(MyResourceMonitor); // Custom monitoring
+
+// Connection configuration
+let config = ConnectionManagerConfig::new()
+    .set_response_timeout(Duration::from_secs(30))
+    .set_connection_timeout(Duration::from_secs(10))
+    .set_number_of_retries(3)
+    .set_security_config(security_config);
+
+// Secure connection with authentication
+let client = Client::open("rediss://:password@secure-redis:6380/")?;
+let manager = client.get_connection_manager_with_config(config).await?;
+```
+
+This configuration provides:
+- Encrypted connections (TLS)
+- Authentication
+- Size limits and validation
+- Reasonable timeouts
+- Resource monitoring
+- Limited retry attempts

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -11,7 +11,7 @@ use crate::{
 use arc_swap::ArcSwap;
 use backon::{ExponentialBuilder, Retryable};
 use futures_channel::oneshot;
-use futures_util::future::{self, BoxFuture, FutureExt, Shared};
+use futures_util::future::{BoxFuture, FutureExt, Shared};
 use std::sync::{Arc, Weak};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 use tokio::sync::Mutex;
@@ -43,6 +43,66 @@ pub struct ConnectionManagerConfig {
     tcp_settings: crate::io::tcp::TcpSettings,
     #[cfg(feature = "cache-aio")]
     pub(crate) cache_config: Option<crate::caching::CacheConfig>,
+    /// Security configuration for the connection manager
+    security_config: SecurityConfig,
+    /// Optional client name to set on (re)connect
+    client_name: Option<String>,
+    /// Optional CLIENT SETINFO key/value pairs
+    client_setinfo_pairs: Option<Vec<(String, String)>>,
+    /// Optional user-provided initialization pipeline
+    user_init_pipeline: Option<Pipeline>,
+    /// Whether to allow arbitrary init commands (dangerous). Default: false
+    allow_arbitrary_init_commands: bool,
+}
+
+/// Security configuration for ConnectionManager initialization
+#[derive(Clone)]
+pub struct SecurityConfig {
+    /// Maximum size for client names in bytes (default: 64KB)
+    max_client_name_size: usize,
+    /// Whether to restrict client names to ASCII-only (default: false)
+    validate_ascii: bool,
+    /// Timeout for initialization pipeline commands (default: 30 seconds)
+    init_timeout: std::time::Duration,
+    /// Whether to enable resource monitoring hooks (default: false)
+    enable_resource_monitoring: bool,
+    /// Resource monitoring callback
+    resource_monitor: Option<Arc<dyn ResourceMonitor>>,
+}
+
+/// Trait for monitoring resource usage during connection initialization
+pub trait ResourceMonitor: Send + Sync {
+    /// Called when connection initialization starts
+    fn on_init_start(&self, client_info: &str);
+
+    /// Called when a command is executed during initialization
+    fn on_command_executed(
+        &self,
+        command: &str,
+        duration: std::time::Duration,
+        memory_delta: Option<i64>,
+    );
+
+    /// Called when initialization completes successfully
+    fn on_init_complete(&self, total_duration: std::time::Duration, final_memory: Option<u64>);
+
+    /// Called when initialization fails
+    fn on_init_failed(&self, error: &InitializationError, total_duration: std::time::Duration);
+}
+
+/// Resource usage statistics
+#[derive(Debug, Clone)]
+pub struct ResourceStats {
+    /// Approximate memory usage observed during initialization (bytes), if available
+    pub memory_usage: Option<u64>,
+    /// Number of connections observed during initialization, if available
+    pub connection_count: Option<u32>,
+    /// CPU time spent during initialization, if available
+    pub cpu_time: Option<std::time::Duration>,
+    /// Total network bytes sent during initialization, if available
+    pub network_bytes_sent: Option<u64>,
+    /// Total network bytes received during initialization, if available
+    pub network_bytes_received: Option<u64>,
 }
 
 impl std::fmt::Debug for ConnectionManagerConfig {
@@ -59,6 +119,8 @@ impl std::fmt::Debug for ConnectionManagerConfig {
             tcp_settings,
             #[cfg(feature = "cache-aio")]
             cache_config,
+            security_config: _,
+            ..
         } = &self;
         let mut str = f.debug_struct("ConnectionManagerConfig");
         str.field("exponent_base", &exponent_base)
@@ -85,6 +147,61 @@ impl std::fmt::Debug for ConnectionManagerConfig {
     }
 }
 
+impl SecurityConfig {
+    const DEFAULT_MAX_CLIENT_NAME_SIZE: usize = 65536; // 64KB
+    const DEFAULT_VALIDATE_ASCII: bool = false;
+    const DEFAULT_INIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+    const DEFAULT_ENABLE_RESOURCE_MONITORING: bool = false;
+
+    /// Creates a new SecurityConfig with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set maximum client name size in bytes
+    pub fn set_max_client_name_size(mut self, size: usize) -> Self {
+        self.max_client_name_size = size;
+        self
+    }
+
+    /// Restrict client names to ASCII-only
+    pub fn set_validate_ascii(mut self, validate: bool) -> Self {
+        self.validate_ascii = validate;
+        self
+    }
+
+    /// Set timeout for initialization pipeline commands
+    pub fn set_init_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.init_timeout = timeout;
+        self
+    }
+
+    /// Enable resource monitoring hooks
+    pub fn set_enable_resource_monitoring(mut self, enable: bool) -> Self {
+        self.enable_resource_monitoring = enable;
+        self
+    }
+
+    /// Set resource monitoring callback
+    pub fn set_resource_monitor(mut self, monitor: impl ResourceMonitor + 'static) -> Self {
+        self.resource_monitor = Some(Arc::new(monitor));
+        self.enable_resource_monitoring = true;
+        self
+    }
+}
+
+impl Default for SecurityConfig {
+    fn default() -> Self {
+        Self {
+            max_client_name_size: Self::DEFAULT_MAX_CLIENT_NAME_SIZE,
+            validate_ascii: Self::DEFAULT_VALIDATE_ASCII,
+            init_timeout: Self::DEFAULT_INIT_TIMEOUT,
+            enable_resource_monitoring: Self::DEFAULT_ENABLE_RESOURCE_MONITORING,
+            resource_monitor: None,
+        }
+    }
+}
+
 impl ConnectionManagerConfig {
     const DEFAULT_CONNECTION_RETRY_EXPONENT_BASE: u64 = 2;
     const DEFAULT_CONNECTION_RETRY_FACTOR: u64 = 100;
@@ -97,9 +214,10 @@ impl ConnectionManagerConfig {
         Self::default()
     }
 
-    /// A multiplicative factor that will be applied to the retry delay.
+    /// A multiplicative scale applied to the exponential backoff delay (milliseconds).
     ///
-    /// For example, using a factor of `1000` will make each delay in units of seconds.
+    /// For example, with `exponent_base = 2` and `factor = 1000`, backoff delays are approximately
+    /// 1000ms, 2000ms, 4000ms (with jitter).
     pub fn set_factor(mut self, factor: u64) -> ConnectionManagerConfig {
         self.factor = factor;
         self
@@ -194,6 +312,38 @@ impl ConnectionManagerConfig {
             ..self
         }
     }
+
+    /// Set security configuration
+    pub fn set_security_config(mut self, security_config: SecurityConfig) -> Self {
+        self.security_config = security_config;
+        self
+    }
+
+    /// Sets a client name to be applied via CLIENT SETNAME during (re)initialization.
+    pub fn set_client_name(mut self, name: String) -> Self {
+        // Validate length and UTF-8 if configured
+        let _ = validate_client_name(&name, &self.security_config);
+        self.client_name = Some(name);
+        self
+    }
+
+    /// Sets key/value pairs to be applied via CLIENT SETINFO during (re)initialization.
+    pub fn set_client_setinfo(mut self, setinfo_pairs: Vec<(String, String)>) -> Self {
+        self.client_setinfo_pairs = Some(setinfo_pairs);
+        self
+    }
+
+    /// Sets a custom initialization pipeline.
+    pub fn set_init_pipeline(mut self, pipeline: Pipeline) -> Self {
+        self.user_init_pipeline = Some(pipeline);
+        self
+    }
+
+    /// Enables arbitrary initialization commands (dangerous). Use with caution.
+    pub fn enable_arbitrary_init_commands(mut self) -> Self {
+        self.allow_arbitrary_init_commands = true;
+        self
+    }
 }
 
 impl Default for ConnectionManagerConfig {
@@ -210,9 +360,114 @@ impl Default for ConnectionManagerConfig {
             tcp_settings: Default::default(),
             #[cfg(feature = "cache-aio")]
             cache_config: None,
+            security_config: SecurityConfig::default(),
+            client_name: None,
+            client_setinfo_pairs: None,
+            user_init_pipeline: None,
+            allow_arbitrary_init_commands: false,
         }
     }
 }
+
+/// Validates a client name according to security configuration
+fn validate_client_name(name: &str, config: &SecurityConfig) -> RedisResult<()> {
+    // Check size limit
+    if name.len() > config.max_client_name_size {
+        return Err(crate::RedisError::from((
+            crate::ErrorKind::ClientError,
+            "Client name too large",
+            format!(
+                "{} bytes exceeds limit of {} bytes",
+                name.len(),
+                config.max_client_name_size
+            ),
+        )));
+    }
+
+    // Check ASCII-only constraint if enabled
+    if config.validate_ascii && !name.is_ascii() {
+        return Err(crate::RedisError::from((
+            crate::ErrorKind::ClientError,
+            "Client name contains invalid UTF-8 sequences",
+        )));
+    }
+
+    Ok(())
+}
+
+/// Enhanced error handling for initialization pipeline commands
+#[derive(Debug, Clone)]
+pub struct InitializationError {
+    /// The command (or logical step) that failed during initialization
+    pub command: String,
+    /// The underlying error, wrapped so the result can be cloned
+    pub error: Arc<RedisError>,
+    /// How many retries were attempted before surfacing the error
+    pub retry_count: usize,
+    /// Whether the error is considered recoverable by reconnect/retry logic
+    pub is_recoverable: bool,
+}
+
+impl InitializationError {
+    fn new(command: String, error: RedisError, retry_count: usize) -> Self {
+        let is_recoverable = Self::is_error_recoverable(&error);
+        Self {
+            command,
+            error: Arc::new(error),
+            retry_count,
+            is_recoverable,
+        }
+    }
+
+    fn is_error_recoverable(error: &RedisError) -> bool {
+        match error.kind() {
+            crate::ErrorKind::IoError => true,
+            crate::ErrorKind::ResponseError => {
+                // Some response errors are recoverable (timeouts, temporary failures)
+                let error_str = error.to_string().to_lowercase();
+                error_str.contains("timeout")
+                    || error_str.contains("loading")
+                    || error_str.contains("busy")
+            }
+            crate::ErrorKind::AuthenticationFailed => false,
+            crate::ErrorKind::TypeError => false,
+            crate::ErrorKind::ExecAbortError => false,
+            crate::ErrorKind::BusyLoadingError => true,
+            crate::ErrorKind::NoScriptError => false,
+            crate::ErrorKind::InvalidClientConfig => false,
+            crate::ErrorKind::Moved => true,
+            crate::ErrorKind::Ask => true,
+            crate::ErrorKind::TryAgain => true,
+            crate::ErrorKind::ClusterDown => true,
+            crate::ErrorKind::CrossSlot => false,
+            crate::ErrorKind::MasterDown => true,
+            crate::ErrorKind::ReadOnly => false,
+            crate::ErrorKind::ClientError => false,
+            _ => false,
+        }
+    }
+}
+
+impl std::fmt::Display for InitializationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Initialization command '{}' failed after {} retries: {}",
+            self.command, self.retry_count, self.error
+        )
+    }
+}
+
+impl std::error::Error for InitializationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.error.as_ref())
+    }
+}
+
+// Readiness tracking types
+type ReadyResult = CloneableRedisResult<()>;
+type ReadySender = tokio::sync::watch::Sender<ReadyResult>;
+type ReadyReceiver = tokio::sync::watch::Receiver<ReadyResult>;
 
 struct Internals {
     /// Information used for the connection. This is needed to be able to reconnect.
@@ -226,10 +481,16 @@ struct Internals {
     runtime: Runtime,
     retry_strategy: ExponentialBuilder,
     connection_config: AsyncConnectionConfig,
+    /// Configured initialization pipeline (built from config)
+    init_pipeline: Option<Pipeline>,
     subscription_tracker: Option<Mutex<SubscriptionTracker>>,
     #[cfg(feature = "cache-aio")]
     cache_manager: Option<CacheManager>,
     _task_handle: HandleContainer,
+    security_config: SecurityConfig,
+    /// Readiness watch channel
+    ready_tx: ReadySender,
+    ready_rx: ReadyReceiver,
 }
 
 /// A `ConnectionManager` is a proxy that wraps a [multiplexed
@@ -294,6 +555,30 @@ macro_rules! reconnect_if_io_error {
 }
 
 impl ConnectionManager {
+    /// Wait until the connection is fully initialized (post-connect init completed)
+    pub async fn await_ready(&self) -> RedisResult<()> {
+        let mut rx = self.0.ready_rx.clone();
+        loop {
+            // Take a snapshot without holding the borrow across await
+            let snapshot = { rx.borrow().clone() };
+            match snapshot {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    if e.kind() == crate::ErrorKind::ClientError {
+                        if rx.changed().await.is_err() {
+                            return Err(
+                                (crate::ErrorKind::IoError, "readiness channel closed").into()
+                            );
+                        }
+                        continue;
+                    } else {
+                        return Err((*e).clone_mostly("await_ready"));
+                    }
+                }
+            }
+        }
+    }
+
     /// Connect to the server and store the connection inside the returned `ConnectionManager`.
     ///
     /// This requires the `connection-manager` feature, which will also pull in
@@ -356,6 +641,50 @@ impl ConnectionManager {
         Self::new_with_config(client, config).await
     }
 
+    /// Build initialization pipeline based on configuration (safe by default)
+    fn build_config_init_pipeline(config: &ConnectionManagerConfig) -> Option<Pipeline> {
+        let mut pipeline = Pipeline::new();
+        let mut has_any = false;
+
+        // CLIENT SETNAME (validated earlier in setter, but validate again defensively)
+        if let Some(name) = &config.client_name {
+            if validate_client_name(name, &config.security_config).is_ok() {
+                pipeline.cmd("CLIENT").arg("SETNAME").arg(name);
+                has_any = true;
+            }
+        }
+
+        // CLIENT SETINFO key/value pairs
+        if let Some(pairs) = &config.client_setinfo_pairs {
+            if !pairs.is_empty() {
+                let mut cmd = cmd("CLIENT");
+                cmd.arg("SETINFO");
+                for (k, v) in pairs.iter() {
+                    cmd.arg(k).arg(v);
+                }
+                pipeline.add_command(cmd);
+                has_any = true;
+            }
+        }
+
+        // User-provided pipeline only if arbitrary init is enabled
+        if config.allow_arbitrary_init_commands {
+            if let Some(user) = &config.user_init_pipeline {
+                // Append user commands as-is
+                for c in user.cmd_iter() {
+                    pipeline.add_command(c.clone());
+                    has_any = true;
+                }
+            }
+        }
+
+        if has_any {
+            Some(pipeline)
+        } else {
+            None
+        }
+    }
+
     /// Connect to the server and store the connection inside the returned `ConnectionManager`.
     ///
     /// This requires the `connection-manager` feature, which will also pull in
@@ -396,7 +725,7 @@ impl ConnectionManager {
         if let Some(response_timeout) = config.response_timeout {
             connection_config = connection_config.set_response_timeout(response_timeout);
         }
-        connection_config = connection_config.set_tcp_settings(config.tcp_settings);
+        connection_config = connection_config.set_tcp_settings(config.tcp_settings.clone());
         #[cfg(feature = "cache-aio")]
         let cache_manager = config
             .cache_config
@@ -412,6 +741,11 @@ impl ConnectionManager {
             runtime.spawn(Self::check_for_disconnect_pushes(oneshot_receiver)),
         );
 
+        // Early security validation (e.g., client name)
+        if let Some(ref name) = config.client_name {
+            validate_client_name(name, &config.security_config)?;
+        }
+
         let mut components_for_reconnection_on_push = None;
         if let Some(push_sender) = config.push_sender.clone() {
             check_resp3!(
@@ -425,6 +759,8 @@ impl ConnectionManager {
             connection_config =
                 connection_config.set_push_sender_internal(Arc::new(internal_sender));
         } else if client.connection_info.redis.protocol != ProtocolVersion::RESP2 {
+            // await_ready will be defined later in impl block, not inside this function body.
+
             let (internal_sender, internal_receiver) = unbounded_channel();
             components_for_reconnection_on_push = Some((internal_receiver, None));
 
@@ -432,25 +768,55 @@ impl ConnectionManager {
                 connection_config.set_push_sender_internal(Arc::new(internal_sender));
         }
 
-        let connection =
-            Self::new_connection(&client, retry_strategy, &connection_config, None).await?;
+        // Build initial initialization pipeline from config (no resubscriptions on first connect)
+        let initial_init = Self::build_config_init_pipeline(&config);
+        let connection = Self::new_connection(
+            &client,
+            retry_strategy,
+            &connection_config,
+            initial_init,
+            &config.security_config,
+        )
+        .await?;
+        // Provide await_ready on the manager
+        // Note: method implemented below in the impl block
+
         let subscription_tracker = if config.resubscribe_automatically {
             Some(Mutex::new(SubscriptionTracker::default()))
         } else {
             None
         };
 
+        // Initialize readiness channel: start as not ready
+        let (ready_tx, ready_rx) = tokio::sync::watch::channel::<ReadyResult>(Err(Arc::new(
+            (crate::ErrorKind::ClientError, "not ready").into(),
+        )));
+
+        // Built init pipeline from config
+        let cfg_init = Self::build_config_init_pipeline(&config);
+
+        // Create initial ready shared future in the required CloneableRedisResult form
+        let initial_future: SharedRedisFuture<MultiplexedConnection> =
+            futures_util::future::ready(Ok(connection)).boxed().shared();
+
         let new_self = Self(Arc::new(Internals {
             client,
-            connection: ArcSwap::from_pointee(future::ok(connection).boxed().shared()),
+            connection: ArcSwap::from_pointee(initial_future),
             runtime,
             retry_strategy,
             connection_config,
+            init_pipeline: cfg_init,
             subscription_tracker,
             #[cfg(feature = "cache-aio")]
             cache_manager,
             _task_handle,
+            security_config: config.security_config,
+            ready_tx,
+            ready_rx,
         }));
+
+        // Mark as ready if there is no init pipeline; otherwise set OK (already executed in new_connection)
+        let _ = new_self.0.ready_tx.send(Ok(()));
 
         if let Some((internal_receiver, external_sender)) = components_for_reconnection_on_push {
             oneshot_sender
@@ -475,6 +841,7 @@ impl ConnectionManager {
         exponential_backoff: ExponentialBuilder,
         connection_config: &AsyncConnectionConfig,
         additional_commands: Option<Pipeline>,
+        security_config: &SecurityConfig,
     ) -> RedisResult<MultiplexedConnection> {
         let connection_config = connection_config.clone();
         let get_conn = || async {
@@ -486,11 +853,57 @@ impl ConnectionManager {
             .retry(exponential_backoff)
             .sleep(|duration| async move { Runtime::locate().sleep(duration).await })
             .await?;
+
         if let Some(pipeline) = additional_commands {
-            // TODO - should we ignore these failures?
-            let _ = pipeline.exec_async(&mut conn).await;
+            // Execute initialization pipeline with timeout and enhanced error handling
+            Self::execute_init_pipeline(&mut conn, pipeline, security_config).await?;
         }
         Ok(conn)
+    }
+
+    /// Execute initialization pipeline with proper timeout and error handling
+    async fn execute_init_pipeline(
+        conn: &mut MultiplexedConnection,
+        pipeline: Pipeline,
+        security_config: &SecurityConfig,
+    ) -> RedisResult<()> {
+        let start_time = std::time::Instant::now();
+
+        // Use runtime timeout helper for portability across runtimes
+        let runtime = Runtime::locate();
+        let result = runtime
+            .timeout(security_config.init_timeout, pipeline.exec_async(conn))
+            .await
+            .map_err(crate::RedisError::from);
+
+        let duration = start_time.elapsed();
+
+        // Handle the result with enhanced error reporting
+        match result {
+            Ok(_values) => {
+                if let Some(monitor) = &security_config.resource_monitor {
+                    monitor.on_init_complete(duration, None);
+                }
+                Ok(())
+            }
+            Err(e) => {
+                let init_error = InitializationError::new(
+                    "initialization_pipeline".to_string(),
+                    e,
+                    0, // retry count handled at higher level
+                );
+
+                if let Some(monitor) = &security_config.resource_monitor {
+                    monitor.on_init_failed(&init_error, duration);
+                }
+
+                Err(crate::RedisError::from((
+                    crate::ErrorKind::ClientError,
+                    "Initialization pipeline failed",
+                    format!("{}", init_error),
+                )))
+            }
+        }
     }
 
     /// Reconnect and overwrite the old connection.
@@ -514,8 +927,15 @@ impl ConnectionManager {
             let new_cache_manager = manager.clone_and_increase_epoch();
             connection_config = connection_config.set_cache_manager(new_cache_manager);
         }
+        // Set readiness to not ready during reconnect
+        let _ = internals.ready_tx.send(Err(Arc::new(
+            (crate::ErrorKind::ClientError, "reconnecting").into(),
+        )));
+
         let new_connection: SharedRedisFuture<MultiplexedConnection> = async move {
-            let additional_commands = match &internals_clone.subscription_tracker {
+            // Combine configured init pipeline with resubscriptions
+            let cfg_init = internals_clone.init_pipeline.clone();
+            let subs_pipe = match &internals_clone.subscription_tracker {
                 Some(subscription_tracker) => Some(
                     subscription_tracker
                         .lock()
@@ -524,15 +944,41 @@ impl ConnectionManager {
                 ),
                 None => None,
             };
+            let combined = match (cfg_init, subs_pipe) {
+                (None, None) => None,
+                (Some(p), None) => Some(p),
+                (None, Some(s)) => Some(s),
+                (Some(mut p), Some(s)) => {
+                    for c in s.cmd_iter() {
+                        p.add_command(c.clone());
+                    }
+                    Some(p)
+                }
+            };
 
-            let con = Self::new_connection(
+            let res = Self::new_connection(
                 &internals_clone.client,
                 internals_clone.retry_strategy,
                 &connection_config,
-                additional_commands,
+                combined,
+                &internals_clone.security_config,
             )
-            .await?;
-            Ok(con)
+            .await;
+
+            // Update readiness based on result
+            match &res {
+                Ok(_) => {
+                    let _ = internals_clone.ready_tx.send(Ok(()));
+                }
+                Err(e) => {
+                    let _ = internals_clone
+                        .ready_tx
+                        .send(Err(Arc::new(e.clone_mostly("reconnect"))));
+                }
+            }
+
+            // Convert to cloneable result for Shared
+            res.map_err(Arc::new)
         }
         .boxed()
         .shared();
@@ -634,7 +1080,7 @@ impl ConnectionManager {
     /// This method is only available when the connection is using RESP3 protocol, and will return an error otherwise.
     /// It should be noted that unless [ConnectionManagerConfig::set_automatic_resubscription] was called,
     /// the subscription will be removed on a disconnect and must be re-subscribed.
-    ///  
+    ///
     /// ```rust,no_run
     /// # async fn func() -> redis::RedisResult<()> {
     /// let client = redis::Client::open("redis://127.0.0.1/?protocol=resp3").unwrap();

--- a/redis/tests/test_connection_manager_init.rs
+++ b/redis/tests/test_connection_manager_init.rs
@@ -1,0 +1,247 @@
+mod support;
+
+#[cfg(all(test, feature = "connection-manager"))]
+mod connection_manager_init {
+    use super::support::*;
+    use redis::aio::ConnectionLike;
+    use redis::{
+        self as redis_crate, aio::ConnectionManagerConfig, cmd, Client, ConnectionInfo,
+        RedisConnectionInfo, Value,
+    };
+    use rstest::rstest;
+
+    #[rstest]
+    #[cfg(feature = "connection-manager")]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    fn test_client_setname_on_connect(#[case] runtime: RuntimeType) {
+        block_on_all(
+            async move {
+                let ctx = TestContext::new();
+                let client = ctx.client.clone();
+                let mut config = ConnectionManagerConfig::new();
+                config = config.set_client_name("cm_test_client".to_string());
+                let mut cm = client
+                    .get_connection_manager_with_config(config)
+                    .await
+                    .unwrap();
+
+                cm.await_ready().await.unwrap();
+
+                // Query CLIENT LIST and verify name
+                let list: String = cmd("CLIENT")
+                    .arg("LIST")
+                    .query_async(&mut cm)
+                    .await
+                    .unwrap();
+                assert!(list.contains("name=cm_test_client"));
+                Ok::<(), redis_crate::RedisError>(())
+            },
+            runtime,
+        )
+        .unwrap();
+    }
+
+    #[rstest]
+    #[cfg(feature = "connection-manager")]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    fn test_reinit_after_reconnect(#[case] runtime: RuntimeType) {
+        block_on_all(
+            async move {
+                let ctx = TestContext::new();
+                let client = ctx.client.clone();
+                let mut config = ConnectionManagerConfig::new();
+                config = config.set_client_name("cm_reconnect".to_string());
+                let mut cm = client
+                    .get_connection_manager_with_config(config)
+                    .await
+                    .unwrap();
+
+                cm.await_ready().await.unwrap();
+
+                // Kill the client connection to force reconnect
+                let mut admin = ctx.async_connection().await.unwrap();
+                kill_client_async(&mut admin, &client).await.unwrap();
+
+                // Wait for readiness again
+                cm.await_ready().await.unwrap();
+
+                let list: String = cmd("CLIENT")
+                    .arg("LIST")
+                    .query_async(&mut cm)
+                    .await
+                    .unwrap();
+                assert!(list.contains("name=cm_reconnect"));
+                Ok::<(), redis_crate::RedisError>(())
+            },
+            runtime,
+        )
+        .unwrap();
+    }
+
+    #[rstest]
+    #[cfg(feature = "connection-manager")]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    fn test_security_validation_too_large_name(#[case] runtime: RuntimeType) {
+        block_on_all(
+            async move {
+                let ctx = TestContext::new();
+                let client = ctx.client.clone();
+                let mut config = ConnectionManagerConfig::new();
+                // Create a very large name > 64KB
+                let big = "x".repeat(70 * 1024);
+                // Early validation should fail manager creation
+                config = config.set_client_name(big);
+                let cm_res = client.get_connection_manager_with_config(config).await;
+                let err = cm_res
+                    .err()
+                    .expect("expected error for oversized client name");
+                assert!(format!("{}", err).contains("Client name too large"));
+                Ok::<(), redis_crate::RedisError>(())
+            },
+            runtime,
+        )
+        .unwrap();
+    }
+
+    #[rstest]
+    #[cfg(feature = "connection-manager")]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    fn test_timeout_behavior(#[case] runtime: RuntimeType) {
+        block_on_all(
+            async move {
+                let ctx = TestContext::new();
+                let client = ctx.client.clone();
+                let mut config = ConnectionManagerConfig::new();
+                // Set very short init timeout
+                let sec = redis_crate::aio::SecurityConfig::new()
+                    .set_init_timeout(std::time::Duration::from_millis(10));
+                config = config.set_security_config(sec);
+                // Use a user pipeline that will delay deterministically (DEBUG SLEEP 2)
+                let mut p = redis_crate::pipe();
+                p.cmd("DEBUG").arg("SLEEP").arg(2);
+                config = config.enable_arbitrary_init_commands().set_init_pipeline(p);
+                let res = client.get_connection_manager_with_config(config).await;
+                let err = res
+                    .err()
+                    .expect("expected manager creation to fail due to init timeout");
+                let msg = format!("{}", err);
+                assert!(
+                    msg.contains("timed out") || msg.contains("Initialization pipeline failed"),
+                    "unexpected error: {}",
+                    msg
+                );
+                Ok::<(), redis_crate::RedisError>(())
+            },
+            runtime,
+        )
+        .unwrap();
+    }
+
+    #[rstest]
+    #[cfg(feature = "connection-manager")]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    fn test_safe_vs_arbitrary_modes(#[case] runtime: RuntimeType) {
+        block_on_all(
+            async move {
+                let ctx = TestContext::new();
+                let client = ctx.client.clone();
+
+                // Safe mode: user pipeline ignored
+                let mut safe_cfg = ConnectionManagerConfig::new();
+                let mut p = redis_crate::pipe();
+                p.cmd("SET").arg("cm_flag").arg("1");
+                safe_cfg = safe_cfg.set_init_pipeline(p.clone());
+                let mut cm_safe = client
+                    .get_connection_manager_with_config(safe_cfg)
+                    .await
+                    .unwrap();
+                cm_safe.await_ready().await.unwrap();
+                let v: Option<String> = cmd("GET")
+                    .arg("cm_flag")
+                    .query_async(&mut cm_safe)
+                    .await
+                    .unwrap();
+                assert!(v.is_none());
+
+                // Arbitrary enabled: user pipeline executes
+                let arb_cfg = ConnectionManagerConfig::new()
+                    .enable_arbitrary_init_commands()
+                    .set_init_pipeline(p);
+                let mut cm_arb = client
+                    .get_connection_manager_with_config(arb_cfg)
+                    .await
+                    .unwrap();
+                cm_arb.await_ready().await.unwrap();
+                let v: String = cmd("GET")
+                    .arg("cm_flag")
+                    .query_async(&mut cm_arb)
+                    .await
+                    .unwrap();
+                assert_eq!(v, "1");
+                Ok::<(), redis_crate::RedisError>(())
+            },
+            runtime,
+        )
+        .unwrap();
+    }
+
+    #[rstest]
+    #[cfg(feature = "connection-manager")]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    fn test_auth_ordering(#[case] runtime: RuntimeType) {
+        block_on_all(
+            async move {
+                // Create a user requiring AUTH and ensure AUTH happens before init
+                let ctx = TestContext::new();
+                let mut admin_conn = ctx.async_connection().await.unwrap();
+
+                let username = "cmuser";
+                let password = "cmpass";
+
+                // Add a user with permissions and password
+                let mut set_user_cmd = redis_crate::Cmd::new();
+                set_user_cmd
+                    .arg("ACL")
+                    .arg("SETUSER")
+                    .arg(username)
+                    .arg("on")
+                    .arg("+acl")
+                    .arg("+client")
+                    .arg(format!(">{password}"));
+                assert_eq!(
+                    admin_conn.req_packed_command(&set_user_cmd).await,
+                    Ok(Value::Okay)
+                );
+
+                let client = Client::open(ConnectionInfo {
+                    addr: ctx.server.client_addr().clone(),
+                    redis: RedisConnectionInfo {
+                        username: Some(username.to_string()),
+                        password: Some(password.to_string()),
+                        ..Default::default()
+                    },
+                })
+                .unwrap();
+
+                let mut config = ConnectionManagerConfig::new();
+                config = config.set_client_name("auth_name".to_string());
+                let mut cm = client
+                    .get_connection_manager_with_config(config)
+                    .await
+                    .unwrap();
+                cm.await_ready().await.unwrap();
+
+                // If AUTH occurred after init, SETNAME would fail. By reaching here, ordering is correct.
+                let list: String = cmd("CLIENT")
+                    .arg("LIST")
+                    .query_async(&mut cm)
+                    .await
+                    .unwrap();
+                assert!(list.contains("name=auth_name"));
+                Ok::<(), redis_crate::RedisError>(())
+            },
+            runtime,
+        )
+        .unwrap();
+    }
+}


### PR DESCRIPTION
This PR addresses test failures and lint/format issues encountered in the CI matrix, and references issue #1727.

Key changes:
- Makefile: allow deprecated warnings for minimal-feature runs; add safe_iterators and async steps for no-default-features test segments.
- tests: add connection-manager initialization tests; remove unused mut to satisfy -D warnings.
- clippy: fix redundant closure in connection_manager.rs reported under -D clippy::all.
- fmt: apply rustfmt to maintain style consistency.

Verification:
- Lint: clippy passes with -D warnings.
- Format: cargo fmt --all --check passes.
- Tests: nextest runs across configurations pass locally:
  - no-default-features + safe_iterators
  - no-default-features + tokio-comp
  - all-features (TCP RESP2/RESP3, TLS, native-tls matrices)
  - unix socket subsets
  - redis-test crate

This should stabilize CI and unblock related work. Fixes and references: https://github.com/redis-rs/redis-rs/issues/1727