### PR TITLE
Enable more ways to build a parsing error.

### DIFF
--- a/redis/src/commands/acl.rs
+++ b/redis/src/commands/acl.rs
@@ -5,9 +5,7 @@ use crate::types::{FromRedisValue, RedisWrite, ToRedisArgs, Value};
 
 macro_rules! not_convertible_error {
     ($v:expr, $det:expr) => {
-        ParsingError {
-            description: format!("{:?} (response was {:?})", $det, $v).into(),
-        }
+        ParsingError::from(format!("{:?} (response was {:?})", $det, $v))
     };
 }
 

--- a/redis/src/commands/geo.rs
+++ b/redis/src/commands/geo.rs
@@ -291,11 +291,7 @@ impl RadiusSearchResult {
         // First item is always the member name
         let name: String = match iter.next().map(FromRedisValue::from_redis_value) {
             Some(Ok(n)) => n,
-            _ => {
-                return Err(ParsingError {
-                    description: arcstr::literal!("Missing member name"),
-                })
-            }
+            _ => return Err(arcstr::literal!("Missing member name").into()),
         };
 
         let (dist, coord) = match (iter.next(), iter.next()) {

--- a/redis/src/commands/streams.rs
+++ b/redis/src/commands/streams.rs
@@ -826,12 +826,16 @@ impl FromRedisValue for StreamPendingReply {
         } else {
             let mut result = StreamPendingData::default();
 
-            let start_id = start.ok_or_else(|| ParsingError {
-                description: "IllegalState: Non-zero pending expects start id".into(),
+            let start_id = start.ok_or_else(|| {
+                ParsingError::from(arcstr::literal!(
+                    "IllegalState: Non-zero pending expects start id"
+                ))
             })?;
 
-            let end_id = end.ok_or_else(|| ParsingError {
-                description: "IllegalState: Non-zero pending expects end id".into(),
+            let end_id = end.ok_or_else(|| {
+                ParsingError::from(arcstr::literal!(
+                    "IllegalState: Non-zero pending expects end id"
+                ))
             })?;
 
             result.count = count;
@@ -874,19 +878,19 @@ impl FromRedisValue for StreamPendingCountReply {
                                     times_delivered,
                                 });
                             }
-                            _ => fail!(ParsingError {
-                                description: "Cannot parse redis data (3)".into()
-                            }),
+                            _ => fail!(ParsingError::from(arcstr::literal!(
+                                "Cannot parse redis data (3)"
+                            ))),
                         },
-                        _ => fail!(ParsingError {
-                            description: "Cannot parse redis data (2)".into()
-                        }),
+                        _ => fail!(ParsingError::from(arcstr::literal!(
+                            "Cannot parse redis data (2)"
+                        ))),
                     }
                 }
             }
-            _ => fail!(ParsingError {
-                description: "Cannot parse redis data (1)".into()
-            }),
+            _ => fail!(ParsingError::from(arcstr::literal!(
+                "Cannot parse redis data (1)"
+            ))),
         };
         Ok(reply)
     }
@@ -1025,13 +1029,9 @@ impl FromRedisValue for XDelExStatusCode {
                 -1 => Ok(XDelExStatusCode::IdNotFound),
                 1 => Ok(XDelExStatusCode::Deleted),
                 2 => Ok(XDelExStatusCode::NotDeletedUnacknowledgedOrStillReferenced),
-                _ => Err(ParsingError {
-                    description: format!("Invalid XDelExStatusCode status code: {code}").into(),
-                }),
+                _ => Err(format!("Invalid XDelExStatusCode status code: {code}").into()),
             },
-            _ => Err(ParsingError {
-                description: "Response type not XAckDelStatusCode compatible".into(),
-            }),
+            _ => Err(arcstr::literal!("Response type not XAckDelStatusCode compatible").into()),
         }
     }
 }
@@ -1057,13 +1057,9 @@ impl FromRedisValue for XAckDelStatusCode {
                 -1 => Ok(XAckDelStatusCode::IdNotFound),
                 1 => Ok(XAckDelStatusCode::AcknowledgedAndDeleted),
                 2 => Ok(XAckDelStatusCode::AcknowledgedNotDeletedStillReferenced),
-                _ => Err(ParsingError {
-                    description: format!("Invalid XAckDelStatusCode status code: {code}").into(),
-                }),
+                _ => Err(arcstr::literal!("Invalid XAckDelStatusCode status code: {code}").into()),
             },
-            _ => Err(ParsingError {
-                description: "Response type not XAckDelStatusCode compatible".into(),
-            }),
+            _ => Err(arcstr::literal!("Response type not XAckDelStatusCode compatible").into()),
         }
     }
 }

--- a/redis/src/errors/mod.rs
+++ b/redis/src/errors/mod.rs
@@ -8,17 +8,13 @@ pub use server_error::*;
 
 macro_rules! invalid_type_error_inner {
     ($v:expr, $det:expr) => {
-        ParsingError {
-            description: format!("{:?} (value was {:?})", $det, $v).into(),
-        }
+        ParsingError::from(format!("{:?} (value was {:?})", $det, $v))
     };
 }
 
 macro_rules! invalid_type_error {
     ($det:expr) => {{
-        fail!(crate::errors::ParsingError {
-            description: format!("{:?}", $det).into(),
-        })
+        fail!(crate::errors::ParsingError::from(format!("{:?}", $det)))
     }};
     ($v:expr, $det:expr) => {{
         fail!(crate::errors::invalid_type_error_inner!($v, $det))

--- a/redis/src/errors/parsing_error.rs
+++ b/redis/src/errors/parsing_error.rs
@@ -1,9 +1,11 @@
 use std::{ffi::NulError, fmt, str::Utf8Error, string::FromUtf8Error};
 
+use arcstr::ArcStr;
+
 /// Describes a type conversion or parsing failure.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ParsingError {
-    pub(crate) description: arcstr::ArcStr,
+    pub(crate) description: ArcStr,
 }
 
 impl std::fmt::Display for ParsingError {
@@ -17,33 +19,47 @@ impl std::error::Error for ParsingError {}
 
 impl From<NulError> for ParsingError {
     fn from(err: NulError) -> ParsingError {
-        ParsingError {
-            description: format!("Value contains interior nul terminator: {err}",).into(),
-        }
+        format!("Value contains interior nul terminator: {err}",).into()
     }
 }
 
 impl From<Utf8Error> for ParsingError {
     fn from(_: Utf8Error) -> ParsingError {
-        ParsingError {
-            description: arcstr::literal!("Invalid UTF-8"),
-        }
+        arcstr::literal!("Invalid UTF-8").into()
     }
 }
 
 #[cfg(feature = "uuid")]
 impl From<uuid::Error> for ParsingError {
     fn from(err: uuid::Error) -> ParsingError {
-        ParsingError {
-            description: format!("Value is not a valid UUID: {err}").into(),
-        }
+        format!("Value is not a valid UUID: {err}").into()
     }
 }
 
 impl From<FromUtf8Error> for ParsingError {
     fn from(err: FromUtf8Error) -> ParsingError {
+        format!("Cannot convert from UTF-8: {err}").into()
+    }
+}
+
+impl From<String> for ParsingError {
+    fn from(err: String) -> ParsingError {
         ParsingError {
-            description: format!("Cannot convert from UTF-8: {err}").into(),
+            description: err.into(),
         }
+    }
+}
+
+impl<'a> From<&'a str> for ParsingError {
+    fn from(err: &'a str) -> ParsingError {
+        ParsingError {
+            description: err.into(),
+        }
+    }
+}
+
+impl From<ArcStr> for ParsingError {
+    fn from(err: ArcStr) -> ParsingError {
+        ParsingError { description: err }
     }
 }

--- a/redis/src/parser.rs
+++ b/redis/src/parser.rs
@@ -337,9 +337,7 @@ macro_rules! to_redis_err {
                         .map_range(|range| format!("{range:?}"))
                         .map_position(|pos| pos.translate_position($decoder.buffer()))
                         .to_string();
-                    RedisError::from(ParsingError {
-                        description: err.into(),
-                    })
+                    RedisError::from(ParsingError::from(err))
                 }
             }
         }
@@ -372,9 +370,7 @@ mod aio_support {
                             .map_position(|pos| pos.translate_position(buffer))
                             .map_range(|range| format!("{range:?}"))
                             .to_string();
-                        return Err(RedisError::from(ParsingError {
-                            description: err.into(),
-                        }));
+                        return Err(RedisError::from(ParsingError::from(err)));
                     }
                 }
             };

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1928,9 +1928,7 @@ impl FromRedisValue for Value {
 impl FromRedisValue for () {
     fn from_redis_value_ref(v: &Value) -> Result<(), ParsingError> {
         match v {
-            Value::ServerError(err) => Err(ParsingError {
-                description: err.to_string().into(),
-            }),
+            Value::ServerError(err) => Err(ParsingError::from(err.to_string())),
             _ => Ok(()),
         }
     }


### PR DESCRIPTION
This should allow users to build these errors on their implementations of `FromRedisValue`.