### PR TITLE
Use a parsed host:port pair in cluster connections.

### DIFF
--- a/redis/src/cluster_handling/async_connection/routing.rs
+++ b/redis/src/cluster_handling/async_connection/routing.rs
@@ -1,6 +1,5 @@
-use arcstr::ArcStr;
-
 use crate::{
+    cluster_handling::slot_map::Node,
     cluster_routing::{
         MultipleNodeRoutingInfo, Redirect, ResponsePolicy, Route, RoutingInfo,
         SingleNodeRoutingInfo, SlotAddr,
@@ -34,9 +33,9 @@ impl<C> From<InternalSingleNodeRouting<C>> for InternalRoutingInfo<C> {
 pub(super) enum InternalSingleNodeRouting<C> {
     Random,
     SpecificNode(Route),
-    ByAddress(ArcStr),
+    ByNode(Node),
     Connection {
-        identifier: ArcStr,
+        identifier: Node,
         conn: C,
     },
     Redirect {
@@ -59,7 +58,10 @@ impl<C> From<SingleNodeRoutingInfo> for InternalSingleNodeRouting<C> {
                 InternalSingleNodeRouting::SpecificNode(route)
             }
             SingleNodeRoutingInfo::ByAddress { host, port } => {
-                InternalSingleNodeRouting::ByAddress(format!("{host}:{port}").into())
+                InternalSingleNodeRouting::ByNode(Node {
+                    host: host.into(),
+                    port,
+                })
             }
             SingleNodeRoutingInfo::RandomPrimary => {
                 InternalSingleNodeRouting::SpecificNode(Route::new_random_primary())

--- a/redis/src/cluster_handling/mod.rs
+++ b/redis/src/cluster_handling/mod.rs
@@ -1,9 +1,7 @@
 use crate::{
     cluster_handling::client::ClusterParams, connection::TlsConnParams, Cmd, ConnectionAddr,
-    ConnectionInfo, ErrorKind, RedisConnectionInfo, RedisError, RedisResult, TlsMode,
+    ConnectionInfo, RedisConnectionInfo, TlsMode,
 };
-
-use std::str::FromStr;
 
 #[cfg(feature = "cluster-async")]
 pub mod async_connection;
@@ -18,18 +16,6 @@ pub(crate) fn slot_cmd() -> Cmd {
     let mut cmd = Cmd::new();
     cmd.arg("CLUSTER").arg("SLOTS");
     cmd
-}
-
-pub(crate) fn split_node_address(node: &str) -> RedisResult<(&str, u16)> {
-    let invalid_error =
-        || RedisError::from((ErrorKind::InvalidClientConfig, "Invalid node string"));
-    node.rsplit_once(':')
-        .and_then(|(host, port)| {
-            Some(host.trim_start_matches('[').trim_end_matches(']'))
-                .filter(|h| !h.is_empty())
-                .zip(u16::from_str(port).ok())
-        })
-        .ok_or_else(invalid_error)
 }
 
 pub(crate) fn get_connection_addr(
@@ -55,19 +41,14 @@ pub(crate) fn get_connection_addr(
     }
 }
 
-// The node string passed to this function will always be in the format host:port as it is either:
-// - Created by calling ConnectionAddr::to_string (unix connections are not supported in cluster mode)
-// - Returned from redis via the ASK/MOVED response
 pub(crate) fn get_connection_info(
-    node: &str,
+    node: &crate::cluster_handling::slot_map::Node,
     cluster_params: &ClusterParams,
-) -> RedisResult<ConnectionInfo> {
-    let (host, port) = split_node_address(node)?;
-
-    Ok(ConnectionInfo {
+) -> ConnectionInfo {
+    ConnectionInfo {
         addr: get_connection_addr(
-            host.to_string(),
-            port,
+            node.host.to_string(),
+            node.port,
             cluster_params.tls,
             cluster_params.tls_params.clone(),
         ),
@@ -78,5 +59,5 @@ pub(crate) fn get_connection_info(
             ..Default::default()
         },
         tcp_settings: cluster_params.tcp_settings.clone(),
-    })
+    }
 }

--- a/redis/src/cluster_handling/routing.rs
+++ b/redis/src/cluster_handling/routing.rs
@@ -1,7 +1,6 @@
-use arcstr::ArcStr;
 use rand::Rng;
 
-use crate::cluster_handling::slot_map::SLOT_SIZE;
+use crate::cluster_handling::slot_map::{Node, SLOT_SIZE};
 use crate::cmd::{Arg, Cmd};
 use crate::commands::is_readonly_cmd;
 use crate::types::Value;
@@ -26,8 +25,8 @@ pub(crate) fn get_slot(key: &[u8]) -> u16 {
 
 #[derive(Clone, PartialEq, Debug)]
 pub(crate) enum Redirect {
-    Moved(ArcStr),
-    Ask(ArcStr),
+    Moved(Node),
+    Ask(Node),
 }
 
 /// Logical bitwise aggregating operators.

--- a/redis/src/cluster_handling/slot_map.rs
+++ b/redis/src/cluster_handling/slot_map.rs
@@ -1,9 +1,15 @@
 use std::collections::{BTreeMap, HashSet};
+use std::fmt;
+use std::str::FromStr;
 
 use arcstr::ArcStr;
 use rand::{rng, seq::IndexedRandom};
 
-use crate::cluster_routing::{Route, SlotAddr};
+use crate::ConnectionAddr;
+use crate::{
+    cluster_routing::{Route, SlotAddr},
+    ErrorKind, RedisError, RedisResult,
+};
 
 pub(crate) const SLOT_SIZE: u16 = 16384;
 
@@ -53,7 +59,7 @@ impl SlotMap {
         }
     }
 
-    pub fn slot_addr_for_route(&self, route: &Route) -> Option<&ArcStr> {
+    pub fn slot_addr_for_route(&self, route: &Route) -> Option<&Node> {
         let slot = route.slot();
         self.slots
             .range(slot..)
@@ -80,33 +86,32 @@ impl SlotMap {
         self.slots.values().map(|slot_value| &slot_value.addrs)
     }
 
-    fn all_unique_addresses(&self, only_primaries: bool) -> HashSet<&ArcStr> {
-        let mut addresses: HashSet<_> = HashSet::new();
+    fn all_unique_nodes(&self, only_primaries: bool) -> HashSet<&Node> {
+        let mut nodes = HashSet::new();
         if only_primaries {
-            addresses.extend(
+            nodes.extend(
                 self.values().map(|slot_addrs| {
                     slot_addrs.slot_addr(&SlotAddr::Master, self.read_from_replica)
                 }),
             );
         } else {
-            addresses.extend(self.values().flat_map(|slot_addrs| slot_addrs.into_iter()));
+            nodes.extend(self.values().flatten());
         }
-
-        addresses
+        nodes
     }
 
-    pub fn addresses_for_all_primaries(&self) -> HashSet<&ArcStr> {
-        self.all_unique_addresses(true)
+    pub fn nodes_for_all_primaries(&self) -> HashSet<&Node> {
+        self.all_unique_nodes(true)
     }
 
-    pub fn addresses_for_all_nodes(&self) -> HashSet<&ArcStr> {
-        self.all_unique_addresses(false)
+    pub fn nodes_for_all_nodes(&self) -> HashSet<&Node> {
+        self.all_unique_nodes(false)
     }
 
-    pub fn addresses_for_multi_slot<'a, 'b>(
+    pub fn nodes_for_multi_slot<'a, 'b>(
         &'a self,
         routes: &'b [(Route, Vec<usize>)],
-    ) -> impl Iterator<Item = Option<&'a ArcStr>> + 'a
+    ) -> impl Iterator<Item = Option<&'a Node>> + 'a
     where
         'b: 'a,
     {
@@ -116,26 +121,76 @@ impl SlotMap {
     }
 }
 
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct Node {
+    pub(crate) host: ArcStr,
+    pub(crate) port: u16,
+}
+
+impl Node {
+    pub(crate) fn from_addr(addr: &str) -> RedisResult<Self> {
+        // Handle IPv6 addresses with brackets
+        let invalid_error =
+            || RedisError::from((ErrorKind::InvalidClientConfig, "Invalid node string"));
+        addr.rsplit_once(':')
+            .and_then(|(host, port)| {
+                Some(host.trim_start_matches('[').trim_end_matches(']'))
+                    .filter(|host| !host.is_empty())
+                    .zip(u16::from_str(port).ok())
+                    .map(|(host, port)| Node {
+                        host: host.into(),
+                        port,
+                    })
+            })
+            .ok_or_else(invalid_error)
+    }
+}
+
+impl fmt::Display for Node {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.host, self.port)
+    }
+}
+
+impl From<&ConnectionAddr> for Node {
+    fn from(value: &ConnectionAddr) -> Self {
+        match value {
+            ConnectionAddr::Tcp(host, port) => Node {
+                host: host.into(),
+                port: *port,
+            },
+            ConnectionAddr::TcpTls { host, port, .. } => Node {
+                host: host.into(),
+                port: *port,
+            },
+            ConnectionAddr::Unix(_) => unreachable!(),
+        }
+    }
+}
+
 /// This is just a simplified version of [`Slot`],
 /// which stores only the master and optional replica
 /// to avoid the need to choose a replica each time
 /// a command is executed
 #[derive(Debug)]
 pub(crate) struct SlotAddrs {
-    primary: ArcStr,
-    replicas: Vec<ArcStr>,
+    primary: Node,
+    replicas: Box<[Node]>,
 }
 
 impl SlotAddrs {
-    pub(crate) fn new(primary: ArcStr, replicas: Vec<ArcStr>) -> Self {
-        Self { primary, replicas }
+    pub(crate) fn new(primary: Node, replicas: Vec<Node>) -> Self {
+        Self {
+            primary,
+            replicas: replicas.into_boxed_slice(),
+        }
     }
 
-    fn get_replica_node(&self) -> &ArcStr {
+    fn get_replica_node(&self) -> &Node {
         self.replicas.choose(&mut rng()).unwrap_or(&self.primary)
     }
 
-    pub(crate) fn slot_addr(&self, slot_addr: &SlotAddr, read_from_replica: bool) -> &ArcStr {
+    pub(crate) fn slot_addr(&self, slot_addr: &SlotAddr, read_from_replica: bool) -> &Node {
         match slot_addr {
             SlotAddr::Master => &self.primary,
             SlotAddr::ReplicaOptional => {
@@ -150,17 +205,15 @@ impl SlotAddrs {
     }
 
     pub(crate) fn from_slot(slot: Slot) -> Self {
-        SlotAddrs::new(slot.master, slot.replicas)
+        SlotAddrs::new(slot.primary, slot.replicas)
     }
 }
 
 impl<'a> IntoIterator for &'a SlotAddrs {
-    type Item = &'a ArcStr;
-    type IntoIter = std::iter::Chain<std::iter::Once<&'a ArcStr>, std::slice::Iter<'a, ArcStr>>;
+    type Item = &'a Node;
+    type IntoIter = std::iter::Chain<std::iter::Once<&'a Node>, std::slice::Iter<'a, Node>>;
 
-    fn into_iter(
-        self,
-    ) -> std::iter::Chain<std::iter::Once<&'a ArcStr>, std::slice::Iter<'a, ArcStr>> {
+    fn into_iter(self) -> std::iter::Chain<std::iter::Once<&'a Node>, std::slice::Iter<'a, Node>> {
         std::iter::once(&self.primary).chain(self.replicas.iter())
     }
 }
@@ -169,26 +222,40 @@ impl<'a> IntoIterator for &'a SlotAddrs {
 pub(crate) struct Slot {
     pub(crate) start: u16,
     pub(crate) end: u16,
-    pub(crate) master: ArcStr,
-    pub(crate) replicas: Vec<ArcStr>,
+    pub(crate) primary: Node,
+    pub(crate) replicas: Vec<Node>,
 }
 
 impl Slot {
-    pub fn new(s: u16, e: u16, m: ArcStr, r: Vec<ArcStr>) -> Self {
-        Self {
-            start: s,
-            end: e,
-            master: m,
-            replicas: r,
+    pub fn new(start: u16, end: u16, primary: Node, replicas: Vec<Node>) -> RedisResult<Self> {
+        // Validate slot range
+        if start > end {
+            return Err(RedisError::from((
+                ErrorKind::InvalidClientConfig,
+                "Slot start cannot be greater than slot end",
+            )));
         }
+
+        Ok(Self {
+            start,
+            end,
+            primary,
+            replicas,
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
     use super::*;
+
+    // Helper function to create a Node for testing
+    fn node(host: &str, port: u16) -> Node {
+        Node {
+            host: ArcStr::from(host),
+            port,
+        }
+    }
 
     #[test]
     fn test_slot_map() {
@@ -197,57 +264,57 @@ mod tests {
                 Slot {
                     start: 1,
                     end: 1000,
-                    master: "node1:6379".into(),
-                    replicas: vec!["replica1:6379".into()],
+                    primary: node("node1", 6379),
+                    replicas: vec![node("replica1", 6379)],
                 },
                 Slot {
                     start: 1001,
                     end: 2000,
-                    master: "node2:6379".into(),
-                    replicas: vec!["replica2:6379".into()],
+                    primary: node("node2", 6379),
+                    replicas: vec![node("replica2", 6379)],
                 },
             ],
             true,
         );
 
         assert_eq!(
-            "node1:6379",
+            &node("node1", 6379),
             slot_map
                 .slot_addr_for_route(&Route::new(1, SlotAddr::Master))
                 .unwrap()
         );
         assert_eq!(
-            "node1:6379",
+            &node("node1", 6379),
             slot_map
                 .slot_addr_for_route(&Route::new(500, SlotAddr::Master))
                 .unwrap()
         );
         assert_eq!(
-            "node1:6379",
+            &node("node1", 6379),
             slot_map
                 .slot_addr_for_route(&Route::new(1000, SlotAddr::Master))
                 .unwrap()
         );
         assert_eq!(
-            "replica1:6379",
+            &node("replica1", 6379),
             slot_map
                 .slot_addr_for_route(&Route::new(1000, SlotAddr::ReplicaOptional))
                 .unwrap()
         );
         assert_eq!(
-            "node2:6379",
+            &node("node2", 6379),
             slot_map
                 .slot_addr_for_route(&Route::new(1001, SlotAddr::Master))
                 .unwrap()
         );
         assert_eq!(
-            "node2:6379",
+            &node("node2", 6379),
             slot_map
                 .slot_addr_for_route(&Route::new(1500, SlotAddr::Master))
                 .unwrap()
         );
         assert_eq!(
-            "node2:6379",
+            &node("node2", 6379),
             slot_map
                 .slot_addr_for_route(&Route::new(2000, SlotAddr::Master))
                 .unwrap()
@@ -263,20 +330,20 @@ mod tests {
             vec![Slot {
                 start: 1,
                 end: 1000,
-                master: "node1:6379".into(),
-                replicas: vec!["replica1:6379".into()],
+                primary: node("node1", 6379),
+                replicas: vec![node("replica1", 6379)],
             }],
             false,
         );
 
         assert_eq!(
-            "node1:6379",
+            &node("node1", 6379),
             slot_map
                 .slot_addr_for_route(&Route::new(1000, SlotAddr::ReplicaOptional))
                 .unwrap()
         );
         assert_eq!(
-            "replica1:6379",
+            &node("replica1", 6379),
             slot_map
                 .slot_addr_for_route(&Route::new(1000, SlotAddr::ReplicaRequired))
                 .unwrap()
@@ -286,29 +353,34 @@ mod tests {
     fn get_slot_map(read_from_replica: bool) -> SlotMap {
         SlotMap::from_slots(
             vec![
-                Slot::new(1, 1000, "node1:6379".into(), vec!["replica1:6379".into()]),
-                Slot::new(
-                    1002,
-                    2000,
-                    "node2:6379".into(),
-                    vec!["replica2:6379".into(), "replica3:6379".into()],
-                ),
-                Slot::new(
-                    2001,
-                    3000,
-                    "node3:6379".into(),
-                    vec![
-                        "replica4:6379".into(),
-                        "replica5:6379".into(),
-                        "replica6:6379".into(),
+                Slot {
+                    start: 1,
+                    end: 1000,
+                    primary: node("node1", 6379),
+                    replicas: vec![node("replica1", 6379)],
+                },
+                Slot {
+                    start: 1002,
+                    end: 2000,
+                    primary: node("node2", 6379),
+                    replicas: vec![node("replica2", 6379), node("replica3", 6379)],
+                },
+                Slot {
+                    start: 2001,
+                    end: 3000,
+                    primary: node("node3", 6379),
+                    replicas: vec![
+                        node("replica4", 6379),
+                        node("replica5", 6379),
+                        node("replica6", 6379),
                     ],
-                ),
-                Slot::new(
-                    3001,
-                    4000,
-                    "node2:6379".into(),
-                    vec!["replica2:6379".into(), "replica3:6379".into()],
-                ),
+                },
+                Slot {
+                    start: 3001,
+                    end: 4000,
+                    primary: node("node2", 6379),
+                    replicas: vec![node("replica2", 6379), node("replica3", 6379)],
+                },
             ],
             read_from_replica,
         )
@@ -317,35 +389,27 @@ mod tests {
     #[test]
     fn test_slot_map_get_all_primaries() {
         let slot_map = get_slot_map(false);
-        let addresses = slot_map.addresses_for_all_primaries();
-        assert_eq!(
-            addresses,
-            HashSet::from_iter([
-                &"node1:6379".into(),
-                &"node2:6379".into(),
-                &"node3:6379".into()
-            ])
-        );
+        let nodes = slot_map.nodes_for_all_primaries();
+        assert_eq!(nodes.len(), 3);
+        assert!(nodes.contains(&&node("node1", 6379)));
+        assert!(nodes.contains(&&node("node2", 6379)));
+        assert!(nodes.contains(&&node("node3", 6379)));
     }
 
     #[test]
     fn test_slot_map_get_all_nodes() {
         let slot_map = get_slot_map(false);
-        let addresses = slot_map.addresses_for_all_nodes();
-        assert_eq!(
-            addresses,
-            HashSet::from_iter([
-                &"node1:6379".into(),
-                &"node2:6379".into(),
-                &"node3:6379".into(),
-                &"replica1:6379".into(),
-                &"replica2:6379".into(),
-                &"replica3:6379".into(),
-                &"replica4:6379".into(),
-                &"replica5:6379".into(),
-                &"replica6:6379".into()
-            ])
-        );
+        let nodes = slot_map.nodes_for_all_nodes();
+        assert_eq!(nodes.len(), 9);
+        assert!(nodes.contains(&&node("node1", 6379)));
+        assert!(nodes.contains(&&node("node2", 6379)));
+        assert!(nodes.contains(&&node("node3", 6379)));
+        assert!(nodes.contains(&&node("replica1", 6379)));
+        assert!(nodes.contains(&&node("replica2", 6379)));
+        assert!(nodes.contains(&&node("replica3", 6379)));
+        assert!(nodes.contains(&&node("replica4", 6379)));
+        assert!(nodes.contains(&&node("replica5", 6379)));
+        assert!(nodes.contains(&&node("replica6", 6379)));
     }
 
     #[test]
@@ -355,14 +419,13 @@ mod tests {
             (Route::new(1, SlotAddr::Master), vec![]),
             (Route::new(2001, SlotAddr::ReplicaOptional), vec![]),
         ];
-        let addresses = slot_map
-            .addresses_for_multi_slot(&routes)
-            .collect::<Vec<_>>();
-        assert!(addresses.contains(&Some(&"node1:6379".into())));
+        let nodes: Vec<_> = slot_map.nodes_for_multi_slot(&routes).collect();
+        assert_eq!(nodes[0].unwrap(), &node("node1", 6379));
+        let replica_node = nodes[1].unwrap();
         assert!(
-            addresses.contains(&Some(&"replica4:6379".into()))
-                || addresses.contains(&Some(&"replica5:6379".into()))
-                || addresses.contains(&Some(&"replica6:6379".into()))
+            replica_node == &node("replica4", 6379)
+                || replica_node == &node("replica5", 6379)
+                || replica_node == &node("replica6", 6379)
         );
     }
 
@@ -373,17 +436,11 @@ mod tests {
             (Route::new(1, SlotAddr::Master), vec![]),
             (Route::new(2001, SlotAddr::ReplicaOptional), vec![]),
         ];
-        let addresses = slot_map
-            .addresses_for_multi_slot(&routes)
-            .collect::<Vec<_>>();
-        assert_eq!(
-            addresses,
-            vec![Some(&"node1:6379".into()), Some(&"node3:6379".into())]
-        );
+        let nodes: Vec<_> = slot_map.nodes_for_multi_slot(&routes).collect();
+        assert_eq!(nodes[0].unwrap(), &node("node1", 6379));
+        assert_eq!(nodes[1].unwrap(), &node("node3", 6379));
     }
 
-    /// This test is needed in order to verify that if the MultiSlot route finds the same node for more than a single route,
-    /// that node's address will appear multiple times, in the same order.
     #[test]
     fn test_slot_map_get_repeating_addresses_when_the_same_node_is_found_in_multi_slot() {
         let slot_map = get_slot_map(true);
@@ -395,20 +452,13 @@ mod tests {
             (Route::new(3, SlotAddr::ReplicaOptional), vec![]),
             (Route::new(2003, SlotAddr::Master), vec![]),
         ];
-        let addresses = slot_map
-            .addresses_for_multi_slot(&routes)
-            .collect::<Vec<_>>();
-        assert_eq!(
-            addresses,
-            vec![
-                Some(&"replica1:6379".into()),
-                Some(&"node3:6379".into()),
-                Some(&"replica1:6379".into()),
-                Some(&"node3:6379".into()),
-                Some(&"replica1:6379".into()),
-                Some(&"node3:6379".into())
-            ]
-        );
+        let nodes: Vec<_> = slot_map.nodes_for_multi_slot(&routes).collect();
+        assert_eq!(nodes[0].unwrap(), &node("replica1", 6379));
+        assert_eq!(nodes[1].unwrap(), &node("node3", 6379));
+        assert_eq!(nodes[2].unwrap(), &node("replica1", 6379));
+        assert_eq!(nodes[3].unwrap(), &node("node3", 6379));
+        assert_eq!(nodes[4].unwrap(), &node("replica1", 6379));
+        assert_eq!(nodes[5].unwrap(), &node("node3", 6379));
     }
 
     #[test]
@@ -420,17 +470,48 @@ mod tests {
             (Route::new(6000, SlotAddr::ReplicaOptional), vec![]),
             (Route::new(2002, SlotAddr::Master), vec![]),
         ];
-        let addresses = slot_map
-            .addresses_for_multi_slot(&routes)
-            .collect::<Vec<_>>();
-        assert_eq!(
-            addresses,
-            vec![
-                Some(&"replica1:6379".into()),
-                None,
-                None,
-                Some(&"node3:6379".into())
-            ]
-        );
+        let nodes: Vec<_> = slot_map.nodes_for_multi_slot(&routes).collect();
+        assert_eq!(nodes[0].unwrap(), &node("replica1", 6379));
+        assert!(nodes[1].is_none());
+        assert!(nodes[2].is_none());
+        assert_eq!(nodes[3].unwrap(), &node("node3", 6379));
+    }
+
+    #[test]
+    fn test_node_address_parsing() {
+        let cases = vec![
+            (
+                "127.0.0.1:6379",
+                ConnectionAddr::Tcp("127.0.0.1".to_string(), 6379u16),
+            ),
+            (
+                "localhost.localdomain:6379",
+                ConnectionAddr::Tcp("localhost.localdomain".to_string(), 6379u16),
+            ),
+            (
+                "dead::cafe:beef:30001",
+                ConnectionAddr::Tcp("dead::cafe:beef".to_string(), 30001u16),
+            ),
+            (
+                "[fe80::cafe:beef%en1]:30001",
+                ConnectionAddr::Tcp("fe80::cafe:beef%en1".to_string(), 30001u16),
+            ),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(Node::from_addr(input), Ok((&expected).into()));
+        }
+
+        let cases = vec![":0", "[]:6379"];
+        for input in cases {
+            let res = Node::from_addr(input);
+            assert_eq!(
+                res.err(),
+                Some(RedisError::from((
+                    ErrorKind::InvalidClientConfig,
+                    "Invalid node string",
+                ))),
+            );
+        }
     }
 }

--- a/redis/src/errors/redis_error.rs
+++ b/redis/src/errors/redis_error.rs
@@ -407,6 +407,17 @@ impl RedisError {
         Some((addr, slot_id))
     }
 
+    #[cfg(feature = "cluster")]
+    pub(crate) fn redirect_node_internal(
+        &self,
+    ) -> Option<(crate::cluster_handling::slot_map::Node, u16)> {
+        self.redirect_node().map(|(addr, slot)| {
+            crate::cluster_handling::slot_map::Node::from_addr(addr)
+                .map(|node| (node, slot))
+                .ok()
+        })?
+    }
+
     /// Specifies what method (if any) should be used to retry this request.
     ///
     /// If you are using the cluster api retrying of requests is already handled by the library.


### PR DESCRIPTION
This saves repeatedly splitting cnd combining the pair to/from strings.