### PR TITLE
Handle server errors more robustly in async aggregate responses.

### DIFF
--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -1,4 +1,12 @@
-### 1.0.0-alpha
+### 1.0.0-alpha.3
+
+#### Changes
+
+* Mark all public enums as non_exhaustive ([#1817](https://github.com/redis-rs/redis-rs/pull/1817) by @nihohit)
+* Enable sync build for Webassembly ([#1818](https://github.com/redis-rs/redis-rs/pull/1818) by @nihohit)
+* Handle server errors more robustly in async aggregate responses. ([#1820](https://github.com/redis-rs/redis-rs/pull/1820) by @nihohit)
+
+### 1.0.0-alpha.2 (2025-10-02)
 
 #### Changes
 
@@ -30,6 +38,15 @@
 * Make FromRedisValue take an owned value by default([#1784](https://github.com/redis-rs/redis-rs/pull/1784) by @nihohit)
 * Enable more ways to build a parsing error([#1788](https://github.com/redis-rs/redis-rs/pull/1788) by @nihohit)
 * Require single arguments for some calls ([#1792](https://github.com/redis-rs/redis-rs/pull/1792) by @nihohit)
+* Mark all public enums as non_exhaustive ([#1817](https://github.com/redis-rs/redis-rs/pull/1817) by @nihohit)
+* Enable sync build for Webassembly ([#1818](https://github.com/redis-rs/redis-rs/pull/1818) by @nihohit)
+* Handle server errors more robustly in async aggregate responses. ([#1820](https://github.com/redis-rs/redis-rs/pull/1820) by @nihohit)
+
+### 0.32.7 (2025-10-03)
+
+#### Changes
+
+* Port https://github.com/redis-rs/redis-rs/pull/1711 to 0.32.x ([#1819](https://github.com/redis-rs/redis-rs/pull/1819) by @nihohit)
 
 ### 0.32.6 (2025-09-26)
 

--- a/redis/src/errors/redis_error.rs
+++ b/redis/src/errors/redis_error.rs
@@ -547,6 +547,17 @@ impl From<ParsingError> for RedisError {
     }
 }
 
+impl TryFrom<RedisError> for ServerError {
+    type Error = RedisError;
+
+    fn try_from(err: RedisError) -> Result<ServerError, RedisError> {
+        match err.repr {
+            ErrorRepr::Server(err) => Ok(err),
+            _ => Err(err),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::parse_redis_value;

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -1553,14 +1553,11 @@ mod cluster_async {
                 respond_startup_with_replica_using_config(name, received_cmd, None)?;
                 if port == 6381 {
                     Err(Ok(Value::Okay))
-                } else if port == 6379 {
-                    Err(Ok(Value::Nil))
                 } else {
-                    Err(Err((
-                        ServerErrorKind::NotBusy.into(),
-                        "some random failure, really",
-                    )
-                        .into()))
+                    Err(Err(RedisError::from(std::io::Error::new(
+                        std::io::ErrorKind::ConnectionReset,
+                        "mock-io-error",
+                    ))))
                 }
             },
         );


### PR DESCRIPTION
Calls that previously failed due to RedisError will now try to propagate those better.