### PR TITLE
tests: Allow tests to detect (and skip on) versions of all components (Redis, Valkey, modules)

### DIFF
--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -202,18 +202,6 @@ impl TestClusterContext {
         }
     }
 
-    /// Gets the Redis version of the first server in the cluster
-    ///
-    /// # Panics
-    ///
-    /// As this function is only meant to be used during testing, it panics upon any issues.
-    pub fn get_version(&self) -> super::Version {
-        let server = self.cluster.servers.first().unwrap();
-        let mut conn = self.build_single_client_connection(server).unwrap();
-
-        super::get_version(&mut conn)
-    }
-
     pub fn get_ports(&self) -> Vec<u16> {
         self.nodes
             .iter()
@@ -225,5 +213,14 @@ impl TestClusterContext {
                 }
             })
             .collect()
+    }
+}
+
+impl super::TestContextVersioning for TestClusterContext {
+    fn get_version(&self) -> super::Version {
+        let server = self.cluster.servers.first().unwrap();
+        let mut conn = self.build_single_client_connection(server).unwrap();
+
+        super::get_version(&mut conn)
     }
 }

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -5,7 +5,7 @@ use std::convert::identity;
 use std::thread::sleep;
 use std::time::Duration;
 
-use crate::support::{build_single_client, start_tls_crypto_provider};
+use crate::support::{AvailableComponents, build_single_client, start_tls_crypto_provider};
 use redis::Connection;
 use redis::ConnectionInfo;
 use redis::ProtocolVersion;
@@ -217,10 +217,10 @@ impl TestClusterContext {
 }
 
 impl super::TestContextVersioning for TestClusterContext {
-    fn get_version(&self) -> super::Version {
+    fn get_available_components(&self) -> AvailableComponents {
         let server = self.cluster.servers.first().unwrap();
         let mut conn = self.build_single_client_connection(server).unwrap();
 
-        super::get_version(&mut conn)
+        AvailableComponents::from(&mut conn)
     }
 }

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -521,6 +521,7 @@ pub fn get_redis_binary_version() -> Option<Version> {
 // Redis version constants for version-gated tests
 pub const REDIS_VERSION_CE_7_0: Version = (7, 0, 0);
 pub const REDIS_VERSION_CE_7_2: Version = (7, 2, 0);
+pub const REDIS_VERSION_CE_7_4: Version = (7, 4, 0);
 pub const REDIS_VERSION_CE_8_0: Version = (8, 0, 0);
 pub const REDIS_VERSION_CE_8_2: Version = (8, 1, 240);
 pub const REDIS_VERSION_CE_8_4: Version = (8, 3, 224);

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -3,8 +3,8 @@
 #[cfg(feature = "aio")]
 use futures::Future;
 use redis::{
-    Commands, ConnectionAddr, ErrorKind, InfoDict, Pipeline, ProtocolVersion, RedisResult,
-    ServerErrorKind, Value,
+    Commands, ConnectionAddr, ErrorKind, Pipeline, ProtocolVersion, RedisResult, ServerErrorKind,
+    Value,
 };
 #[cfg(feature = "aio")]
 use redis::{aio, cmd};
@@ -21,6 +21,10 @@ use std::{io, thread::sleep, time::Duration};
 use redis::caching::CacheConfig;
 #[cfg(feature = "tls-rustls")]
 use redis::{ClientTlsConfig, TlsCertificates};
+
+#[macro_use]
+mod version;
+pub use version::*;
 
 pub fn current_thread_runtime() -> tokio::runtime::Runtime {
     let mut builder = tokio::runtime::Builder::new_current_thread();
@@ -465,120 +469,6 @@ where
         },
         _ => panic!("unknown value {value:?}"),
     }
-}
-
-pub type Version = (u16, u16, u16);
-
-pub fn parse_version(info: InfoDict) -> Version {
-    let version: String = info.get("redis_version").unwrap();
-    let versions: Vec<u16> = version
-        .split('.')
-        .map(|version| version.parse::<u16>().unwrap())
-        .collect();
-    assert_eq!(versions.len(), 3);
-    (versions[0], versions[1], versions[2])
-}
-
-fn get_version(conn: &mut impl redis::ConnectionLike) -> Version {
-    let info: InfoDict = redis::Cmd::new().arg("INFO").query(conn).unwrap();
-    parse_version(info)
-}
-
-/// Get the Redis server version by running `redis-server --version`.
-/// Returns `None` if the binary is not available.
-pub fn get_redis_binary_version() -> Option<Version> {
-    use std::process::Command;
-
-    let binary = std::env::var("REDISRS_SERVER_BIN").unwrap_or_else(|_| "redis-server".to_string());
-
-    let output = match Command::new(&binary).arg("--version").output() {
-        Ok(output) => output,
-        Err(_) => {
-            eprintln!("Failed to execute redis-server --version");
-            return None;
-        }
-    };
-
-    let full_string =
-        String::from_utf8(output.stdout).expect("Invalid UTF-8 in redis-server version output");
-
-    let version_str = full_string
-        .split_whitespace()
-        .find(|s| s.starts_with("v="))
-        .and_then(|s| s.strip_prefix("v="))
-        .expect("Could not find version in redis-server output");
-
-    let versions: Vec<u16> = version_str
-        .split('.')
-        .take(3)
-        .map(|v| v.parse::<u16>().expect("Failed to parse version number"))
-        .collect();
-
-    assert_eq!(versions.len(), 3, "Expected version format x.y.z");
-    Some((versions[0], versions[1], versions[2]))
-}
-
-// Redis version constants for version-gated tests
-pub const REDIS_VERSION_CE_7_0: Version = (7, 0, 0);
-pub const REDIS_VERSION_CE_7_2: Version = (7, 2, 0);
-pub const REDIS_VERSION_CE_7_4: Version = (7, 4, 0);
-pub const REDIS_VERSION_CE_8_0: Version = (8, 0, 0);
-pub const REDIS_VERSION_CE_8_2: Version = (8, 1, 240);
-pub const REDIS_VERSION_CE_8_4: Version = (8, 3, 224);
-pub const REDIS_VERSION_CE_8_6: Version = (8, 6, 0);
-
-/// Macro to run tests only if the Redis version meets the minimum requirement.
-/// If the version is insufficient, the test is skipped with a message.
-#[macro_export]
-macro_rules! run_test_if_version_supported {
-    ($minimum_required_version:expr) => {{
-        let ctx = $crate::support::TestContext::new();
-        let redis_version = ctx.get_version();
-
-        if redis_version < *$minimum_required_version {
-            eprintln!("Skipping the test because the current version of Redis {:?} doesn't match the minimum required version {:?}.",
-            redis_version, $minimum_required_version);
-            return;
-        }
-
-        ctx
-    }};
-}
-
-/// Macro to run tests only if the version of the Redis binary meets the minimum requirement.
-/// If the binary is not available or the version is insufficient, the test is skipped with a message.
-///
-/// # Example
-/// ```rust,no_run
-/// #[test]
-/// fn test_redis_8_6_feature() {
-///     run_test_if_redis_binary_version_supported!(&REDIS_VERSION_CE_8_6);
-///     // Only now create the expensive test context
-///     let ctx = TestContext::new_with_cert_auth(tls_files);
-///     // ...
-/// }
-/// ```
-#[macro_export]
-macro_rules! run_test_if_redis_binary_version_supported {
-    ($minimum_required_version:expr) => {{
-        match $crate::get_redis_binary_version() {
-            None => {
-                eprintln!(
-                    "Skipping the test because the Redis binary was not found."
-                );
-                return;
-            }
-            Some(redis_version) => {
-                if redis_version < *$minimum_required_version {
-                    eprintln!(
-                        "Skipping the test because the current version of Redis {:?} doesn't match the minimum required version {:?}.",
-                        redis_version, $minimum_required_version
-                    );
-                    return;
-                }
-            }
-        }
-    }};
 }
 
 #[cfg(feature = "tls-rustls")]

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -378,9 +378,9 @@ impl TestContext {
 }
 
 impl TestContextVersioning for TestContext {
-    fn get_version(&self) -> Version {
+    fn get_available_components(&self) -> AvailableComponents {
         let mut conn = self.connection();
-        get_version(&mut conn)
+        AvailableComponents::from(&mut conn)
     }
 }
 

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -375,8 +375,10 @@ impl TestContext {
                 .await
         }
     }
+}
 
-    pub fn get_version(&self) -> Version {
+impl TestContextVersioning for TestContext {
+    fn get_version(&self) -> Version {
         let mut conn = self.connection();
         get_version(&mut conn)
     }

--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -70,6 +70,32 @@ pub trait TestContextVersioning {
     ///
     /// As this function is only meant to be used during testing, it panics upon any issues.
     fn get_version(&self) -> Version;
+
+    /// Returns whether the context's server has at least the given Redis version
+    fn supports(&self, version: &Version) -> bool {
+        self.get_version() >= *version
+    }
+}
+
+/// Skips the current test if it does not support the given Redis version
+///
+/// # Arguments
+///
+/// * `$ctx` - The context the test uses for its servers
+/// * `$minimum_required_version` - The minimum required Redis version
+/// * `$ret` - (Optional. Default: `()`) The value to return to skip the test
+#[macro_export]
+macro_rules! skip_if_context_does_not_support {
+    ($ctx:expr, $minimum_required_version:expr) => {{
+        $crate::skip_if_context_does_not_support!($ctx, $minimum_required_version, ())
+    }};
+    ($ctx:expr, $minimum_required_version:expr, $ret:expr) => {{
+        if !$ctx.supports($minimum_required_version) {
+            eprintln!("Skipping the test because the current version of Redis doesn't match the minimum required version {:?}.",
+            $minimum_required_version);
+            return $ret;
+        }
+    }};
 }
 
 /// Macro to run tests only if the Redis version meets the minimum requirement.
@@ -78,13 +104,8 @@ pub trait TestContextVersioning {
 macro_rules! run_test_if_version_supported {
     ($minimum_required_version:expr) => {{
         let ctx = $crate::support::TestContext::new();
-        let redis_version = ctx.get_version();
 
-        if redis_version < *$minimum_required_version {
-            eprintln!("Skipping the test because the current version of Redis {:?} doesn't match the minimum required version {:?}.",
-            redis_version, $minimum_required_version);
-            return;
-        }
+        $crate::skip_if_context_does_not_support!(ctx, $minimum_required_version);
 
         ctx
     }};
@@ -125,3 +146,7 @@ macro_rules! run_test_if_redis_binary_version_supported {
         }
     }};
 }
+
+// As this module is included in many integration tests, adding unit tests here would also (re)run
+// them during each of those intregration tests. Hence, we move out unit tests of this module into
+// `test_support.rs`

--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -250,40 +250,6 @@ impl<'a> From<&'a AvailableComponents> for Vec<Component<'a>> {
     }
 }
 
-/// Get the Redis server version by running `redis-server --version`.
-/// Returns `None` if the binary is not available.
-pub fn get_redis_binary_version() -> Option<Version> {
-    use std::process::Command;
-
-    let binary = std::env::var("REDISRS_SERVER_BIN").unwrap_or_else(|_| "redis-server".to_string());
-
-    let output = match Command::new(&binary).arg("--version").output() {
-        Ok(output) => output,
-        Err(_) => {
-            eprintln!("Failed to execute redis-server --version");
-            return None;
-        }
-    };
-
-    let full_string =
-        String::from_utf8(output.stdout).expect("Invalid UTF-8 in redis-server version output");
-
-    let version_str = full_string
-        .split_whitespace()
-        .find(|s| s.starts_with("v="))
-        .and_then(|s| s.strip_prefix("v="))
-        .expect("Could not find version in redis-server output");
-
-    let versions: Vec<u16> = version_str
-        .split('.')
-        .take(3)
-        .map(|v| v.parse::<u16>().expect("Failed to parse version number"))
-        .collect();
-
-    assert_eq!(versions.len(), 3, "Expected version format x.y.z");
-    Some((versions[0], versions[1], versions[2]))
-}
-
 /// Server version extraction and matching
 pub trait TestContextVersioning {
     /// Gets the components for the first server in the context
@@ -341,42 +307,6 @@ macro_rules! run_test_if_version_supported {
         $crate::skip_if_context_does_not_support!(ctx, $component);
 
         ctx
-    }};
-}
-
-/// Macro to run tests only if the version of the Redis binary meets the minimum requirement.
-/// If the binary is not available or the version is insufficient, the test is skipped with a message.
-///
-/// # Example
-/// ```rust,no_run
-/// #[test]
-/// fn test_redis_8_6_feature() {
-///     run_test_if_redis_binary_version_supported!(&REDIS_VERSION_CE_8_6);
-///     // Only now create the expensive test context
-///     let ctx = TestContext::new_with_cert_auth(tls_files);
-///     // ...
-/// }
-/// ```
-#[macro_export]
-macro_rules! run_test_if_redis_binary_version_supported {
-    ($minimum_required_version:expr) => {{
-        match $crate::get_redis_binary_version() {
-            None => {
-                eprintln!(
-                    "Skipping the test because the Redis binary was not found."
-                );
-                return;
-            }
-            Some(redis_version) => {
-                if redis_version < (*$minimum_required_version).1 {
-                    eprintln!(
-                        "Skipping the test because the current version of Redis {:?} doesn't match the minimum required version {:?}.",
-                        redis_version, $minimum_required_version
-                    );
-                    return;
-                }
-            }
-        }
     }};
 }
 

--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -1,0 +1,117 @@
+//! Tooling to handle server version extraction and matching
+
+use redis::InfoDict;
+
+// Redis version constants for version-gated tests
+pub const REDIS_VERSION_CE_7_0: Version = (7, 0, 0);
+pub const REDIS_VERSION_CE_7_2: Version = (7, 2, 0);
+pub const REDIS_VERSION_CE_7_4: Version = (7, 4, 0);
+pub const REDIS_VERSION_CE_8_0: Version = (8, 0, 0);
+pub const REDIS_VERSION_CE_8_2: Version = (8, 1, 240);
+pub const REDIS_VERSION_CE_8_4: Version = (8, 3, 224);
+pub const REDIS_VERSION_CE_8_6: Version = (8, 6, 0);
+
+pub type Version = (u16, u16, u16);
+
+pub fn parse_version(info: InfoDict) -> Version {
+    let version: String = info.get("redis_version").unwrap();
+    let versions: Vec<u16> = version
+        .split('.')
+        .map(|version| version.parse::<u16>().unwrap())
+        .collect();
+    assert_eq!(versions.len(), 3);
+    (versions[0], versions[1], versions[2])
+}
+
+pub fn get_version(conn: &mut impl redis::ConnectionLike) -> Version {
+    let info: InfoDict = redis::Cmd::new().arg("INFO").query(conn).unwrap();
+    parse_version(info)
+}
+
+/// Get the Redis server version by running `redis-server --version`.
+/// Returns `None` if the binary is not available.
+pub fn get_redis_binary_version() -> Option<Version> {
+    use std::process::Command;
+
+    let binary = std::env::var("REDISRS_SERVER_BIN").unwrap_or_else(|_| "redis-server".to_string());
+
+    let output = match Command::new(&binary).arg("--version").output() {
+        Ok(output) => output,
+        Err(_) => {
+            eprintln!("Failed to execute redis-server --version");
+            return None;
+        }
+    };
+
+    let full_string =
+        String::from_utf8(output.stdout).expect("Invalid UTF-8 in redis-server version output");
+
+    let version_str = full_string
+        .split_whitespace()
+        .find(|s| s.starts_with("v="))
+        .and_then(|s| s.strip_prefix("v="))
+        .expect("Could not find version in redis-server output");
+
+    let versions: Vec<u16> = version_str
+        .split('.')
+        .take(3)
+        .map(|v| v.parse::<u16>().expect("Failed to parse version number"))
+        .collect();
+
+    assert_eq!(versions.len(), 3, "Expected version format x.y.z");
+    Some((versions[0], versions[1], versions[2]))
+}
+
+/// Macro to run tests only if the Redis version meets the minimum requirement.
+/// If the version is insufficient, the test is skipped with a message.
+#[macro_export]
+macro_rules! run_test_if_version_supported {
+    ($minimum_required_version:expr) => {{
+        let ctx = $crate::support::TestContext::new();
+        let redis_version = ctx.get_version();
+
+        if redis_version < *$minimum_required_version {
+            eprintln!("Skipping the test because the current version of Redis {:?} doesn't match the minimum required version {:?}.",
+            redis_version, $minimum_required_version);
+            return;
+        }
+
+        ctx
+    }};
+}
+
+/// Macro to run tests only if the version of the Redis binary meets the minimum requirement.
+/// If the binary is not available or the version is insufficient, the test is skipped with a message.
+///
+/// # Example
+/// ```rust,no_run
+/// #[test]
+/// fn test_redis_8_6_feature() {
+///     run_test_if_redis_binary_version_supported!(&REDIS_VERSION_CE_8_6);
+///     // Only now create the expensive test context
+///     let ctx = TestContext::new_with_cert_auth(tls_files);
+///     // ...
+/// }
+/// ```
+#[macro_export]
+macro_rules! run_test_if_redis_binary_version_supported {
+    ($minimum_required_version:expr) => {{
+        match $crate::get_redis_binary_version() {
+            None => {
+                eprintln!(
+                    "Skipping the test because the Redis binary was not found."
+                );
+                return;
+            }
+            Some(redis_version) => {
+                if redis_version < *$minimum_required_version {
+                    eprintln!(
+                        "Skipping the test because the current version of Redis {:?} doesn't match the minimum required version {:?}.",
+                        redis_version, $minimum_required_version
+                    );
+                    return;
+                }
+            }
+        }
+    }};
+}

--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -1,31 +1,169 @@
 //! Tooling to handle server version extraction and matching
 
-use redis::InfoDict;
+use redis::ConnectionLike;
+use std::collections::HashMap;
 
 // Redis version constants for version-gated tests
-pub const REDIS_VERSION_CE_7_0: Version = (7, 0, 0);
-pub const REDIS_VERSION_CE_7_2: Version = (7, 2, 0);
-pub const REDIS_VERSION_CE_7_4: Version = (7, 4, 0);
-pub const REDIS_VERSION_CE_8_0: Version = (8, 0, 0);
-pub const REDIS_VERSION_CE_8_2: Version = (8, 1, 240);
-pub const REDIS_VERSION_CE_8_4: Version = (8, 3, 224);
-pub const REDIS_VERSION_CE_8_6: Version = (8, 6, 0);
+pub const REDIS_VERSION_CE_6_0: Component = ("redis", (6, 0, 0));
+pub const REDIS_VERSION_CE_7_0: Component = ("redis", (7, 0, 0));
+pub const REDIS_VERSION_CE_7_2: Component = ("redis", (7, 2, 0));
+pub const REDIS_VERSION_CE_7_4: Component = ("redis", (7, 4, 0));
+pub const REDIS_VERSION_CE_8_0: Component = ("redis", (8, 0, 0));
+pub const REDIS_VERSION_CE_8_2: Component = ("redis", (8, 1, 240));
+pub const REDIS_VERSION_CE_8_4: Component = ("redis", (8, 3, 224));
+pub const REDIS_VERSION_CE_8_6: Component = ("redis", (8, 6, 0));
 
+/// Version of a software component
 pub type Version = (u16, u16, u16);
 
-pub fn parse_version(info: InfoDict) -> Version {
-    let version: String = info.get("redis_version").unwrap();
-    let versions: Vec<u16> = version
-        .split('.')
-        .map(|version| version.parse::<u16>().unwrap())
-        .collect();
-    assert_eq!(versions.len(), 3);
-    (versions[0], versions[1], versions[2])
+/// Software component name along with its version
+pub type Component<'a> = (&'a str, Version);
+
+#[derive(Clone)]
+pub struct AvailableComponents {
+    /// The available components' versions by their name
+    components: HashMap<String, Version>,
 }
 
-pub fn get_version(conn: &mut impl redis::ConnectionLike) -> Version {
-    let info: InfoDict = redis::Cmd::new().arg("INFO").query(conn).unwrap();
-    parse_version(info)
+impl AvailableComponents {
+    /// Extracts the available/used/usable software components from an `INFO` response
+    ///
+    /// # Panics
+    ///
+    /// This method panics upon issues
+    fn parse_info(info_response: &str) -> HashMap<String, Version> {
+        let mut ret = HashMap::new();
+        for raw_line in info_response.lines() {
+            // Strip off comments
+            let line = raw_line.split("#").next().unwrap();
+
+            let mut split = line.splitn(2, ":");
+            let (name, version) = match (split.next(), split.next()) {
+                (Some(key), Some(value)) => {
+                    let key = key.trim();
+                    let value = value.trim();
+                    if key.ends_with("_version") {
+                        // Direct key/value version (E.g.: `redis_version`, `valkey_version`)
+                        let name = &key[0..key.len() - 8];
+                        (name, Self::extract_version(value))
+                    } else if key == "module" {
+                        // Module info line (e.g.: 'module:name=foo,ver=10203,...')
+
+                        // Collect the module's options
+                        let mut options = HashMap::new();
+                        for pair in value.split(",") {
+                            let mut inner_split = pair.splitn(2, "=");
+                            match (inner_split.next(), inner_split.next()) {
+                                (Some(key), Some(value)) => {
+                                    options.insert(key.trim(), value.trim());
+                                }
+                                _ => continue,
+                            }
+                        }
+
+                        // Extract name and version
+                        let Some(name) = options.get("name") else {
+                            continue;
+                        };
+                        let Some(version_str) = options.get("ver") else {
+                            continue;
+                        };
+
+                        (*name, Self::extract_version(version_str))
+                    } else {
+                        continue;
+                    }
+                }
+                _ => continue,
+            };
+            ret.insert(name.to_owned(), version);
+        }
+        ret
+    }
+
+    /// Extracts the version triplet of a `&str`
+    ///
+    /// # Panics
+    ///
+    /// This method panics upon issues
+    fn extract_version(value: &str) -> Version {
+        // Cut-off suffixes (e.g.: the trailing `-rc1` in `1.2.3-rc1`)
+        let number_str = value.split("-").next().unwrap();
+
+        // Convert each number part to a number
+        let numbers = number_str
+            .split('.')
+            .map(|version| version.parse::<u32>().unwrap())
+            .collect::<Vec<_>>();
+
+        // Massage the numbers into a [`Version`]
+        let (major, minor, patch) = match numbers.len() {
+            1 => {
+                let mut rest = numbers[0];
+
+                let patch = rest % 100;
+                rest = (rest - patch) / 100;
+
+                let minor = rest % 100;
+                let major = (rest - minor) / 100;
+
+                (major, minor, patch)
+            }
+            2 => (numbers[0], numbers[1], 0),
+            3 => (numbers[0], numbers[1], numbers[2]),
+            _ => panic!(
+                "version number extraction not implemented for {} parts of '{}'",
+                numbers.len(),
+                value
+            ),
+        };
+
+        // Yield as [`Version`]
+        (major as u16, minor as u16, patch as u16)
+    }
+
+    /// Checks if the instance has the given component in at least the given version
+    pub fn supports(&self, component: &Component) -> bool {
+        // Extract the parts we need from the component
+        let (name, requested_version) = component;
+
+        // Get the available version for the component
+        let Some(available_version) = self.components.get(*name) else {
+            return false;
+        };
+
+        // Compare versions
+        available_version >= requested_version
+    }
+}
+
+impl<C: ConnectionLike> From<&mut C> for AvailableComponents {
+    /// Extracts the available/used/usable software components from a connection
+    ///
+    /// # Panics
+    ///
+    /// This method panics upon issues
+    fn from(conn: &mut C) -> Self {
+        // We'd like to use [`InfoDict`]. But it stores only the last value if a key occurs multiple
+        // times. As each module gets reported with another `module` key, we could only get the last
+        // module's information, which is not fit for our use case.
+        // Hence, we have to parse `INFO` manually.
+        let info_response: String = redis::Cmd::new().arg("INFO").query(conn).unwrap();
+
+        let components = Self::parse_info(info_response.as_str());
+
+        Self { components }
+    }
+}
+
+impl<'a> From<&'a AvailableComponents> for Vec<Component<'a>> {
+    fn from(value: &'a AvailableComponents) -> Self {
+        value
+            .components
+            .iter()
+            .map(|(name, version)| (name.as_str(), *version))
+            .collect::<Vec<Component<'a>>>()
+    }
 }
 
 /// Get the Redis server version by running `redis-server --version`.
@@ -64,48 +202,57 @@ pub fn get_redis_binary_version() -> Option<Version> {
 
 /// Server version extraction and matching
 pub trait TestContextVersioning {
-    /// Gets the Redis version for the first server in the context
+    /// Gets the components for the first server in the context
     ///
     /// # Panics
     ///
     /// As this function is only meant to be used during testing, it panics upon any issues.
-    fn get_version(&self) -> Version;
+    fn get_available_components(&self) -> AvailableComponents;
 
-    /// Returns whether the context's server has at least the given Redis version
-    fn supports(&self, version: &Version) -> bool {
-        self.get_version() >= *version
+    /// Returns whether the context's server has the given component in at least the given version
+    fn supports(&self, component: &Component) -> bool {
+        self.get_available_components().supports(component)
     }
 }
 
-/// Skips the current test if it does not support the given Redis version
+/// Skips the current test if it does not support the given component
 ///
 /// # Arguments
 ///
 /// * `$ctx` - The context the test uses for its servers
-/// * `$minimum_required_version` - The minimum required Redis version
+/// * `$component` - The component that has to be present to run the test
 /// * `$ret` - (Optional. Default: `()`) The value to return to skip the test
 #[macro_export]
 macro_rules! skip_if_context_does_not_support {
-    ($ctx:expr, $minimum_required_version:expr) => {{
-        $crate::skip_if_context_does_not_support!($ctx, $minimum_required_version, ())
-    }};
-    ($ctx:expr, $minimum_required_version:expr, $ret:expr) => {{
-        if !$ctx.supports($minimum_required_version) {
-            eprintln!("Skipping the test because the current version of Redis doesn't match the minimum required version {:?}.",
-            $minimum_required_version);
+    ($ctx:expr, $component:expr) => {{ $crate::skip_if_context_does_not_support!($ctx, $component, ()) }};
+    ($ctx:expr, $component:expr, $ret:expr) => {{
+        if !$ctx.supports($component) {
+            eprintln!(
+                "Skipping the test because the running server does not support {:?}.",
+                $component
+            );
             return $ret;
         }
     }};
 }
 
-/// Macro to run tests only if the Redis version meets the minimum requirement.
+/// Macro to run tests only if the default [`TestContext`] supports the given component
+///
 /// If the version is insufficient, the test is skipped with a message.
+///
+/// # Arguments
+///
+/// * `$component` - The component that has to be present to run the test
+///
+/// # Returns
+///
+/// A [`TestContext`], if `$component` is available
 #[macro_export]
 macro_rules! run_test_if_version_supported {
-    ($minimum_required_version:expr) => {{
+    ($component:expr) => {{
         let ctx = $crate::support::TestContext::new();
 
-        $crate::skip_if_context_does_not_support!(ctx, $minimum_required_version);
+        $crate::skip_if_context_does_not_support!(ctx, $component);
 
         ctx
     }};
@@ -135,7 +282,7 @@ macro_rules! run_test_if_redis_binary_version_supported {
                 return;
             }
             Some(redis_version) => {
-                if redis_version < *$minimum_required_version {
+                if redis_version < (*$minimum_required_version).1 {
                     eprintln!(
                         "Skipping the test because the current version of Redis {:?} doesn't match the minimum required version {:?}.",
                         redis_version, $minimum_required_version
@@ -148,5 +295,5 @@ macro_rules! run_test_if_redis_binary_version_supported {
 }
 
 // As this module is included in many integration tests, adding unit tests here would also (re)run
-// them during each of those intregration tests. Hence, we move out unit tests of this module into
+// them during each of those integration tests. Hence, we move out unit tests of this module into
 // `test_support.rs`

--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -19,6 +19,90 @@ pub type Version = (u16, u16, u16);
 /// Software component name along with its version
 pub type Component<'a> = (&'a str, Version);
 
+/// Matcher for [`Component`]s
+pub struct ComponentMatcher<'a> {
+    conjunctive_parts: Vec<Vec<&'a Component<'a>>>,
+}
+
+impl<'a> ComponentMatcher<'a> {
+    /// Checks if this matcher matches the given available components
+    ///
+    /// # Arguments
+    ///
+    /// * `available_components` - The available components to check against
+    pub fn matches(&self, available_components: &AvailableComponents) -> bool {
+        self.conjunctive_parts.iter().all(|disjunctive_parts| {
+            disjunctive_parts
+                .iter()
+                .any(|component| available_components.supports(component))
+        })
+    }
+}
+
+/// Matcher for a single [`Component`]
+impl<'a> From<&'a Component<'a>> for ComponentMatcher<'a> {
+    fn from(value: &'a Component<'a>) -> Self {
+        Self {
+            conjunctive_parts: vec![vec![value]],
+        }
+    }
+}
+
+/// Disjuntive (`OR`) matcher for a list of [`Component`]s
+///
+/// If any of the given components are supported, it's a match.
+impl<'a> From<&[&'a Component<'a>]> for ComponentMatcher<'a> {
+    fn from(value: &[&'a Component<'a>]) -> Self {
+        Self {
+            conjunctive_parts: vec![value.to_vec()],
+        }
+    }
+}
+
+/// Conjunctive (`AND`) matcher for a list of disjunctively (`OR`) matched lists of [`Component`]s
+///
+/// If all elements have at least one supported subelement, it's a match.
+impl<'a> From<&[&[&'a Component<'a>]]> for ComponentMatcher<'a> {
+    fn from(value: &[&[&'a Component<'a>]]) -> Self {
+        Self {
+            conjunctive_parts: value
+                .iter()
+                .map(|disjunctive_part| disjunctive_part.to_vec())
+                .collect(),
+        }
+    }
+}
+
+/// Macros to provide array implementations for matchers' slice implementations
+///
+/// Rust can auto-coerce array to slices. But with generic arguments, this
+/// array-to-slice-auto-coercion does not kick in. So one would have to convert manually. To avoid
+/// this for the common cases, this macro implements coercing `From`s. for a given array length
+///
+/// # Arguments
+///
+/// * `$n` - The array lengths to implement coercing `From`s for.
+macro_rules! matcher_array_impls {
+    ($n:expr) => {
+        impl<'a> From<&[&'a Component<'a>; $n]> for ComponentMatcher<'a> {
+            fn from(value: &[&'a Component<'a>; $n]) -> Self {
+                let coerced_value: &[&'a Component<'a>] = value;
+                Self::from(coerced_value)
+            }
+        }
+
+        impl<'a> From<&[&[&'a Component<'a>]; $n]> for ComponentMatcher<'a> {
+            fn from(value: &[&[&'a Component<'a>]; $n]) -> Self {
+                let coerced_value: &[&[&'a Component<'a>]] = value;
+                Self::from(coerced_value)
+            }
+        }
+    };
+}
+matcher_array_impls!(1);
+matcher_array_impls!(2);
+matcher_array_impls!(3);
+
 #[derive(Clone)]
 pub struct AvailableComponents {
     /// The available components' versions by their name
@@ -210,8 +294,10 @@ pub trait TestContextVersioning {
     fn get_available_components(&self) -> AvailableComponents;
 
     /// Returns whether the context's server has the given component in at least the given version
-    fn supports(&self, component: &Component) -> bool {
-        self.get_available_components().supports(component)
+    fn supports<'a, T: Into<ComponentMatcher<'a>>>(&self, into_matcher: T) -> bool {
+        into_matcher
+            .into()
+            .matches(&self.get_available_components())
     }
 }
 

--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -62,6 +62,16 @@ pub fn get_redis_binary_version() -> Option<Version> {
     Some((versions[0], versions[1], versions[2]))
 }
 
+/// Server version extraction and matching
+pub trait TestContextVersioning {
+    /// Gets the Redis version for the first server in the context
+    ///
+    /// # Panics
+    ///
+    /// As this function is only meant to be used during testing, it panics upon any issues.
+    fn get_version(&self) -> Version;
+}
+
 /// Macro to run tests only if the Redis version meets the minimum requirement.
 /// If the version is insufficient, the test is skipped with a message.
 #[macro_export]

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -370,7 +370,7 @@ mod basic {
     #[test]
     fn test_hash_expiration() {
         // Hash expiration is only supported in Redis 7.4.0 and later.
-        let ctx = run_test_if_version_supported!(&(7, 4, 0));
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_7_4);
 
         let mut con = ctx.connection();
         redis::cmd("HMSET")
@@ -3368,7 +3368,7 @@ mod basic {
     #[test]
     fn test_expire_time() {
         // EXPIRETIME/PEXPIRETIME is available from Redis version 7.4.0
-        let ctx = run_test_if_version_supported!(&(7, 4, 0));
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_7_4);
 
         let mut con = ctx.connection();
 

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -3503,13 +3503,6 @@ mod basic {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
-        // setup version & input data followed by assertions that take into account Redis version
-        // BZPOPMIN & BZPOPMAX are available from Redis version 5.0.0
-        // BZMPOP is available from Redis version 7.0.0
-
-        let redis_version = ctx.get_version();
-        assert!(redis_version.0 >= 5);
-
         assert_matches!(con.zadd("a", "1a", 1), Ok(_));
         assert_matches!(con.zadd("b", "2b", 2), Ok(_));
         assert_matches!(con.zadd("c", "3c", 3), Ok(_));
@@ -3531,7 +3524,8 @@ mod basic {
             (String::from("b"), String::from("6b"), 6.0)
         );
 
-        if redis_version.0 >= 7 {
+        // BZMPOP is available from Redis version 7.0.0
+        if ctx.supports(&REDIS_VERSION_CE_7_0) {
             let min = con.bzmpop_min(0.0, vec!["a", "b", "c", "d"].as_slice(), 1);
             let max = con.bzmpop_max(0.0, vec!["a", "b", "c", "d"].as_slice(), 1);
 

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -2354,14 +2354,15 @@ mod cluster_async {
     mod pubsub {
         use super::*;
 
-        fn check_if_redis_6(ctx: &TestClusterContext) -> bool {
-            ctx.get_version().0 == 6
+        /// Yields `true` iff Redis is at least version 7
+        fn check_if_supports_redis_7(ctx: &TestClusterContext) -> bool {
+            ctx.get_version() >= REDIS_VERSION_CE_7_0
         }
 
         async fn subscribe_to_channels(
             pubsub_conn: &mut ClusterConnection,
             rx: &mut UnboundedReceiver<PushInfo>,
-            is_redis_6: bool,
+            supports_redis_7: bool,
         ) {
             let _: () = pubsub_conn.subscribe("regular-phonewave").await.unwrap();
             let push: PushInfo = get_push(rx).await;
@@ -2383,7 +2384,7 @@ mod cluster_async {
                 }
             );
 
-            if !is_redis_6 {
+            if supports_redis_7 {
                 let _: () = pubsub_conn.ssubscribe("sphonewave").await.unwrap();
                 let push = get_push(rx).await;
                 assert_eq!(
@@ -2407,7 +2408,7 @@ mod cluster_async {
         async fn check_publishing(
             publish_conn: &mut ClusterConnection,
             rx: &mut UnboundedReceiver<PushInfo>,
-            is_redis_6: bool,
+            supports_redis_7: bool,
         ) {
             let _: () = publish_conn
                 .publish("regular-phonewave", "banana")
@@ -2439,7 +2440,7 @@ mod cluster_async {
                 }
             );
 
-            if !is_redis_6 {
+            if supports_redis_7 {
                 let _: () = publish_conn.spublish("sphonewave", "banana").await.unwrap();
                 let push = get_push(rx).await;
                 assert_eq!(
@@ -2463,11 +2464,11 @@ mod cluster_async {
 
             let (mut publish_conn, mut pubsub_conn) =
                 join!(ctx.async_connection(), ctx.async_connection());
-            let is_redis_6 = check_if_redis_6(&ctx);
+            let supports_redis_7 = check_if_supports_redis_7(&ctx);
 
-            subscribe_to_channels(&mut pubsub_conn, &mut rx, is_redis_6).await;
+            subscribe_to_channels(&mut pubsub_conn, &mut rx, supports_redis_7).await;
 
-            check_publishing(&mut publish_conn, &mut rx, is_redis_6).await;
+            check_publishing(&mut publish_conn, &mut rx, supports_redis_7).await;
         }
 
         #[async_test]
@@ -2482,11 +2483,11 @@ mod cluster_async {
                 ctx.async_connection_with_config(config.clone()),
                 ctx.async_connection_with_config(config)
             );
-            let is_redis_6 = check_if_redis_6(&ctx);
+            let supports_redis_7 = check_if_supports_redis_7(&ctx);
 
-            subscribe_to_channels(&mut pubsub_conn, &mut rx, is_redis_6).await;
+            subscribe_to_channels(&mut pubsub_conn, &mut rx, supports_redis_7).await;
 
-            check_publishing(&mut publish_conn, &mut rx, is_redis_6).await;
+            check_publishing(&mut publish_conn, &mut rx, supports_redis_7).await;
         }
 
         #[async_test]
@@ -2496,7 +2497,7 @@ mod cluster_async {
             });
 
             let mut pubsub_conn = ctx.async_connection().await;
-            if check_if_redis_6(&ctx) {
+            if !check_if_supports_redis_7(&ctx) {
                 return;
             }
 
@@ -2522,7 +2523,7 @@ mod cluster_async {
 
             let (mut publish_conn, mut pubsub_conn) =
                 join!(ctx.async_connection(), ctx.async_connection());
-            let is_redis_6 = check_if_redis_6(&ctx);
+            let supports_redis_7 = check_if_supports_redis_7(&ctx);
 
             let _: () = pubsub_conn.subscribe("regular-phonewave").await.unwrap();
             let push = get_push(&mut rx).await;
@@ -2562,7 +2563,7 @@ mod cluster_async {
                 }
             );
 
-            if !is_redis_6 {
+            if supports_redis_7 {
                 let _: () = pubsub_conn.ssubscribe("sphonewave").await.unwrap();
                 let push = get_push(&mut rx).await;
                 assert_eq!(
@@ -2591,7 +2592,7 @@ mod cluster_async {
                 .publish("phonewave-pattern", "banana")
                 .await
                 .unwrap();
-            if !is_redis_6 {
+            if supports_redis_7 {
                 let _: () = publish_conn.spublish("sphonewave", "banana").await.unwrap();
             }
 
@@ -2611,9 +2612,9 @@ mod cluster_async {
             });
 
             let mut pubsub_conn = ctx.async_connection().await;
-            let is_redis_6 = check_if_redis_6(&ctx);
+            let supports_redis_7 = check_if_supports_redis_7(&ctx);
 
-            subscribe_to_channels(&mut pubsub_conn, &mut rx, is_redis_6).await;
+            subscribe_to_channels(&mut pubsub_conn, &mut rx, supports_redis_7).await;
 
             drop(rx);
 
@@ -2637,7 +2638,7 @@ mod cluster_async {
             });
 
             let mut pubsub_conn = ctx.async_connection().await;
-            let is_redis_6 = check_if_redis_6(&ctx);
+            let supports_redis_7 = check_if_supports_redis_7(&ctx);
 
             let _: () = pubsub_conn
                 .subscribe(&[
@@ -2707,7 +2708,7 @@ mod cluster_async {
                     }
                 );
             }
-            if !is_redis_6 {
+            if supports_redis_7 {
                 // we use the curly braces in order to avoid cross slots errors.
                 let _: () = pubsub_conn
                     .ssubscribe(&["{sphonewave}1", "{sphonewave}2", "{sphonewave}3"])
@@ -2765,9 +2766,9 @@ mod cluster_async {
 
             let (mut publish_conn, mut pubsub_conn) =
                 join!(ctx.async_connection(), ctx.async_connection());
-            let is_redis_6 = check_if_redis_6(&ctx);
+            let supports_redis_7 = check_if_supports_redis_7(&ctx);
 
-            subscribe_to_channels(&mut pubsub_conn, &mut rx, is_redis_6).await;
+            subscribe_to_channels(&mut pubsub_conn, &mut rx, supports_redis_7).await;
 
             println!("dropped");
             drop(ctx);
@@ -2812,7 +2813,7 @@ mod cluster_async {
             let mut pushes = Vec::new();
             pushes.push(get_push(&mut rx).await);
             pushes.push(get_push(&mut rx).await);
-            if !is_redis_6 {
+            if supports_redis_7 {
                 pushes.push(get_push(&mut rx).await);
             }
             // we expect only 3 resubscriptions.
@@ -2826,14 +2827,14 @@ mod cluster_async {
                 data: vec![redis_value!("phonewave*"), redis_value!(2)]
             }));
 
-            if !is_redis_6 {
+            if supports_redis_7 {
                 assert!(pushes.contains(&PushInfo {
                     kind: PushKind::SSubscribe,
                     data: vec![redis_value!("sphonewave"), redis_value!(1)]
                 }));
             }
 
-            check_publishing(&mut publish_conn, &mut rx, is_redis_6).await;
+            check_publishing(&mut publish_conn, &mut rx, supports_redis_7).await;
         }
 
         #[async_test]

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -2354,10 +2354,7 @@ mod cluster_async {
     mod pubsub {
         use super::*;
 
-        /// Yields `true` iff Redis is at least version 7
-        fn check_if_supports_redis_7(ctx: &TestClusterContext) -> bool {
-            ctx.get_version() >= REDIS_VERSION_CE_7_0
-        }
+        use crate::skip_if_context_does_not_support;
 
         async fn subscribe_to_channels(
             pubsub_conn: &mut ClusterConnection,
@@ -2464,7 +2461,7 @@ mod cluster_async {
 
             let (mut publish_conn, mut pubsub_conn) =
                 join!(ctx.async_connection(), ctx.async_connection());
-            let supports_redis_7 = check_if_supports_redis_7(&ctx);
+            let supports_redis_7 = ctx.supports(&REDIS_VERSION_CE_7_0);
 
             subscribe_to_channels(&mut pubsub_conn, &mut rx, supports_redis_7).await;
 
@@ -2483,7 +2480,7 @@ mod cluster_async {
                 ctx.async_connection_with_config(config.clone()),
                 ctx.async_connection_with_config(config)
             );
-            let supports_redis_7 = check_if_supports_redis_7(&ctx);
+            let supports_redis_7 = ctx.supports(&REDIS_VERSION_CE_7_0);
 
             subscribe_to_channels(&mut pubsub_conn, &mut rx, supports_redis_7).await;
 
@@ -2495,12 +2492,9 @@ mod cluster_async {
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
                 builder.use_protocol(ProtocolVersion::RESP3)
             });
+            skip_if_context_does_not_support!(ctx, &REDIS_VERSION_CE_7_0);
 
             let mut pubsub_conn = ctx.async_connection().await;
-            if !check_if_supports_redis_7(&ctx) {
-                return;
-            }
-
             let _: () = pubsub_conn.ssubscribe("foo").await.unwrap();
 
             let res = cmd("pubsub")
@@ -2523,7 +2517,7 @@ mod cluster_async {
 
             let (mut publish_conn, mut pubsub_conn) =
                 join!(ctx.async_connection(), ctx.async_connection());
-            let supports_redis_7 = check_if_supports_redis_7(&ctx);
+            let supports_redis_7 = ctx.supports(&REDIS_VERSION_CE_7_0);
 
             let _: () = pubsub_conn.subscribe("regular-phonewave").await.unwrap();
             let push = get_push(&mut rx).await;
@@ -2612,7 +2606,7 @@ mod cluster_async {
             });
 
             let mut pubsub_conn = ctx.async_connection().await;
-            let supports_redis_7 = check_if_supports_redis_7(&ctx);
+            let supports_redis_7 = ctx.supports(&REDIS_VERSION_CE_7_0);
 
             subscribe_to_channels(&mut pubsub_conn, &mut rx, supports_redis_7).await;
 
@@ -2638,7 +2632,7 @@ mod cluster_async {
             });
 
             let mut pubsub_conn = ctx.async_connection().await;
-            let supports_redis_7 = check_if_supports_redis_7(&ctx);
+            let supports_redis_7 = ctx.supports(&REDIS_VERSION_CE_7_0);
 
             let _: () = pubsub_conn
                 .subscribe(&[
@@ -2766,7 +2760,7 @@ mod cluster_async {
 
             let (mut publish_conn, mut pubsub_conn) =
                 join!(ctx.async_connection(), ctx.async_connection());
-            let supports_redis_7 = check_if_supports_redis_7(&ctx);
+            let supports_redis_7 = ctx.supports(&REDIS_VERSION_CE_7_0);
 
             subscribe_to_channels(&mut pubsub_conn, &mut rx, supports_redis_7).await;
 

--- a/redis/tests/test_hotkeys.rs
+++ b/redis/tests/test_hotkeys.rs
@@ -329,11 +329,7 @@ mod hotkeys_cluster {
         let port = port_of(info.addr());
         let mut direct = direct_connection(info.clone(), protocol);
 
-        let version = cluster_ctx.get_version();
-        if version < REDIS_VERSION_CE_8_6 {
-            eprintln!("Skipping: Redis version {version:?} < {REDIS_VERSION_CE_8_6:?}");
-            return None;
-        }
+        skip_if_context_does_not_support!(cluster_ctx, &REDIS_VERSION_CE_8_6, None);
 
         let (range_start, range_end) = first_owned_slot_range(&mut direct, port);
         let (hot_key, target_slot) = find_key_in_range(&mut direct, range_start, range_end);

--- a/redis/tests/test_module_json.rs
+++ b/redis/tests/test_module_json.rs
@@ -349,7 +349,7 @@ fn test_module_json_num_incr_by() {
 
     assert_eq!(set_initial, Ok(true));
 
-    if ctx.protocol.supports_resp3() && ctx.get_version() >= REDIS_VERSION_CE_7_0 {
+    if ctx.protocol.supports_resp3() && ctx.supports(&REDIS_VERSION_CE_7_0) {
         // cannot increment a string
         let json_numincrby_a: RedisResult<Vec<Value>> = con.json_num_incr_by(TEST_KEY, "$.a", 2);
         assert_eq!(json_numincrby_a, Ok(vec![Nil]));
@@ -501,7 +501,7 @@ fn test_module_json_type() {
     let json_type_b: RedisResult<Value> = con.json_type(TEST_KEY, "$..a");
     let json_type_c: RedisResult<Value> = con.json_type(TEST_KEY, "$..dummy");
 
-    if ctx.protocol.supports_resp3() && ctx.get_version() >= REDIS_VERSION_CE_7_0 {
+    if ctx.protocol.supports_resp3() && ctx.supports(&REDIS_VERSION_CE_7_0) {
         // In RESP3 current RedisJSON always gives response in an array.
         assert_eq!(
             json_type_a,

--- a/redis/tests/test_streams.rs
+++ b/redis/tests/test_streams.rs
@@ -2290,7 +2290,7 @@ fn test_xautoclaim_invalid_pel_entries_claiming_full_entries() {
         .unwrap();
     assert_eq!(reply.claimed, claimed_entries);
 
-    if ctx.get_version().0 > 6 {
+    if ctx.supports(&REDIS_VERSION_CE_7_0) {
         assert_eq!(
             reply.deleted_ids,
             vec![claim.id.clone(), claim_1.id.clone()]
@@ -2344,7 +2344,7 @@ fn test_xautoclaim_invalid_pel_entries_claiming_just_ids() {
     std::mem::take(&mut claimed_entries[0].map);
     std::mem::take(&mut claimed_entries[1].map);
 
-    if ctx.get_version().0 > 6 {
+    if ctx.supports(&REDIS_VERSION_CE_7_0) {
         assert_eq!(reply.claimed, claimed_entries);
         assert_eq!(
             reply.deleted_ids,

--- a/redis/tests/test_support.rs
+++ b/redis/tests/test_support.rs
@@ -113,6 +113,69 @@ fn ctx_supports_major_match_minor_match_patch_bigger() {
     assert!(!mock.supports(&("foo", (42, 4711, 24))));
 }
 
+/// Tries to assure that `support` correctly handles a disjunctive match
+#[test]
+fn ctx_supports_disjunctive() {
+    // The context to check with
+    let mock = MockTestContext::new("bar_version: 42.4711.23");
+
+    // Check for support when `bar` is `42.0.0` (matches)
+    assert!(mock.supports(&[
+        &("foo", (23_u16, 23_u16, 23_u16)),
+        &("bar", (42, 0, 0)),
+        &("baz", (42, 42, 42)),
+    ]));
+
+    // Check for support when `bar` is `43.0.0` (too high)
+    assert!(!mock.supports(&[
+        &("foo", (23_u16, 23_u16, 23_u16)),
+        &("bar", (43, 0, 0)),
+        &("baz", (42, 42, 42)),
+    ]));
+
+    // Check for support when `bar` is missing
+    assert!(!mock.supports(&[&("foo", (23_u16, 23_u16, 23_u16)), &("baz", (42, 42, 42)),]));
+}
+
+/// Tries to assure that `support` correctly handles a conjunctive match
+#[test]
+fn ctx_supports_conjunctive() {
+    // The context to check with
+    let input = r#"
+foo_version: 42.0.0
+bar_version: 4711.0.0
+baz_version: 23.0.0
+"#;
+    let mock = MockTestContext::new(input);
+
+    // Check for successful support
+    assert!(mock.supports(&[
+        &[
+            &("foo", (43_u16, 0_u16, 0_u16)), // does not match (too high)
+            &("bar", (151, 0, 0))             // matches
+        ][..],
+        &[&("baz", (23, 0, 0))], // matches
+    ]));
+
+    // Check for failing support (first disjunctive fails)
+    assert!(!mock.supports(&[
+        &[
+            &("foo", (43_u16, 0_u16, 0_u16)), // does not match (too high)
+            &("bar", (4712, 0, 0))            // does not match (too high)
+        ][..],
+        &[&("baz", (23, 0, 0))], // matches
+    ]));
+
+    // Check for failing support (second disjunctive fails)
+    assert!(!mock.supports(&[
+        &[
+            &("foo", (43_u16, 0_u16, 0_u16)), // does not match (too high)
+            &("bar", (151, 0, 0))             // matches
+        ][..],
+        &[&("baz", (151, 0, 0))], // does not match (too high)
+    ]));
+}
+
 /// Tries to assure that the current server allows to parse the versions
 #[test]
 fn ctx_live_test_server() {

--- a/redis/tests/test_support.rs
+++ b/redis/tests/test_support.rs
@@ -4,96 +4,229 @@
 //! `support` module itself would include (and compile and run) them for each integration test
 //! module. This is unwarranted. So we instead collect them in this module.
 
-use crate::support::{TestContextVersioning, Version};
+use crate::support::{
+    AvailableComponents, Component, REDIS_VERSION_CE_6_0, TestContext, TestContextVersioning,
+};
+use redis_test::{MockCmd, MockRedisConnection};
 
-#[macro_use]
 mod support;
+
+fn build_available_components(input: &str) -> AvailableComponents {
+    let mut conn = MockRedisConnection::new(vec![MockCmd::new(redis::cmd("INFO"), Ok(input))]);
+    AvailableComponents::from(&mut conn)
+}
+
+fn assert_components_eq(components: AvailableComponents, mut expected: Vec<Component>) {
+    let mut actual: Vec<Component> = (&components).into();
+    actual.sort();
+    expected.sort();
+    assert_eq!(actual, expected);
+}
 
 /// Mock implementation of [`TestContextVersioning`] to allow testing default implementations
 struct MockTestContext {
-    /// The version to return during `get_version`
-    version: Version,
+    /// The components to return during `get_available_components`
+    components: AvailableComponents,
 }
 
 impl MockTestContext {
     /// Builds a new instance
-    fn new(version: Version) -> Self {
-        Self { version }
+    fn new(input: &str) -> Self {
+        let components = build_available_components(input);
+        Self { components }
     }
 }
 
 impl TestContextVersioning for MockTestContext {
-    fn get_version(&self) -> Version {
-        self.version
+    fn get_available_components(&self) -> AvailableComponents {
+        self.components.clone()
     }
 }
 
 /// Tries to assure that `support` matches the same version
 #[test]
-fn support_exact_match() {
+fn ctx_supports_exact_match() {
     // The context to check with
-    let mock = MockTestContext::new((42, 4711, 23));
+    let mock = MockTestContext::new("foo_version: 42.4711.23");
 
     // Check for support
-    assert!(mock.supports(&(42, 4711, 23)));
+    assert!(mock.supports(&("foo", (42, 4711, 23))));
 }
 
 /// Tries to assure that `support` correctly handles a smaller major number
 #[test]
-fn support_major_smaller() {
+fn ctx_supports_major_smaller() {
     // The context to check with
-    let mock = MockTestContext::new((42, 4711, 23));
+    let mock = MockTestContext::new("foo_version: 42.4711.23");
 
     // Check for support
-    assert!(mock.supports(&(41, 4712, 24)));
+    assert!(mock.supports(&("foo", (41, 4712, 24))));
 }
 
 /// Tries to assure that `support` correctly handles a bigger major number
 #[test]
-fn support_major_bigger() {
+fn ctx_supports_major_bigger() {
     // The context to check with
-    let mock = MockTestContext::new((42, 4711, 23));
+    let mock = MockTestContext::new("foo_version: 42.4711.23");
 
     // Check for support
-    assert!(!mock.supports(&(43, 4710, 22)));
+    assert!(!mock.supports(&("foo", (43, 4710, 22))));
 }
 
 /// Tries to assure that `support` correctly handles a matching major but bigger minor number
 #[test]
-fn support_major_match_minor_smaller() {
+fn ctx_supports_major_match_minor_smaller() {
     // The context to check with
-    let mock = MockTestContext::new((42, 4711, 23));
+    let mock = MockTestContext::new("foo_version: 42.4711.23");
 
     // Check for support
-    assert!(mock.supports(&(42, 4710, 24)));
+    assert!(mock.supports(&("foo", (42, 4710, 24))));
 }
 
 /// Tries to assure that `support` correctly handles a matching major but smaller minor number
 #[test]
-fn support_major_match_minor_bigger() {
+fn ctx_supports_major_match_minor_bigger() {
     // The context to check with
-    let mock = MockTestContext::new((42, 4711, 23));
+    let mock = MockTestContext::new("foo_version: 42.4711.23");
 
     // Check for support
-    assert!(!mock.supports(&(42, 4712, 22)));
+    assert!(!mock.supports(&("foo", (42, 4712, 22))));
 }
 
 /// Tries to assure that `support` correctly handles a matching major and minor but bigger patch number
 #[test]
-fn support_major_match_minor_match_patch_smaller() {
+fn ctx_supports_major_match_minor_match_patch_smaller() {
     // The context to check with
-    let mock = MockTestContext::new((42, 4711, 23));
+    let mock = MockTestContext::new("foo_version: 42.4711.23");
 
     // Check for support
-    assert!(mock.supports(&(42, 4711, 22)));
+    assert!(mock.supports(&("foo", (42, 4711, 22))));
 }
 
 /// Tries to assure that `support` correctly handles a matching major and minor but smaller patch number
 #[test]
-fn support_major_match_minor_match_patch_bigger() {
+fn ctx_supports_major_match_minor_match_patch_bigger() {
     // The context to check with
-    let mock = MockTestContext::new((42, 4711, 23));
+    let mock = MockTestContext::new("foo_version: 42.4711.23");
 
     // Check for support
-    assert!(!mock.supports(&(42, 4711, 24)));
+    assert!(!mock.supports(&("foo", (42, 4711, 24))));
+}
+
+/// Tries to assure that the current server allows to parse the versions
+#[test]
+fn ctx_live_test_server() {
+    let ctx = TestContext::new();
+    let mut conn = ctx.connection();
+
+    let components = AvailableComponents::from(&mut conn);
+
+    assert!(components.supports(&REDIS_VERSION_CE_6_0));
+}
+
+/// Tries to assure versions get correctly extracted from a single number with single digit components
+#[test]
+fn component_parse_single_all_single_digit() {
+    let input = "foo_version: 10203";
+
+    let components = build_available_components(input);
+
+    assert_components_eq(components, vec![("foo", (1, 2, 3))]);
+}
+
+/// Tries to assure versions get correctly extracted from a single number with multiple digit components and a suffix
+#[test]
+fn component_parse_single_multiple_digits_suffixed() {
+    let input = "foo_version: 1234567-rc23";
+
+    let components = build_available_components(input);
+
+    assert_components_eq(components, vec![("foo", (123, 45, 67))]);
+}
+
+/// Tries to assure versions get correctly extracted from a pair with single digit components
+#[test]
+fn component_parse_pair_all_single_digit() {
+    let input = "foo_version: 4.2";
+
+    let components = build_available_components(input);
+
+    assert_components_eq(components, vec![("foo", (4, 2, 0))]);
+}
+
+/// Tries to assure versions get correctly extracted from a pair with multiple digit components and a suffix
+#[test]
+fn component_parse_pair_multiple_digits_suffixed() {
+    let input = "foo_version: 42.4711-rc23";
+
+    let components = build_available_components(input);
+
+    assert_components_eq(components, vec![("foo", (42, 4711, 0))]);
+}
+
+/// Tries to assure versions get correctly extracted from a triplet with single digit components
+#[test]
+fn component_parse_triplet_all_single_digit() {
+    let input = "foo_version: 4.2.6";
+
+    let components = build_available_components(input);
+
+    assert_components_eq(components, vec![("foo", (4, 2, 6))]);
+}
+
+/// Tries to assure versions get correctly extracted from a triplet with multiple digit components and a suffix
+#[test]
+fn component_parse_triplet_multiple_digits_suffixed() {
+    let input = "foo_version: 42.4711.23-rc121";
+
+    let components = build_available_components(input);
+
+    assert_components_eq(components, vec![("foo", (42, 4711, 23))]);
+}
+
+/// Tries to assure that a simple server version gets properly extracted from an info response
+#[test]
+fn component_parse_multiline_simple_server_version() {
+    let input = r#"
+bar: baz
+foo_version:4711.23.42
+quux: quuux
+"#;
+
+    let components = build_available_components(input);
+
+    assert_components_eq(components, vec![("foo", (4711, 23, 42))]);
+}
+
+/// Tries to assure that a simple module version gets properly extracted from an info response
+#[test]
+fn component_parse_multiline_simple_module_version() {
+    let input = r#"
+bar: baz
+module:name=foo,ver=47112342
+quux: quuux
+"#;
+
+    let components = build_available_components(input);
+
+    assert_components_eq(components, vec![("foo", (4711, 23, 42))]);
+}
+
+/// Tries to assure that versions properly parse from a complex info response
+#[test]
+fn component_parse_mix() {
+    let input = r#"
+   foo_version   :  2600.3.14159  # with whitespace padding
+#bar_version:1.2.3 # commented out
+this is # partly commented out
+
+   module  :  foo=bar, ver  =  47112342, quux=quuux,  name = baz , baz =
+"#;
+
+    let components = build_available_components(input);
+
+    assert_components_eq(
+        components,
+        vec![("foo", (2600, 3, 14159)), ("baz", (4711, 23, 42))],
+    );
 }

--- a/redis/tests/test_support.rs
+++ b/redis/tests/test_support.rs
@@ -1,0 +1,99 @@
+//! (Unit) tests for the support module
+//!
+//! As the `support` module gets included in most integration tests, adding its unit tests to the
+//! `support` module itself would include (and compile and run) them for each integration test
+//! module. This is unwarranted. So we instead collect them in this module.
+
+use crate::support::{TestContextVersioning, Version};
+
+#[macro_use]
+mod support;
+
+/// Mock implementation of [`TestContextVersioning`] to allow testing default implementations
+struct MockTestContext {
+    /// The version to return during `get_version`
+    version: Version,
+}
+
+impl MockTestContext {
+    /// Builds a new instance
+    fn new(version: Version) -> Self {
+        Self { version }
+    }
+}
+
+impl TestContextVersioning for MockTestContext {
+    fn get_version(&self) -> Version {
+        self.version
+    }
+}
+
+/// Tries to assure that `support` matches the same version
+#[test]
+fn support_exact_match() {
+    // The context to check with
+    let mock = MockTestContext::new((42, 4711, 23));
+
+    // Check for support
+    assert!(mock.supports(&(42, 4711, 23)));
+}
+
+/// Tries to assure that `support` correctly handles a smaller major number
+#[test]
+fn support_major_smaller() {
+    // The context to check with
+    let mock = MockTestContext::new((42, 4711, 23));
+
+    // Check for support
+    assert!(mock.supports(&(41, 4712, 24)));
+}
+
+/// Tries to assure that `support` correctly handles a bigger major number
+#[test]
+fn support_major_bigger() {
+    // The context to check with
+    let mock = MockTestContext::new((42, 4711, 23));
+
+    // Check for support
+    assert!(!mock.supports(&(43, 4710, 22)));
+}
+
+/// Tries to assure that `support` correctly handles a matching major but bigger minor number
+#[test]
+fn support_major_match_minor_smaller() {
+    // The context to check with
+    let mock = MockTestContext::new((42, 4711, 23));
+
+    // Check for support
+    assert!(mock.supports(&(42, 4710, 24)));
+}
+
+/// Tries to assure that `support` correctly handles a matching major but smaller minor number
+#[test]
+fn support_major_match_minor_bigger() {
+    // The context to check with
+    let mock = MockTestContext::new((42, 4711, 23));
+
+    // Check for support
+    assert!(!mock.supports(&(42, 4712, 22)));
+}
+
+/// Tries to assure that `support` correctly handles a matching major and minor but bigger patch number
+#[test]
+fn support_major_match_minor_match_patch_smaller() {
+    // The context to check with
+    let mock = MockTestContext::new((42, 4711, 23));
+
+    // Check for support
+    assert!(mock.supports(&(42, 4711, 22)));
+}
+
+/// Tries to assure that `support` correctly handles a matching major and minor but smaller patch number
+#[test]
+fn support_major_match_minor_match_patch_bigger() {
+    // The context to check with
+    let mock = MockTestContext::new((42, 4711, 23));
+
+    // Check for support
+    assert!(!mock.supports(&(42, 4711, 24)));
+}

--- a/redis/tests/test_tls_cert_auth.rs
+++ b/redis/tests/test_tls_cert_auth.rs
@@ -92,9 +92,7 @@ fn generate_random_username() -> String {
 fn test_tls_certificate_authentication_with_matching_acl_user() {
     // This test verifies that Redis 8.6+ can automatically authenticate a client
     // based on the Common Name (CN) field in the client's TLS certificate.
-
-    // Check Redis binary version before creating the test context.
-    run_test_if_redis_binary_version_supported!(&REDIS_VERSION_CE_8_6);
+    run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
 
     // Generate a random username for the test.
     let test_username = generate_random_username();
@@ -171,9 +169,7 @@ fn test_tls_certificate_authentication_with_matching_acl_user() {
 fn test_tls_certificate_authentication_no_matching_user() {
     // This test verifies that when a client certificate's CN doesn't match
     // any existing ACL user, Redis falls back to the "default" user.
-
-    // Check Redis binary version before creating the test context.
-    run_test_if_redis_binary_version_supported!(&REDIS_VERSION_CE_8_6);
+    run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
 
     // Generate a random username (that won't have a corresponding ACL user).
     let test_username = generate_random_username();


### PR DESCRIPTION
This extracts versions from all `*_version` and `module` keys from `INFO`.

And it allows to use a list of components to `OR` them and write
version guards like

```
let ctx = run_test_if_version_supported!(&[&REDIS_8_8, &VALKEY_9_0]);
```

to run the test only on `Redis v8.8 || Valkey v9.0` and skip otherwise.

It also allows to use list of lists of components to `OR` the inner lists
and `AND` the outer lists to write version guards like

```
let ctx = run_test_if_version_supported!(&[&[&REDIS_8_8, &VALKEY_9_0][..], &[&REJSON_MODULE_8_8]]);
```

to match `(Redis v8.8 || Valkey v9.0) && REJSON module v8.8`.

Fixes #2118 