### PR TITLE
tests: Add test guards for Valkey servers (Version refactor 10/10)

### DIFF
--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -3,7 +3,7 @@
 use redis::ConnectionLike;
 use std::collections::HashMap;
 
-// Redis version constants for version-gated tests
+// Version constants for version-gated tests
 pub const REDIS_CE_6_0: Component = ("redis", (6, 0, 0));
 pub const REDIS_CE_7_0: Component = ("redis", (7, 0, 0));
 pub const REDIS_CE_7_2: Component = ("redis", (7, 2, 0));
@@ -13,7 +13,12 @@ pub const REDIS_CE_8_2: Component = ("redis", (8, 1, 240));
 pub const REDIS_CE_8_4: Component = ("redis", (8, 3, 224));
 pub const REDIS_CE_8_6: Component = ("redis", (8, 6, 0));
 
+// Valkey forked off at Redis 7.2.4 and still reports its Redis version 7.2.4. So tests that run
+// on Redis<=7.2.4 automatically also run on any Valkey server, and we only need version guards for
+// later versions.
+pub const VALKEY_8_1: Component = ("valkey", (8, 1, 0));
 pub const VALKEY_9_0: Component = ("valkey", (9, 0, 0));
+pub const VALKEY_9_1: Component = ("valkey", (9, 1, 0));
 
 /// Version of a software component
 pub type Version = (u32, u32, u32);

--- a/redis/tests/test_acl.rs
+++ b/redis/tests/test_acl.rs
@@ -186,7 +186,6 @@ fn test_acl_dryrun() {
 }
 #[test]
 fn test_acl_info() {
-    // Skip the test <7.2, as `sanitize-payload` was not available before 7.2
     let ctx = run_test_if_version_supported!(REDIS_CE_7_2);
     let mut conn = ctx.connection();
     let username = "tenant";
@@ -264,7 +263,6 @@ fn test_acl_info() {
 }
 #[test]
 fn test_acl_sample_info() {
-    // Skip the test <7.2, as `sanitize-payload` was not available before 7.2
     let ctx = run_test_if_version_supported!(REDIS_CE_7_2);
     let mut conn = ctx.connection();
     let sample_rule = vec![

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -369,8 +369,7 @@ mod basic {
 
     #[test]
     fn test_hash_expiration() {
-        // Hash expiration is only supported in Redis 7.4.0 and later.
-        let ctx = run_test_if_version_supported!(REDIS_CE_7_4);
+        let ctx = run_test_if_version_supported!([REDIS_CE_7_4, VALKEY_9_0]);
 
         let mut con = ctx.connection();
         redis::cmd("HMSET")
@@ -484,7 +483,7 @@ mod basic {
     /// 5. Attempting to delete a field from a non-existing hash results in a NIL response.
     #[test]
     fn test_hget_del() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_0);
+        let ctx = run_test_if_version_supported!([REDIS_CE_8_0, VALKEY_9_1]);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
@@ -561,7 +560,7 @@ mod basic {
     /// 6. Attempting to retrieve a field from a non-existing hash returns in a NIL response.
     #[test]
     fn test_hget_ex() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_0);
+        let ctx = run_test_if_version_supported!([REDIS_CE_8_0, VALKEY_9_0]);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
@@ -680,7 +679,7 @@ mod basic {
     /// as well as removing an existing expiration using the PERSIST option.
     #[test]
     fn test_hget_ex_field_expiration_options() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_0);
+        let ctx = run_test_if_version_supported!([REDIS_CE_8_0, VALKEY_9_0]);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
@@ -775,7 +774,7 @@ mod basic {
     ///        and verifies that their values have been modified and the fields are set to expire.
     #[test]
     fn test_hset_ex() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_0);
+        let ctx = run_test_if_version_supported!([REDIS_CE_8_0, VALKEY_9_0]);
         let mut con = ctx.connection();
 
         let generated_hash_key = generate_random_testing_hash_key(&mut con);
@@ -961,7 +960,7 @@ mod basic {
     /// as well as keeping an existing expiration using the KEEPTTL option.
     #[test]
     fn test_hsetex_field_expiration_options() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_0);
+        let ctx = run_test_if_version_supported!([REDIS_CE_8_0, VALKEY_9_0]);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
@@ -1023,7 +1022,7 @@ mod basic {
 
     #[test]
     fn test_hsetex_can_update_the_expiration_of_a_field_that_has_already_been_set_to_expire() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_0);
+        let ctx = run_test_if_version_supported!([REDIS_CE_8_0, VALKEY_9_0]);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
@@ -2207,7 +2206,7 @@ mod basic {
 
     #[test]
     fn test_bit_operations() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_2);
+        let ctx = TestContext::new();
         let mut con = ctx.connection();
 
         fn perform_bitwise_operation<F>(str1: &str, str2: &str, op: F) -> String
@@ -2281,6 +2280,9 @@ mod basic {
         assert_eq!(con.bit_not(result, random_key), Ok(1));
         let not_result: Vec<u8> = redis::Commands::get(&mut con, result).unwrap();
         assert_eq!(not_result, vec![!key_values.get(random_key).unwrap()[0]]);
+
+        // `BITOPS` mode `DIFF` is only supported in Redis 8.2+ (but not Valkey<=9.1)
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_2);
 
         // BITOP DIFF
         // DIFF(K1, K2, K3) = K1 ∧ ¬(K2 ∨ K3) = Members of K1 that are not members of any of K2, K3
@@ -2747,7 +2749,7 @@ mod basic {
     /// The test validates the IFEQ value comparison option for the SET command
     #[test]
     fn test_set_value_comparison_value_equals() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
+        let ctx = run_test_if_version_supported!([REDIS_CE_8_4, VALKEY_8_1]);
         let mut con = ctx.connection();
 
         let key = "test_ifeq_key";
@@ -2806,6 +2808,7 @@ mod basic {
     /// The test validates the IFNE value comparison option for the SET command
     #[test]
     fn test_set_value_comparison_value_not_equals() {
+        // `SET` option `IFNE` is only supported in Redis 8.4+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
         let mut con = ctx.connection();
 
@@ -2871,6 +2874,7 @@ mod basic {
     /// The test validates the DIGEST command
     #[test]
     fn test_digest_command() {
+        // `DIGEST` is only supported in Redis 8.4+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
         let mut con = ctx.connection();
 
@@ -2915,6 +2919,7 @@ mod basic {
     /// The test validates the IFDEQ value comparison option for the SET command
     #[test]
     fn test_set_value_comparison_digest_equals() {
+        // `SET` option `IFDEQ` is only supported in Redis 8.4+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
         let mut con = ctx.connection();
 
@@ -2978,6 +2983,7 @@ mod basic {
     /// The test validates the IFDNE value comparison option for the SET command
     #[test]
     fn test_set_value_comparison_digest_not_equals() {
+        // `SET` option `IFDNE` is only supported in Redis 8.4+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
         let mut con = ctx.connection();
 
@@ -3046,6 +3052,7 @@ mod basic {
 
     #[test]
     fn test_del_ex() {
+        // `DELEX` is only supported in Redis 8.4+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
         let mut con = ctx.connection();
 
@@ -3175,7 +3182,7 @@ mod basic {
     /// Test the MSETEX command with the NX existence option
     #[test]
     fn test_mset_ex_nx() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
+        let ctx = run_test_if_version_supported!([REDIS_CE_8_4, VALKEY_9_1]);
         let mut con = ctx.connection();
 
         let key1 = "mset_ex_nx_key1";
@@ -3221,7 +3228,7 @@ mod basic {
     /// Test the MSETEX command with the XX existence option
     #[test]
     fn test_mset_ex_xx() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
+        let ctx = run_test_if_version_supported!([REDIS_CE_8_4, VALKEY_9_1]);
         let mut con = ctx.connection();
 
         let key1 = "mset_ex_xx_key1";
@@ -3275,7 +3282,7 @@ mod basic {
     /// Test the MSETEX command with all supported expiration options
     #[test]
     fn test_mset_ex_expiration_options() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
+        let ctx = run_test_if_version_supported!([REDIS_CE_8_4, VALKEY_9_1]);
         let mut con = ctx.connection();
 
         let current_timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
@@ -3383,8 +3390,7 @@ mod basic {
 
     #[test]
     fn test_expire_time() {
-        // EXPIRETIME/PEXPIRETIME is available from Redis version 7.4.0
-        let ctx = run_test_if_version_supported!(REDIS_CE_7_4);
+        let ctx = run_test_if_version_supported!(REDIS_CE_7_0);
 
         let mut con = ctx.connection();
 
@@ -3540,7 +3546,6 @@ mod basic {
             (String::from("b"), String::from("6b"), 6.0)
         );
 
-        // BZMPOP is available from Redis version 7.0.0
         if ctx.supports(REDIS_CE_7_0) {
             let min = con.bzmpop_min(0.0, vec!["a", "b", "c", "d"].as_slice(), 1);
             let max = con.bzmpop_max(0.0, vec!["a", "b", "c", "d"].as_slice(), 1);
@@ -3628,6 +3633,7 @@ mod basic {
     #[test]
     #[cfg(feature = "vector-sets")]
     fn test_vector_sets_basic_operations() {
+        // `VADD` is only supported in Redis 8.0+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_0);
         let mut con = ctx.connection();
 
@@ -3712,6 +3718,7 @@ mod basic {
     #[test]
     #[cfg(feature = "vector-sets")]
     fn test_vector_sets_similarity_search() {
+        // `VADD` is only supported in Redis 8.0+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_0);
         let mut con = ctx.connection();
 
@@ -3893,6 +3900,7 @@ mod basic {
     #[test]
     #[cfg(feature = "vector-sets")]
     fn test_vector_sets_auxiliary_commands() {
+        // `VADD` is only supported in Redis 8.0+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_0);
         let mut con = ctx.connection();
 
@@ -4124,6 +4132,7 @@ mod basic {
     #[test]
     #[cfg(feature = "vector-sets")]
     fn test_vector_sets_edge_cases() {
+        // `VADD` is only supported in Redis 8.0+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_0);
         let mut con = ctx.connection();
 
@@ -4513,7 +4522,6 @@ mod basic {
 
     #[test]
     fn test_connection_info_lib_name() {
-        // Setting the lib_name etc is only supported in Redis 7.2.0 and later.
         let ctx = run_test_if_version_supported!(REDIS_CE_7_2);
 
         // Build a `ConnectionInfo` that sets lib_name etc

--- a/redis/tests/test_hotkeys.rs
+++ b/redis/tests/test_hotkeys.rs
@@ -69,6 +69,7 @@ mod hotkeys {
     #[case(ProtocolVersion::RESP2)]
     #[case(ProtocolVersion::RESP3)]
     fn test_hotkeys_state_machine_behavior(#[case] protocol: ProtocolVersion) {
+        // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
         let mut con = setup_connection_with_protocol(&ctx, protocol);
 
@@ -145,6 +146,7 @@ mod hotkeys {
     #[case(ProtocolVersion::RESP2, Metric::All)]
     #[case(ProtocolVersion::RESP3, Metric::All)]
     fn test_hotkeys_with_metric(#[case] protocol: ProtocolVersion, #[case] metric: Metric) {
+        // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
         let mut con = setup_connection_with_protocol(&ctx, protocol);
 
@@ -171,6 +173,7 @@ mod hotkeys {
     #[case(ProtocolVersion::RESP2)]
     #[case(ProtocolVersion::RESP3)]
     fn test_hotkeys_options_with_duration_and_count(#[case] protocol: ProtocolVersion) {
+        // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
         let mut con = setup_connection_with_protocol(&ctx, protocol);
 
@@ -203,6 +206,7 @@ mod hotkeys {
     #[case(ProtocolVersion::RESP2)]
     #[case(ProtocolVersion::RESP3)]
     fn test_hotkeys_options_with_sample_ratio(#[case] protocol: ProtocolVersion) {
+        // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
         let mut con = setup_connection_with_protocol(&ctx, protocol);
 
@@ -223,6 +227,7 @@ mod hotkeys {
     #[case(ProtocolVersion::RESP2)]
     #[case(ProtocolVersion::RESP3)]
     fn test_hotkeys_start_with_slots_on_standalone_errors(#[case] protocol: ProtocolVersion) {
+        // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
         let mut con = setup_connection_with_protocol(&ctx, protocol);
 
@@ -329,6 +334,7 @@ mod hotkeys_cluster {
         let port = port_of(info.addr());
         let mut direct = direct_connection(info.clone(), protocol);
 
+        // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
         skip_if_context_does_not_support!(cluster_ctx, REDIS_CE_8_6, None);
 
         let (range_start, range_end) = first_owned_slot_range(&mut direct, port);
@@ -634,6 +640,7 @@ mod async_hotkeys {
         #[case] runtime: RuntimeType,
         #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
     ) {
+        // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
 
         println!("Starting test_hotkeys_state_machine_behavior_async - Protocol: {protocol:?}");
@@ -712,6 +719,7 @@ mod async_hotkeys {
         #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
         #[values(Metric::Cpu, Metric::Net, Metric::All)] metric: Metric,
     ) {
+        // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
 
         println!(
@@ -748,6 +756,7 @@ mod async_hotkeys {
         #[case] runtime: RuntimeType,
         #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
     ) {
+        // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
 
         println!(
@@ -792,6 +801,7 @@ mod async_hotkeys {
         #[case] runtime: RuntimeType,
         #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
     ) {
+        // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
 
         println!("Starting test_hotkeys_options_with_sample_ratio_async - Protocol: {protocol:?}");
@@ -824,6 +834,7 @@ mod async_hotkeys {
         #[case] runtime: RuntimeType,
         #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
     ) {
+        // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
 
         println!(

--- a/redis/tests/test_streams.rs
+++ b/redis/tests/test_streams.rs
@@ -794,6 +794,7 @@ fn test_xclaim_last_id() {
 
 #[test]
 fn test_xreadgroup_with_claim_option() {
+    // `XREADGROUP` option `CLAIM` is only supported in Redis 8.4+ (but not Valkey<=9.1)
     let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
     let mut con = ctx.connection();
 
@@ -895,6 +896,7 @@ fn test_xreadgroup_with_claim_option() {
 
 #[test]
 fn test_xreadgroup_claim_with_idle_and_incoming_messages() {
+    // `XREADGROUP` option `CLAIM` is only supported in Redis 8.4+ (but not Valkey<=9.1)
     let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
     let mut con = ctx.connection();
 
@@ -1026,6 +1028,7 @@ fn test_xreadgroup_claim_with_idle_and_incoming_messages() {
 
 #[test]
 fn test_xreadgroup_claim_multiple_streams() {
+    // `XREADGROUP` option `CLAIM` is only supported in Redis 8.4+ (but not Valkey<=9.1)
     let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
     let mut con = ctx.connection();
 
@@ -1121,6 +1124,7 @@ fn test_xdel() {
 
 #[test]
 fn test_xadd_options_deletion_policy_keepref() {
+    // `XADD` mode `KEEPREF` is only supported in Redis 8.2+ (but not Valkey<=9.1)
     let ctx = run_test_if_version_supported!(REDIS_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
@@ -1206,6 +1210,7 @@ fn test_xadd_options_deletion_policy_keepref() {
 
 #[test]
 fn test_xadd_options_deletion_policy_delref() {
+    // `XADD` mode `DELREF` is only supported in Redis 8.2+ (but not Valkey<=9.1)
     let ctx = run_test_if_version_supported!(REDIS_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
@@ -1291,6 +1296,7 @@ fn test_xadd_options_deletion_policy_delref() {
 
 #[test]
 fn test_xadd_options_deletion_policy_acked() {
+    // `XADD` mode `ACKED` is only supported in Redis 8.2+ (but not Valkey<=9.1)
     let ctx = run_test_if_version_supported!(REDIS_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
@@ -1379,6 +1385,7 @@ fn test_xadd_options_deletion_policy_acked() {
 
 #[test]
 fn test_xtrim_options_deletion_policy_keepref() {
+    // `XTRIM` mode `KEEPREF` is only supported in Redis 8.2+ (but not Valkey<=9.1)
     let ctx = run_test_if_version_supported!(REDIS_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
@@ -1450,6 +1457,7 @@ fn test_xtrim_options_deletion_policy_keepref() {
 
 #[test]
 fn test_xtrim_options_deletion_policy_delref() {
+    // `XTRIM` mode `DELREF` is only supported in Redis 8.2+ (but not Valkey<=9.1)
     let ctx = run_test_if_version_supported!(REDIS_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
@@ -1521,6 +1529,7 @@ fn test_xtrim_options_deletion_policy_delref() {
 
 #[test]
 fn test_xtrim_options_deletion_policy_acked() {
+    // `XTRIM` mode `ACKED` is only supported in Redis 8.2+ (but not Valkey<=9.1)
     let ctx = run_test_if_version_supported!(REDIS_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
@@ -1592,6 +1601,7 @@ fn test_xtrim_options_deletion_policy_acked() {
 
 #[test]
 fn test_xdel_ex() {
+    // `XDELEX` is only supported in Redis 8.2+ (but not Valkey<=9.1)
     let ctx = run_test_if_version_supported!(REDIS_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
@@ -1792,6 +1802,7 @@ fn test_xdel_ex() {
 
 #[test]
 fn test_xack_del() {
+    // `XACKDEL` is only supported in Redis 8.2+ (but not Valkey<=9.1)
     let ctx = run_test_if_version_supported!(REDIS_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
@@ -2394,6 +2405,7 @@ mod idempotency_tests {
     #[test]
     fn test_xadd_idempotency_manual_mode() {
         // Test IDMP (manual mode) - prevents messages with the same PID and IID from being added to the stream.
+        // Stream idempotency is only supported in Redis 8.6+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
         let mut con = ctx.connection();
 
@@ -2475,6 +2487,7 @@ mod idempotency_tests {
     #[test]
     fn test_xadd_idempotency_automatic_mode() {
         // Test IDMPAUTO (automatic mode) - prevents messages with the same PID and content from being added to the stream.
+        // Stream idempotency is only supported in Redis 8.6+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
         let mut con = ctx.connection();
 
@@ -2544,6 +2557,7 @@ mod idempotency_tests {
     #[test]
     fn test_xadd_idempotency_with_other_options() {
         // Test that idempotency works correctly with other XADD options
+        // Stream idempotency is only supported in Redis 8.6+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
         let mut con = ctx.connection();
 
@@ -2695,6 +2709,7 @@ mod idempotency_tests {
 
     #[test]
     fn test_xcfgset() {
+        // `XCFGSET` is only supported in Redis 8.6+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
         let mut con = ctx.connection();
 
@@ -2784,6 +2799,7 @@ mod idempotency_tests {
 
     #[test]
     fn test_xcfgset_with_idempotent_messages() {
+        // `XCFGSET` is only supported in Redis 8.6+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
         let mut con = ctx.connection();
 
@@ -2889,6 +2905,7 @@ mod idempotency_tests {
 
     #[test]
     fn test_xcfgset_idempotency_behavior() {
+        // `XCFGSET` is only supported in Redis 8.6+ (but not Valkey<=9.1)
         let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
         let mut con = ctx.connection();
 

--- a/redis/tests/test_tls_cert_auth.rs
+++ b/redis/tests/test_tls_cert_auth.rs
@@ -90,10 +90,10 @@ fn generate_random_username() -> String {
 
 #[test]
 fn test_tls_certificate_authentication_with_matching_acl_user() {
-    // This test verifies that Redis 8.6+ can automatically authenticate a client
+    // This test verifies that Redis can automatically authenticate a client
     // based on the Common Name (CN) field in the client's TLS certificate.
 
-    run_test_if_version_supported!(REDIS_CE_8_6);
+    run_test_if_version_supported!([REDIS_CE_8_6, VALKEY_9_0]);
 
     // Generate a random username for the test.
     let test_username = generate_random_username();
@@ -170,7 +170,7 @@ fn test_tls_certificate_authentication_with_matching_acl_user() {
 fn test_tls_certificate_authentication_no_matching_user() {
     // This test verifies that when a client certificate's CN doesn't match
     // any existing ACL user, Redis falls back to the "default" user.
-    run_test_if_version_supported!(REDIS_CE_8_6);
+    run_test_if_version_supported!([REDIS_CE_8_6, VALKEY_9_0]);
 
     // Generate a random username (that won't have a corresponding ACL user).
     let test_username = generate_random_username();


### PR DESCRIPTION
This allows to run more tests against newer Valkey servers.

Although Valkey 9.1 is not tested in CI, we nonetheless add
corresponding guards, as they will automatically enable tests if CI
adds newer Valkey servers.
