### PR TITLE
Makefile: Select module tests directly to reduce output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,23 +46,23 @@ test-module-json:
 	@echo "===================================================================="
 	@echo "Testing RESP2 with RedisJSON module"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features -E 'test(test_module_json)'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features --test test_module_json
 
 	@echo "===================================================================="
 	@echo "Testing RESP3 with RedisJSON module"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --all-features -E 'test(test_module_json)'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --all-features --test test_module_json
 
 test-module-bloom:
 	@echo "===================================================================="
 	@echo "Testing RESP2 with RedisBloom module"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features -E 'test(test_module_bloom)'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features --test test_module_bloom
 
 	@echo "===================================================================="
 	@echo "Testing RESP3 with RedisBloom module"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --all-features -E 'test(test_module_bloom)'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --all-features --test test_module_bloom
 
 test-modules: test-module-json test-module-bloom
 


### PR DESCRIPTION
We selected module tests by their test name, which first collected all tests into the candidate set and then skipped those that were not for the given module. This resulted in 100s of `SKIPPED` lines and made it hard to spot the signal.

By selecting the module tests directly, the output of the module tests easily fits on a single screen and better exposes what's going on.