### PR TITLE
commands/macros: Move `RV` to last position for Generic typed commands

### DIFF
--- a/redis/src/commands/macros.rs
+++ b/redis/src/commands/macros.rs
@@ -8,16 +8,12 @@ macro_rules! implement_command_async {
         fn $name:ident<$($tyargs:ident : $ty:ident),*>(
             $($argname:ident: $argty:ty),*) $body:block Generic
     ) => {
-        $(#[$attr])*
-        #[inline]
-        #[allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
-        fn $name<$lifetime, RV: FromRedisValue, $($tyargs: $ty + Send + Sync + $lifetime,)*>(
-            & $lifetime mut self
-            $(, $argname: $argty)*
-        ) -> crate::types::RedisFuture<$lifetime, RV>
-        {
-            Box::pin(async move { $body.query_async(self).await })
-        }
+        implement_command_async!(
+            $lifetime
+            $(#[$attr])+
+            fn $name<RV: FromRedisValue$(, $tyargs : $ty)*>(
+                $($argname: $argty),*) $body RV
+        );
     };
 
     // If return type is specified in the input skeleton, then we will return it in the generated function (note match rule `$rettype:ty`)
@@ -49,16 +45,12 @@ macro_rules! implement_command_sync {
         fn $name:ident<$($tyargs:ident : $ty:ident),*>(
             $($argname:ident: $argty:ty),*) $body:block Generic
     ) => {
-        $(#[$attr])*
-        #[inline]
-        #[allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
-        fn $name<$lifetime, RV: FromRedisValue, $($tyargs: $ty + Send + Sync + $lifetime,)*>(
-            & $lifetime mut self
-            $(, $argname: $argty)*
-        ) -> RedisResult<RV>
-        {
-            Cmd::$name($($argname),*).query(self)
-        }
+        implement_command_sync!(
+            $lifetime
+            $(#[$attr])+
+            fn $name<RV: FromRedisValue$(, $tyargs : $ty)*>(
+                $($argname: $argty),*) $body RV
+        );
     };
 
     // If return type is specified in the input skeleton, then we will return it in the generated function (note match rule `$rettype:ty`)

--- a/redis/src/commands/macros.rs
+++ b/redis/src/commands/macros.rs
@@ -11,7 +11,7 @@ macro_rules! implement_command_async {
         implement_command_async!(
             $lifetime
             $(#[$attr])+
-            fn $name<RV: FromRedisValue$(, $tyargs : $ty)*>(
+            fn $name<$($tyargs : $ty,)* RV: FromRedisValue>(
                 $($argname: $argty),*) $body RV
         );
     };
@@ -48,7 +48,7 @@ macro_rules! implement_command_sync {
         implement_command_sync!(
             $lifetime
             $(#[$attr])+
-            fn $name<RV: FromRedisValue$(, $tyargs : $ty)*>(
+            fn $name<$($tyargs : $ty,)* RV: FromRedisValue>(
                 $($argname: $argty),*) $body RV
         );
     };

--- a/version2.md
+++ b/version2.md
@@ -10,6 +10,24 @@ redis = "2"
 
 ## Breaking Changes
 
+### `Generic` typed commands have their `RV` moved from first to last parameter (Breaking Change)
+
+Untyped commands (`Commands`, `AsyncCommands`) have the return value's type (`RV`) as last type parameter, while for typed commands (`TypedCommands`, `AsyncTypedCommands`) it was the first.
+
+Now both typed and untyped commands have their return value's type as last type parameter.
+
+**Migration:** Move the return type parameter to the last position, if you explicitly gave it.
+
+```rust
+// Before:
+con.rpop::<Vec<String>, _>("foo", NonZeroUsize::new(1));
+//         ^^^ RV as first type parameter
+
+// After:
+con.rpop::<_, Vec<String>>("foo", NonZeroUsize::new(1));
+//            ^^^ RV as last type parameter
+```
+
 ### TCP_NODELAY is now enabled by default (Breaking Change)
 
 By default, Nagle's algorithm is now disabled on every TCP connection the crate creates (sync and async, plaintext and TLS). Previously it was left enabled, which serialized writes on a multiplexed connection to one per ACK round-trip under concurrency — measured at 39–68% lower throughput and roughly double the p50 latency on a real network (see [#2195](https://github.com/redis-rs/redis-rs/issues/2195) for the full evidence). Sequential request-response traffic is unaffected, and Redis clients in other ecosystems already ship with TCP_NODELAY enabled.


### PR DESCRIPTION
While untyped commands have their return value's type (`RV`) in the last
position, `Generic` typed commands had it in the first position.

This difference is unexpected. So we harmonize on the last position, as
this is what the untyped commands, which were around longer, use.

As the `Generic` handling was duplicating logic, we also switch to
delegating to the general case.
