### PR TITLE
tests: Switch direct use of RedisServer to better suited TestContext

### DIFF
--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -1455,8 +1455,11 @@ mod basic_async {
             redis::aio::ConnectionManager::new_with_config(ctx.client.clone(), config)
                 .await
                 .unwrap();
+
+        // Store the server's address and kill the server
         let addr = ctx.server.client_addr().clone();
         drop(ctx);
+
         let result: RedisResult<redis::Value> = manager.set("foo", "bar").await;
         // we expect a connection failure error.
         assert!(result.unwrap_err().is_unrecoverable_error());
@@ -1464,7 +1467,8 @@ mod basic_async {
             assert_eq!(rx.recv().await.unwrap().kind, PushKind::Disconnection);
         }
 
-        let _server = redis_test::server::RedisServer::new_with_addr_and_modules(addr, &[], false);
+        // Start a new server, re-using the previous address
+        let _ctx = TestContext::new_with_addr(addr);
 
         for _ in 0..5 {
             let Ok(result) = manager.set::<_, _, Value>("foo", "bar").await else {

--- a/redis/tests/test_cache.rs
+++ b/redis/tests/test_cache.rs
@@ -619,14 +619,17 @@ async fn test_connection_manager_maintains_statistics_after_crashes(test_with_op
     assert_hit!(&manager, 1);
     assert_miss!(&manager, 1);
 
+    // Store the server's address and kill the server
     let addr = ctx.server.client_addr().clone();
     drop(ctx);
 
+    // With the server gone, commands should fail
     let result: Result<redis::Value, RedisError> =
         manager.send_packed_command(&redis::cmd("PING")).await;
     assert!(result.unwrap_err().is_unrecoverable_error());
 
-    let _server = redis_test::server::RedisServer::new_with_addr_and_modules(addr, &[], false);
+    // Start a new server, re-using the previous address
+    let _ctx = TestContext::new_with_addr(addr);
 
     loop {
         if manager.send_packed_command(&get).await.is_ok() {


### PR DESCRIPTION
`TestContext` has methods that better match the use cases than `RedisServer` and using them makes the tests easier to understand.