### PR TITLE
Improve `RedisServer` readability

### DIFF
--- a/redis-test/src/cluster.rs
+++ b/redis-test/src/cluster.rs
@@ -171,7 +171,7 @@ impl RedisCluster {
         let max_attempts = 5;
 
         let mut make_server = |port| {
-            RedisServer::new_with_addr_tls_modules_and_spawner(
+            RedisServer::new_with_addr_tls_modules_and_arg_refiner(
                 ClusterType::build_addr(port),
                 None,
                 tls_paths.clone(),
@@ -210,7 +210,6 @@ impl RedisCluster {
                     }
                     cmd.current_dir(tempdir.path());
                     folders.push(tempdir);
-                    cmd.spawn().unwrap()
                 },
             )
         };

--- a/redis-test/src/cluster.rs
+++ b/redis-test/src/cluster.rs
@@ -190,22 +190,17 @@ impl RedisCluster {
                         Self::password()
                     );
                     std::fs::write(&acl_path, acl_content).expect("failed to write acl file");
-                    cmd.arg("--cluster-enabled")
-                        .arg("yes")
-                        .arg("--cluster-config-file")
-                        .arg(tempdir.path().join("nodes.conf"))
-                        .arg("--cluster-node-timeout")
-                        .arg("5000")
-                        .arg("--aclfile")
-                        .arg(&acl_path);
+                    cmd.arg2("--cluster-enabled", "yes")
+                        .arg2("--cluster-config-file", tempdir.path().join("nodes.conf"))
+                        .arg2("--cluster-node-timeout", "5000")
+                        .arg2("--aclfile", &acl_path);
                     if let Some(num_databases) = cluster_databases {
-                        cmd.arg("--cluster-databases")
-                            .arg(num_databases.to_string());
+                        cmd.arg2("--cluster-databases", num_databases.to_string());
                     }
                     if is_tls {
-                        cmd.arg("--tls-cluster").arg("yes");
+                        cmd.arg2("--tls-cluster", "yes");
                         if replicas > 0 {
-                            cmd.arg("--tls-replication").arg("yes");
+                            cmd.arg2("--tls-replication", "yes");
                         }
                     }
                     cmd.current_dir(tempdir.path());

--- a/redis-test/src/sentinel.rs
+++ b/redis-test/src/sentinel.rs
@@ -144,9 +144,9 @@ fn spawn_master_server(
         modules,
         |cmd| {
             // Minimize startup delay
-            cmd.arg("--repl-diskless-sync-delay").arg("0");
+            cmd.arg2("--repl-diskless-sync-delay", "0");
             if let ConnectionAddr::TcpTls { .. } = get_addr(port) {
-                cmd.arg("--tls-replication").arg("yes");
+                cmd.arg2("--tls-replication", "yes");
             }
             cmd.current_dir(dir.path());
         },
@@ -171,11 +171,9 @@ fn spawn_replica_server(
         None, // cert_auth_field - not used in sentinel tests
         modules,
         |cmd| {
-            cmd.arg("--replicaof")
-                .arg("127.0.0.1")
-                .arg(master_port.to_string());
+            cmd.arg3("--replicaof", "127.0.0.1", master_port.to_string());
             if let ConnectionAddr::TcpTls { .. } = get_addr(port) {
-                cmd.arg("--tls-replication").arg("yes");
+                cmd.arg2("--tls-replication", "yes");
             }
             cmd.current_dir(dir.path());
         },
@@ -209,7 +207,7 @@ fn spawn_sentinel_server(
         |cmd| {
             cmd.arg("--sentinel");
             if let ConnectionAddr::TcpTls { .. } = get_addr(port) {
-                cmd.arg("--tls-replication").arg("yes");
+                cmd.arg2("--tls-replication", "yes");
             }
             cmd.current_dir(dir.path());
         },

--- a/redis-test/src/sentinel.rs
+++ b/redis-test/src/sentinel.rs
@@ -135,7 +135,7 @@ fn spawn_master_server(
     tlspaths: &TlsFilePaths,
     modules: &[Module],
 ) -> RedisServer {
-    RedisServer::new_with_addr_tls_modules_and_spawner(
+    RedisServer::new_with_addr_tls_modules_and_arg_refiner(
         get_addr(port),
         None,
         Some(tlspaths.clone()),
@@ -149,7 +149,6 @@ fn spawn_master_server(
                 cmd.arg("--tls-replication").arg("yes");
             }
             cmd.current_dir(dir.path());
-            cmd.spawn().unwrap()
         },
     )
 }
@@ -164,7 +163,7 @@ fn spawn_replica_server(
     let config_file_path = dir.path().join("redis_config.conf");
     File::create(&config_file_path).unwrap();
 
-    RedisServer::new_with_addr_tls_modules_and_spawner(
+    RedisServer::new_with_addr_tls_modules_and_arg_refiner(
         get_addr(port),
         Some(&config_file_path),
         Some(tlspaths.clone()),
@@ -179,7 +178,6 @@ fn spawn_replica_server(
                 cmd.arg("--tls-replication").arg("yes");
             }
             cmd.current_dir(dir.path());
-            cmd.spawn().unwrap()
         },
     )
 }
@@ -201,7 +199,7 @@ fn spawn_sentinel_server(
     }
     file.flush().unwrap();
 
-    RedisServer::new_with_addr_tls_modules_and_spawner(
+    RedisServer::new_with_addr_tls_modules_and_arg_refiner(
         get_addr(port),
         Some(&config_file_path),
         Some(tlspaths.clone()),
@@ -214,7 +212,6 @@ fn spawn_sentinel_server(
                 cmd.arg("--tls-replication").arg("yes");
             }
             cmd.current_dir(dir.path());
-            cmd.spawn().unwrap()
         },
     )
 }

--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -188,10 +188,10 @@ impl RedisServer {
         }
 
         match addr {
-            redis::ConnectionAddr::Tcp(ref bind, server_port) => {
+            redis::ConnectionAddr::Tcp(ref host, port) => {
                 redis_cmd
-                    .arg2("--port", server_port.to_string())
-                    .arg2("--bind", bind);
+                    .arg2("--port", port.to_string())
+                    .arg2("--bind", host);
             }
             redis::ConnectionAddr::TcpTls { ref host, port, .. } => {
                 let tls_paths =

--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -375,6 +375,9 @@ impl RedisServerCommand {
 
     /// Loads a module from the given path
     fn load_module(&mut self, path: String) {
+        if !Path::new(&path).is_file() {
+            panic!("Module doesn't exist or is not a file: {path}");
+        }
         self.arg2("--loadmodule", path);
     }
 

--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -175,40 +175,7 @@ impl RedisServer {
         // This stops littering `dump.rdb` files during testing/development.
         redis_cmd.arg2("--save", "");
 
-        // Load Redis Modules
-        for module in modules {
-            match module {
-                Module::Json => {
-                    // Try to pick up json module path from REDISRS_REDIS_JSON_PATH environment variable
-                    let path = match env::var("REDISRS_REDIS_JSON_PATH") {
-                        Ok(path) => path,
-                        // Falling back to legacy REDIS_RS_REDIS_JSON_PATH environment variable
-                        Err(_) => match env::var("REDIS_RS_REDIS_JSON_PATH") {
-                            Ok(path) => {
-                                eprintln!(
-                                    "Warning: Use of REDIS_RS_REDIS_JSON_PATH is deprecated. Use REDISRS_REDIS_JSON_PATH (no '_' before 'RS') instead"
-                                );
-                                path
-                            }
-                            Err(_) => {
-                                panic!(
-                                    "Unable to find path to RedisJSON at REDISRS_REDIS_JSON_PATH, is it set?"
-                                );
-                            }
-                        },
-                    };
-
-                    redis_cmd.arg2("--loadmodule", path);
-                }
-                Module::Bloom => {
-                    let path = env::var("REDISRS_REDIS_BLOOM_PATH").expect(
-                        "Unable to find path to RedisBloom at REDISRS_REDIS_BLOOM_PATH, is it set?",
-                    );
-
-                    redis_cmd.arg2("--loadmodule", path);
-                }
-            };
-        }
+        redis_cmd.load_modules(modules);
 
         let tempdir = tempfile::Builder::new()
             .prefix("redis")
@@ -404,6 +371,50 @@ impl RedisServerCommand {
         self.cmd
             .spawn()
             .unwrap_or_else(|err| panic!("Failed to run {:?}: {err}", self.cmd))
+    }
+
+    /// Loads a module from the given path
+    fn load_module(&mut self, path: String) {
+        self.arg2("--loadmodule", path);
+    }
+
+    /// Loads the given modules
+    ///
+    /// The paths to the modules are inferred from environment variables.
+    pub(crate) fn load_modules(&mut self, modules: &[Module]) {
+        for module in modules {
+            match module {
+                Module::Json => {
+                    // Try to pick up json module path from REDISRS_REDIS_JSON_PATH environment variable
+                    let path = match env::var("REDISRS_REDIS_JSON_PATH") {
+                        Ok(path) => path,
+                        // Falling back to legacy REDIS_RS_REDIS_JSON_PATH environment variable
+                        Err(_) => match env::var("REDIS_RS_REDIS_JSON_PATH") {
+                            Ok(path) => {
+                                eprintln!(
+                                    "Warning: Use of REDIS_RS_REDIS_JSON_PATH is deprecated. Use REDISRS_REDIS_JSON_PATH (no '_' before 'RS') instead"
+                                );
+                                path
+                            }
+                            Err(_) => {
+                                panic!(
+                                    "Unable to find path to RedisJSON at REDISRS_REDIS_JSON_PATH, is it set?"
+                                );
+                            }
+                        },
+                    };
+
+                    self.load_module(path);
+                }
+                Module::Bloom => {
+                    let path = env::var("REDISRS_REDIS_BLOOM_PATH").expect(
+                        "Unable to find path to RedisBloom at REDISRS_REDIS_BLOOM_PATH, is it set?",
+                    );
+
+                    self.load_module(path);
+                }
+            };
+        }
     }
 }
 

--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -1,7 +1,7 @@
 use redis::{ConnectionAddr, IntoConnectionInfo, ProtocolVersion, RedisConnectionInfo};
+use std::ffi::OsStr;
 use std::path::Path;
 use std::{env, fs, path::PathBuf, process};
-
 use tempfile::TempDir;
 
 use crate::utils::{TlsFilePaths, build_keys_and_certs_for_tls, get_random_available_port};
@@ -129,17 +129,14 @@ impl RedisServer {
         let redis_port = get_random_available_port();
         let addr = RedisServer::get_addr(redis_port);
 
-        RedisServer::new_with_addr_tls_modules_and_spawner(
+        RedisServer::new_with_addr_tls_modules_and_arg_refiner(
             addr,
             None,
             None,
             mtls_enabled,
             None,
             modules,
-            |cmd| {
-                cmd.spawn()
-                    .unwrap_or_else(|err| panic!("Failed to run {cmd:?}: {err}"))
-            },
+            |_cmd| {},
         )
     }
 
@@ -148,33 +145,27 @@ impl RedisServer {
         modules: &[Module],
         mtls_enabled: bool,
     ) -> RedisServer {
-        RedisServer::new_with_addr_tls_modules_and_spawner(
+        RedisServer::new_with_addr_tls_modules_and_arg_refiner(
             addr,
             None,
             None,
             mtls_enabled,
             None,
             modules,
-            |cmd| {
-                cmd.spawn()
-                    .unwrap_or_else(|err| panic!("Failed to run {cmd:?}: {err}"))
-            },
+            |_cmd| {},
         )
     }
 
-    pub fn new_with_addr_tls_modules_and_spawner<
-        F: FnOnce(&mut process::Command) -> process::Child,
-    >(
+    pub fn new_with_addr_tls_modules_and_arg_refiner<F: FnOnce(&mut RedisServerCommand)>(
         mut addr: redis::ConnectionAddr,
         config_file: Option<&Path>,
         mut tls_paths: Option<TlsFilePaths>,
         mtls_enabled: bool,
         cert_auth_field: Option<&str>,
         modules: &[Module],
-        spawner: F,
+        arg_refiner: F,
     ) -> RedisServer {
-        let bin = env::var("REDISRS_SERVER_BIN").unwrap_or_else(|_| "redis-server".to_string());
-        let mut redis_cmd = process::Command::new(&bin);
+        let mut redis_cmd = RedisServerCommand::new();
 
         if let Some(config_path) = config_file {
             redis_cmd.arg(config_path);
@@ -219,18 +210,16 @@ impl RedisServer {
             };
         }
 
-        redis_cmd
-            .stdout(process::Stdio::piped())
-            .stderr(process::Stdio::piped());
         let tempdir = tempfile::Builder::new()
             .prefix("redis")
             .tempdir()
             .expect("failed to create tempdir");
         let log_file = Self::log_file(&tempdir);
         redis_cmd.arg("--logfile").arg(log_file.clone());
-        if get_major_version(&bin) > 6 {
+        if get_major_version() > 6 {
             redis_cmd.arg("--enable-debug-command").arg("yes");
         }
+
         match addr {
             redis::ConnectionAddr::Tcp(ref bind, server_port) => {
                 redis_cmd
@@ -289,8 +278,10 @@ impl RedisServer {
             _ => panic!("Unknown address format: {addr:?}"),
         };
 
+        arg_refiner(&mut redis_cmd);
+
         RedisServer {
-            process: spawner(&mut redis_cmd),
+            process: redis_cmd.spawn(),
             log_file,
             tempdir,
             addr,
@@ -331,11 +322,65 @@ impl RedisServer {
     }
 }
 
-fn get_major_version(server_binary: &str) -> u8 {
+pub struct RedisServerCommand {
+    // The actual command to run
+    cmd: process::Command,
+}
+
+impl Default for RedisServerCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RedisServerCommand {
+    pub fn new() -> Self {
+        let bin = env::var("REDISRS_SERVER_BIN").unwrap_or_else(|_| "redis-server".to_string());
+
+        // Build the main command
+        let mut cmd = process::Command::new(&bin);
+
+        // Capture the command's stdout and stderr
+        cmd.stdout(process::Stdio::piped());
+        cmd.stderr(process::Stdio::piped());
+
+        // Build the instance
+        Self { cmd }
+    }
+
+    /// Appends a new argument to the command
+    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
+        self.cmd.arg(arg);
+        self
+    }
+
+    /// Set the directory to run the command in
+    pub fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut Self {
+        self.cmd.current_dir(dir);
+        self
+    }
+
+    /// Runs the command
+    ///
+    /// # Panics
+    ///
+    /// This method panics if spawning fails.
+    ///
+    /// If the command itself exits (immediately or not, regardless of the exit code) this function
+    /// does _not_ panic but returns the `Child` instance.
+    pub fn spawn(&mut self) -> process::Child {
+        self.cmd
+            .spawn()
+            .unwrap_or_else(|err| panic!("Failed to run {:?}: {err}", self.cmd))
+    }
+}
+
+fn get_major_version() -> u8 {
     let full_string = String::from_utf8(
-        process::Command::new(server_binary)
+        RedisServerCommand::new()
             .arg("-v")
-            .output()
+            .spawn()
+            .wait_with_output()
             .unwrap()
             .stdout,
     )

--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -165,9 +165,9 @@ impl RedisServer {
     pub fn new_with_addr_tls_modules_and_spawner<
         F: FnOnce(&mut process::Command) -> process::Child,
     >(
-        addr: redis::ConnectionAddr,
+        mut addr: redis::ConnectionAddr,
         config_file: Option<&Path>,
-        tls_paths: Option<TlsFilePaths>,
+        mut tls_paths: Option<TlsFilePaths>,
         mtls_enabled: bool,
         cert_auth_field: Option<&str>,
         modules: &[Module],
@@ -238,17 +238,10 @@ impl RedisServer {
                     .arg(server_port.to_string())
                     .arg("--bind")
                     .arg(bind);
-
-                RedisServer {
-                    process: spawner(&mut redis_cmd),
-                    log_file,
-                    tempdir,
-                    addr,
-                    tls_paths: None,
-                }
             }
             redis::ConnectionAddr::TcpTls { ref host, port, .. } => {
-                let tls_paths = tls_paths.unwrap_or_else(|| build_keys_and_certs_for_tls(&tempdir));
+                let tls_paths =
+                    tls_paths.get_or_insert_with(|| build_keys_and_certs_for_tls(&tempdir));
 
                 let auth_client = if mtls_enabled { "yes" } else { "no" };
 
@@ -279,20 +272,12 @@ impl RedisServer {
                 // Insecure only disabled if `mtls` is enabled
                 let insecure = !mtls_enabled;
 
-                let addr = redis::ConnectionAddr::TcpTls {
+                addr = redis::ConnectionAddr::TcpTls {
                     host: host.clone(),
                     port,
                     insecure,
                     tls_params: None,
                 };
-
-                RedisServer {
-                    process: spawner(&mut redis_cmd),
-                    log_file,
-                    tempdir,
-                    addr,
-                    tls_paths: Some(tls_paths),
-                }
             }
             redis::ConnectionAddr::Unix(ref path) => {
                 redis_cmd
@@ -300,15 +285,16 @@ impl RedisServer {
                     .arg("0")
                     .arg("--unixsocket")
                     .arg(path);
-                RedisServer {
-                    process: spawner(&mut redis_cmd),
-                    log_file,
-                    tempdir,
-                    addr,
-                    tls_paths: None,
-                }
             }
             _ => panic!("Unknown address format: {addr:?}"),
+        };
+
+        RedisServer {
+            process: spawner(&mut redis_cmd),
+            log_file,
+            tempdir,
+            addr,
+            tls_paths,
         }
     }
 

--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -187,6 +187,9 @@ impl RedisServer {
             redis_cmd.arg2("--enable-debug-command", "yes");
         }
 
+        // Disable all default listening
+        redis_cmd.arg2("--port", "0");
+
         match addr {
             redis::ConnectionAddr::Tcp(ref host, port) => {
                 redis_cmd
@@ -202,7 +205,6 @@ impl RedisServer {
                 // prepare redis with TLS
                 redis_cmd
                     .arg2("--tls-port", port.to_string())
-                    .arg2("--port", "0")
                     .arg2("--tls-cert-file", &tls_paths.redis_crt)
                     .arg2("--tls-key-file", &tls_paths.redis_key)
                     .arg2("--tls-ca-cert-file", &tls_paths.ca_crt)
@@ -227,7 +229,7 @@ impl RedisServer {
                 };
             }
             redis::ConnectionAddr::Unix(ref path) => {
-                redis_cmd.arg2("--port", "0").arg2("--unixsocket", path);
+                redis_cmd.arg2("--unixsocket", path);
             }
             _ => panic!("Unknown address format: {addr:?}"),
         };

--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -173,7 +173,7 @@ impl RedisServer {
 
         // Disable snapshotting
         // This stops littering `dump.rdb` files during testing/development.
-        redis_cmd.arg("--save").arg("");
+        redis_cmd.arg2("--save", "");
 
         // Load Redis Modules
         for module in modules {
@@ -198,14 +198,14 @@ impl RedisServer {
                         },
                     };
 
-                    redis_cmd.arg("--loadmodule").arg(path);
+                    redis_cmd.arg2("--loadmodule", path);
                 }
                 Module::Bloom => {
                     let path = env::var("REDISRS_REDIS_BLOOM_PATH").expect(
                         "Unable to find path to RedisBloom at REDISRS_REDIS_BLOOM_PATH, is it set?",
                     );
 
-                    redis_cmd.arg("--loadmodule").arg(path);
+                    redis_cmd.arg2("--loadmodule", path);
                 }
             };
         }
@@ -215,18 +215,16 @@ impl RedisServer {
             .tempdir()
             .expect("failed to create tempdir");
         let log_file = Self::log_file(&tempdir);
-        redis_cmd.arg("--logfile").arg(log_file.clone());
+        redis_cmd.arg2("--logfile", log_file.clone());
         if get_major_version() > 6 {
-            redis_cmd.arg("--enable-debug-command").arg("yes");
+            redis_cmd.arg2("--enable-debug-command", "yes");
         }
 
         match addr {
             redis::ConnectionAddr::Tcp(ref bind, server_port) => {
                 redis_cmd
-                    .arg("--port")
-                    .arg(server_port.to_string())
-                    .arg("--bind")
-                    .arg(bind);
+                    .arg2("--port", server_port.to_string())
+                    .arg2("--bind", bind);
             }
             redis::ConnectionAddr::TcpTls { ref host, port, .. } => {
                 let tls_paths =
@@ -236,26 +234,19 @@ impl RedisServer {
 
                 // prepare redis with TLS
                 redis_cmd
-                    .arg("--tls-port")
-                    .arg(port.to_string())
-                    .arg("--port")
-                    .arg("0")
-                    .arg("--tls-cert-file")
-                    .arg(&tls_paths.redis_crt)
-                    .arg("--tls-key-file")
-                    .arg(&tls_paths.redis_key)
-                    .arg("--tls-ca-cert-file")
-                    .arg(&tls_paths.ca_crt)
-                    .arg("--tls-auth-clients")
-                    .arg(auth_client)
-                    .arg("--bind")
-                    .arg(host);
+                    .arg2("--tls-port", port.to_string())
+                    .arg2("--port", "0")
+                    .arg2("--tls-cert-file", &tls_paths.redis_crt)
+                    .arg2("--tls-key-file", &tls_paths.redis_key)
+                    .arg2("--tls-ca-cert-file", &tls_paths.ca_crt)
+                    .arg2("--tls-auth-clients", auth_client)
+                    .arg2("--bind", host);
 
                 // Enable certificate-based authentication (Redis 8.6+)
                 // The cert_auth_field specifies which certificate field to use for username mapping
                 // (e.g., "CN" for Common Name)
                 if let Some(field) = cert_auth_field {
-                    redis_cmd.arg("--tls-auth-clients-user").arg(field);
+                    redis_cmd.arg2("--tls-auth-clients-user", field);
                 }
 
                 // Insecure only disabled if `mtls` is enabled
@@ -269,11 +260,7 @@ impl RedisServer {
                 };
             }
             redis::ConnectionAddr::Unix(ref path) => {
-                redis_cmd
-                    .arg("--port")
-                    .arg("0")
-                    .arg("--unixsocket")
-                    .arg(path);
+                redis_cmd.arg2("--port", "0").arg2("--unixsocket", path);
             }
             _ => panic!("Unknown address format: {addr:?}"),
         };
@@ -351,6 +338,51 @@ impl RedisServerCommand {
     /// Appends a new argument to the command
     pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
         self.cmd.arg(arg);
+        self
+    }
+
+    /// Appends two new arguments to the command
+    ///
+    /// This method is purely convenience to get more readable argument setting as it allows to
+    /// re-write
+    ///
+    /// ```rust,no_run
+    /// # use redis_test::server::RedisServerCommand;
+    /// # let mut redis_cmd = RedisServerCommand::new();
+    /// redis_cmd
+    ///     .arg("--foo")
+    ///     .arg("some-value-for-foo")
+    ///     .arg("--bar")
+    ///     .arg("some-value-for-bar")
+    ///     .arg("--baz")
+    ///     .arg("some-value-for-baz");
+    /// ```
+    ///
+    /// in a more readable fashion:
+    ///
+    /// ```rust,no_run
+    /// # use redis_test::server::RedisServerCommand;
+    /// # let mut redis_cmd = RedisServerCommand::new();
+    /// redis_cmd
+    ///     .arg2("--foo", "some-value-for-foo")
+    ///     .arg2("--bar", "some-value-for-bar")
+    ///     .arg2("--baz", "some-value-for-baz");
+    /// ```
+    pub fn arg2<S1: AsRef<OsStr>, S2: AsRef<OsStr>>(&mut self, arg1: S1, arg2: S2) -> &mut Self {
+        self.cmd.arg(arg1).arg(arg2);
+        self
+    }
+
+    /// Appends three new arguments to the command
+    ///
+    /// This method is purely convenience to get more readable argument setting (cf. [`arg2`](Self::arg2)).
+    pub fn arg3<S1: AsRef<OsStr>, S2: AsRef<OsStr>, S3: AsRef<OsStr>>(
+        &mut self,
+        arg1: S1,
+        arg2: S2,
+        arg3: S3,
+    ) -> &mut Self {
+        self.cmd.arg(arg1).arg(arg2).arg(arg3);
         self
     }
 

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -246,17 +246,14 @@ impl TestContext {
         tls_files: Option<TlsFilePaths>,
         cert_auth_field: Option<&str>,
     ) -> Self {
-        let server = RedisServer::new_with_addr_tls_modules_and_spawner(
+        let server = RedisServer::new_with_addr_tls_modules_and_arg_refiner(
             addr,
             None,
             tls_files,
             mtls_enabled,
             cert_auth_field,
             modules,
-            |cmd| {
-                cmd.spawn()
-                    .unwrap_or_else(|err| panic!("Failed to run {cmd:?}: {err}"))
-            },
+            |_cmd| {},
         );
 
         let client =

--- a/version2.md
+++ b/version2.md
@@ -26,6 +26,8 @@ The arg_refiner function takes a `RedisStartCommand` as argument (instead of a `
 
 This new `RedisStartCommand` also has a `arg()` method, so your spawners probably work out of the box.
 
+But it also comes with `arg2()`, and `arg3()`, which takes multiple arguments in a single function, and can help to make things more readable.
+
 ```rust
 // Before:
 
@@ -52,10 +54,8 @@ let server = RedisServer::new_with_addr_tls_modules_and_arg_refiner(
     false,
     None,
     &[], |cmd| {
-        cmd.arg("--foo")
-            .arg("value-foo")
-            .arg("--bar")
-            .arg("value-baz");
+        cmd.arg2("--foo", "value-foo")
+            .arg2("--bar", "value-baz");
     }
 );
 ```

--- a/version2.md
+++ b/version2.md
@@ -10,6 +10,56 @@ redis = "2"
 
 ## Breaking Changes
 
+### `RedisServer::new_with_addr_tls_modules_and_spawner` got removed (Breaking Change)
+
+All callers used the spawner function to adjust the command's arguments, then spawn and unwrap it.
+The spawning was the same across all of them, hence duplicated.
+The unwrapping only differed in thoroughness of the error handling.
+So the common spawning and unwrapping got moved into `RedisServer` to ease its use.
+
+Refining arguments is available via `RedisServer::new_with_addr_tls_modules_and_arg_refiner`.
+
+**Migration:** Switch from `RedisServer::new_with_addr_tls_modules_and_spawner` to `RedisServer::new_with_addr_tls_modules_and_arg_refiner`.
+
+Typically, replacing `new_with_addr_tls_modules_and_spawner` by `new_with_addr_tls_modules_and_arg_refiner` and removing the `cmd.spawn().unwrap()` from your spawning function end will be enough.
+The arg_refiner function takes a `RedisStartCommand` as argument (instead of a `Command` before).
+
+This new `RedisStartCommand` also has a `arg()` method, so your spawners probably work out of the box.
+
+```rust
+// Before:
+
+let server = RedisServer::new_with_addr_tls_modules_and_spawner(
+    addr,
+    None,
+    None,
+    false,
+    None,
+    &[], |cmd| {
+        cmd.arg("--foo")
+            .arg("value-foo")
+            .arg("--bar")
+            .arg("value-baz");
+        cmd.spawn().unwrap()
+    }
+);
+
+// After:
+let server = RedisServer::new_with_addr_tls_modules_and_arg_refiner(
+    addr,
+    None,
+    None,
+    false,
+    None,
+    &[], |cmd| {
+        cmd.arg("--foo")
+            .arg("value-foo")
+            .arg("--bar")
+            .arg("value-baz");
+    }
+);
+```
+
 ### TCP_NODELAY is now enabled by default (Breaking Change)
 
 By default, Nagle's algorithm is now disabled on every TCP connection the crate creates (sync and async, plaintext and TLS). Previously it was left enabled, which serialized writes on a multiplexed connection to one per ACK round-trip under concurrency — measured at 39–68% lower throughput and roughly double the p50 latency on a real network (see [#2195](https://github.com/redis-rs/redis-rs/issues/2195) for the full evidence). Sequential request-response traffic is unaffected, and Redis clients in other ecosystems already ship with TCP_NODELAY enabled.


### PR DESCRIPTION
Over time, `RedisServer::new_with_addr_tls_modules_and_spawner` grew hard to read.

The instantiation of `RedisServer` was duplicated over all `match addr` branches. Different names are used for the same things (`host` vs. `bind`). Etc.

We clean the them up to improve readability.
