### PR TITLE
tests: Stop running sentinel tests when testing on unix sockets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test:
 	@echo "===================================================================="
 	@echo "Testing Connection Type UNIX SOCKETS"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features -E 'not (test(test_module) | test(cluster))'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features -E 'not (test(test_module) | test(cluster) | binary(test_sentinel))'
 
 	@echo "===================================================================="
 	@echo "Testing redis-test"

--- a/redis-test/src/sentinel.rs
+++ b/redis-test/src/sentinel.rs
@@ -123,10 +123,9 @@ const MTLS_NOT_ENABLED: bool = false;
 fn get_addr(port: u16) -> ConnectionAddr {
     let addr = RedisServer::get_addr(port);
     if let ConnectionAddr::Unix(_) = addr {
-        ConnectionAddr::Tcp(String::from("127.0.0.1"), port)
-    } else {
-        addr
+        panic!("Sentinels are not supported on unix sockets");
     }
+    addr
 }
 
 fn spawn_master_server(


### PR DESCRIPTION
When using `REDISRS_SERVER_TYPE=unix`, sentinel tests were run. But (as
sentinels require TCP) they did not test on unix sockets, but fell back
to TCP.

But that's was a dupe, as sentinels on TCP got tested already during the
`REDISRS_SERVER_TYPE=tcp` parts of `make test`.

So we tested the same thing twice.

This only slowed test runs down and we therefore now stop running
sentinels during unix sockets testing.

We also turn the unix sockets -> TCP fallback off in `get_addr`, as we
should not second guess user choices. This would have allowed us to
detect the "running tests twice" earlier.
