### PR TITLE
test: Switch to selecting tests through profiles

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,3 +9,19 @@ status-level = "skip"
 [[profile.default.overrides]]
 filter = 'test(cluster_async::test_async_cluster_basic_failover)'
 slow-timeout = { period = "20s", terminate-after = 2 }
+
+
+[profile.tcp_tls]
+default-filter = 'not (test(test_module))'
+
+[profile.tcp]
+default-filter = 'not (test(tls) | test(test_module))'
+
+[profile.unix]
+default-filter = 'not (test(cluster) | binary(test_sentinel) | test(tls) | test(test_module))'
+
+[profile.module_bloom]
+default-filter = 'binary(test_module_bloom*)'
+
+[profile.module_json]
+default-filter = 'test(test_module_json)'

--- a/Makefile
+++ b/Makefile
@@ -10,32 +10,32 @@ test:
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP without features"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run --locked -p redis --no-default-features -E 'not test(test_module)'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run --locked -p redis --no-default-features --profile tcp
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features and RESP2"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features -E 'not test(test_module)'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features --profile tcp
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features and RESP3"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run --locked -p redis --all-features -E 'not test(test_module)'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run --locked -p redis --all-features --profile tcp
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features and Rustls support"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features -E 'not test(test_module)'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features --profile tcp_tls
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with native-TLS support"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo nextest run --locked -p redis --features=json,tokio-native-tls-comp,smol-native-tls-comp,connection-manager,cluster-async -E 'not test(test_module)'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo nextest run --locked -p redis --features=json,tokio-native-tls-comp,smol-native-tls-comp,connection-manager,cluster-async --profile tcp_tls
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type UNIX SOCKETS"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features -E 'not (test(test_module) | test(cluster) | binary(test_sentinel))'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features --profile unix
 
 	@echo "===================================================================="
 	@echo "Testing redis-test"
@@ -46,23 +46,23 @@ test-module-json:
 	@echo "===================================================================="
 	@echo "Testing RESP2 with RedisJSON module"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features --test test_module_json
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features --profile module_json
 
 	@echo "===================================================================="
 	@echo "Testing RESP3 with RedisJSON module"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --all-features --test test_module_json
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --all-features --profile module_json
 
 test-module-bloom:
 	@echo "===================================================================="
 	@echo "Testing RESP2 with RedisBloom module"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features --test test_module_bloom
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features --profile module_bloom
 
 	@echo "===================================================================="
 	@echo "Testing RESP3 with RedisBloom module"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --all-features --test test_module_bloom
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --all-features --profile module_bloom
 
 test-modules: test-module-json test-module-bloom
 

--- a/redis/tests/test_cache.rs
+++ b/redis/tests/test_cache.rs
@@ -149,7 +149,7 @@ async fn test_cache_mget() {
 
 #[cfg(feature = "json")]
 #[async_test]
-async fn test_module_cache_json_get_mget() {
+async fn test_module_json_cache_get_mget() {
     let ctx = TestContext::with_modules(&[Module::Json]);
     if !ctx.protocol.supports_resp3() {
         return;
@@ -219,7 +219,7 @@ async fn test_module_cache_json_get_mget() {
 
 #[cfg(feature = "json")]
 #[async_test]
-async fn test_module_cache_json_get_mget_different_paths() {
+async fn test_module_json_cache_get_mget_different_paths() {
     let ctx = TestContext::with_modules(&[Module::Json]);
     if !ctx.protocol.supports_resp3() {
         return;


### PR DESCRIPTION
We needlessly ran a few tests more than once (e.g.: `test_tls_cert_auth`
was running for `tcp+tls`. But unwarranted also for `unix`, and for
`tcp` without TLS).

Updating all selectors in-situ would have resulted in a maintenance
burden.

So nextest is now run through profiles, which take care to not run tests
needlessly. This gives us a better readable `Makefile`, allows to re-use
the profiles when running manually. And the updating the filtersets is
easy too.

We re-enable the tests that went missing in a16079a and c34fb33 due to
non-grep-able test names.