### PR TITLE
tests/acl: Add the missing requirements for token based authentication

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -194,6 +194,7 @@ rustls = { version = "0.23", features = ["ring"] }
 test-macros = { path = "../test-macros" }
 assert_matches = "1.5.0"
 env_logger = "0.11.10"
+futures-channel = "0.3.31"
 
 [[test]]
 name = "test_async"

--- a/redis/tests/test_acl.rs
+++ b/redis/tests/test_acl.rs
@@ -308,7 +308,11 @@ fn test_acl_sample_info() {
     );
 }
 
-#[cfg(all(feature = "acl", feature = "token-based-authentication"))]
+#[cfg(all(
+    feature = "acl",
+    feature = "aio",
+    feature = "token-based-authentication"
+))]
 mod token_based_authentication_acl_tests {
     use crate::support::*;
     use futures_channel::oneshot;


### PR DESCRIPTION
`aio` gets added to the `test_acl::token_based_authentication_acl_tests` guard, as it imports from `redis::aio`.

The mod also relied on `futures_channel`, which is available only for the `connection-manager` feature. But as that is not needed, we add it as general dev dependency.