### PR TITLE
Add support for the `INCREX` command

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -519,33 +519,34 @@ implement_commands! {
         cmd("DECRBY").arg(key).arg(delta).take()
     }
 
-    /// Increment the integer value of a key by the given amount and set its expiration.
+    /// Increment the numeric value of a key by the given amount and set its expiration.
     ///
     /// Uses 0 as the initial value if the key does not exist.
-    /// The reply is an [`IncrexResult`] holding the value after the increment and the increment that was actually applied
+    /// The increment's type determines the operation: integer increments use BYINT, while floating-point ones use BYFLOAT.
+    /// The reply is an [`IncrexResult<V>`] holding the value after the increment and the increment that was actually applied
     /// (see [`IncrexOptions`] for the bounds and `SATURATE` behavior).
+    /// Note that `V` also types the `LBOUND`/`UBOUND` bounds.
     ///
-    /// The server operates on 64-bit signed integers, so `i64` is an exact match.
+    /// For `BYINT`, the server operates on 64-bit signed integers, so `i64` is an exact match.
     /// Every storable or clamped value fits in `i64`, the implicit `SATURATE` limits are `i64::MAX`/`i64::MIN`.
     /// Out-of-range increment or bound is rejected by the server.
-    /// [Redis Docs](https://redis.io/commands/INCREX)
-    fn increx_by_int<K: ToSingleRedisArg>(key: K, increment: i64, options: IncrexOptions<i64>) -> (IncrexResult<i64>) {
-        cmd("INCREX").arg(key).arg("BYINT").arg(increment).arg(options).take()
-    }
-
-    /// Increment the floating-point value of a key by the given amount and set its expiration.
     ///
-    /// Uses 0 as the initial value if the key does not exist.
-    /// The reply is an [`IncrexResult`] holding the value after the increment and the increment that was actually applied
-    /// (see [`IncrexOptions`] for the bounds and `SATURATE` behavior).
-    ///
-    /// The server computes in C `long double`, whose range and precision exceed `f64`.
+    /// For `BYFLOAT`, the server computes in C `long double`, whose range and precision exceed `f64`.
     /// A magnitude beyond `f64::MAX`, including the implicit `SATURATE` limit of `±LDBL_MAX`, therefore decodes to `±f64::INFINITY` rather than the exact value.
-    /// This is lossy saturation, not an error. If the exact value is needed, call the generic variant instead and choose a wider return type
-    /// (e.g. `(String, String)`, or a `bigdecimal::BigDecimal` pair with the `bigdecimal` feature).
+    /// This is lossy saturation, not an error. If the exact value, keep the `f64` increment, but call the generic variant and decode into a wider return type, e.g.
+    /// `let r: (String, String) = con.increx(key, 1.0f64, opts)?;` (or a `(BigDecimal, BigDecimal)` pair with the `bigdecimal` feature).
     /// [Redis Docs](https://redis.io/commands/INCREX)
-    fn increx_by_float<K: ToSingleRedisArg>(key: K, increment: f64, options: IncrexOptions<f64>) -> (IncrexResult<f64>) {
-        cmd("INCREX").arg(key).arg("BYFLOAT").arg(increment).arg(options).take()
+    fn increx<K: ToSingleRedisArg, V: IncrexNumber>(key: K, increment: V, options: IncrexOptions<V>) -> (IncrexResult<V>) {
+        cmd("INCREX")
+            .arg(key)
+            .arg(if increment.describe_numeric_behavior() == NumericBehavior::NumberIsFloat {
+                "BYFLOAT"
+            } else {
+                "BYINT"
+            })
+            .arg(increment)
+            .arg(options)
+            .take()
     }
 
     /// Sets or clears the bit at offset in the string value stored at key.
@@ -3858,10 +3859,20 @@ impl ToRedisArgs for Expiry {
     }
 }
 
+/// Numeric types accepted as an [`increx`](crate::TypedCommands::increx) increment.
+///
+/// A blanket implementation covers every type that is both
+/// a single Redis argument ([`ToSingleRedisArg`]) and decodable from the reply ([`FromRedisValue`]).
+/// Whether an increment issues `BYINT` or `BYFLOAT` is decided at runtime from its [`describe_numeric_behavior`](ToRedisArgs::describe_numeric_behavior).
+pub trait IncrexNumber: ToSingleRedisArg + FromRedisValue {}
+
+impl<T: ToSingleRedisArg + FromRedisValue> IncrexNumber for T {}
+
 /// Options for the [INCREX](https://redis.io/commands/increx) command.
 ///
 /// `T` is the type of the increment and of the `LBOUND`/`UBOUND` bounds.
-///  Use `IncrexOptions<i64>` with [`increx_by_int`] and `IncrexOptions<f64>` with [`increx_by_float`].
+/// It matches the increment passed to [`increx`](crate::TypedCommands::increx).
+/// (e.g. `IncrexOptions<i64>` for an `i64` increment, `IncrexOptions<f64>` for an `f64` one).
 ///
 /// # Example
 /// ```rust,no_run
@@ -3871,12 +3882,9 @@ impl ToRedisArgs for Expiry {
 ///         .saturate()
 ///         .upper_bound(100)
 ///         .with_expiration(Expiry::EX(60));
-///     con.increx_by_int("counter", 5, opts)
+///     con.increx("counter", 5i64, opts)
 /// }
 /// ```
-///
-/// [`increx_by_int`]: crate::TypedCommands::increx_by_int
-/// [`increx_by_float`]: crate::TypedCommands::increx_by_float
 #[derive(Clone, Default)]
 pub struct IncrexOptions<T> {
     saturate: bool,

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -4,9 +4,9 @@ use crate::cmd::{Cmd, Iter, cmd};
 use crate::connection::{Connection, ConnectionLike, Msg, RedisConnectionInfo};
 use crate::pipeline::Pipeline;
 use crate::types::{
-    ExistenceCheck, ExpireOption, Expiry, FieldExistenceCheck, FromRedisValue, IntegerReplyOrNoOp,
-    NumericBehavior, RedisResult, RedisWrite, SetExpiry, ToRedisArgs, ToSingleRedisArg,
-    ValueComparison,
+    ExistenceCheck, ExpireOption, Expiry, FieldExistenceCheck, FromRedisValue, IncrexResult,
+    IntegerReplyOrNoOp, NumericBehavior, RedisResult, RedisWrite, SetExpiry, ToRedisArgs,
+    ToSingleRedisArg, ValueComparison,
 };
 
 #[cfg(feature = "vector-sets")]
@@ -517,6 +517,35 @@ implement_commands! {
     /// [Redis Docs](https://redis.io/commands/DECRBY)
     fn decr<K: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, delta: V) -> (isize) {
         cmd("DECRBY").arg(key).arg(delta).take()
+    }
+
+    /// Increment the integer value of a key by the given amount and set its expiration.
+    ///
+    /// Uses 0 as the initial value if the key does not exist.
+    /// The reply is an [`IncrexResult`] holding the value after the increment and the increment that was actually applied
+    /// (see [`IncrexOptions`] for the bounds and `SATURATE` behavior).
+    ///
+    /// The server operates on 64-bit signed integers, so `i64` is an exact match.
+    /// Every storable or clamped value fits in `i64`, the implicit `SATURATE` limits are `i64::MAX`/`i64::MIN`.
+    /// Out-of-range increment or bound is rejected by the server.
+    /// [Redis Docs](https://redis.io/commands/INCREX)
+    fn increx_by_int<K: ToSingleRedisArg>(key: K, increment: i64, options: IncrexOptions<i64>) -> (IncrexResult<i64>) {
+        cmd("INCREX").arg(key).arg("BYINT").arg(increment).arg(options).take()
+    }
+
+    /// Increment the floating-point value of a key by the given amount and set its expiration.
+    ///
+    /// Uses 0 as the initial value if the key does not exist.
+    /// The reply is an [`IncrexResult`] holding the value after the increment and the increment that was actually applied
+    /// (see [`IncrexOptions`] for the bounds and `SATURATE` behavior).
+    ///
+    /// The server computes in C `long double`, whose range and precision exceed `f64`.
+    /// A magnitude beyond `f64::MAX`, including the implicit `SATURATE` limit of `±LDBL_MAX`, therefore decodes to `±f64::INFINITY` rather than the exact value.
+    /// This is lossy saturation, not an error. If the exact value is needed, call the generic variant instead and choose a wider return type
+    /// (e.g. `(String, String)`, or a `bigdecimal::BigDecimal` pair with the `bigdecimal` feature).
+    /// [Redis Docs](https://redis.io/commands/INCREX)
+    fn increx_by_float<K: ToSingleRedisArg>(key: K, increment: f64, options: IncrexOptions<f64>) -> (IncrexResult<f64>) {
+        cmd("INCREX").arg(key).arg("BYFLOAT").arg(increment).arg(options).take()
     }
 
     /// Sets or clears the bit at offset in the string value stored at key.
@@ -3825,6 +3854,95 @@ impl ToRedisArgs for Expiry {
             Expiry::PERSIST => {
                 out.write_arg(b"PERSIST");
             }
+        }
+    }
+}
+
+/// Options for the [INCREX](https://redis.io/commands/increx) command.
+///
+/// `T` is the type of the increment and of the `LBOUND`/`UBOUND` bounds.
+///  Use `IncrexOptions<i64>` with [`increx_by_int`] and `IncrexOptions<f64>` with [`increx_by_float`].
+///
+/// # Example
+/// ```rust,no_run
+/// use redis::{Commands, RedisResult, IncrexOptions, IncrexResult, Expiry};
+/// fn bump(con: &mut redis::Connection) -> RedisResult<IncrexResult<i64>> {
+///     let opts = IncrexOptions::default()
+///         .saturate()
+///         .upper_bound(100)
+///         .with_expiration(Expiry::EX(60));
+///     con.increx_by_int("counter", 5, opts)
+/// }
+/// ```
+///
+/// [`increx_by_int`]: crate::TypedCommands::increx_by_int
+/// [`increx_by_float`]: crate::TypedCommands::increx_by_float
+#[derive(Clone, Default)]
+pub struct IncrexOptions<T> {
+    saturate: bool,
+    lower_bound: Option<T>,
+    upper_bound: Option<T>,
+    expiration: Option<Expiry>,
+    enx: bool,
+}
+
+impl<T: ToSingleRedisArg> IncrexOptions<T> {
+    /// Instead of rejecting an out-of-bounds operation,
+    /// clamp the result to the specified bound or to the type's limit when no explicit bound is set.
+    pub fn saturate(mut self) -> Self {
+        self.saturate = true;
+        self
+    }
+
+    /// Set the lower bound for the operation (`LBOUND`).
+    pub fn lower_bound(mut self, lower_bound: T) -> Self {
+        self.lower_bound = Some(lower_bound);
+        self
+    }
+
+    /// Set the upper bound for the operation (`UBOUND`).
+    pub fn upper_bound(mut self, upper_bound: T) -> Self {
+        self.upper_bound = Some(upper_bound);
+        self
+    }
+
+    /// Set the expiration to apply to the key (`EX`/`PX`/`EXAT`/`PXAT`/`PERSIST`).
+    pub fn with_expiration(mut self, expiration: Expiry) -> Self {
+        self.expiration = Some(expiration);
+        self
+    }
+
+    /// Only apply the expiration if the key currently has no TTL (`ENX`).
+    ///
+    /// Requires an expiration other than [`Expiry::PERSIST`] to be set.
+    /// The server rejects `ENX` combined with `PERSIST`.
+    pub fn enx(mut self) -> Self {
+        self.enx = true;
+        self
+    }
+}
+
+impl<T: ToRedisArgs> ToRedisArgs for IncrexOptions<T> {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        if self.saturate {
+            out.write_arg(b"SATURATE");
+        }
+        if let Some(ref lower_bound) = self.lower_bound {
+            out.write_arg(b"LBOUND");
+            lower_bound.write_redis_args(out);
+        }
+        if let Some(ref upper_bound) = self.upper_bound {
+            out.write_arg(b"UBOUND");
+            upper_bound.write_redis_args(out);
+        }
+        if let Some(ref expiration) = self.expiration {
+            expiration.write_redis_args(out);
+        }
+        if self.enx {
+            out.write_arg(b"ENX");
         }
     }
 }

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -525,33 +525,37 @@ implement_commands! {
         cmd("DECRBY").arg(key).arg(delta).take()
     }
 
-    /// Increment the integer value of a key by the given amount and set its expiration.
+    /// Increment the numeric value of a key by the given amount and set its expiration.
     ///
     /// Uses 0 as the initial value if the key does not exist.
-    /// The reply is an [`IncrexResult`] holding the value after the increment and the increment that was actually applied
-    /// (see [`IncrexOptions`] for the bounds and `SATURATE` behavior).
+    /// The increment's type determines the operation: integer increments use `BYINT`, while floating-point ones use `BYFLOAT`.
+    /// The reply is an [`IncrexResult`] holding the raw value after the increment and the raw
+    /// increment that was actually applied (see [`IncrexOptions`] for the bounds and `SATURATE`
+    /// behavior). Read it with [`IncrexResult::as_i64`] / [`IncrexResult::as_f64`] for the common
+    /// typed pairs, or [`IncrexResult::value_as`] / [`IncrexResult::actual_increment_as`] to decode
+    /// a single field into any other [`FromRedisValue`] type.
     ///
-    /// The server operates on 64-bit signed integers, so `i64` is an exact match.
+    /// For `BYINT`, the server operates on 64-bit signed integers, so `i64` is an exact match.
     /// Every storable or clamped value fits in `i64`, the implicit `SATURATE` limits are `i64::MAX`/`i64::MIN`.
     /// Out-of-range increment or bound is rejected by the server.
-    /// [Redis Docs](https://redis.io/commands/INCREX)
-    fn increx_by_int<K: ToSingleRedisArg>(key: K, increment: i64, options: IncrexOptions<i64>) -> (IncrexResult<i64>) {
-        cmd("INCREX").arg(key).arg("BYINT").arg(increment).arg(options).take()
-    }
-
-    /// Increment the floating-point value of a key by the given amount and set its expiration.
     ///
-    /// Uses 0 as the initial value if the key does not exist.
-    /// The reply is an [`IncrexResult`] holding the value after the increment and the increment that was actually applied
-    /// (see [`IncrexOptions`] for the bounds and `SATURATE` behavior).
-    ///
-    /// The server computes in C `long double`, whose range and precision exceed `f64`.
-    /// A magnitude beyond `f64::MAX`, including the implicit `SATURATE` limit of `±LDBL_MAX`, therefore decodes to `±f64::INFINITY` rather than the exact value.
-    /// This is lossy saturation, not an error. If the exact value is needed, call the generic variant instead and choose a wider return type
-    /// (e.g. `(String, String)`, or a `bigdecimal::BigDecimal` pair with the `bigdecimal` feature).
+    /// For `BYFLOAT`, the server computes with more range and precision than `f64`, so decoding a
+    /// result beyond `f64::MAX` (including the implicit `±LDBL_MAX` limit) as `f64` yields
+    /// `±f64::INFINITY`. On RESP2 the value arrives as a bulk string, so `value_as::<String>()`
+    /// recovers the server's exact text; on RESP3 it arrives as a double the client has already
+    /// narrowed to `f64`, so `f64` is the full precision available there.
     /// [Redis Docs](https://redis.io/commands/INCREX)
-    fn increx_by_float<K: ToSingleRedisArg>(key: K, increment: f64, options: IncrexOptions<f64>) -> (IncrexResult<f64>) {
-        cmd("INCREX").arg(key).arg("BYFLOAT").arg(increment).arg(options).take()
+    fn increx<K: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, increment: V, options: IncrexOptions<V>) -> (IncrexResult) {
+        cmd("INCREX")
+            .arg(key)
+            .arg(if increment.describe_numeric_behavior() == NumericBehavior::NumberIsFloat {
+                "BYFLOAT"
+            } else {
+                "BYINT"
+            })
+            .arg(increment)
+            .arg(options)
+            .take()
     }
 
     /// Sets or clears the bit at offset in the string value stored at key.
@@ -3958,22 +3962,20 @@ impl ToRedisArgs for Expiry {
 /// Options for the [INCREX](https://redis.io/commands/increx) command.
 ///
 /// `T` is the type of the increment and of the `LBOUND`/`UBOUND` bounds.
-///  Use `IncrexOptions<i64>` with [`increx_by_int`] and `IncrexOptions<f64>` with [`increx_by_float`].
+/// It matches the increment passed to [`increx`](crate::TypedCommands::increx).
+/// (e.g. `IncrexOptions<i64>` for an `i64` increment, `IncrexOptions<f64>` for an `f64` one).
 ///
 /// # Example
 /// ```rust,no_run
 /// use redis::{Commands, RedisResult, IncrexOptions, IncrexResult, Expiry};
-/// fn bump(con: &mut redis::Connection) -> RedisResult<IncrexResult<i64>> {
+/// fn bump(con: &mut redis::Connection) -> RedisResult<IncrexResult> {
 ///     let opts = IncrexOptions::default()
 ///         .saturate()
 ///         .upper_bound(100)
 ///         .with_expiration(Expiry::EX(60));
-///     con.increx_by_int("counter", 5, opts)
+///     con.increx("counter", 5, opts)
 /// }
 /// ```
-///
-/// [`increx_by_int`]: crate::TypedCommands::increx_by_int
-/// [`increx_by_float`]: crate::TypedCommands::increx_by_float
 #[derive(Clone, Default)]
 pub struct IncrexOptions<T> {
     saturate: bool,

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -6,9 +6,9 @@ use crate::pipeline::Pipeline;
 #[cfg(feature = "search_unfinished")]
 use crate::search::{CreateOptions, SearchSchema};
 use crate::types::{
-    ExistenceCheck, ExpireOption, Expiry, FieldExistenceCheck, FromRedisValue, IntegerReplyOrNoOp,
-    NumericBehavior, RedisResult, RedisWrite, SetExpiry, ToRedisArgs, ToSingleRedisArg,
-    ValueComparison,
+    ExistenceCheck, ExpireOption, Expiry, FieldExistenceCheck, FromRedisValue, IncrexResult,
+    IntegerReplyOrNoOp, NumericBehavior, RedisResult, RedisWrite, SetExpiry, ToRedisArgs,
+    ToSingleRedisArg, ValueComparison,
 };
 
 #[cfg(feature = "vector-sets")]
@@ -523,6 +523,35 @@ implement_commands! {
     /// [Redis Docs](https://redis.io/commands/DECRBY)
     fn decr<K: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, delta: V) -> (isize) {
         cmd("DECRBY").arg(key).arg(delta).take()
+    }
+
+    /// Increment the integer value of a key by the given amount and set its expiration.
+    ///
+    /// Uses 0 as the initial value if the key does not exist.
+    /// The reply is an [`IncrexResult`] holding the value after the increment and the increment that was actually applied
+    /// (see [`IncrexOptions`] for the bounds and `SATURATE` behavior).
+    ///
+    /// The server operates on 64-bit signed integers, so `i64` is an exact match.
+    /// Every storable or clamped value fits in `i64`, the implicit `SATURATE` limits are `i64::MAX`/`i64::MIN`.
+    /// Out-of-range increment or bound is rejected by the server.
+    /// [Redis Docs](https://redis.io/commands/INCREX)
+    fn increx_by_int<K: ToSingleRedisArg>(key: K, increment: i64, options: IncrexOptions<i64>) -> (IncrexResult<i64>) {
+        cmd("INCREX").arg(key).arg("BYINT").arg(increment).arg(options).take()
+    }
+
+    /// Increment the floating-point value of a key by the given amount and set its expiration.
+    ///
+    /// Uses 0 as the initial value if the key does not exist.
+    /// The reply is an [`IncrexResult`] holding the value after the increment and the increment that was actually applied
+    /// (see [`IncrexOptions`] for the bounds and `SATURATE` behavior).
+    ///
+    /// The server computes in C `long double`, whose range and precision exceed `f64`.
+    /// A magnitude beyond `f64::MAX`, including the implicit `SATURATE` limit of `±LDBL_MAX`, therefore decodes to `±f64::INFINITY` rather than the exact value.
+    /// This is lossy saturation, not an error. If the exact value is needed, call the generic variant instead and choose a wider return type
+    /// (e.g. `(String, String)`, or a `bigdecimal::BigDecimal` pair with the `bigdecimal` feature).
+    /// [Redis Docs](https://redis.io/commands/INCREX)
+    fn increx_by_float<K: ToSingleRedisArg>(key: K, increment: f64, options: IncrexOptions<f64>) -> (IncrexResult<f64>) {
+        cmd("INCREX").arg(key).arg("BYFLOAT").arg(increment).arg(options).take()
     }
 
     /// Sets or clears the bit at offset in the string value stored at key.
@@ -3922,6 +3951,95 @@ impl ToRedisArgs for Expiry {
             Self::PERSIST => {
                 out.write_arg(b"PERSIST");
             }
+        }
+    }
+}
+
+/// Options for the [INCREX](https://redis.io/commands/increx) command.
+///
+/// `T` is the type of the increment and of the `LBOUND`/`UBOUND` bounds.
+///  Use `IncrexOptions<i64>` with [`increx_by_int`] and `IncrexOptions<f64>` with [`increx_by_float`].
+///
+/// # Example
+/// ```rust,no_run
+/// use redis::{Commands, RedisResult, IncrexOptions, IncrexResult, Expiry};
+/// fn bump(con: &mut redis::Connection) -> RedisResult<IncrexResult<i64>> {
+///     let opts = IncrexOptions::default()
+///         .saturate()
+///         .upper_bound(100)
+///         .with_expiration(Expiry::EX(60));
+///     con.increx_by_int("counter", 5, opts)
+/// }
+/// ```
+///
+/// [`increx_by_int`]: crate::TypedCommands::increx_by_int
+/// [`increx_by_float`]: crate::TypedCommands::increx_by_float
+#[derive(Clone, Default)]
+pub struct IncrexOptions<T> {
+    saturate: bool,
+    lower_bound: Option<T>,
+    upper_bound: Option<T>,
+    expiration: Option<Expiry>,
+    enx: bool,
+}
+
+impl<T: ToSingleRedisArg> IncrexOptions<T> {
+    /// Instead of rejecting an out-of-bounds operation,
+    /// clamp the result to the specified bound or to the type's limit when no explicit bound is set.
+    pub fn saturate(mut self) -> Self {
+        self.saturate = true;
+        self
+    }
+
+    /// Set the lower bound for the operation (`LBOUND`).
+    pub fn lower_bound(mut self, lower_bound: T) -> Self {
+        self.lower_bound = Some(lower_bound);
+        self
+    }
+
+    /// Set the upper bound for the operation (`UBOUND`).
+    pub fn upper_bound(mut self, upper_bound: T) -> Self {
+        self.upper_bound = Some(upper_bound);
+        self
+    }
+
+    /// Set the expiration to apply to the key (`EX`/`PX`/`EXAT`/`PXAT`/`PERSIST`).
+    pub fn with_expiration(mut self, expiration: Expiry) -> Self {
+        self.expiration = Some(expiration);
+        self
+    }
+
+    /// Only apply the expiration if the key currently has no TTL (`ENX`).
+    ///
+    /// Requires an expiration other than [`Expiry::PERSIST`] to be set.
+    /// The server rejects `ENX` combined with `PERSIST`.
+    pub fn enx(mut self) -> Self {
+        self.enx = true;
+        self
+    }
+}
+
+impl<T: ToRedisArgs> ToRedisArgs for IncrexOptions<T> {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        if self.saturate {
+            out.write_arg(b"SATURATE");
+        }
+        if let Some(ref lower_bound) = self.lower_bound {
+            out.write_arg(b"LBOUND");
+            lower_bound.write_redis_args(out);
+        }
+        if let Some(ref upper_bound) = self.upper_bound {
+            out.write_arg(b"UBOUND");
+            upper_bound.write_redis_args(out);
+        }
+        if let Some(ref expiration) = self.expiration {
+            expiration.write_redis_args(out);
+        }
+        if self.enx {
+            out.write_arg(b"ENX");
         }
     }
 }

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -648,8 +648,9 @@ pub use crate::cmd::CommandCacheConfig;
 pub use crate::cmd::{Arg, Cmd, Iter, cmd, pack_command, pipe};
 pub use crate::commands::{
     Commands, ControlFlow, CopyOptions, Direction, FlushAllOptions, FlushDbOptions,
-    HashFieldExpirationOptions, HotkeysCommands, IncrexOptions, LposOptions, MSetOptions,
-    PubSubCommands, ScanOptions, SetOptions, SortedSetAddOptions, TypedCommands, UpdateCheck,
+    HashFieldExpirationOptions, HotkeysCommands, IncrexNumber, IncrexOptions, LposOptions,
+    MSetOptions, PubSubCommands, ScanOptions, SetOptions, SortedSetAddOptions, TypedCommands,
+    UpdateCheck,
     hotkeys::{
         HOTKEYS_COUNT_MAX, HOTKEYS_COUNT_MIN, HotKeyEntry, HotkeysOptions, HotkeysResponse,
         SlotRange,

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -648,8 +648,8 @@ pub use crate::cmd::CommandCacheConfig;
 pub use crate::cmd::{Arg, Cmd, Iter, cmd, pack_command, pipe};
 pub use crate::commands::{
     Commands, ControlFlow, CopyOptions, Direction, FlushAllOptions, FlushDbOptions,
-    HashFieldExpirationOptions, HotkeysCommands, LposOptions, MSetOptions, PubSubCommands,
-    ScanOptions, SetOptions, SortedSetAddOptions, TypedCommands, UpdateCheck,
+    HashFieldExpirationOptions, HotkeysCommands, IncrexOptions, LposOptions, MSetOptions,
+    PubSubCommands, ScanOptions, SetOptions, SortedSetAddOptions, TypedCommands, UpdateCheck,
     hotkeys::{
         HOTKEYS_COUNT_MAX, HOTKEYS_COUNT_MIN, HotKeyEntry, HotkeysOptions, HotkeysResponse,
         SlotRange,
@@ -699,6 +699,7 @@ pub use crate::types::{
     Role,
     ReplicaInfo,
     IntegerReplyOrNoOp,
+    IncrexResult,
     ValueType,
     RedisResult,
     RedisWrite,

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -655,8 +655,8 @@ pub use crate::cmd::CommandCacheConfig;
 pub use crate::cmd::{Arg, Cmd, Iter, cmd, pack_command, pipe};
 pub use crate::commands::{
     Commands, ControlFlow, CopyOptions, Direction, FlushAllOptions, FlushDbOptions,
-    HashFieldExpirationOptions, HotkeysCommands, LposOptions, MSetOptions, PubSubCommands,
-    ScanOptions, SetOptions, SortedSetAddOptions, TypedCommands, UpdateCheck,
+    HashFieldExpirationOptions, HotkeysCommands, IncrexOptions, LposOptions, MSetOptions,
+    PubSubCommands, ScanOptions, SetOptions, SortedSetAddOptions, TypedCommands, UpdateCheck,
     hotkeys::{
         HOTKEYS_COUNT_MAX, HOTKEYS_COUNT_MIN, HotKeyEntry, HotkeysOptions, HotkeysResponse,
         SlotRange,
@@ -706,6 +706,7 @@ pub use crate::types::{
     Role,
     ReplicaInfo,
     IntegerReplyOrNoOp,
+    IncrexResult,
     ValueType,
     RedisResult,
     RedisWrite,

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -17,6 +17,7 @@ use std::str::from_utf8;
 use crate::errors::{RedisError, ServerError};
 
 /// Helper enum that is used to define expiry time
+#[derive(Clone)]
 #[non_exhaustive]
 pub enum Expiry {
     /// EX seconds -- Set the specified expire time, in seconds.
@@ -2756,5 +2757,44 @@ impl PartialEq<u32> for IntegerReplyOrNoOp {
             IntegerReplyOrNoOp::IntegerReply(s) => *s as u32 == *other,
             _ => false,
         }
+    }
+}
+
+/// The two-element reply of the [INCREX](https://redis.io/commands/increx) command.
+///
+/// `T` is `i64` for `BYINT` operations (see [`increx_by_int`])
+/// and `f64` for `BYFLOAT` operations (see [`increx_by_float`]).
+///
+/// [`increx_by_int`]: crate::TypedCommands::increx_by_int
+/// [`increx_by_float`]: crate::TypedCommands::increx_by_float
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
+pub struct IncrexResult<T> {
+    /// The key's value after the increment.
+    pub value: T,
+    /// The increment that was actually applied.
+    ///
+    /// This is `0` when the default policy (when `SATURATE` is not set) rejected an out-of-bounds operation.
+    /// In that case `value` holds the unchanged current value and the TTL is left untouched.
+    /// When `SATURATE` is set, it clamps the result to a bound.
+    /// This reflects the clamped delta, which may differ from the requested increment.
+    pub actual_increment: T,
+}
+
+impl<T: FromRedisValue> FromRedisValue for IncrexResult<T> {
+    fn from_redis_value_ref(v: &Value) -> Result<Self, ParsingError> {
+        let (value, actual_increment) = <(T, T)>::from_redis_value_ref(v)?;
+        Ok(IncrexResult {
+            value,
+            actual_increment,
+        })
+    }
+
+    fn from_redis_value(v: Value) -> Result<Self, ParsingError> {
+        let (value, actual_increment) = <(T, T)>::from_redis_value(v)?;
+        Ok(IncrexResult {
+            value,
+            actual_increment,
+        })
     }
 }

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2762,11 +2762,8 @@ impl PartialEq<u32> for IntegerReplyOrNoOp {
 
 /// The two-element reply of the [INCREX](https://redis.io/commands/increx) command.
 ///
-/// `T` is `i64` for `BYINT` operations (see [`increx_by_int`])
-/// and `f64` for `BYFLOAT` operations (see [`increx_by_float`]).
-///
-/// [`increx_by_int`]: crate::TypedCommands::increx_by_int
-/// [`increx_by_float`]: crate::TypedCommands::increx_by_float
+/// `T` matches the increment type passed to [`increx`](crate::TypedCommands::increx) -
+///  `i64` for `BYINT` operations and `f64` for `BYFLOAT` operations.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[non_exhaustive]
 pub struct IncrexResult<T> {

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -17,6 +17,7 @@ use std::str::from_utf8;
 use crate::errors::{RedisError, ServerError};
 
 /// Helper enum that is used to define expiry time
+#[derive(Clone)]
 #[non_exhaustive]
 pub enum Expiry {
     /// EX seconds -- Set the specified expire time, in seconds.
@@ -2750,5 +2751,44 @@ impl PartialEq<u32> for IntegerReplyOrNoOp {
             Self::IntegerReply(s) => *s as u32 == *other,
             _ => false,
         }
+    }
+}
+
+/// The two-element reply of the [INCREX](https://redis.io/commands/increx) command.
+///
+/// `T` is `i64` for `BYINT` operations (see [`increx_by_int`])
+/// and `f64` for `BYFLOAT` operations (see [`increx_by_float`]).
+///
+/// [`increx_by_int`]: crate::TypedCommands::increx_by_int
+/// [`increx_by_float`]: crate::TypedCommands::increx_by_float
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
+pub struct IncrexResult<T> {
+    /// The key's value after the increment.
+    pub value: T,
+    /// The increment that was actually applied.
+    ///
+    /// This is `0` when the default policy (when `SATURATE` is not set) rejected an out-of-bounds operation.
+    /// In that case `value` holds the unchanged current value and the TTL is left untouched.
+    /// When `SATURATE` is set, it clamps the result to a bound.
+    /// This reflects the clamped delta, which may differ from the requested increment.
+    pub actual_increment: T,
+}
+
+impl<T: FromRedisValue> FromRedisValue for IncrexResult<T> {
+    fn from_redis_value_ref(v: &Value) -> Result<Self, ParsingError> {
+        let (value, actual_increment) = <(T, T)>::from_redis_value_ref(v)?;
+        Ok(IncrexResult {
+            value,
+            actual_increment,
+        })
+    }
+
+    fn from_redis_value(v: Value) -> Result<Self, ParsingError> {
+        let (value, actual_increment) = <(T, T)>::from_redis_value(v)?;
+        Ok(IncrexResult {
+            value,
+            actual_increment,
+        })
     }
 }

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2756,37 +2756,52 @@ impl PartialEq<u32> for IntegerReplyOrNoOp {
 
 /// The two-element reply of the [INCREX](https://redis.io/commands/increx) command.
 ///
-/// `T` is `i64` for `BYINT` operations (see [`increx_by_int`])
-/// and `f64` for `BYFLOAT` operations (see [`increx_by_float`]).
-///
-/// [`increx_by_int`]: crate::TypedCommands::increx_by_int
-/// [`increx_by_float`]: crate::TypedCommands::increx_by_float
-#[derive(Clone, Copy, Debug, PartialEq)]
+/// Each field holds the raw [`Value`] returned by the server.
+/// For `BYINT` operations this is an integer, while for `BYFLOAT` it is a bulk string (RESP2) or double (RESP3).
+/// Decode a field into a concrete type with [`value_as`](Self::value_as) / [`actual_increment_as`](Self::actual_increment_as)
+/// - e.g. `i64` for `BYINT` or `f64` (or a wider type such as `bigdecimal::BigDecimal`) for `BYFLOAT`.
+#[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
-pub struct IncrexResult<T> {
+pub struct IncrexResult {
     /// The key's value after the increment.
-    pub value: T,
+    pub value: Value,
     /// The increment that was actually applied.
     ///
     /// This is `0` when the default policy (when `SATURATE` is not set) rejected an out-of-bounds operation.
     /// In that case `value` holds the unchanged current value and the TTL is left untouched.
     /// When `SATURATE` is set, it clamps the result to a bound.
     /// This reflects the clamped delta, which may differ from the requested increment.
-    pub actual_increment: T,
+    pub actual_increment: Value,
 }
 
-impl<T: FromRedisValue> FromRedisValue for IncrexResult<T> {
-    fn from_redis_value_ref(v: &Value) -> Result<Self, ParsingError> {
-        let (value, actual_increment) = <(T, T)>::from_redis_value_ref(v)?;
-        Ok(IncrexResult {
-            value,
-            actual_increment,
-        })
+impl IncrexResult {
+    /// Decode [`value`](Self::value) into the desired type.
+    /// - e.g. `i64` for `BYINT` operations and `f64` or a wider type for `BYFLOAT` operations.
+    pub fn value_as<T: FromRedisValue>(&self) -> Result<T, ParsingError> {
+        T::from_redis_value_ref(&self.value)
     }
 
+    /// Decode [`actual_increment`](Self::actual_increment) into the desired type.
+    /// - e.g. `i64` for `BYINT` operations and `f64` or a wider type for `BYFLOAT` operations.
+    pub fn actual_increment_as<T: FromRedisValue>(&self) -> Result<T, ParsingError> {
+        T::from_redis_value_ref(&self.actual_increment)
+    }
+
+    /// Decode both fields as `i64`, the natural type for a `BYINT` result, returning `(value, actual_increment)`.
+    pub fn as_i64(&self) -> Result<(i64, i64), ParsingError> {
+        Ok((self.value_as()?, self.actual_increment_as()?))
+    }
+
+    /// Decode both fields as `f64`, the natural type for a `BYFLOAT` result, returning `(value, actual_increment)`.
+    pub fn as_f64(&self) -> Result<(f64, f64), ParsingError> {
+        Ok((self.value_as()?, self.actual_increment_as()?))
+    }
+}
+
+impl FromRedisValue for IncrexResult {
     fn from_redis_value(v: Value) -> Result<Self, ParsingError> {
-        let (value, actual_increment) = <(T, T)>::from_redis_value(v)?;
-        Ok(IncrexResult {
+        let [value, actual_increment] = <[Value; 2]>::from_redis_value(v)?;
+        Ok(Self {
             value,
             actual_increment,
         })

--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -12,6 +12,7 @@ pub const REDIS_CE_8_0: Component = ("redis", (8, 0, 0));
 pub const REDIS_CE_8_2: Component = ("redis", (8, 1, 240));
 pub const REDIS_CE_8_4: Component = ("redis", (8, 3, 224));
 pub const REDIS_CE_8_6: Component = ("redis", (8, 6, 0));
+pub const REDIS_CE_8_8: Component = ("redis", (8, 8, 0));
 
 pub const REDIS_BLOOM_ANY: Component = ("redis:bf", (0, 0, 0));
 

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -282,14 +282,14 @@ mod basic {
     }
 
     #[test]
-    fn test_increx_by_int() {
+    fn test_increx_with_integers() {
         let ctx = run_test_if_version_supported!([REDIS_CE_8_8]);
         let mut con = ctx.connection();
 
         // A fresh key starts at 0.
         // A normal in-bounds increment applies fully.
         let result = con
-            .increx_by_int("counter", 5, IncrexOptions::default())
+            .increx("counter", 5i64, IncrexOptions::default())
             .unwrap();
         assert_eq!(result.value, 5);
         assert_eq!(result.actual_increment, 5);
@@ -297,16 +297,16 @@ mod basic {
         // The default policy rejects out-of-bounds operations.
         // The reply is a regular successful `Ok`, reporting the unchanged current value and a zero applied increment.
         let result = con
-            .increx_by_int("counter", 100, IncrexOptions::default().upper_bound(10))
+            .increx("counter", 100i64, IncrexOptions::default().upper_bound(10))
             .unwrap();
         assert_eq!(result.value, 5);
         assert_eq!(result.actual_increment, 0);
 
         // SATURATE clamps the result to an explicit upper bound and reports the clamped delta (10 - 5 = 5), not the requested increment (100).
         let result = con
-            .increx_by_int(
+            .increx(
                 "counter",
-                100,
+                100i64,
                 IncrexOptions::default().saturate().upper_bound(10),
             )
             .unwrap();
@@ -317,9 +317,9 @@ mod basic {
         // The actual_increment is again the clamped delta (-10 - 5 = -15), not the requested -100.
         con.set("underflow", 5).unwrap();
         let result = con
-            .increx_by_int(
+            .increx(
                 "underflow",
-                -100,
+                -100i64,
                 IncrexOptions::default().saturate().lower_bound(-10),
             )
             .unwrap();
@@ -330,22 +330,22 @@ mod basic {
         // which are exactly i64::MAX / i64::MIN (the server operates on 64-bit `long long`).
         con.set("hi", i64::MAX - 100).unwrap();
         let result = con
-            .increx_by_int("hi", 200, IncrexOptions::default().saturate())
+            .increx("hi", 200i64, IncrexOptions::default().saturate())
             .unwrap();
         assert_eq!(result.value, i64::MAX);
         assert_eq!(result.actual_increment, 100);
         con.set("lo", i64::MIN + 100).unwrap();
         let result = con
-            .increx_by_int("lo", -200, IncrexOptions::default().saturate())
+            .increx("lo", -200i64, IncrexOptions::default().saturate())
             .unwrap();
         assert_eq!(result.value, i64::MIN);
         assert_eq!(result.actual_increment, -100);
 
         // Expiration is applied alongside the increment.
         let result = con
-            .increx_by_int(
+            .increx(
                 "ttl_counter",
-                1,
+                1i64,
                 IncrexOptions::default().with_expiration(Expiry::EX(100)),
             )
             .unwrap();
@@ -356,9 +356,9 @@ mod basic {
         // Rejected operations leave the key's value *and* TTL untouched.
         con.set_ex("bounded", 5, 100).unwrap();
         let result = con
-            .increx_by_int(
+            .increx(
                 "bounded",
-                100,
+                100i64,
                 IncrexOptions::default()
                     .upper_bound(10)
                     .with_expiration(Expiry::EX(999)),
@@ -374,9 +374,9 @@ mod basic {
         // This differs from the default policy rejection above, which leaves the TTL untouched.
         con.set("at_bound", 10).unwrap();
         let result = con
-            .increx_by_int(
+            .increx(
                 "at_bound",
-                100,
+                100i64,
                 IncrexOptions::default()
                     .saturate() // Because of this, the operation is applied even though the value doesn't change.
                     .upper_bound(10)
@@ -391,9 +391,9 @@ mod basic {
         // ENX takes into account if a TTL is already present and blocks the update even though the clamp itself is applied.
         con.set_ex("at_bound_enx", 10, 100).unwrap();
         let result = con
-            .increx_by_int(
+            .increx(
                 "at_bound_enx",
-                100,
+                100i64,
                 IncrexOptions::default()
                     .saturate()
                     .upper_bound(10)
@@ -407,13 +407,13 @@ mod basic {
     }
 
     #[test]
-    fn test_increx_by_float() {
+    fn test_increx_with_floats() {
         let ctx = run_test_if_version_supported!([REDIS_CE_8_8]);
         let mut con = ctx.connection();
 
         // A normal in-bounds float increment applies fully.
         let result = con
-            .increx_by_float("balance", 2.5, IncrexOptions::default())
+            .increx("balance", 2.5f64, IncrexOptions::default())
             .unwrap();
         assert_approx_eq!(result.value, 2.5);
         assert_approx_eq!(result.actual_increment, 2.5);
@@ -421,9 +421,9 @@ mod basic {
         // SATURATE clamps to a floating-point upper bound.
         // The actual_increment is the clamped delta (4.0 - 2.5 = 1.5), not the requested 5.5.
         let result = con
-            .increx_by_float(
+            .increx(
                 "balance",
-                5.5,
+                5.5f64,
                 IncrexOptions::default().saturate().upper_bound(4.0),
             )
             .unwrap();
@@ -432,7 +432,7 @@ mod basic {
 
         // The default policy rejects an out-of-bounds floating-point operation, leaving the value unchanged.
         let result = con
-            .increx_by_float("balance", 5.5, IncrexOptions::default().upper_bound(4.0))
+            .increx("balance", 5.5f64, IncrexOptions::default().upper_bound(4.0))
             .unwrap();
         assert_approx_eq!(result.value, 4.0);
         assert_approx_eq!(result.actual_increment, 0.0);
@@ -440,9 +440,9 @@ mod basic {
         // SATURATE clamps to a floating-point lower bound on underflow.
         // From 0, -5.5 clamps to -1.5, so the clamped delta is -1.5 rather than the requested -5.5.
         let result = con
-            .increx_by_float(
+            .increx(
                 "debt",
-                -5.5,
+                -5.5f64,
                 IncrexOptions::default().saturate().lower_bound(-1.5),
             )
             .unwrap();
@@ -451,9 +451,9 @@ mod basic {
 
         // Expiration is applied alongside the increment.
         let result = con
-            .increx_by_float(
+            .increx(
                 "ttl_counter",
-                1.0,
+                1.0f64,
                 IncrexOptions::default().with_expiration(Expiry::EX(100)),
             )
             .unwrap();
@@ -464,9 +464,9 @@ mod basic {
         // Rejected operations leave the key's value *and* TTL untouched.
         con.set_ex("bounded", 5.0, 100).unwrap();
         let result = con
-            .increx_by_float(
+            .increx(
                 "bounded",
-                100.0,
+                100.0f64,
                 IncrexOptions::default()
                     .upper_bound(10.0)
                     .with_expiration(Expiry::EX(999)),
@@ -480,9 +480,9 @@ mod basic {
         // which means that the supplied expiration still takes effect.
         con.set("at_bound", 10.0).unwrap();
         let result = con
-            .increx_by_float(
+            .increx(
                 "at_bound",
-                100.0,
+                100.0f64,
                 IncrexOptions::default()
                     .saturate() // Because of this, the operation is applied even though the value doesn't change.
                     .upper_bound(10.0)
@@ -496,9 +496,9 @@ mod basic {
         // ENX takes into account if a TTL is already present and blocks the update even though the clamp itself is applied.
         con.set_ex("at_bound_enx", 10.0, 100).unwrap();
         let result = con
-            .increx_by_float(
+            .increx(
                 "at_bound_enx",
-                100.0,
+                100.0f64,
                 IncrexOptions::default()
                     .saturate()
                     .upper_bound(10.0)
@@ -519,7 +519,7 @@ mod basic {
         // Type mismatch: INCREX against a list key yields WRONGTYPE, surfaced with the server's exact code and detail.
         con.rpush("list_key", "a").unwrap();
         let err = con
-            .increx_by_int("list_key", 1, IncrexOptions::default())
+            .increx("list_key", 1i64, IncrexOptions::default())
             .unwrap_err();
         assert_eq!(err.code(), Some("WRONGTYPE"));
         assert_eq!(
@@ -532,7 +532,7 @@ mod basic {
         // Note: The error message wording differs between BYINT and BYFLOAT.
         con.set("str_key", "hello").unwrap();
         let err = con
-            .increx_by_int("str_key", 1, IncrexOptions::default())
+            .increx("str_key", 1i64, IncrexOptions::default())
             .unwrap_err();
         assert_eq!(err.code(), Some("ERR"));
         assert_eq!(
@@ -541,7 +541,7 @@ mod basic {
         );
 
         let err = con
-            .increx_by_float("str_key", 1.5, IncrexOptions::default())
+            .increx("str_key", 1.5f64, IncrexOptions::default())
             .unwrap_err();
         assert_eq!(err.code(), Some("ERR"));
         assert_eq!(err.detail(), Some("value is not a valid float"));
@@ -549,7 +549,7 @@ mod basic {
         // Malformed arguments reachable through the typed API - ENX with no expiration.
         // The server's argument error is forwarded verbatim.
         let err = con
-            .increx_by_int("misc", 1, IncrexOptions::default().enx())
+            .increx("misc", 1i64, IncrexOptions::default().enx())
             .unwrap_err();
         assert_eq!(err.code(), Some("ERR"));
         assert_eq!(err.detail(), Some("ENX flag requires an expiration"));

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -14,6 +14,7 @@ mod basic {
     use redis::{
         Client, Connection, ConnectionInfo, ConnectionLike, ControlFlow, CopyOptions, ErrorKind,
         ExistenceCheck, ExpireOption, Expiry, FieldExistenceCheck, HashFieldExpirationOptions,
+        IncrexOptions,
         IntegerReplyOrNoOp::{ExistsButNotRelevant, IntegerReply},
         MSetOptions, ProtocolVersion, PubSubCommands, PushInfo, PushKind, RedisConnectionInfo,
         RedisResult, Role, ScanOptions, SetExpiry, SetOptions, SortedSetAddOptions, ToRedisArgs,
@@ -254,6 +255,304 @@ mod basic {
 
         redis::cmd("SET").arg("foo").arg(42).exec(&mut con).unwrap();
         assert_eq!(redis::cmd("INCR").arg("foo").query(&mut con), Ok(43usize));
+    }
+
+    #[test]
+    fn test_increx_options_args() {
+        assert_eq!(
+            ToRedisArgs::to_redis_args(&IncrexOptions::<i64>::default()).len(),
+            0
+        );
+
+        let opts = IncrexOptions::default()
+            .saturate()
+            .lower_bound(-5)
+            .upper_bound(100)
+            .with_expiration(Expiry::EX(60))
+            .enx();
+        assert_args!(
+            &opts, "SATURATE", "LBOUND", "-5", "UBOUND", "100", "EX", "60", "ENX"
+        );
+
+        let opts = IncrexOptions::default()
+            .saturate()
+            .upper_bound(2.5)
+            .with_expiration(Expiry::PERSIST);
+        assert_args!(&opts, "SATURATE", "UBOUND", "2.5", "PERSIST");
+    }
+
+    #[test]
+    fn test_increx_by_int() {
+        let ctx = run_test_if_version_supported!([REDIS_CE_8_8]);
+        let mut con = ctx.connection();
+
+        // A fresh key starts at 0.
+        // A normal in-bounds increment applies fully.
+        let result = con
+            .increx_by_int("counter", 5, IncrexOptions::default())
+            .unwrap();
+        assert_eq!(result.value, 5);
+        assert_eq!(result.actual_increment, 5);
+
+        // The default policy rejects out-of-bounds operations.
+        // The reply is a regular successful `Ok`, reporting the unchanged current value and a zero applied increment.
+        let result = con
+            .increx_by_int("counter", 100, IncrexOptions::default().upper_bound(10))
+            .unwrap();
+        assert_eq!(result.value, 5);
+        assert_eq!(result.actual_increment, 0);
+
+        // SATURATE clamps the result to an explicit upper bound and reports the clamped delta (10 - 5 = 5), not the requested increment (100).
+        let result = con
+            .increx_by_int(
+                "counter",
+                100,
+                IncrexOptions::default().saturate().upper_bound(10),
+            )
+            .unwrap();
+        assert_eq!(result.value, 10);
+        assert_eq!(result.actual_increment, 5);
+
+        // SATURATE clamps to an explicit lower bound on underflow.
+        // The actual_increment is again the clamped delta (-10 - 5 = -15), not the requested -100.
+        con.set("underflow", 5).unwrap();
+        let result = con
+            .increx_by_int(
+                "underflow",
+                -100,
+                IncrexOptions::default().saturate().lower_bound(-10),
+            )
+            .unwrap();
+        assert_eq!(result.value, -10);
+        assert_eq!(result.actual_increment, -15);
+
+        // With no explicit bound, SATURATE clamps to the server's integer type limits,
+        // which are exactly i64::MAX / i64::MIN (the server operates on 64-bit `long long`).
+        con.set("hi", i64::MAX - 100).unwrap();
+        let result = con
+            .increx_by_int("hi", 200, IncrexOptions::default().saturate())
+            .unwrap();
+        assert_eq!(result.value, i64::MAX);
+        assert_eq!(result.actual_increment, 100);
+        con.set("lo", i64::MIN + 100).unwrap();
+        let result = con
+            .increx_by_int("lo", -200, IncrexOptions::default().saturate())
+            .unwrap();
+        assert_eq!(result.value, i64::MIN);
+        assert_eq!(result.actual_increment, -100);
+
+        // Expiration is applied alongside the increment.
+        let result = con
+            .increx_by_int(
+                "ttl_counter",
+                1,
+                IncrexOptions::default().with_expiration(Expiry::EX(100)),
+            )
+            .unwrap();
+        assert_eq!(result.value, 1);
+        assert_eq!(result.actual_increment, 1);
+        assert!((0..=100).contains(&con.ttl("ttl_counter").unwrap().raw()));
+
+        // Rejected operations leave the key's value *and* TTL untouched.
+        con.set_ex("bounded", 5, 100).unwrap();
+        let result = con
+            .increx_by_int(
+                "bounded",
+                100,
+                IncrexOptions::default()
+                    .upper_bound(10)
+                    .with_expiration(Expiry::EX(999)),
+            )
+            .unwrap();
+        assert_eq!(result.value, 5);
+        assert_eq!(result.actual_increment, 0);
+        assert_eq!(con.get("bounded").unwrap(), Some("5".to_string()));
+        assert!((0..=100).contains(&con.ttl("bounded").unwrap().raw()));
+
+        // A SATURATE clamp that lands on the current value has an effective delta of 0, yet it counts as an *applied* operation,
+        // which means that the supplied expiration still takes effect.
+        // This differs from the default policy rejection above, which leaves the TTL untouched.
+        con.set("at_bound", 10).unwrap();
+        let result = con
+            .increx_by_int(
+                "at_bound",
+                100,
+                IncrexOptions::default()
+                    .saturate() // Because of this, the operation is applied even though the value doesn't change.
+                    .upper_bound(10)
+                    .with_expiration(Expiry::EX(500)),
+            )
+            .unwrap();
+        assert_eq!(result.value, 10);
+        assert_eq!(result.actual_increment, 0);
+        // The key started with no TTL, so EX must have set one.
+        assert!((0..=500).contains(&con.ttl("at_bound").unwrap().raw()));
+
+        // ENX takes into account if a TTL is already present and blocks the update even though the clamp itself is applied.
+        con.set_ex("at_bound_enx", 10, 100).unwrap();
+        let result = con
+            .increx_by_int(
+                "at_bound_enx",
+                100,
+                IncrexOptions::default()
+                    .saturate()
+                    .upper_bound(10)
+                    .with_expiration(Expiry::EX(999))
+                    .enx(),
+            )
+            .unwrap();
+        assert_eq!(result.value, 10);
+        assert_eq!(result.actual_increment, 0);
+        assert!((0..=100).contains(&con.ttl("at_bound_enx").unwrap().raw()));
+    }
+
+    #[test]
+    fn test_increx_by_float() {
+        let ctx = run_test_if_version_supported!([REDIS_CE_8_8]);
+        let mut con = ctx.connection();
+
+        // A normal in-bounds float increment applies fully.
+        let result = con
+            .increx_by_float("balance", 2.5, IncrexOptions::default())
+            .unwrap();
+        assert_approx_eq!(result.value, 2.5);
+        assert_approx_eq!(result.actual_increment, 2.5);
+
+        // SATURATE clamps to a floating-point upper bound.
+        // The actual_increment is the clamped delta (4.0 - 2.5 = 1.5), not the requested 5.5.
+        let result = con
+            .increx_by_float(
+                "balance",
+                5.5,
+                IncrexOptions::default().saturate().upper_bound(4.0),
+            )
+            .unwrap();
+        assert_approx_eq!(result.value, 4.0);
+        assert_approx_eq!(result.actual_increment, 1.5);
+
+        // The default policy rejects an out-of-bounds floating-point operation, leaving the value unchanged.
+        let result = con
+            .increx_by_float("balance", 5.5, IncrexOptions::default().upper_bound(4.0))
+            .unwrap();
+        assert_approx_eq!(result.value, 4.0);
+        assert_approx_eq!(result.actual_increment, 0.0);
+
+        // SATURATE clamps to a floating-point lower bound on underflow.
+        // From 0, -5.5 clamps to -1.5, so the clamped delta is -1.5 rather than the requested -5.5.
+        let result = con
+            .increx_by_float(
+                "debt",
+                -5.5,
+                IncrexOptions::default().saturate().lower_bound(-1.5),
+            )
+            .unwrap();
+        assert_approx_eq!(result.value, -1.5);
+        assert_approx_eq!(result.actual_increment, -1.5);
+
+        // Expiration is applied alongside the increment.
+        let result = con
+            .increx_by_float(
+                "ttl_counter",
+                1.0,
+                IncrexOptions::default().with_expiration(Expiry::EX(100)),
+            )
+            .unwrap();
+        assert_approx_eq!(result.value, 1.0);
+        assert_approx_eq!(result.actual_increment, 1.0);
+        assert!((0..=100).contains(&con.ttl("ttl_counter").unwrap().raw()));
+
+        // Rejected operations leave the key's value *and* TTL untouched.
+        con.set_ex("bounded", 5.0, 100).unwrap();
+        let result = con
+            .increx_by_float(
+                "bounded",
+                100.0,
+                IncrexOptions::default()
+                    .upper_bound(10.0)
+                    .with_expiration(Expiry::EX(999)),
+            )
+            .unwrap();
+        assert_approx_eq!(result.value, 5.0);
+        assert_approx_eq!(result.actual_increment, 0.0);
+        assert!((0..=100).contains(&con.ttl("bounded").unwrap().raw()));
+
+        // A SATURATE clamp that lands on the current value has an effective delta of 0, yet it counts as an *applied* operation,
+        // which means that the supplied expiration still takes effect.
+        con.set("at_bound", 10.0).unwrap();
+        let result = con
+            .increx_by_float(
+                "at_bound",
+                100.0,
+                IncrexOptions::default()
+                    .saturate() // Because of this, the operation is applied even though the value doesn't change.
+                    .upper_bound(10.0)
+                    .with_expiration(Expiry::EX(500)),
+            )
+            .unwrap();
+        assert_approx_eq!(result.value, 10.0);
+        assert_approx_eq!(result.actual_increment, 0.0);
+        assert!((0..=500).contains(&con.ttl("at_bound").unwrap().raw()));
+
+        // ENX takes into account if a TTL is already present and blocks the update even though the clamp itself is applied.
+        con.set_ex("at_bound_enx", 10.0, 100).unwrap();
+        let result = con
+            .increx_by_float(
+                "at_bound_enx",
+                100.0,
+                IncrexOptions::default()
+                    .saturate()
+                    .upper_bound(10.0)
+                    .with_expiration(Expiry::EX(999))
+                    .enx(),
+            )
+            .unwrap();
+        assert_approx_eq!(result.value, 10.0);
+        assert_approx_eq!(result.actual_increment, 0.0);
+        assert!((0..=100).contains(&con.ttl("at_bound_enx").unwrap().raw()));
+    }
+
+    #[test]
+    fn test_increx_server_errors_forwarded_verbatim() {
+        let ctx = run_test_if_version_supported!([REDIS_CE_8_8]);
+        let mut con = ctx.connection();
+
+        // Type mismatch: INCREX against a list key yields WRONGTYPE, surfaced with the server's exact code and detail.
+        con.rpush("list_key", "a").unwrap();
+        let err = con
+            .increx_by_int("list_key", 1, IncrexOptions::default())
+            .unwrap_err();
+        assert_eq!(err.code(), Some("WRONGTYPE"));
+        assert_eq!(
+            err.detail(),
+            Some("Operation against a key holding the wrong kind of value")
+        );
+
+        // Non-numeric value under BYINT / BYFLOAT.
+        // The server's value-type errors are forwarded verbatim.
+        // Note: The error message wording differs between BYINT and BYFLOAT.
+        con.set("str_key", "hello").unwrap();
+        let err = con
+            .increx_by_int("str_key", 1, IncrexOptions::default())
+            .unwrap_err();
+        assert_eq!(err.code(), Some("ERR"));
+        assert_eq!(
+            err.detail(),
+            Some("value is not an integer or out of range")
+        );
+
+        let err = con
+            .increx_by_float("str_key", 1.5, IncrexOptions::default())
+            .unwrap_err();
+        assert_eq!(err.code(), Some("ERR"));
+        assert_eq!(err.detail(), Some("value is not a valid float"));
+
+        // Malformed arguments reachable through the typed API - ENX with no expiration.
+        // The server's argument error is forwarded verbatim.
+        let err = con
+            .increx_by_int("misc", 1, IncrexOptions::default().enx())
+            .unwrap_err();
+        assert_eq!(err.code(), Some("ERR"));
+        assert_eq!(err.detail(), Some("ENX flag requires an expiration"));
     }
 
     #[test]

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -282,81 +282,86 @@ mod basic {
     }
 
     #[test]
-    fn test_increx_by_int() {
+    fn test_increx_with_integers() {
         let ctx = run_test_if_version_supported!([REDIS_CE_8_8]);
         let mut con = ctx.connection();
 
         // A fresh key starts at 0.
         // A normal in-bounds increment applies fully.
-        let result = con
-            .increx_by_int("counter", 5, IncrexOptions::default())
-            .unwrap();
-        assert_eq!(result.value, 5);
-        assert_eq!(result.actual_increment, 5);
+        let result = con.increx("counter", 5, IncrexOptions::default()).unwrap();
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, 5);
+        assert_eq!(actual_increment, 5);
 
         // The default policy rejects out-of-bounds operations.
         // The reply is a regular successful `Ok`, reporting the unchanged current value and a zero applied increment.
         let result = con
-            .increx_by_int("counter", 100, IncrexOptions::default().upper_bound(10))
+            .increx("counter", 100, IncrexOptions::default().upper_bound(10))
             .unwrap();
-        assert_eq!(result.value, 5);
-        assert_eq!(result.actual_increment, 0);
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, 5);
+        assert_eq!(actual_increment, 0);
 
         // SATURATE clamps the result to an explicit upper bound and reports the clamped delta (10 - 5 = 5), not the requested increment (100).
         let result = con
-            .increx_by_int(
+            .increx(
                 "counter",
                 100,
                 IncrexOptions::default().saturate().upper_bound(10),
             )
             .unwrap();
-        assert_eq!(result.value, 10);
-        assert_eq!(result.actual_increment, 5);
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, 10);
+        assert_eq!(actual_increment, 5);
 
         // SATURATE clamps to an explicit lower bound on underflow.
         // The actual_increment is again the clamped delta (-10 - 5 = -15), not the requested -100.
         con.set("underflow", 5).unwrap();
         let result = con
-            .increx_by_int(
+            .increx(
                 "underflow",
                 -100,
                 IncrexOptions::default().saturate().lower_bound(-10),
             )
             .unwrap();
-        assert_eq!(result.value, -10);
-        assert_eq!(result.actual_increment, -15);
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, -10);
+        assert_eq!(actual_increment, -15);
 
         // With no explicit bound, SATURATE clamps to the server's integer type limits,
         // which are exactly i64::MAX / i64::MIN (the server operates on 64-bit `long long`).
         con.set("hi", i64::MAX - 100).unwrap();
         let result = con
-            .increx_by_int("hi", 200, IncrexOptions::default().saturate())
+            .increx("hi", 200, IncrexOptions::default().saturate())
             .unwrap();
-        assert_eq!(result.value, i64::MAX);
-        assert_eq!(result.actual_increment, 100);
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, i64::MAX);
+        assert_eq!(actual_increment, 100);
         con.set("lo", i64::MIN + 100).unwrap();
         let result = con
-            .increx_by_int("lo", -200, IncrexOptions::default().saturate())
+            .increx("lo", -200, IncrexOptions::default().saturate())
             .unwrap();
-        assert_eq!(result.value, i64::MIN);
-        assert_eq!(result.actual_increment, -100);
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, i64::MIN);
+        assert_eq!(actual_increment, -100);
 
         // Expiration is applied alongside the increment.
         let result = con
-            .increx_by_int(
+            .increx(
                 "ttl_counter",
                 1,
                 IncrexOptions::default().with_expiration(Expiry::EX(100)),
             )
             .unwrap();
-        assert_eq!(result.value, 1);
-        assert_eq!(result.actual_increment, 1);
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, 1);
+        assert_eq!(actual_increment, 1);
         assert!((0..=100).contains(&con.ttl("ttl_counter").unwrap().raw()));
 
         // Rejected operations leave the key's value *and* TTL untouched.
         con.set_ex("bounded", 5, 100).unwrap();
         let result = con
-            .increx_by_int(
+            .increx(
                 "bounded",
                 100,
                 IncrexOptions::default()
@@ -364,8 +369,9 @@ mod basic {
                     .with_expiration(Expiry::EX(999)),
             )
             .unwrap();
-        assert_eq!(result.value, 5);
-        assert_eq!(result.actual_increment, 0);
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, 5);
+        assert_eq!(actual_increment, 0);
         assert_eq!(con.get("bounded").unwrap(), Some("5".to_string()));
         assert!((0..=100).contains(&con.ttl("bounded").unwrap().raw()));
 
@@ -374,7 +380,7 @@ mod basic {
         // This differs from the default policy rejection above, which leaves the TTL untouched.
         con.set("at_bound", 10).unwrap();
         let result = con
-            .increx_by_int(
+            .increx(
                 "at_bound",
                 100,
                 IncrexOptions::default()
@@ -383,15 +389,16 @@ mod basic {
                     .with_expiration(Expiry::EX(500)),
             )
             .unwrap();
-        assert_eq!(result.value, 10);
-        assert_eq!(result.actual_increment, 0);
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, 10);
+        assert_eq!(actual_increment, 0);
         // The key started with no TTL, so EX must have set one.
         assert!((0..=500).contains(&con.ttl("at_bound").unwrap().raw()));
 
         // ENX takes into account if a TTL is already present and blocks the update even though the clamp itself is applied.
         con.set_ex("at_bound_enx", 10, 100).unwrap();
         let result = con
-            .increx_by_int(
+            .increx(
                 "at_bound_enx",
                 100,
                 IncrexOptions::default()
@@ -401,70 +408,76 @@ mod basic {
                     .enx(),
             )
             .unwrap();
-        assert_eq!(result.value, 10);
-        assert_eq!(result.actual_increment, 0);
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, 10);
+        assert_eq!(actual_increment, 0);
         assert!((0..=100).contains(&con.ttl("at_bound_enx").unwrap().raw()));
     }
 
     #[test]
-    fn test_increx_by_float() {
+    fn test_increx_with_floats() {
         let ctx = run_test_if_version_supported!([REDIS_CE_8_8]);
         let mut con = ctx.connection();
 
         // A normal in-bounds float increment applies fully.
         let result = con
-            .increx_by_float("balance", 2.5, IncrexOptions::default())
+            .increx("balance", 2.5, IncrexOptions::default())
             .unwrap();
-        assert_approx_eq!(result.value, 2.5);
-        assert_approx_eq!(result.actual_increment, 2.5);
+        let (value, actual_increment) = result.as_f64().unwrap();
+        assert_approx_eq!(value, 2.5);
+        assert_approx_eq!(actual_increment, 2.5);
 
         // SATURATE clamps to a floating-point upper bound.
         // The actual_increment is the clamped delta (4.0 - 2.5 = 1.5), not the requested 5.5.
         let result = con
-            .increx_by_float(
+            .increx(
                 "balance",
                 5.5,
                 IncrexOptions::default().saturate().upper_bound(4.0),
             )
             .unwrap();
-        assert_approx_eq!(result.value, 4.0);
-        assert_approx_eq!(result.actual_increment, 1.5);
+        let (value, actual_increment) = result.as_f64().unwrap();
+        assert_approx_eq!(value, 4.0);
+        assert_approx_eq!(actual_increment, 1.5);
 
         // The default policy rejects an out-of-bounds floating-point operation, leaving the value unchanged.
         let result = con
-            .increx_by_float("balance", 5.5, IncrexOptions::default().upper_bound(4.0))
+            .increx("balance", 5.5, IncrexOptions::default().upper_bound(4.0))
             .unwrap();
-        assert_approx_eq!(result.value, 4.0);
-        assert_approx_eq!(result.actual_increment, 0.0);
+        let (value, actual_increment) = result.as_f64().unwrap();
+        assert_approx_eq!(value, 4.0);
+        assert_approx_eq!(actual_increment, 0.0);
 
         // SATURATE clamps to a floating-point lower bound on underflow.
         // From 0, -5.5 clamps to -1.5, so the clamped delta is -1.5 rather than the requested -5.5.
         let result = con
-            .increx_by_float(
+            .increx(
                 "debt",
                 -5.5,
                 IncrexOptions::default().saturate().lower_bound(-1.5),
             )
             .unwrap();
-        assert_approx_eq!(result.value, -1.5);
-        assert_approx_eq!(result.actual_increment, -1.5);
+        let (value, actual_increment) = result.as_f64().unwrap();
+        assert_approx_eq!(value, -1.5);
+        assert_approx_eq!(actual_increment, -1.5);
 
         // Expiration is applied alongside the increment.
         let result = con
-            .increx_by_float(
+            .increx(
                 "ttl_counter",
                 1.0,
                 IncrexOptions::default().with_expiration(Expiry::EX(100)),
             )
             .unwrap();
-        assert_approx_eq!(result.value, 1.0);
-        assert_approx_eq!(result.actual_increment, 1.0);
+        let (value, actual_increment) = result.as_f64().unwrap();
+        assert_approx_eq!(value, 1.0);
+        assert_approx_eq!(actual_increment, 1.0);
         assert!((0..=100).contains(&con.ttl("ttl_counter").unwrap().raw()));
 
         // Rejected operations leave the key's value *and* TTL untouched.
         con.set_ex("bounded", 5.0, 100).unwrap();
         let result = con
-            .increx_by_float(
+            .increx(
                 "bounded",
                 100.0,
                 IncrexOptions::default()
@@ -472,15 +485,16 @@ mod basic {
                     .with_expiration(Expiry::EX(999)),
             )
             .unwrap();
-        assert_approx_eq!(result.value, 5.0);
-        assert_approx_eq!(result.actual_increment, 0.0);
+        let (value, actual_increment) = result.as_f64().unwrap();
+        assert_approx_eq!(value, 5.0);
+        assert_approx_eq!(actual_increment, 0.0);
         assert!((0..=100).contains(&con.ttl("bounded").unwrap().raw()));
 
         // A SATURATE clamp that lands on the current value has an effective delta of 0, yet it counts as an *applied* operation,
         // which means that the supplied expiration still takes effect.
         con.set("at_bound", 10.0).unwrap();
         let result = con
-            .increx_by_float(
+            .increx(
                 "at_bound",
                 100.0,
                 IncrexOptions::default()
@@ -489,14 +503,15 @@ mod basic {
                     .with_expiration(Expiry::EX(500)),
             )
             .unwrap();
-        assert_approx_eq!(result.value, 10.0);
-        assert_approx_eq!(result.actual_increment, 0.0);
+        let (value, actual_increment) = result.as_f64().unwrap();
+        assert_approx_eq!(value, 10.0);
+        assert_approx_eq!(actual_increment, 0.0);
         assert!((0..=500).contains(&con.ttl("at_bound").unwrap().raw()));
 
         // ENX takes into account if a TTL is already present and blocks the update even though the clamp itself is applied.
         con.set_ex("at_bound_enx", 10.0, 100).unwrap();
         let result = con
-            .increx_by_float(
+            .increx(
                 "at_bound_enx",
                 100.0,
                 IncrexOptions::default()
@@ -506,8 +521,9 @@ mod basic {
                     .enx(),
             )
             .unwrap();
-        assert_approx_eq!(result.value, 10.0);
-        assert_approx_eq!(result.actual_increment, 0.0);
+        let (value, actual_increment) = result.as_f64().unwrap();
+        assert_approx_eq!(value, 10.0);
+        assert_approx_eq!(actual_increment, 0.0);
         assert!((0..=100).contains(&con.ttl("at_bound_enx").unwrap().raw()));
     }
 
@@ -519,7 +535,7 @@ mod basic {
         // Type mismatch: INCREX against a list key yields WRONGTYPE, surfaced with the server's exact code and detail.
         con.rpush("list_key", "a").unwrap();
         let err = con
-            .increx_by_int("list_key", 1, IncrexOptions::default())
+            .increx("list_key", 1, IncrexOptions::default())
             .unwrap_err();
         assert_eq!(err.code(), Some("WRONGTYPE"));
         assert_eq!(
@@ -532,7 +548,7 @@ mod basic {
         // Note: The error message wording differs between BYINT and BYFLOAT.
         con.set("str_key", "hello").unwrap();
         let err = con
-            .increx_by_int("str_key", 1, IncrexOptions::default())
+            .increx("str_key", 1, IncrexOptions::default())
             .unwrap_err();
         assert_eq!(err.code(), Some("ERR"));
         assert_eq!(
@@ -541,7 +557,7 @@ mod basic {
         );
 
         let err = con
-            .increx_by_float("str_key", 1.5, IncrexOptions::default())
+            .increx("str_key", 1.5, IncrexOptions::default())
             .unwrap_err();
         assert_eq!(err.code(), Some("ERR"));
         assert_eq!(err.detail(), Some("value is not a valid float"));
@@ -549,7 +565,7 @@ mod basic {
         // Malformed arguments reachable through the typed API - ENX with no expiration.
         // The server's argument error is forwarded verbatim.
         let err = con
-            .increx_by_int("misc", 1, IncrexOptions::default().enx())
+            .increx("misc", 1, IncrexOptions::default().enx())
             .unwrap_err();
         assert_eq!(err.code(), Some("ERR"));
         assert_eq!(err.detail(), Some("ENX flag requires an expiration"));


### PR DESCRIPTION
# Add support for the `INCREX` command

## Summary

Add support for the `INCREX` command introduced in **Redis 8.8**.
`INCREX` increments a key's numeric value and sets its expiration in a single call, with optional lower/upper bounds and a
choice between rejecting or **saturating** out-of-bounds results.

## Background

Before `INCREX`, incrementing a counter and (re)setting its `TTL` required two round-trips - 
`INCRBY` / `INCRBYFLOAT` followed by `EXPIRE`, which is not atomic and cannot express "clamp to a ceiling" in one step.
`INCREX` folds all of this into one command and adds a bounds policy.

| Concern | Before (`INCRBY` + `EXPIRE`) | After (`INCREX`) |
| --- | --- | --- |
| Increment + set TTL | Two commands, non-atomic | One atomic command |
| Bounded increment (cap/floor) | Manual read-modify-write | Done through `LBOUND` / `UBOUND` |
| Overflow handling | Errors out (`INCRBY`) | Reject silently or `SATURATE` to the bound |
| Was it applied? | Inferred by the caller | Reported directly as `actual_increment` |

Example:

```
> SET counter 98
> INCREX counter BYINT 5 SATURATE UBOUND 100
1) (integer) 100   ; value after the (clamped) increment
2) (integer) 2     ; actual increment applied (100 - 98), not the requested 5
```

## Syntax

```
INCREX key [BYFLOAT increment | BYINT increment]
           [SATURATE]
           [LBOUND lower-bound] [UBOUND upper-bound]
           [EX seconds | PX milliseconds | EXAT unix-time-seconds
            | PXAT unix-time-milliseconds | PERSIST]
           [ENX]
```

The reply is always a two-element array `[value, actual_increment]`:

- **`value`** - the key's value after the increment.
- **`actual_increment`** - the increment actually applied. It is `0` when the default policy rejected an out-of-bounds operation and equals the clamped delta (which may differ from the requested increment) under `SATURATE`.

## Behavior

- **Default policy (no `SATURATE`), out of bounds** - the operation is rejected silently.
The reply is `[current_value, 0]`, which is a regular successful reply and not an error.
The key's value **and TTL** are left unchanged (a supplied expiration is **not** applied).
- **`SATURATE`** - the result is clamped to the explicit `LBOUND`/`UBOUND` or to the type limit when no bound is given (`i64::MAX`/`i64::MIN` for `BYINT`; `±LDBL_MAX` for `BYFLOAT`). `actual_increment` reports the clamped delta.
- **Zero-delta `SATURATE`** - a clamp that lands on the current value has an `actual_increment == 0` but still counts as *applied*, so a supplied expiration **is** applied (subject to `ENX`). This differs from the default-policy reject above.
- **`ENX`** - only sets the expiration if the key has no TTL. It requires one of `EX`/`PX`/`EXAT`/`PXAT` and cannot be combined with `PERSIST` because the server rejects the combination.
- **Server errors** are forwarded verbatim through `RedisError::code()` / `detail()`.

### Numeric type fidelity

| Rust type | Server type | Notes |
| --- | --- | --- |
| `i64` | 64-bit `long long` | **Exact** - clamp limits are `i64::MAX`/`i64::MIN`. Out-of-range arguments are rejected server-side. |
| `f64` | C `long double` | Matches the crate-wide convention. The generic `Commands` variant with a wider `FromRedisValue` type should be used for full precision. |

## Testing

| Test | Gating | Covers |
| --- | --- | --- |
| `test_increx_options_args` | none | unit test coverage of `IncrexOptions`. |
| `test_increx_with_integers` | `REDIS_CE_8_8` | integration test that tests the behavior of the increment by integer method with scenarios such as - normal apply, default rejection policy `[value, 0]`, explicit bounds clamp, implicit saturating clamp and more. |
| `test_increx_with_floats` | `REDIS_CE_8_8` | same as the one above, but for the increment by float method and without the implicit saturating clamp.  |
| `test_increx_server_errors_forwarded_verbatim` | `REDIS_CE_8_8` | verbatim `code()`/`detail()` for `WRONGTYPE`, non-numeric value (BYINT/BYFLOAT) and `ENX`-without-expiration. |

## Compatibility

- The changes are additive and no existing public APIs were changed.
- No new cargo feature was added, since `INCREX` is a core string command.
- Server behavior gated to **Redis CE 8.8+** in tests via the `REDIS_CE_8_8` constant.
- The one change to existing code is adding `#[derive(Clone)]` to `Expiry`, which is backward compatible.

## Relevant documentation

- [`INCREX`](https://redis.io/commands/increx/), [`INCRBY`](https://redis.io/commands/incrby/), [`INCRBYFLOAT`](https://redis.io/commands/incrbyfloat/)
