### PR TITLE
ci: Allow `semicolon_in_expressions_from_macros` to make nightly pass

### DIFF
--- a/redis/src/parser.rs
+++ b/redis/src/parser.rs
@@ -1,3 +1,8 @@
+// TODO remove this `allow` once `combine` released a fix. Upstream bug: https://github.com/Marwes/combine/issues/372
+#![allow(
+    semicolon_in_expressions_from_macros,
+    reason = "This lint is on in nightly since 2026-07-16, but `combine-4.6.7` violates it in `opaque`. As we cannot decorate directly, we allow it for the whole module for now"
+)]
 use std::{
     io::{self, Read},
     str,


### PR DESCRIPTION
`nightly` enabled `semicolon_in_expressions_from_macros`, which hits us in `parser`'s use of `opaque` from `combine-4.6.7` (Marwes/combine#372). As there is no newer `combine` release for now, we allow the lint for now.

Fixes #2217