### PR TITLE
redis-test: Add dedicated struct for a Redis server's start commands (2/19)

### DIFF
--- a/redis-test/src/cluster.rs
+++ b/redis-test/src/cluster.rs
@@ -171,7 +171,7 @@ impl RedisCluster {
         let max_attempts = 5;
 
         let mut make_server = |port| {
-            RedisServer::new_with_addr_tls_modules_and_spawner(
+            RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
                 ClusterType::build_addr(port),
                 None,
                 tls_paths.clone(),
@@ -210,7 +210,6 @@ impl RedisCluster {
                     }
                     cmd.current_dir(tempdir.path());
                     folders.push(tempdir);
-                    cmd.spawn().unwrap()
                 },
             )
         };

--- a/redis-test/src/sentinel.rs
+++ b/redis-test/src/sentinel.rs
@@ -134,7 +134,7 @@ fn spawn_master_server(
     tlspaths: &TlsFilePaths,
     modules: &[Module],
 ) -> RedisServer {
-    RedisServer::new_with_addr_tls_modules_and_spawner(
+    RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
         get_addr(port),
         None,
         Some(tlspaths.clone()),
@@ -148,7 +148,6 @@ fn spawn_master_server(
                 cmd.arg("--tls-replication").arg("yes");
             }
             cmd.current_dir(dir.path());
-            cmd.spawn().unwrap()
         },
     )
 }
@@ -163,7 +162,7 @@ fn spawn_replica_server(
     let config_file_path = dir.path().join("redis_config.conf");
     File::create(&config_file_path).unwrap();
 
-    RedisServer::new_with_addr_tls_modules_and_spawner(
+    RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
         get_addr(port),
         Some(&config_file_path),
         Some(tlspaths.clone()),
@@ -178,7 +177,6 @@ fn spawn_replica_server(
                 cmd.arg("--tls-replication").arg("yes");
             }
             cmd.current_dir(dir.path());
-            cmd.spawn().unwrap()
         },
     )
 }
@@ -200,7 +198,7 @@ fn spawn_sentinel_server(
     }
     file.flush().unwrap();
 
-    RedisServer::new_with_addr_tls_modules_and_spawner(
+    RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
         get_addr(port),
         Some(&config_file_path),
         Some(tlspaths.clone()),
@@ -213,7 +211,6 @@ fn spawn_sentinel_server(
                 cmd.arg("--tls-replication").arg("yes");
             }
             cmd.current_dir(dir.path());
-            cmd.spawn().unwrap()
         },
     )
 }

--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -1,7 +1,7 @@
 use redis::{ConnectionAddr, IntoConnectionInfo, ProtocolVersion, RedisConnectionInfo};
+use std::ffi::OsStr;
 use std::path::Path;
 use std::{env, fs, path::PathBuf, process};
-
 use tempfile::TempDir;
 
 use crate::utils::{TlsFilePaths, build_keys_and_certs_for_tls, get_random_available_port};
@@ -129,17 +129,14 @@ impl RedisServer {
         let redis_port = get_random_available_port();
         let addr = RedisServer::get_addr(redis_port);
 
-        RedisServer::new_with_addr_tls_modules_and_spawner(
+        RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
             addr,
             None,
             None,
             mtls_enabled,
             None,
             modules,
-            |cmd| {
-                cmd.spawn()
-                    .unwrap_or_else(|err| panic!("Failed to run {cmd:?}: {err}"))
-            },
+            |_cmd| {},
         )
     }
 
@@ -148,33 +145,27 @@ impl RedisServer {
         modules: &[Module],
         mtls_enabled: bool,
     ) -> RedisServer {
-        RedisServer::new_with_addr_tls_modules_and_spawner(
+        RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
             addr,
             None,
             None,
             mtls_enabled,
             None,
             modules,
-            |cmd| {
-                cmd.spawn()
-                    .unwrap_or_else(|err| panic!("Failed to run {cmd:?}: {err}"))
-            },
+            |_cmd| {},
         )
     }
 
-    pub fn new_with_addr_tls_modules_and_spawner<
-        F: FnOnce(&mut process::Command) -> process::Child,
-    >(
+    pub fn new_with_addr_tls_modules_and_cmd_refiner(
         mut addr: redis::ConnectionAddr,
         config_file: Option<&Path>,
         mut tls_paths: Option<TlsFilePaths>,
         mtls_enabled: bool,
         cert_auth_field: Option<&str>,
         modules: &[Module],
-        spawner: F,
+        cmd_refiner: impl FnOnce(&mut RedisServerCommand),
     ) -> RedisServer {
-        let bin = env::var("REDISRS_SERVER_BIN").unwrap_or_else(|_| "redis-server".to_string());
-        let mut redis_cmd = process::Command::new(&bin);
+        let mut redis_cmd = RedisServerCommand::new();
 
         if let Some(config_path) = config_file {
             redis_cmd.arg(config_path);
@@ -219,18 +210,16 @@ impl RedisServer {
             };
         }
 
-        redis_cmd
-            .stdout(process::Stdio::piped())
-            .stderr(process::Stdio::piped());
         let tempdir = tempfile::Builder::new()
             .prefix("redis")
             .tempdir()
             .expect("failed to create tempdir");
         let log_file = Self::log_file(&tempdir);
         redis_cmd.arg("--logfile").arg(log_file.clone());
-        if get_major_version(&bin) > 6 {
+        if get_major_version() > 6 {
             redis_cmd.arg("--enable-debug-command").arg("yes");
         }
+
         match addr {
             redis::ConnectionAddr::Tcp(ref bind, server_port) => {
                 redis_cmd
@@ -289,8 +278,10 @@ impl RedisServer {
             _ => panic!("Unknown address format: {addr:?}"),
         };
 
+        cmd_refiner(&mut redis_cmd);
+
         RedisServer {
-            process: spawner(&mut redis_cmd),
+            process: redis_cmd.spawn(),
             log_file,
             tempdir,
             addr,
@@ -331,11 +322,65 @@ impl RedisServer {
     }
 }
 
-fn get_major_version(server_binary: &str) -> u8 {
+pub struct RedisServerCommand {
+    // The actual command to run
+    cmd: process::Command,
+}
+
+impl Default for RedisServerCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RedisServerCommand {
+    pub fn new() -> Self {
+        let bin = env::var("REDISRS_SERVER_BIN").unwrap_or_else(|_| "redis-server".to_string());
+
+        // Build the main command
+        let mut cmd = process::Command::new(&bin);
+
+        // Capture the command's stdout and stderr
+        cmd.stdout(process::Stdio::piped());
+        cmd.stderr(process::Stdio::piped());
+
+        // Build the instance
+        Self { cmd }
+    }
+
+    /// Appends a new argument to the command
+    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
+        self.cmd.arg(arg);
+        self
+    }
+
+    /// Set the directory to run the command in
+    pub fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut Self {
+        self.cmd.current_dir(dir);
+        self
+    }
+
+    /// Runs the command
+    ///
+    /// # Panics
+    ///
+    /// This method panics if spawning fails.
+    ///
+    /// If the command itself exits (immediately or not, regardless of the exit code) this function
+    /// does _not_ panic but returns the `Child` instance.
+    pub fn spawn(&mut self) -> process::Child {
+        self.cmd
+            .spawn()
+            .unwrap_or_else(|err| panic!("Failed to run {:?}: {err}", self.cmd))
+    }
+}
+
+fn get_major_version() -> u8 {
     let full_string = String::from_utf8(
-        process::Command::new(server_binary)
+        RedisServerCommand::new()
             .arg("-v")
-            .output()
+            .spawn()
+            .wait_with_output()
             .unwrap()
             .stdout,
     )

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -246,17 +246,14 @@ impl TestContext {
         tls_files: Option<TlsFilePaths>,
         cert_auth_field: Option<&str>,
     ) -> Self {
-        let server = RedisServer::new_with_addr_tls_modules_and_spawner(
+        let server = RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
             addr,
             None,
             tls_files,
             mtls_enabled,
             cert_auth_field,
             modules,
-            |cmd| {
-                cmd.spawn()
-                    .unwrap_or_else(|err| panic!("Failed to run {cmd:?}: {err}"))
-            },
+            |_cmd| {},
         );
 
         let client =

--- a/version2.md
+++ b/version2.md
@@ -10,6 +10,56 @@ redis = "2"
 
 ## Breaking Changes
 
+### `RedisServer::new_with_addr_tls_modules_and_spawner` got removed (Breaking Change)
+
+All callers used the spawner function to adjust the command's arguments, then spawn and unwrap it.
+The spawning was the same across all of them, hence duplicated.
+The unwrapping only differed in thoroughness of the error handling.
+So the common spawning and unwrapping got moved into `RedisServer` to ease its use.
+
+Refining the server's start command is available via `RedisServer::new_with_addr_tls_modules_and_cmd_refiner`.
+
+**Migration:** Switch from `RedisServer::new_with_addr_tls_modules_and_spawner` to `RedisServer::new_with_addr_tls_modules_and_cmd_refiner`.
+
+Typically, replacing `new_with_addr_tls_modules_and_spawner` by `new_with_addr_tls_modules_and_cmd_refiner` and removing the `cmd.spawn().unwrap()` from your spawning function end will be enough.
+The `cmd_refiner` function takes a `RedisStartCommand` as argument (instead of a `Command` before).
+
+This new `RedisStartCommand` also has a `arg()` method, so your spawners probably work out of the box.
+
+```rust
+// Before:
+
+let server = RedisServer::new_with_addr_tls_modules_and_spawner(
+    addr,
+    None,
+    None,
+    false,
+    None,
+    &[], |cmd| {
+        cmd.arg("--foo")
+            .arg("value-foo")
+            .arg("--bar")
+            .arg("value-baz");
+        cmd.spawn().unwrap()
+    }
+);
+
+// After:
+let server = RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
+    addr,
+    None,
+    None,
+    false,
+    None,
+    &[], |cmd| {
+        cmd.arg("--foo")
+            .arg("value-foo")
+            .arg("--bar")
+            .arg("value-baz");
+    }
+);
+```
+
 ### `Generic` typed commands have their `RV` moved from first to last parameter (Breaking Change)
 
 Untyped commands (`Commands`, `AsyncCommands`) have the return value's type (`RV`) as last type parameter, while for typed commands (`TypedCommands`, `AsyncTypedCommands`) it was the first.


### PR DESCRIPTION
We want to bring `RedisServer::new_with_addr_tls_modules_and_spawner`'s
complexity down and make it easier to read and use.

The main ingredients will be:
* Moving `REDISRS_SERVER_BIN` handling into a dedicated function, so it
  can be re-used and need not be passed to `get_major_version`
* Moving module loading logic into a dedicated function.
* Collect configuration directives and their values in a single
  line. This would turn the current, harder to read:

  ```
  cmnd.arg("--foo")
      .arg("value-foo")
      .arg("--bar")
      .arg("value-bar")
      .arg("--baz")
      .arg("value-baz")
  ```

  into the way simpler

  ```
  cmnd.arg2("--foo", "value-foo")
      .arg2("--bar", "value-bar")
      .arg2("--baz", "value-baz")
  ```

* Harmonize the error handling of a failed spawning. Some callers just
  let things crash, others give a proper error message. Regardless: It's
  needlessly duping logic and should get collected in one place for
  easier maintenance.

That could all be done directly within `RedisServer` and would improve
the overall situation a bit.

But the first three items are are all concerned with building the actual
command line to start the server. So we refactor that part out into a
dedicated `RedisServerCommand` struct. This moves the logic out of
`RedisServer` (rendering `RedisServer` simpler), allows for easy
customization, and gives clear responsibilities.

To keep the diffs managable and reviewable, we tackle the first and last
item (they are the ones that directly affect callers and give a compact
diff) in this commit and leave items 2 and 3 for separate follow-up
commits.
