### PR TITLE
Makefile: Switch to `--locked` for module tests on RESP3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ test-module-json:
 	@echo "===================================================================="
 	@echo "Testing RESP3 with RedisJSON module"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --all-features --profile module_json
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --locked --all-features --profile module_json
 
 test-module-bloom:
 	@echo "===================================================================="
@@ -62,7 +62,7 @@ test-module-bloom:
 	@echo "===================================================================="
 	@echo "Testing RESP3 with RedisBloom module"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --all-features --profile module_bloom
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --locked --all-features --profile module_bloom
 
 test-modules: test-module-json test-module-bloom
 


### PR DESCRIPTION
The json module tests ran without `--locked` on RESP3. When adding bloom module tests, this got copy/pasted there.

To limit it creeping further, we add `--locked` to these calls.