### PR TITLE
redis-test: Panic, when trying to load a module that does not exist (5/19)

### DIFF
--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -375,6 +375,9 @@ impl RedisServerCommand {
 
     /// Loads a module from the given path
     fn load_module(&mut self, path: String) {
+        if !Path::new(&path).is_file() {
+            panic!("Module doesn't exist or is not a file: {path}");
+        }
         self.arg2("--loadmodule", path);
     }
 


### PR DESCRIPTION
When running module tests locally, one sometimes forgets to set the module's file. Then starting Redis fails and tests hang until they time out.

So we before-hand check if the module's path exists and abort otherwise. This allows to detect setup problems immediately and speeds up the dev cycle.