### PR TITLE
docs: Remove remarks about Redis docs to `BF.MEXISTS` being wrong

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -3172,8 +3172,7 @@ assert_eq!(invok_2_res, 5);
     /// # Caveats
     ///
     /// If `key` is not a Bloom filter, Redis' module yields an array of `false`s as if all items
-    /// were missing (although its documentation as of 2026-04-16 claims to raise an error), while
-    /// Valkey yields a `WRONGKEY` error.
+    /// were missing, while Valkey yields a `WRONGTYPE` error.
     ///
     /// [Redis Docs](https://redis.io/commands/BF.MEXISTS)
     /// [Valkey Docs](https://valkey.io/commands/bf.mexists/)

--- a/redis/tests/test_module_bloom.rs
+++ b/redis/tests/test_module_bloom.rs
@@ -107,9 +107,6 @@ fn test_module_bloom_infos() {
     assert_matches!(con.bf_info(KEY_1).unwrap_err().detail(), Some(d) if d.contains("not found"));
     assert_matches!(con.bf_info_type(KEY_1, BloomFilterInfoType::Items).unwrap_err().detail(), Some(d) if d.contains("not found"));
     assert_eq!(con.bf_exists(KEY_1, "foo"), Ok(false));
-    // As of 2026-04-16, the following command should produce an error according to
-    // https://redis.io/docs/latest/commands/bf.mexists/
-    // as the key is missing. But instead it returns a proper array result
     assert_eq!(
         con.bf_mexists(KEY_1, &["foo", "bar", "baz"]),
         Ok(vec![false, false, false])
@@ -204,9 +201,6 @@ fn test_module_bloom_infos() {
     // to non-Bloom filter keys.
     if ctx.supports(REDIS_BLOOM_ANY) {
         assert_eq!(res_exists, Ok(false));
-        // As of 2026-04-16, the following command should produce an error according to
-        // https://redis.io/docs/latest/commands/bf.mexists/
-        // as the key is of the wrong type. But instead it returns a proper array result
         assert_eq!(res_mexists, Ok(vec![false, false, false]));
     } else {
         assert_eq!(res_exists.unwrap_err().code(), Some("WRONGTYPE"));


### PR DESCRIPTION
Upstream docs got fixed in `02b8bfd` [1] and is meanwhile live. So we can remove the remarks about the docs being wrong.

[1] redis/docs#3606
https://github.com/redis/docs/pull/3606