### PR TITLE
redis-test/RedisServer: Dedupe disabling Redis' default listening (7/19)

### DIFF
--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -187,6 +187,10 @@ impl RedisServer {
             redis_cmd.arg2("--enable-debug-command", "yes");
         }
 
+        // Disable all default listening
+        redis_cmd.arg2("--port", "0");
+
+        // Enable one kind of listening
         match addr {
             redis::ConnectionAddr::Tcp(ref host, port) => {
                 redis_cmd
@@ -202,7 +206,6 @@ impl RedisServer {
                 // prepare redis with TLS
                 redis_cmd
                     .arg2("--tls-port", port.to_string())
-                    .arg2("--port", "0")
                     .arg2("--tls-cert-file", &tls_paths.redis_crt)
                     .arg2("--tls-key-file", &tls_paths.redis_key)
                     .arg2("--tls-ca-cert-file", &tls_paths.ca_crt)
@@ -227,7 +230,7 @@ impl RedisServer {
                 };
             }
             redis::ConnectionAddr::Unix(ref path) => {
-                redis_cmd.arg2("--port", "0").arg2("--unixsocket", path);
+                redis_cmd.arg2("--unixsocket", path);
             }
             _ => panic!("Unknown address format: {addr:?}"),
         };


### PR DESCRIPTION
In two branches, we have to disable Redis' default listening configuration, only to setup a different listening configuration.

We now instead dedupe it and disable the default listening setup before-hand. This allows different arms to only focus on their setup, which makes things easier to read (e.g.: TLS setup no longer has a `--port 0` mixed in)