### PR TITLE
tests: Stop enforcing TLS when testing ConnectionManager's reconnect (9/19)

### DIFF
--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -207,10 +207,6 @@ impl TestContext {
         )
     }
 
-    pub fn with_tls(tls_files: TlsFilePaths, mtls_enabled: bool) -> TestContext {
-        Self::with_modules_and_tls(&[], mtls_enabled, Some(tls_files))
-    }
-
     pub fn with_modules(modules: &[Module]) -> TestContext {
         Self::with_modules_and_tls(modules, false, None)
     }

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -1438,13 +1438,7 @@ mod basic_async {
             .set_exponent_base(10000.0)
             .set_max_delay(max_delay_between_attempts);
 
-        let tempdir = tempfile::Builder::new()
-            .prefix("redis")
-            .tempdir()
-            .expect("failed to create tempdir");
-        let tls_files = redis_test::utils::build_keys_and_certs_for_tls(&tempdir);
-
-        let ctx = TestContext::with_tls(tls_files.clone(), false);
+        let ctx = TestContext::new();
         let protocol = ctx.protocol;
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();


### PR DESCRIPTION
Even with `REDIS_SERVER_TYPE=tcp` (no `+tls`),
`test_connection_manager_reconnect_after_delay` used TLS.

This was unwarranted, and we switch to using TLS only if requested.

This makes `TestContext::with_tls` unused, and we hence drop it.