### PR TITLE
redis-test: Add `RedisServerBuilder` (11/19)

### DIFF
--- a/redis-test/src/cluster.rs
+++ b/redis-test/src/cluster.rs
@@ -2,6 +2,7 @@ use std::{env, process, thread::sleep, time::Duration};
 
 use tempfile::TempDir;
 
+use crate::server::RedisServerBuilder;
 use crate::{
     server::{Module, RedisServer},
     utils::{TlsFilePaths, build_keys_and_certs_for_tls_ext, get_random_available_port},
@@ -171,14 +172,12 @@ impl RedisCluster {
         let max_attempts = 5;
 
         let mut make_server = |port| {
-            RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
-                ClusterType::build_addr(port),
-                None,
-                tls_paths.clone(),
-                mtls_enabled,
-                None, // cert_auth_field - not used in cluster tests
-                &modules,
-                |cmd| {
+            RedisServerBuilder::new()
+                .address(ClusterType::build_addr(port))
+                .tls_paths_opt(tls_paths.clone())
+                .mtls(mtls_enabled)
+                .modules(&modules)
+                .refine_and_build(|cmd| {
                     let tempdir = tempfile::Builder::new()
                         .prefix("redis")
                         .tempdir()
@@ -205,8 +204,7 @@ impl RedisCluster {
                     }
                     cmd.current_dir(tempdir.path());
                     folders.push(tempdir);
-                },
-            )
+                })
         };
 
         let verify_server = |server: &mut RedisServer| {

--- a/redis-test/src/lib.rs
+++ b/redis-test/src/lib.rs
@@ -5,7 +5,7 @@
 //! * **Mock Connections**: `MockRedisConnection` implements `ConnectionLike` and can be
 //!   used in the same place as any other type that behaves like a Redis connection. This is useful
 //!   for writing unit tests without needing a real Redis server.
-//! * **Standalone Servers**: [`server::RedisServer`] provides an easy way to spin up
+//! * **Standalone Servers**: [`server::RedisServerBuilder`] provides an easy way to spin up
 //!   and manage a real local Redis instance for integration tests.
 //! * **Clusters**: [`cluster::RedisCluster`] provides functionality to spawn and configure
 //!   a local Redis cluster with multiple nodes and replicas.

--- a/redis-test/src/sentinel.rs
+++ b/redis-test/src/sentinel.rs
@@ -3,6 +3,7 @@ use std::{fs::File, io::Write, thread::sleep, time::Duration};
 use redis::{Client, ConnectionAddr, FromRedisValue, RedisResult};
 use tempfile::TempDir;
 
+use crate::server::RedisServerBuilder;
 use crate::{
     server::{Module, RedisServer},
     utils::{TlsFilePaths, build_keys_and_certs_for_tls, get_random_available_port},
@@ -118,8 +119,6 @@ impl RedisSentinelCluster {
     }
 }
 
-const MTLS_NOT_ENABLED: bool = false;
-
 fn get_addr(port: u16) -> ConnectionAddr {
     let addr = RedisServer::get_addr(port);
     if let ConnectionAddr::Unix(_) = addr {
@@ -134,22 +133,18 @@ fn spawn_master_server(
     tlspaths: &Option<TlsFilePaths>,
     modules: &[Module],
 ) -> RedisServer {
-    RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
-        get_addr(port),
-        None,
-        tlspaths.clone(),
-        MTLS_NOT_ENABLED,
-        None, // cert_auth_field - not used in sentinel tests
-        modules,
-        |cmd| {
+    RedisServerBuilder::new()
+        .address(get_addr(port))
+        .tls_paths_opt(tlspaths.clone())
+        .modules(modules)
+        .refine_and_build(|cmd| {
             // Minimize startup delay
             cmd.arg2("--repl-diskless-sync-delay", "0");
             if tlspaths.is_some() {
                 cmd.arg2("--tls-replication", "yes");
             }
             cmd.current_dir(dir.path());
-        },
-    )
+        })
 }
 
 fn spawn_replica_server(
@@ -162,21 +157,18 @@ fn spawn_replica_server(
     let config_file_path = dir.path().join("redis_config.conf");
     File::create(&config_file_path).unwrap();
 
-    RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
-        get_addr(port),
-        Some(&config_file_path),
-        tlspaths.clone(),
-        MTLS_NOT_ENABLED,
-        None, // cert_auth_field - not used in sentinel tests
-        modules,
-        |cmd| {
+    RedisServerBuilder::new()
+        .address(get_addr(port))
+        .config(config_file_path)
+        .tls_paths_opt(tlspaths.clone())
+        .modules(modules)
+        .refine_and_build(|cmd| {
             cmd.arg3("--replicaof", "127.0.0.1", master_port.to_string());
             if tlspaths.is_some() {
                 cmd.arg2("--tls-replication", "yes");
             }
             cmd.current_dir(dir.path());
-        },
-    )
+        })
 }
 
 fn spawn_sentinel_server(
@@ -196,21 +188,18 @@ fn spawn_sentinel_server(
     }
     file.flush().unwrap();
 
-    RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
-        get_addr(port),
-        Some(&config_file_path),
-        tlspaths.clone(),
-        MTLS_NOT_ENABLED,
-        None, // cert_auth_field - not used in sentinel tests
-        modules,
-        |cmd| {
+    RedisServerBuilder::new()
+        .address(get_addr(port))
+        .config(config_file_path)
+        .tls_paths_opt(tlspaths.clone())
+        .modules(modules)
+        .refine_and_build(|cmd| {
             cmd.arg("--sentinel");
             if tlspaths.is_some() {
                 cmd.arg2("--tls-replication", "yes");
             }
             cmd.current_dir(dir.path());
-        },
-    )
+        })
 }
 
 pub struct SentinelError;

--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -30,10 +30,117 @@ enum ServerType {
 }
 
 /// Represents a module that can be loaded into the Redis server.
+#[derive(Clone)]
 #[non_exhaustive]
 pub enum Module {
     Bloom,
     Json,
+}
+
+/// A builder for [`RedisServer`]
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use redis_test::server::{RedisServerBuilder, Module};
+///
+/// let server = RedisServerBuilder::new().module(Module::Json).build();
+/// let info = server.connection_info();
+/// // Connect to the server using `info`...
+/// ```
+// Note that this builder is an owned-builder as we want to build in a single chain anyway and do
+// not have to build multiple instances from the same builder. Also, this spares us cloning
+// considerations.
+#[derive(Default)]
+pub struct RedisServerBuilder {
+    address: Option<ConnectionAddr>,
+    config_file: Option<PathBuf>,
+    cert_auth_field: Option<String>,
+    modules: Vec<Module>,
+    mtls: bool,
+    tls_paths: Option<TlsFilePaths>,
+}
+
+impl RedisServerBuilder {
+    /// Starts a fresh builder
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn address(mut self, address: ConnectionAddr) -> Self {
+        self.address = Some(address);
+        self
+    }
+
+    pub fn config(mut self, config_file: PathBuf) -> Self {
+        self.config_file = Some(config_file);
+        self
+    }
+
+    pub fn cert_auth_field(mut self, cert_auth_field: impl Into<String>) -> Self {
+        self.cert_auth_field = Some(cert_auth_field.into());
+        self
+    }
+
+    pub fn cert_auth_field_opt(mut self, opt_cert_auth_field: Option<impl Into<String>>) -> Self {
+        self.cert_auth_field = opt_cert_auth_field.map(|value| value.into());
+        self
+    }
+
+    pub fn module(self, module: Module) -> Self {
+        self.modules(&[module])
+    }
+
+    pub fn modules(mut self, modules: &[Module]) -> Self {
+        self.modules = modules.to_vec();
+        self
+    }
+
+    pub fn mtls(mut self, enable_mtls: bool) -> Self {
+        self.mtls = enable_mtls;
+        self
+    }
+
+    pub fn tls_paths(mut self, tls_paths: TlsFilePaths) -> Self {
+        self.tls_paths = Some(tls_paths);
+        self
+    }
+
+    pub fn tls_paths_opt(mut self, opt_tls_paths: Option<TlsFilePaths>) -> Self {
+        self.tls_paths = opt_tls_paths;
+        self
+    }
+
+    /// Builds the [`RedisServer`] for this instance
+    pub fn build(self) -> RedisServer {
+        self.refine_and_build(|_| {})
+    }
+
+    /// Builds the [`RedisServer`] for this instance after refining the arguments for the server
+    ///
+    /// # Arguments
+    ///
+    /// * `refiner` - This method is called just before starting the server. It takes one argument,
+    ///   which is the command to start the server with. This allows to add additional config to
+    ///   the server command.
+    pub fn refine_and_build(self, refiner: impl FnOnce(&mut RedisServerCommand)) -> RedisServer {
+        let addr = self.address.unwrap_or_else(|| {
+            // This is technically a race, but we can't do better with
+            // the tools that redis gives us :(
+            let redis_port = get_random_available_port();
+            RedisServer::get_addr(redis_port)
+        });
+
+        RedisServer::new(
+            addr,
+            self.config_file,
+            self.tls_paths,
+            self.mtls,
+            self.cert_auth_field,
+            self.modules.as_slice(),
+            refiner,
+        )
+    }
 }
 
 /// A standalone Redis server instance for testing.
@@ -42,10 +149,23 @@ pub enum Module {
 /// configuration, and shutdown.
 ///
 /// # Example
+///
+/// Use `default()` to build a [`RedisServer`] with default settings:
+///
 /// ```rust,no_run
 /// use redis_test::server::RedisServer;
 ///
-/// let server = RedisServer::new();
+/// let server = RedisServer::default();
+/// let info = server.connection_info();
+/// // Connect to the server using `info`...
+/// ```
+///
+/// If you need a custom setup, use [`RedisServerBuilder`]:
+///
+/// ```rust,no_run
+/// use redis_test::server::{RedisServerBuilder, Module};
+///
+/// let server = RedisServerBuilder::new().module(Module::Json).build();
 /// let info = server.connection_info();
 /// // Connect to the server using `info`...
 /// ```
@@ -83,19 +203,11 @@ impl Drop for RedisServer {
 
 impl Default for RedisServer {
     fn default() -> Self {
-        Self::new()
+        RedisServerBuilder::new().build()
     }
 }
 
 impl RedisServer {
-    pub fn new() -> RedisServer {
-        RedisServer::with_modules(&[], false)
-    }
-
-    pub fn new_with_mtls() -> RedisServer {
-        RedisServer::with_modules(&[], true)
-    }
-
     pub fn log_file_contents(&self) -> Option<String> {
         std::fs::read_to_string(self.log_file.clone()).ok()
     }
@@ -123,45 +235,12 @@ impl RedisServer {
         }
     }
 
-    pub fn with_modules(modules: &[Module], mtls_enabled: bool) -> RedisServer {
-        // this is technically a race but we can't do better with
-        // the tools that redis gives us :(
-        let redis_port = get_random_available_port();
-        let addr = RedisServer::get_addr(redis_port);
-
-        RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
-            addr,
-            None,
-            None,
-            mtls_enabled,
-            None,
-            modules,
-            |_cmd| {},
-        )
-    }
-
-    pub fn new_with_addr_and_modules(
-        addr: redis::ConnectionAddr,
-        modules: &[Module],
-        mtls_enabled: bool,
-    ) -> RedisServer {
-        RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
-            addr,
-            None,
-            None,
-            mtls_enabled,
-            None,
-            modules,
-            |_cmd| {},
-        )
-    }
-
-    pub fn new_with_addr_tls_modules_and_cmd_refiner(
+    fn new(
         mut addr: redis::ConnectionAddr,
-        config_file: Option<&Path>,
+        config_file: Option<PathBuf>,
         mut tls_paths: Option<TlsFilePaths>,
         mtls_enabled: bool,
-        cert_auth_field: Option<&str>,
+        cert_auth_field: Option<String>,
         modules: &[Module],
         cmd_refiner: impl FnOnce(&mut RedisServerCommand),
     ) -> RedisServer {

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -8,7 +8,7 @@ use redis::{
 };
 #[cfg(feature = "aio")]
 use redis::{aio, cmd};
-use redis_test::server::{Module, RedisServer, use_protocol};
+use redis_test::server::{Module, RedisServer, RedisServerBuilder, use_protocol};
 use redis_test::utils::{TlsFilePaths, get_random_available_port};
 #[cfg(feature = "tls-rustls")]
 use std::{
@@ -242,15 +242,13 @@ impl TestContext {
         tls_files: Option<TlsFilePaths>,
         cert_auth_field: Option<&str>,
     ) -> Self {
-        let server = RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
-            addr,
-            None,
-            tls_files,
-            mtls_enabled,
-            cert_auth_field,
-            modules,
-            |_cmd| {},
-        );
+        let server = RedisServerBuilder::new()
+            .address(addr)
+            .tls_paths_opt(tls_files)
+            .mtls(mtls_enabled)
+            .cert_auth_field_opt(cert_auth_field)
+            .modules(modules)
+            .build();
 
         let client =
             build_single_client(server.connection_info(), &server.tls_paths, mtls_enabled).unwrap();

--- a/version2.md
+++ b/version2.md
@@ -10,23 +10,22 @@ redis = "2"
 
 ## Breaking Changes
 
-### `RedisServer::new_with_addr_tls_modules_and_spawner` got removed (Breaking Change)
+### `RedisServer::new...` got removed; use `RedisServerBuilder` instead (Breaking Change)
 
-All callers used the spawner function to adjust the command's arguments, then spawn and unwrap it.
-The spawning was the same across all of them, hence duplicated.
-The unwrapping only differed in thoroughness of the error handling.
-So the common spawning and unwrapping got moved into `RedisServer` to ease its use.
+Over time `RedisServer::new...` methods grew in parameters and made them hard to use.
+So they got removed in favor of `RedisServerBuilder`, which is now the recommended way to build `RedisServer` instances.
 
-Refining the server's start command is available via `RedisServer::new_with_addr_tls_modules_and_cmd_refiner`.
+**Migration:** Switch from `RedisServer::new...` to `RedisServerBuilder`
 
-**Migration:** Switch from `RedisServer::new_with_addr_tls_modules_and_spawner` to `RedisServer::new_with_addr_tls_modules_and_cmd_refiner`.
+`RedisServerBuilder::new()` starts a new builder.
 
-Typically, replacing `new_with_addr_tls_modules_and_spawner` by `new_with_addr_tls_modules_and_cmd_refiner` and removing the `cmd.spawn().unwrap()` from your spawning function end will be enough.
-The `cmd_refiner` function takes a `RedisStartCommand` as argument (instead of a `Command` before).
+It's fluent interface allows to set the needed parameters in a chaining manner (`.address(...).mtls(...).modules(...)`).
 
-This new `RedisStartCommand` also has a `arg()` method, so your spawners probably work out of the box.
+Call `.build()` to finally build the `RedisServer` with the set properties.
 
-But it also comes with `arg2()`, and `arg3()`, which takes multiple arguments in a single function, and can help to make things more readable.
+To refine the command before actually starting the server, use `refine_and_build(...)` instead.
+This allows to fine tune the start command.
+The passed `RedisServerCommand` comes with syntactic sugar to make things more readable (e.g. `arg2`).
 
 ```rust
 // Before:
@@ -35,7 +34,7 @@ let server = RedisServer::new_with_addr_tls_modules_and_spawner(
     addr,
     None,
     None,
-    false,
+    true,
     None,
     &[], |cmd| {
         cmd.arg("--foo")
@@ -47,17 +46,13 @@ let server = RedisServer::new_with_addr_tls_modules_and_spawner(
 );
 
 // After:
-let server = RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
-    addr,
-    None,
-    None,
-    false,
-    None,
-    &[], |cmd| {
+let server = RedisServerBuilder::new()
+    .address(addr)
+    .mtls(true)
+    .refine_and_build(|cmd| {
         cmd.arg2("--foo", "value-foo")
             .arg2("--bar", "value-baz");
-    }
-);
+    });
 ```
 
 ### `Generic` typed commands have their `RV` moved from first to last parameter (Breaking Change)


### PR DESCRIPTION
`RedisServerBuilder` replaces the `RedisServer::new...` methods, whose number of arguments grew over time and made it unwieldingly.