### PR TITLE
Switch `ScanOptions::with_type` to `ValueType`

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -6,7 +6,7 @@ use crate::pipeline::Pipeline;
 use crate::types::{
     ExistenceCheck, ExpireOption, Expiry, FieldExistenceCheck, FromRedisValue, IntegerReplyOrNoOp,
     NumericBehavior, RedisResult, RedisWrite, SetExpiry, ToRedisArgs, ToSingleRedisArg,
-    ValueComparison,
+    ValueComparison, ValueType,
 };
 
 #[cfg(feature = "vector-sets")]
@@ -3353,7 +3353,7 @@ impl PubSubCommands for Connection {
 pub struct ScanOptions {
     pattern: Option<String>,
     count: Option<usize>,
-    scan_type: Option<String>,
+    scan_type: Option<ValueType>,
 }
 
 impl ScanOptions {
@@ -3370,8 +3370,8 @@ impl ScanOptions {
     }
 
     /// Limit the results to those with the given Redis type
-    pub fn with_type(mut self, t: impl Into<String>) -> Self {
-        self.scan_type = Some(t.into());
+    pub fn with_type(mut self, t: ValueType) -> Self {
+        self.scan_type = Some(t);
         self
     }
 }
@@ -3393,7 +3393,7 @@ impl ToRedisArgs for ScanOptions {
 
         if let Some(t) = &self.scan_type {
             out.write_arg(b"TYPE");
-            out.write_arg_fmt(t);
+            t.write_redis_args(out);
         }
     }
 

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2629,31 +2629,37 @@ impl<T: AsRef<str>> From<T> for ValueType {
 
 impl From<ValueType> for String {
     fn from(v: ValueType) -> Self {
+        <&ValueType as Into<&str>>::into(&v).to_string()
+    }
+}
+
+impl<'a> From<&'a ValueType> for &'a str {
+    fn from(v: &'a ValueType) -> &'a str {
         match v {
-            ValueType::None => "none".to_string(),
-            ValueType::String => "string".to_string(),
-            ValueType::List => "list".to_string(),
-            ValueType::Set => "set".to_string(),
-            ValueType::ZSet => "zset".to_string(),
-            ValueType::Hash => "hash".to_string(),
-            ValueType::Stream => "stream".to_string(),
-            ValueType::VectorSet => "vectorset".to_string(),
+            ValueType::None => "none",
+            ValueType::String => "string",
+            ValueType::List => "list",
+            ValueType::Set => "set",
+            ValueType::ZSet => "zset",
+            ValueType::Hash => "hash",
+            ValueType::Stream => "stream",
+            ValueType::VectorSet => "vectorset",
             // JSON module
-            ValueType::JSON => "ReJSON-RL".to_string(),
+            ValueType::JSON => "ReJSON-RL",
             // Bloom module (Redis)
-            ValueType::BloomFilterRedis => "MBbloom--".to_string(),
-            ValueType::CuckooFilter => "MBbloomCF".to_string(),
-            ValueType::TDigest => "TDIS-TYPE".to_string(),
-            ValueType::TopK => "TopK-TYPE".to_string(),
-            ValueType::CountMin => "CMSk-TYPE".to_string(),
+            ValueType::BloomFilterRedis => "MBbloom--",
+            ValueType::CuckooFilter => "MBbloomCF",
+            ValueType::TDigest => "TDIS-TYPE",
+            ValueType::TopK => "TopK-TYPE",
+            ValueType::CountMin => "CMSk-TYPE",
             // Search module
-            ValueType::Trie => "trietype0".to_string(),
+            ValueType::Trie => "trietype0",
             // Timeseries module
-            ValueType::TimeSeries => "TSDB-TYPE".to_string(),
+            ValueType::TimeSeries => "TSDB-TYPE",
             // Bloom module (ValKey)
-            ValueType::BloomFilterValKey => "bloomfltr".to_string(),
+            ValueType::BloomFilterValKey => "bloomfltr",
             // Fallback
-            ValueType::Unknown(s) => s,
+            ValueType::Unknown(s) => s.as_str(),
         }
     }
 }
@@ -2671,6 +2677,16 @@ impl FromRedisValue for ValueType {
             Value::SimpleString(s) => Ok(s.into()),
             _ => crate::errors::invalid_type_error!(v, "Value type should be a simple string"),
         }
+    }
+}
+
+impl ToRedisArgs for ValueType {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        let as_str = <&ValueType as Into<&str>>::into(self);
+        out.write_arg(as_str.as_bytes());
     }
 }
 

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -1280,12 +1280,12 @@ mod basic {
         let values: Vec<_> = values.collect();
         assert_eq!(values.len(), 41);
         // scan with type string
-        let opts = ScanOptions::default().with_type("string");
+        let opts = ScanOptions::default().with_type(ValueType::String);
         let values = con.scan_options::<String>(opts).unwrap();
         let values: Vec<_> = values.collect();
         assert_eq!(values.len(), 40);
         // scan with type hash
-        let opts = ScanOptions::default().with_type("hash");
+        let opts = ScanOptions::default().with_type(ValueType::Hash);
         let values = con.scan_options::<String>(opts).unwrap();
         let values: Vec<_> = values.collect();
         assert_eq!(values.len(), 1);

--- a/version2.md
+++ b/version2.md
@@ -10,6 +10,27 @@ redis = "2"
 
 ## Breaking Changes
 
+### `ScanOptions::with_type` takes `ValueType` instead of `Into<String>` (Breaking Change)
+
+To increase type safety, `ScanOptions::with_type` now takes a `ValueType`.
+This allows to check at compile time that correct type names are used, and hence helps to avoid accidental typos.
+
+It also gives more readable code, as `ValueType::CountMin` is easier to understand than `CMSk-TYPE`.
+
+For types that lack a `ValueType` dedicated variant, any `String`-like value converts `into` `ValueType`.
+
+**Migration:** Switch from `String`, `&str`, or `Into<String>` to `ValueType`
+
+```rust
+// Before:
+let opts1 = ScanOptions::default().with_type("ReJSON-RL"); // Has a `ValueType`; we switch to it.
+let opts2 = ScanOptions::default().with_type("your-custom-type"); // Does not have a `ValueType`; we convert into it.
+
+// After:
+let opts1 = ScanOptions::default().with_type(ValueType::JSON); // Use `ValueType`
+let opts2 = ScanOptions::default().with_type("your-custom-type".into()); // Convert to `ValueType`
+```
+
 ### `RedisServer::new...` got removed; use `RedisServerBuilder` instead (Breaking Change)
 
 Over time `RedisServer::new...` methods grew in parameters and made them hard to use.


### PR DESCRIPTION
This switch increases type safety, as the types can now be checked at runtime.

As any `String`-like still convert `into` `ValueType`, this change is not a limitation.