### PR TITLE
tests: Migrate `TestContext::with_modules` onto `TestContextBuilder` (15/19)

### DIFF
--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -15,7 +15,9 @@ use redis::{aio, cmd};
 use redis_test::server::{
     Module, RedisServer, RedisServerBuilder, RedisServerCommand, use_protocol,
 };
-use redis_test::utils::{TlsFilePaths, get_random_available_port};
+use redis_test::utils::TlsFilePaths;
+#[cfg(feature = "tls-rustls")]
+use redis_test::utils::get_random_available_port;
 use std::path::PathBuf;
 #[cfg(feature = "tls-rustls")]
 use std::{
@@ -272,7 +274,7 @@ impl Default for TestContext {
 
 impl TestContext {
     pub fn new() -> TestContext {
-        TestContext::with_modules(&[])
+        TestContextBuilder::new().build()
     }
 
     #[cfg(feature = "tls-rustls")]
@@ -319,23 +321,8 @@ impl TestContext {
         )
     }
 
-    pub fn with_modules(modules: &[Module]) -> TestContext {
-        Self::with_modules_and_tls(modules, false, None)
-    }
-
     pub fn new_with_addr(addr: ConnectionAddr) -> Self {
         Self::with_modules_addr_and_tls(&[], false, addr, None)
-    }
-
-    fn with_modules_and_tls(
-        modules: &[Module],
-        mtls_enabled: bool,
-        tls_files: Option<TlsFilePaths>,
-    ) -> Self {
-        start_tls_crypto_provider();
-        let redis_port = get_random_available_port();
-        let addr = RedisServer::get_addr(redis_port);
-        Self::with_modules_addr_and_tls(modules, mtls_enabled, addr, tls_files)
     }
 
     fn with_modules_addr_and_tls(

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -356,7 +356,7 @@ mod basic_async {
     #[async_test]
     #[cfg(feature = "json")]
     async fn test_module_json_and_pipeline_transaction_with_ignore_errors() {
-        let ctx = TestContext::with_modules(&[Module::Json]);
+        let ctx = TestContextBuilder::new().module(Module::Json).build();
         let mut con = ctx.async_connection().await.unwrap();
         con.set::<_, _, ()>("x", 42).await.unwrap();
         con.json_set::<_, _, _, ()>("y", "$", &serde_json::json!({"path": "value"}))

--- a/redis/tests/test_cache.rs
+++ b/redis/tests/test_cache.rs
@@ -150,7 +150,7 @@ async fn test_cache_mget() {
 #[cfg(feature = "json")]
 #[async_test]
 async fn test_module_json_cache_get_mget() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -220,7 +220,7 @@ async fn test_module_json_cache_get_mget() {
 #[cfg(feature = "json")]
 #[async_test]
 async fn test_module_json_cache_get_mget_different_paths() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     if !ctx.protocol.supports_resp3() {
         return;
     }

--- a/redis/tests/test_module_bloom.rs
+++ b/redis/tests/test_module_bloom.rs
@@ -20,7 +20,7 @@ const KEY_3: &str = "test_bloom_3";
 /// Tries to assure single value updates work
 #[test]
 fn test_module_bloom_single_value_updates() {
-    let ctx = TestContext::with_modules(&[Module::Bloom]);
+    let ctx = TestContextBuilder::new().module(Module::Bloom).build();
     let mut con = ctx.connection();
 
     // Add a single value, and check containment
@@ -56,7 +56,7 @@ fn test_module_bloom_single_value_updates() {
 /// Tries to assure that multi-value updates work
 #[test]
 fn test_module_bloom_multiple_value_updates() {
-    let ctx = TestContext::with_modules(&[Module::Bloom]);
+    let ctx = TestContextBuilder::new().module(Module::Bloom).build();
     let mut con = ctx.connection();
 
     // Init the key by adding multiple values at once
@@ -98,7 +98,7 @@ fn test_module_bloom_multiple_value_updates() {
 /// Tries to assure that information functions work
 #[test]
 fn test_module_bloom_infos() {
-    let ctx = TestContext::with_modules(&[Module::Bloom]);
+    let ctx = TestContextBuilder::new().module(Module::Bloom).build();
     let mut con = ctx.connection();
 
     // Check that getting infos on a not yet existing key does not panic
@@ -213,7 +213,7 @@ fn test_module_bloom_infos() {
 /// Tries to assure that reserving is effective
 #[test]
 fn test_module_bloom_reserving() {
-    let ctx = TestContext::with_modules(&[Module::Bloom]);
+    let ctx = TestContextBuilder::new().module(Module::Bloom).build();
     let mut con = ctx.connection();
 
     // Reserving without options
@@ -253,7 +253,7 @@ fn test_module_bloom_reserving() {
 /// Tries to assure that dumping/loading works
 #[test]
 fn test_module_bloom_dump_and_load() {
-    let ctx = TestContext::with_modules(&[Module::Bloom]);
+    let ctx = TestContextBuilder::new().module(Module::Bloom).build();
     skip_if_context_does_not_support!(ctx, REDIS_BLOOM_ANY);
     let mut con = ctx.connection();
 
@@ -307,7 +307,7 @@ fn test_module_bloom_dump_and_load() {
 /// Tries to assure that dumping through an iterator works
 #[test]
 fn test_module_bloom_dump_iterator() {
-    let ctx = TestContext::with_modules(&[Module::Bloom]);
+    let ctx = TestContextBuilder::new().module(Module::Bloom).build();
     skip_if_context_does_not_support!(ctx, REDIS_BLOOM_ANY);
     let mut con = ctx.connection();
 

--- a/redis/tests/test_module_json.rs
+++ b/redis/tests/test_module_json.rs
@@ -21,7 +21,7 @@ const TEST_KEY: &str = "my_json";
 
 #[test]
 fn test_module_json_serialize_error() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     let mut con = ctx.connection();
 
     #[derive(Debug, Serialize)]
@@ -52,7 +52,7 @@ fn test_module_json_serialize_error() {
 
 #[test]
 fn test_module_json_arr_append() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -70,7 +70,7 @@ fn test_module_json_arr_append() {
 
 #[test]
 fn test_module_json_arr_index() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -101,7 +101,7 @@ fn test_module_json_arr_index() {
 
 #[test]
 fn test_module_json_arr_insert() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -131,7 +131,7 @@ fn test_module_json_arr_insert() {
 
 #[test]
 fn test_module_json_arr_len() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -161,7 +161,7 @@ fn test_module_json_arr_len() {
 
 #[test]
 fn test_module_json_arr_pop() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -205,7 +205,7 @@ fn test_module_json_arr_pop() {
 
 #[test]
 fn test_module_json_arr_trim() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -235,7 +235,7 @@ fn test_module_json_arr_trim() {
 
 #[test]
 fn test_module_json_clear() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(TEST_KEY, "$", &json!({"obj": {"a": 1i64, "b": 2i64}, "arr": [1i64, 2i64, 3i64], "str": "foo", "bool": true, "int": 42i64, "float": std::f64::consts::PI}));
@@ -260,7 +260,7 @@ fn test_module_json_clear() {
 
 #[test]
 fn test_module_json_del() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -278,7 +278,7 @@ fn test_module_json_del() {
 
 #[test]
 fn test_module_json_get() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -304,7 +304,7 @@ fn test_module_json_get() {
 
 #[test]
 fn test_module_json_mget() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_mset(&[
@@ -338,7 +338,7 @@ fn test_module_json_mget() {
 
 #[test]
 fn test_module_json_num_incr_by() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -372,7 +372,7 @@ fn test_module_json_num_incr_by() {
 
 #[test]
 fn test_module_json_obj_keys() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -399,7 +399,7 @@ fn test_module_json_obj_keys() {
 
 #[test]
 fn test_module_json_obj_len() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -417,7 +417,7 @@ fn test_module_json_obj_len() {
 
 #[test]
 fn test_module_json_set() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     let mut con = ctx.connection();
 
     let set: RedisResult<bool> = con.json_set(TEST_KEY, "$", &json!({"key": "value"}));
@@ -427,7 +427,7 @@ fn test_module_json_set() {
 
 #[test]
 fn test_module_json_str_append() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -452,7 +452,7 @@ fn test_module_json_str_append() {
 
 #[test]
 fn test_module_json_str_len() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -470,7 +470,7 @@ fn test_module_json_str_len() {
 
 #[test]
 fn test_module_json_toggle() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(TEST_KEY, "$", &json!({"bool": true}));
@@ -486,7 +486,7 @@ fn test_module_json_toggle() {
 
 #[test]
 fn test_module_json_type() {
-    let ctx = TestContext::with_modules(&[Module::Json]);
+    let ctx = TestContextBuilder::new().module(Module::Json).build();
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(


### PR DESCRIPTION
This makes `TestContext::with_modules_and_tls` unused, and we hence drop it.