### PR TITLE
tests: Migrate `TestContext::new_with_addr` onto `TestContextBuilder` (16/19)

### DIFF
--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -321,19 +321,6 @@ impl TestContext {
         )
     }
 
-    pub fn new_with_addr(addr: ConnectionAddr) -> Self {
-        Self::with_modules_addr_and_tls(&[], false, addr, None)
-    }
-
-    fn with_modules_addr_and_tls(
-        modules: &[Module],
-        mtls_enabled: bool,
-        addr: ConnectionAddr,
-        tls_files: Option<TlsFilePaths>,
-    ) -> Self {
-        Self::with_modules_addr_tls_and_cert_auth(modules, mtls_enabled, addr, tls_files, None)
-    }
-
     fn with_modules_addr_tls_and_cert_auth(
         modules: &[Module],
         mtls_enabled: bool,

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -1355,7 +1355,7 @@ mod basic_async {
             sleep(Duration::from_millis(1).into()).await;
             let push = rx.recv().await.unwrap();
             assert_eq!(push.kind, PushKind::Disconnection);
-            let ctx = TestContext::new_with_addr(addr);
+            let ctx = TestContextBuilder::new().address(addr).build();
 
             let push1 = rx.recv().await.unwrap();
             assert_eq!(push1.kind, PushKind::Subscribe);
@@ -1462,7 +1462,7 @@ mod basic_async {
         }
 
         // Start a new server, re-using the previous address
-        let _ctx = TestContext::new_with_addr(addr);
+        let _ctx = TestContextBuilder::new().address(addr).build();
 
         for _ in 0..5 {
             let Ok(result) = manager.set::<_, _, Value>("foo", "bar").await else {
@@ -1499,7 +1499,7 @@ mod basic_async {
 
         let addr = ctx.server.client_addr().clone();
         drop(ctx);
-        let _ctx = TestContext::new_with_addr(addr);
+        let _ctx = TestContextBuilder::new().address(addr).build();
 
         sleep(Duration::from_secs_f32(0.01).into()).await;
 
@@ -1575,7 +1575,7 @@ mod basic_async {
         drop(ctx);
         let push = rx.recv().await.unwrap();
         assert_eq!(push.kind, PushKind::Disconnection);
-        let _ctx = TestContext::new_with_addr(addr.clone());
+        let _ctx = TestContextBuilder::new().address(addr.clone()).build();
 
         assert_matches!(cmd("PING").exec_async(&mut conn).await, Ok(_));
         assert_matches!(rx.try_recv(), Err(_));
@@ -1584,7 +1584,7 @@ mod basic_async {
         drop(_ctx);
         let push = rx.recv().await.unwrap();
         assert_eq!(push.kind, PushKind::Disconnection);
-        let _ctx = TestContext::new_with_addr(addr);
+        let _ctx = TestContextBuilder::new().address(addr).build();
 
         sleep(Duration::from_secs_f32(0.01).into()).await;
         assert_matches!(cmd("PING").exec_async(&mut conn).await, Ok(_));
@@ -1995,7 +1995,7 @@ mod basic_async {
             let result: RedisResult<String> = manager.get("key").await;
             assert!(result.is_err());
 
-            let _ctx = TestContext::new_with_addr(addr);
+            let _ctx = TestContextBuilder::new().address(addr).build();
 
             for _ in 0..10 {
                 sleep(Duration::from_millis(10).into()).await;

--- a/redis/tests/test_cache.rs
+++ b/redis/tests/test_cache.rs
@@ -629,7 +629,7 @@ async fn test_connection_manager_maintains_statistics_after_crashes(test_with_op
     assert!(result.unwrap_err().is_unrecoverable_error());
 
     // Start a new server, re-using the previous address
-    let _ctx = TestContext::new_with_addr(addr);
+    let _ctx = TestContextBuilder::new().address(addr).build();
 
     loop {
         if manager.send_packed_command(&get).await.is_ok() {


### PR DESCRIPTION
This makes `TestContext::with_modules_addr_and_tls` unused, and we hence drop it.