### PR TITLE
tests: Migrate `TestContext::new_with_cert_auth` onto `TestContextBui… (17/19)

### DIFF
--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -16,8 +16,6 @@ use redis_test::server::{
     Module, RedisServer, RedisServerBuilder, RedisServerCommand, use_protocol,
 };
 use redis_test::utils::TlsFilePaths;
-#[cfg(feature = "tls-rustls")]
-use redis_test::utils::get_random_available_port;
 use std::path::PathBuf;
 #[cfg(feature = "tls-rustls")]
 use std::{
@@ -275,66 +273,6 @@ impl Default for TestContext {
 impl TestContext {
     pub fn new() -> TestContext {
         TestContextBuilder::new().build()
-    }
-
-    #[cfg(feature = "tls-rustls")]
-    pub fn new_with_cert_auth(tls_files: TlsFilePaths) -> TestContext {
-        Self::new_with_cert_auth_field(tls_files, "CN")
-    }
-
-    #[cfg(feature = "tls-rustls")]
-    pub fn new_with_cert_auth_field(tls_files: TlsFilePaths, cert_field: &str) -> TestContext {
-        start_tls_crypto_provider();
-        let redis_port = get_random_available_port();
-        let addr = RedisServer::get_addr(redis_port);
-
-        // TLS certificate-based authentication requires TLS connection.
-        let addr = match addr {
-            ConnectionAddr::Tcp(host, port) => ConnectionAddr::TcpTls {
-                host,
-                port,
-                insecure: true,
-                tls_params: None,
-            },
-            ConnectionAddr::TcpTls { .. } => addr, // Already TLS
-            ConnectionAddr::Unix(_) => {
-                // Unix sockets don't support TLS - fall back to TCP+TLS
-                // Use the same default host that get_addr() would use for TCP
-                ConnectionAddr::TcpTls {
-                    host: redis_test::server::get_default_host(),
-                    port: redis_port,
-                    insecure: true,
-                    tls_params: None,
-                }
-            }
-            _ => {
-                panic!("Unsupported ConnectionAddr variant for cert-based authentication: {addr:?}")
-            }
-        };
-
-        Self::with_modules_addr_tls_and_cert_auth(
-            &[],
-            true,
-            addr,
-            Some(tls_files),
-            Some(cert_field),
-        )
-    }
-
-    fn with_modules_addr_tls_and_cert_auth(
-        modules: &[Module],
-        mtls_enabled: bool,
-        addr: ConnectionAddr,
-        tls_files: Option<TlsFilePaths>,
-        cert_auth_field: Option<&str>,
-    ) -> Self {
-        TestContextBuilder::new()
-            .modules(modules)
-            .mtls(mtls_enabled)
-            .address(addr)
-            .tls_paths_opt(tls_files)
-            .cert_auth_field_opt(cert_auth_field)
-            .build()
     }
 
     /// Builds a new instance from a [`RedisServer`]

--- a/redis/tests/test_tls_cert_auth.rs
+++ b/redis/tests/test_tls_cert_auth.rs
@@ -72,7 +72,11 @@ fn create_cert_auth_context_with_username(username: &str) -> CertAuthTestContext
         build_client_cert_with_custom_cn(&tempdir, username, &tls_paths.ca_crt, &ca_key_path);
 
     // Create a single server context with cert-based auth enabled
-    let server_ctx = TestContext::new_with_cert_auth(tls_paths.clone());
+    let server_ctx = TestContextBuilder::new()
+        .tls_paths(tls_paths.clone())
+        .mtls(true)
+        .cert_auth_field("CN")
+        .build();
 
     CertAuthTestContext {
         server_ctx,


### PR DESCRIPTION
…lder`

This makes `TestContext::new_with_cert_auth_field`, and `TestContext::with_modules_addr_tls_and_cert_auth` unused, and we hence drop them.