### PR TITLE
tests: Migrate away from `TestContext::new` (18/19)

### DIFF
--- a/redis/benches/bench_basic.rs
+++ b/redis/benches/bench_basic.rs
@@ -8,7 +8,7 @@ use support::*;
 mod support;
 
 fn bench_simple_getsetdel(b: &mut Bencher) {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     b.iter(|| {
@@ -20,7 +20,7 @@ fn bench_simple_getsetdel(b: &mut Bencher) {
 }
 
 fn bench_simple_getsetdel_async(b: &mut Bencher) {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let runtime = current_thread_runtime();
     let mut con = runtime.block_on(ctx.async_connection()).unwrap();
 
@@ -42,7 +42,7 @@ fn bench_simple_getsetdel_async(b: &mut Bencher) {
 }
 
 fn bench_simple_getsetdel_pipeline(b: &mut Bencher) {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     b.iter(|| {
@@ -63,7 +63,7 @@ fn bench_simple_getsetdel_pipeline(b: &mut Bencher) {
 }
 
 fn bench_simple_getsetdel_pipeline_precreated(b: &mut Bencher) {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
     let key = "test_key";
     let mut pipe = redis::pipe();
@@ -94,7 +94,7 @@ fn long_pipeline() -> redis::Pipeline {
 }
 
 fn bench_long_pipeline(b: &mut Bencher) {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     let pipe = long_pipeline();
@@ -105,7 +105,7 @@ fn bench_long_pipeline(b: &mut Bencher) {
 }
 
 fn bench_async_long_pipeline(b: &mut Bencher) {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let runtime = current_thread_runtime();
     let mut con = runtime.block_on(ctx.async_connection()).unwrap();
 
@@ -119,7 +119,7 @@ fn bench_async_long_pipeline(b: &mut Bencher) {
 }
 
 fn bench_multiplexed_async_long_pipeline(b: &mut Bencher) {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let runtime = current_thread_runtime();
     let mut con = runtime
         .block_on(ctx.multiplexed_async_connection_tokio())
@@ -135,7 +135,7 @@ fn bench_multiplexed_async_long_pipeline(b: &mut Bencher) {
 }
 
 fn bench_multiplexed_async_implicit_pipeline(b: &mut Bencher) {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let runtime = current_thread_runtime();
     let con = runtime
         .block_on(ctx.multiplexed_async_connection_tokio())

--- a/redis/benches/bench_cache.rs
+++ b/redis/benches/bench_cache.rs
@@ -41,7 +41,7 @@ async fn benchmark_executer(
     per_key_command: u32,
     key_count: u32,
 ) {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let con = if is_cache_enabled {
         ctx.async_connection_with_cache_config(CacheConfig::new())
             .await

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -271,10 +271,6 @@ impl Default for TestContext {
 }
 
 impl TestContext {
-    pub fn new() -> TestContext {
-        TestContextBuilder::new().build()
-    }
-
     /// Builds a new instance from a [`RedisServer`]
     // We intentionally do _not_ implement `From<RedisServer>` as that would be public.
     //

--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -326,7 +326,7 @@ macro_rules! skip_if_context_does_not_support {
 #[macro_export]
 macro_rules! run_test_if_version_supported {
     ($component:expr) => {{
-        let ctx = $crate::support::TestContext::new();
+        let ctx = $crate::support::TestContext::default();
 
         $crate::skip_if_context_does_not_support!(ctx, $component);
 

--- a/redis/tests/test_acl.rs
+++ b/redis/tests/test_acl.rs
@@ -9,14 +9,14 @@ use crate::support::*;
 
 #[test]
 fn test_acl_whoami() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
     assert_eq!(con.acl_whoami(), Ok("default".to_owned()));
 }
 
 #[test]
 fn test_acl_help() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
     let res = con.acl_help().expect("Got help manual");
     assert!(!res.is_empty());
@@ -26,7 +26,7 @@ fn test_acl_help() {
 #[test]
 #[ignore]
 fn test_acl_getsetdel_users() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
     assert_eq!(
         con.acl_list(),
@@ -96,7 +96,7 @@ fn test_acl_getsetdel_users() {
 
 #[test]
 fn test_acl_cat() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
     let res: HashSet<String> = con.acl_cat().expect("Got categories");
     let expects = vec![
@@ -137,7 +137,7 @@ fn test_acl_cat() {
 
 #[test]
 fn test_acl_genpass() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
     let pass: String = con.acl_genpass().expect("Got password");
     assert_eq!(pass.len(), 64);
@@ -148,7 +148,7 @@ fn test_acl_genpass() {
 
 #[test]
 fn test_acl_log() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
     let logs: Vec<String> = con.acl_log(1).expect("Got logs");
     assert_eq!(logs.len(), 0);
@@ -627,7 +627,7 @@ mod token_based_authentication_acl_tests {
     #[async_test]
     async fn test_authentication_with_mock_streaming_credentials_provider() {
         init_logger();
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         // Set up a Redis user that expects a JWT token as password
         let mut admin_con = ctx.async_connection().await.unwrap();
         let expected_username = OID_CLAIM_VALUE;
@@ -707,7 +707,7 @@ mod token_based_authentication_acl_tests {
     #[async_test]
     async fn token_rotation_with_mock_streaming_credentials_provider() {
         init_logger();
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let users_cmd = redis::cmd("ACL").arg("USERS").clone();
         let whoami_cmd = redis::cmd("ACL").arg("WHOAMI").clone();
 
@@ -767,7 +767,7 @@ mod token_based_authentication_acl_tests {
     #[async_test]
     async fn test_authentication_error_handling_with_mock_streaming_credentials_provider() {
         init_logger();
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let whoami_cmd = redis::cmd("ACL").arg("WHOAMI").clone();
 
         // Create a user with the JWT token as password and full permissions for each token
@@ -826,7 +826,7 @@ mod token_based_authentication_acl_tests {
     #[async_test]
     async fn test_multiple_connections_from_one_client_sharing_a_single_credentials_provider() {
         init_logger();
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let whoami_cmd = redis::cmd("ACL").arg("WHOAMI").clone();
 
         // Create a user with the JWT token as password and full permissions for each token
@@ -893,7 +893,7 @@ mod token_based_authentication_acl_tests {
     #[async_test]
     async fn test_multiple_clients_sharing_a_single_credentials_provider() {
         init_logger();
-        let ctx1 = TestContext::new();
+        let ctx1 = TestContext::default();
         let whoami_cmd = redis::cmd("ACL").arg("WHOAMI").clone();
 
         // Create a user with the JWT token as password and full permissions for each token
@@ -964,7 +964,7 @@ mod token_based_authentication_acl_tests {
     #[async_test]
     async fn test_server_rejects_after_user_invalidated() {
         init_logger();
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
 
         // Create a user with the JWT token as password and full permissions for each token
         println!("Setting up Redis users for re-authentication failure test...");

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -124,7 +124,7 @@ mod basic_async {
                 .await
                 .unwrap();
         }
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
 
         let conn = ctx
             .client
@@ -156,7 +156,7 @@ mod basic_async {
 
     #[async_test]
     async fn test_set_write_backpressure_boundary_does_not_break_connection() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let config =
             redis::AsyncConnectionConfig::new().set_write_backpressure_boundary(16 * 1024 * 1024);
         let mut conn = ctx
@@ -171,7 +171,7 @@ mod basic_async {
 
     #[async_test]
     async fn test_can_authenticate_with_username_and_password() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.async_connection().await.unwrap();
 
         let username = "foo";
@@ -246,7 +246,7 @@ mod basic_async {
 
     #[async_test]
     async fn test_dont_panic_on_closed_multiplexed_connection() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let client = ctx.client.clone();
         let connect = client.get_multiplexed_async_connection();
         drop(ctx);
@@ -642,7 +642,7 @@ mod basic_async {
 
     #[async_test]
     async fn test_response_timeout_multiplexed_connection() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
 
         let mut connection = ctx.async_connection().await.unwrap();
         connection.set_response_timeout(Duration::from_millis(1));
@@ -712,7 +712,7 @@ mod basic_async {
     #[allow(clippy::let_unit_value, clippy::iter_nth_zero)]
     #[async_test]
     async fn test_io_error_on_kill_issue_320() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
 
         let mut conn_to_kill = ctx.async_connection().await.unwrap();
         kill_client_async(&mut conn_to_kill, &ctx.client)
@@ -732,7 +732,7 @@ mod basic_async {
 
     #[async_test]
     async fn test_invalid_password_issue_343() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
 
         let redis = RedisConnectionInfo::default().set_password("asdcasc");
         let connection_info = ctx
@@ -825,7 +825,7 @@ mod basic_async {
 
         #[async_test]
         async fn test_pub_sub_subscription() {
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
 
             let mut pubsub_conn = ctx.async_pubsub().await.unwrap();
             let _: () = pubsub_conn.subscribe("phonewave").await.unwrap();
@@ -847,7 +847,7 @@ mod basic_async {
 
         #[async_test]
         async fn test_pub_sub_subscription_to_multiple_channels() {
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
 
             let mut pubsub_conn = ctx.async_pubsub().await.unwrap();
             let _: () = pubsub_conn
@@ -930,7 +930,7 @@ mod basic_async {
         async fn test_pub_sub_unsubscription() {
             const SUBSCRIPTION_KEY: &str = "phonewave-pub-sub-unsubscription";
 
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
 
             let mut pubsub_conn = ctx.async_pubsub().await.unwrap();
             pubsub_conn.subscribe(SUBSCRIPTION_KEY).await.unwrap();
@@ -949,7 +949,7 @@ mod basic_async {
 
         #[async_test]
         async fn test_can_receive_messages_while_sending_requests_from_split_pub_sub() {
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
 
             let (mut sink, mut stream) = ctx.async_pubsub().await.unwrap().split();
             let mut publish_conn = ctx.async_connection().await.unwrap();
@@ -969,7 +969,7 @@ mod basic_async {
 
         #[async_test]
         async fn test_can_send_ping_on_split_pubsub() {
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
 
             let (mut sink, mut stream) = ctx.async_pubsub().await.unwrap().split();
             let mut publish_conn = ctx.async_connection().await.unwrap();
@@ -1012,7 +1012,7 @@ mod basic_async {
 
         #[async_test]
         async fn test_can_receive_messages_from_split_pub_sub_after_sink_was_dropped() {
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
 
             let (mut sink, mut stream) = ctx.async_pubsub().await.unwrap().split();
             let mut publish_conn = ctx.async_connection().await.unwrap();
@@ -1033,7 +1033,7 @@ mod basic_async {
 
         #[async_test]
         async fn test_can_receive_messages_from_split_pub_sub_after_into_on_message() {
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
 
             let mut pubsub = ctx.async_pubsub().await.unwrap();
             let mut publish_conn = ctx.async_connection().await.unwrap();
@@ -1056,7 +1056,7 @@ mod basic_async {
 
         #[async_test]
         async fn test_cannot_subscribe_on_split_pub_sub_after_stream_was_dropped() {
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
 
             let (mut sink, stream) = ctx.async_pubsub().await.unwrap().split();
             drop(stream);
@@ -1068,7 +1068,7 @@ mod basic_async {
         async fn test_automatic_unsubscription() {
             const SUBSCRIPTION_KEY: &str = "phonewave-automatic-unsubscription";
 
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
 
             let mut pubsub_conn = ctx.async_pubsub().await.unwrap();
             pubsub_conn.subscribe(SUBSCRIPTION_KEY).await.unwrap();
@@ -1098,7 +1098,7 @@ mod basic_async {
         async fn test_automatic_unsubscription_on_split() {
             const SUBSCRIPTION_KEY: &str = "phonewave-automatic-unsubscription-on-split";
 
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
 
             let (mut sink, stream) = ctx.async_pubsub().await.unwrap().split();
             sink.subscribe(SUBSCRIPTION_KEY).await.unwrap();
@@ -1155,7 +1155,7 @@ mod basic_async {
 
         #[async_test]
         async fn test_multiplexed_pub_sub_subscribe_on_multiple_channels() {
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
             if !ctx.protocol.supports_resp3() {
                 return;
             }
@@ -1206,7 +1206,7 @@ mod basic_async {
 
         #[async_test]
         async fn test_pub_sub_multiple() {
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
             let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
             let connection_info = ctx.server.connection_info().set_redis_settings(redis);
             let client = redis::Client::open(connection_info).unwrap();
@@ -1273,7 +1273,7 @@ mod basic_async {
             if use_protocol().supports_resp3() {
                 return;
             }
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
             let mut conn = ctx.async_connection().await.unwrap();
 
             let res = conn.subscribe("foo").await;
@@ -1286,7 +1286,7 @@ mod basic_async {
 
         #[async_test]
         async fn test_push_sender_send_on_disconnect() {
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
             let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
             let connection_info = ctx.server.connection_info().set_redis_settings(redis);
             let client = redis::Client::open(connection_info).unwrap();
@@ -1308,7 +1308,7 @@ mod basic_async {
         #[cfg(feature = "connection-manager")]
         #[async_test]
         async fn test_manager_should_resubscribe_to_pubsub_channels_after_disconnect() {
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
             if !ctx.protocol.supports_resp3() {
                 return;
             }
@@ -1438,7 +1438,7 @@ mod basic_async {
             .set_exponent_base(10000.0)
             .set_max_delay(max_delay_between_attempts);
 
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let protocol = ctx.protocol;
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -1481,7 +1481,7 @@ mod basic_async {
     #[cfg(feature = "connection-manager")]
     #[async_test]
     async fn test_manager_should_reconnect_without_actions_if_resp3_is_set() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         if !ctx.protocol.supports_resp3() {
             return;
         }
@@ -1509,7 +1509,7 @@ mod basic_async {
     #[cfg(feature = "connection-manager")]
     #[async_test]
     async fn test_manager_should_completely_disconnect_when_drop() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
         let connection_info = ctx.server.connection_info().set_redis_settings(redis);
         let client = redis::Client::open(connection_info).unwrap();
@@ -1551,7 +1551,7 @@ mod basic_async {
     #[async_test]
     async fn test_manager_should_reconnect_without_actions_if_push_sender_is_set_even_after_sender_returns_error()
      {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         if !ctx.protocol.supports_resp3() {
             return;
         }
@@ -1593,7 +1593,7 @@ mod basic_async {
 
     #[async_test]
     async fn test_multiplexed_connection_kills_connection_on_drop_even_when_blocking() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
 
         let mut conn = ctx.async_connection().await.unwrap();
         let mut connection_to_dispose_of = ctx.async_connection().await.unwrap();
@@ -1630,7 +1630,7 @@ mod basic_async {
 
     #[async_test]
     async fn test_monitor() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
 
         let mut conn = ctx.async_connection().await.unwrap();
         let monitor_conn = ctx.client.get_async_monitor().await.unwrap();
@@ -1726,7 +1726,7 @@ mod basic_async {
     #[async_test]
     #[cfg(feature = "connection-manager")]
     async fn test_resp3_pushes_connection_manager() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
         let connection_info = ctx.server.connection_info().set_redis_settings(redis);
         let client = redis::Client::open(connection_info).unwrap();
@@ -1752,7 +1752,7 @@ mod basic_async {
 
     #[async_test]
     async fn test_select_db() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let redis = redis_settings().set_db(5);
         let connection_info = ctx.server.connection_info().set_redis_settings(redis);
         let client = redis::Client::open(connection_info).unwrap();
@@ -1769,7 +1769,7 @@ mod basic_async {
 
     #[async_test]
     async fn test_multiplexed_connection_send_single_disconnect_on_connection_failure() {
-        let mut ctx = TestContext::new();
+        let mut ctx = TestContext::default();
         if !ctx.protocol.supports_resp3() {
             return;
         }
@@ -1792,7 +1792,7 @@ mod basic_async {
 
     #[async_test]
     async fn test_fail_on_empty_command() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut connection = ctx.async_connection().await.unwrap();
 
         let error: RedisError = redis::Pipeline::new()
@@ -1848,7 +1848,7 @@ mod basic_async {
 
         #[async_test]
         async fn test_transaction_should_retry_on_watch() {
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
             let con1 = ctx.async_connection().await.unwrap();
             let mut con2 = ctx.async_connection().await.unwrap();
 
@@ -1894,7 +1894,7 @@ mod basic_async {
 
         #[async_test]
         async fn test_transaction_should_retry_on_none_from_closure() {
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
             let con = ctx.async_connection().await.unwrap();
 
             let attempts = Arc::new(AtomicUsize::new(0));
@@ -1921,7 +1921,7 @@ mod basic_async {
 
         #[async_test]
         async fn test_transaction_abort_if_internal_function_returns_error() {
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
             let con = ctx.async_connection().await.unwrap();
             let attempts = Arc::new(AtomicUsize::new(0));
 
@@ -1963,7 +1963,7 @@ mod basic_async {
 
         #[async_test]
         async fn test_lazy_connection_manager_can_be_created_synchronously() {
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
 
             let config = redis::aio::ConnectionManagerConfig::new()
                 .set_pipeline_buffer_size(100)
@@ -1979,7 +1979,7 @@ mod basic_async {
 
         #[async_test]
         async fn test_lazy_connection_manager_reconnects_after_disconnect() {
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
 
             let max_delay_between_attempts = Duration::from_millis(2);
             let config = redis::aio::ConnectionManagerConfig::new()
@@ -2010,7 +2010,7 @@ mod basic_async {
 
         #[async_test]
         async fn test_lazy_connection_manager_can_be_cloned_before_sending() {
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
 
             let config = redis::aio::ConnectionManagerConfig::new();
             let manager = ctx.client.get_connection_manager_lazy(config).unwrap();
@@ -2029,7 +2029,7 @@ mod basic_async {
 
         #[async_test]
         async fn test_lazy_connection_manager_with_resp3_push() {
-            let ctx = TestContext::new();
+            let ctx = TestContext::default();
             if !ctx.protocol.supports_resp3() {
                 return;
             }

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -87,7 +87,7 @@ mod basic {
 
     #[test]
     fn test_args() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         redis::cmd("SET")
@@ -108,7 +108,7 @@ mod basic {
 
     #[test]
     fn test_can_authenticate_with_username_and_password() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let username = "foo";
@@ -139,7 +139,7 @@ mod basic {
 
     #[test]
     fn test_getset() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         redis::cmd("SET").arg("foo").arg(42).exec(&mut con).unwrap();
@@ -159,7 +159,7 @@ mod basic {
     //unit test for key_type function
     #[test]
     fn test_key_type() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         // The key does not have a value
@@ -215,7 +215,7 @@ mod basic {
     #[test]
     fn test_client_tracking_doesnt_block_execution() {
         //It checks if the library distinguish a push-type message from the others and continues its normal operation.
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
         let (k1, k2): (i32, i32) = redis::pipe()
             .cmd("CLIENT")
@@ -251,7 +251,7 @@ mod basic {
 
     #[test]
     fn test_incr() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         redis::cmd("SET").arg("foo").arg(42).exec(&mut con).unwrap();
@@ -260,7 +260,7 @@ mod basic {
 
     #[test]
     fn test_ping() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let res: String = con.ping_message("foobar").unwrap();
@@ -271,7 +271,7 @@ mod basic {
 
     #[test]
     fn test_getdel() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         redis::cmd("SET").arg("foo").arg(42).exec(&mut con).unwrap();
@@ -286,7 +286,7 @@ mod basic {
 
     #[test]
     fn test_getex() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         redis::cmd("SET")
@@ -329,7 +329,7 @@ mod basic {
 
     #[test]
     fn test_info() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let info: redis::InfoDict = redis::cmd("INFO").query(&mut con).unwrap();
@@ -342,7 +342,7 @@ mod basic {
 
     #[test]
     fn test_hash_ops() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         redis::cmd("HSET")
@@ -1074,7 +1074,7 @@ mod basic {
     #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_unlink() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         redis::cmd("SET").arg("foo").arg(42).exec(&mut con).unwrap();
@@ -1088,7 +1088,7 @@ mod basic {
 
     #[test]
     fn test_set_ops() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         assert_eq!(con.sadd("foo", &[1, 2, 3]), Ok(3));
@@ -1113,7 +1113,7 @@ mod basic {
 
     #[test]
     fn test_scan() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         assert_eq!(con.sadd("foo", &[1, 2, 3]), Ok(3));
@@ -1131,7 +1131,7 @@ mod basic {
 
     #[test]
     fn test_optionals() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         redis::cmd("SET").arg("foo").arg(1).exec(&mut con).unwrap();
@@ -1153,7 +1153,7 @@ mod basic {
 
     #[test]
     fn test_scanning() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
         let mut unseen = HashSet::new();
 
@@ -1183,7 +1183,7 @@ mod basic {
     fn test_checked_scanning_error() {
         const KEY_COUNT: u32 = 1000;
 
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         // Insert a bunch of keys with legit UTF-8 first
@@ -1234,7 +1234,7 @@ mod basic {
 
     #[test]
     fn test_filtered_scanning() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
         let mut unseen = HashSet::new();
 
@@ -1261,7 +1261,7 @@ mod basic {
 
     #[test]
     fn test_scan_with_options_works() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
         for i in 0..20usize {
             con.append(format!("test/{i}"), i).unwrap();
@@ -1293,7 +1293,7 @@ mod basic {
 
     #[test]
     fn test_pipeline() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let ((k1, k2),): ((i32, i32),) = redis::pipe()
@@ -1316,7 +1316,7 @@ mod basic {
 
     #[test]
     fn test_pipeline_with_err() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         redis::cmd("SET")
@@ -1356,7 +1356,7 @@ mod basic {
 
     #[test]
     fn test_pipeline_returns_server_errors() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
         let mut pipe = redis::pipe();
         pipe.set("x", "x-value")
@@ -1375,7 +1375,7 @@ mod basic {
 
     #[test]
     fn test_empty_pipeline() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         redis::pipe().cmd("PING").ignore().exec(&mut con).unwrap();
@@ -1383,7 +1383,7 @@ mod basic {
 
     #[test]
     fn test_pipeline_transaction() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let ((k1, k2),): ((i32, i32),) = redis::pipe()
@@ -1407,7 +1407,7 @@ mod basic {
 
     #[test]
     fn test_pipeline_transaction_with_errors() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let _: () = con.set("x", 42).unwrap();
@@ -1444,7 +1444,7 @@ mod basic {
 
     #[test]
     fn test_pipeline_reuse_query() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let mut pl = redis::pipe();
@@ -1482,7 +1482,7 @@ mod basic {
 
     #[test]
     fn test_pipeline_reuse_query_clear() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let mut pl = redis::pipe();
@@ -1537,7 +1537,7 @@ mod basic {
 
     #[test]
     fn test_real_transaction() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let key = "the_key";
@@ -1571,7 +1571,7 @@ mod basic {
 
     #[test]
     fn test_real_transaction_highlevel() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let key = "the_key";
@@ -1595,7 +1595,7 @@ mod basic {
     #[test]
     fn test_pubsub() {
         use std::sync::{Arc, Barrier};
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         // Connection for subscriber api
@@ -1666,7 +1666,7 @@ mod basic {
 
     #[test]
     fn test_pubsub_handles_timeout() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         // Connection for subscriber api
@@ -1690,7 +1690,7 @@ mod basic {
     #[test]
     fn test_pubsub_send_ping() {
         use std::sync::{Arc, Barrier};
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         // Connection for subscriber api
@@ -1755,7 +1755,7 @@ mod basic {
 
     #[test]
     fn pub_sub_subscription_to_multiple_channels() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut conn = ctx.connection();
         let mut pubsub_conn = conn.as_pubsub();
         pubsub_conn.subscribe(&["phonewave", "foo", "bar"]).unwrap();
@@ -1772,7 +1772,7 @@ mod basic {
 
     #[test]
     fn test_pubsub_unsubscribe() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let (tx, rx) = std::sync::mpsc::channel();
@@ -1824,7 +1824,7 @@ mod basic {
 
     #[test]
     fn test_pubsub_subscribe_while_messages_are_sent() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut conn_external = ctx.connection();
         let mut conn_internal = ctx.connection();
         let received = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
@@ -1882,7 +1882,7 @@ mod basic {
 
     #[test]
     fn test_pubsub_unsubscribe_no_subs() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         {
@@ -1897,7 +1897,7 @@ mod basic {
 
     #[test]
     fn test_pubsub_unsubscribe_one_sub() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         {
@@ -1913,7 +1913,7 @@ mod basic {
 
     #[test]
     fn test_pubsub_unsubscribe_one_sub_one_psub() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         {
@@ -1930,7 +1930,7 @@ mod basic {
 
     #[test]
     fn scoped_pubsub() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         // Connection for subscriber api
@@ -1982,7 +1982,7 @@ mod basic {
 
     #[test]
     fn test_tuple_args() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         redis::cmd("HMSET")
@@ -2009,7 +2009,7 @@ mod basic {
 
     #[test]
     fn test_nice_api() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         assert_matches!(con.set("my_key", 42), Ok(_));
@@ -2032,7 +2032,7 @@ mod basic {
 
     #[test]
     fn test_auto_m_versions() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         assert_matches!(con.mset(&[("key1", 1), ("key2", 2)]), Ok(_));
@@ -2049,7 +2049,7 @@ mod basic {
 
     #[test]
     fn test_nice_hash_api() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         assert_eq!(
@@ -2112,7 +2112,7 @@ mod basic {
 
     #[test]
     fn test_nice_list_api() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         assert_eq!(con.rpush("my_list", &[1, 2, 3, 4]), Ok(4));
@@ -2147,7 +2147,7 @@ mod basic {
 
     #[test]
     fn test_tuple_decoding_regression() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         assert_matches!(con.del("my_zset"), Ok(_));
@@ -2166,7 +2166,7 @@ mod basic {
     #[test]
     fn test_tuple_decoding_from_iter() {
         const KEY: &str = "my_iter_tuple";
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let map = HashMap::from([("one", 1), ("two", 2), ("three", 3)]);
@@ -2199,7 +2199,7 @@ mod basic {
 
     #[test]
     fn test_setbit_and_getbit_single_offset() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         assert_eq!(con.setbit("bitvec", 10, true), Ok(false));
@@ -2208,7 +2208,7 @@ mod basic {
 
     #[test]
     fn test_bit_operations() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         fn perform_bitwise_operation<F>(str1: &str, str2: &str, op: F) -> String
@@ -2316,7 +2316,7 @@ mod basic {
 
     #[test]
     fn test_redis_server_down() {
-        let mut ctx = TestContext::new();
+        let mut ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let ping = redis::cmd("PING").query::<String>(&mut con);
@@ -2333,7 +2333,7 @@ mod basic {
 
     #[test]
     fn test_zinterstore_zunionstore() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         // Shared members (one, two) have different scores in each set so that
@@ -2535,7 +2535,7 @@ mod basic {
 
     #[test]
     fn test_zinter_zunion() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         // Shared members (one, two) have different scores in each set so that
@@ -2769,7 +2769,7 @@ mod basic {
 
     #[test]
     fn test_zrembylex() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let setname = "myzset";
@@ -2801,7 +2801,7 @@ mod basic {
     #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_zrandmember() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let setname = "myzrandset";
@@ -2849,7 +2849,7 @@ mod basic {
 
     #[test]
     fn test_sismember() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let setname = "myset";
@@ -2867,7 +2867,7 @@ mod basic {
     #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_smismember() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let setname = "myset";
@@ -2878,7 +2878,7 @@ mod basic {
 
     #[test]
     fn test_object_freq_command() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         // Enable an LFU `maxmemory-policy`. This is required for `OBJECT FREQ` to work.
@@ -2907,7 +2907,7 @@ mod basic {
 
     #[test]
     fn test_object_idletime_command() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         con.set("object_key_str", "object_value_str").unwrap();
@@ -2929,7 +2929,7 @@ mod basic {
 
     #[test]
     fn test_mget() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         con.set(1, "1").unwrap();
@@ -2959,7 +2959,7 @@ mod basic {
 
     #[test]
     fn test_variable_length_get() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         con.set(1, "1").unwrap();
@@ -2971,7 +2971,7 @@ mod basic {
 
     #[test]
     fn test_multi_generics() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         assert_eq!(con.sadd(b"set1", vec![5, 42]), Ok(2));
@@ -2982,7 +2982,7 @@ mod basic {
 
     #[test]
     fn test_set_options_with_get() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let opts = SetOptions::default().get(true);
@@ -3690,7 +3690,7 @@ mod basic {
 
     #[test]
     fn test_copy() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let opts = CopyOptions::default();
@@ -3753,7 +3753,7 @@ mod basic {
 
     #[test]
     fn test_timeout_leaves_usable_connection() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         con.set("key", "value").unwrap();
@@ -3850,7 +3850,7 @@ mod basic {
 
     #[test]
     fn test_blocking_sorted_set_api() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         assert_matches!(con.zadd("a", "1a", 1), Ok(_));
@@ -3885,7 +3885,7 @@ mod basic {
 
     #[test]
     fn test_sorted_set_add_options() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         // Scenario 1
@@ -4588,7 +4588,7 @@ mod basic {
 
     #[test]
     fn test_push_manager() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
         let connection_info = ctx.server.connection_info().set_redis_settings(redis);
 
@@ -4635,7 +4635,7 @@ mod basic {
 
     #[test]
     fn test_push_manager_disconnection() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
         let connection_info = ctx.server.connection_info().set_redis_settings(redis);
         let client = redis::Client::open(connection_info).unwrap();
@@ -4658,7 +4658,7 @@ mod basic {
     #[test]
     fn test_raw_pubsub_with_push_manager() {
         // Tests PubSub usage with raw connection.
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         if !ctx.protocol.supports_resp3() {
             return;
         }
@@ -4753,7 +4753,7 @@ mod basic {
 
     #[test]
     fn test_select_db() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let redis = redis_settings().set_db(5);
         let connection_info = ctx.server.connection_info().set_redis_settings(redis);
 
@@ -4768,7 +4768,7 @@ mod basic {
 
     #[test]
     fn test_client_getname() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
         redis::cmd("CLIENT")
             .arg("SETNAME")
@@ -4781,14 +4781,14 @@ mod basic {
 
     #[test]
     fn test_client_id() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
         let _num = con.client_id().unwrap();
     }
 
     #[test]
     fn test_client_setname() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
         assert_eq!(con.client_setname("connection-name"), Ok(()));
         let res: String = redis::cmd("CLIENT").arg("GETNAME").query(&mut con).unwrap();
@@ -4797,7 +4797,7 @@ mod basic {
 
     #[test]
     fn test_role_primary() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
         let ret = redis::cmd("ROLE").query::<Role>(&mut con).unwrap();
         assert_matches!(ret, Role::Primary { .. });
@@ -4805,7 +4805,7 @@ mod basic {
 
     #[test]
     fn test_connection_timeout_on_busy_server() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
         // we stop the server on another thread, in order to move forwardd while the server is stopped.
         let handle = thread::spawn(move || {
@@ -4832,7 +4832,7 @@ mod basic {
 
     #[test]
     fn fail_on_empty_command() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut connection = ctx.connection();
 
         let error: RedisError = redis::Pipeline::new()

--- a/redis/tests/test_cache.rs
+++ b/redis/tests/test_cache.rs
@@ -36,7 +36,7 @@ macro_rules! assert_invalidate {
 // Basic testing should work with both CacheMode::All and CacheMode::OptIn if commands has called cache()
 #[async_test]
 async fn test_cache_basic(test_with_optin: bool) {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -94,7 +94,7 @@ async fn test_cache_basic(test_with_optin: bool) {
 
 #[async_test]
 async fn test_cache_mget() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -333,7 +333,7 @@ async fn test_module_json_cache_get_mget_different_paths() {
 
 #[async_test]
 async fn test_cache_is_not_target_type_dependent() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -352,7 +352,7 @@ async fn test_cache_is_not_target_type_dependent() {
 
 #[async_test]
 async fn test_cache_with_pipeline(atomic: bool) {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -400,7 +400,7 @@ async fn test_cache_with_pipeline(atomic: bool) {
 #[async_test]
 async fn test_cache_basic_partial_opt_in() {
     // In OptIn mode cache must not be utilized without explicit per command configuration.
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -466,7 +466,7 @@ async fn test_cache_basic_partial_opt_in() {
 #[async_test]
 async fn test_cache_pipeline_partial_opt_in(atomic: bool) {
     // In OptIn mode cache must not be utilized without explicit per command configuration.
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -521,7 +521,7 @@ async fn test_cache_pipeline_partial_opt_in(atomic: bool) {
 
 #[async_test]
 async fn test_cache_different_commands(test_with_opt_in: bool) {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -585,7 +585,7 @@ async fn test_cache_different_commands(test_with_opt_in: bool) {
 #[cfg(feature = "connection-manager")]
 #[async_test]
 async fn test_connection_manager_maintains_statistics_after_crashes(test_with_optin: bool) {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -959,7 +959,7 @@ fn get_cmd(name: &str, enable_opt_in: bool) -> redis::Cmd {
 
 #[async_test]
 async fn test_readonly_commands_with_patterns_are_not_cached() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -978,7 +978,7 @@ async fn test_readonly_commands_with_patterns_are_not_cached() {
 
 #[async_test]
 async fn test_bitcount_is_handled_correctly() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -1032,7 +1032,7 @@ async fn test_bitcount_is_handled_correctly() {
 
 #[async_test]
 async fn test_that_a_pipeline_with_all_commands_cached_does_not_hang() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     if !ctx.protocol.supports_resp3() {
         return;
     }

--- a/redis/tests/test_credentials_provider_failures.rs
+++ b/redis/tests/test_credentials_provider_failures.rs
@@ -70,7 +70,7 @@ mod credentials_provider_failures_tests {
     #[async_test]
     async fn test_connection_fails_when_initial_credentials_request_returns_error() {
         init_logger();
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
 
         let provider = ImmediatelyFailingCredentialsProvider;
         let config = redis::AsyncConnectionConfig::new().set_credentials_provider(provider);
@@ -92,7 +92,7 @@ mod credentials_provider_failures_tests {
     #[async_test]
     async fn test_connection_fails_when_credentials_stream_closes() {
         init_logger();
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
 
         let provider = EmptyStreamCredentialsProvider;
         let config = redis::AsyncConnectionConfig::new().set_credentials_provider(provider);

--- a/redis/tests/test_geospatial.rs
+++ b/redis/tests/test_geospatial.rs
@@ -14,7 +14,7 @@ const AGRIGENTO: (&str, &str, &str) = ("13.5833332", "37.316667", "Agrigento");
 
 #[test]
 fn test_geoadd_single_tuple() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     assert_eq!(con.geo_add("my_gis", PALERMO), Ok(1));
@@ -22,7 +22,7 @@ fn test_geoadd_single_tuple() {
 
 #[test]
 fn test_geoadd_multiple_tuples() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     assert_eq!(con.geo_add("my_gis", &[PALERMO, CATANIA]), Ok(2));
@@ -30,7 +30,7 @@ fn test_geoadd_multiple_tuples() {
 
 #[test]
 fn test_geodist_existing_members() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     assert_eq!(con.geo_add("my_gis", &[PALERMO, CATANIA]), Ok(2));
@@ -44,7 +44,7 @@ fn test_geodist_existing_members() {
 
 #[test]
 fn test_geodist_support_option() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     assert_eq!(con.geo_add("my_gis", &[PALERMO, CATANIA]), Ok(2));
@@ -64,7 +64,7 @@ fn test_geodist_support_option() {
 
 #[test]
 fn test_geohash() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     assert_eq!(con.geo_add("my_gis", &[PALERMO, CATANIA]), Ok(2));
@@ -83,7 +83,7 @@ fn test_geohash() {
 
 #[test]
 fn test_geopos() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     assert_eq!(con.geo_add("my_gis", &[PALERMO, CATANIA]), Ok(2));
@@ -107,7 +107,7 @@ fn test_geopos() {
 
 #[test]
 fn test_use_coord_struct() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     assert_eq!(
@@ -127,7 +127,7 @@ fn test_use_coord_struct() {
 
 #[test]
 fn test_georadius() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     assert_eq!(con.geo_add("my_gis", &[PALERMO, CATANIA]), Ok(2));
@@ -204,7 +204,7 @@ fn test_georadius() {
 
 #[test]
 fn test_georadius_by_member() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     assert_eq!(con.geo_add("my_gis", &[PALERMO, CATANIA, AGRIGENTO]), Ok(3));

--- a/redis/tests/test_script.rs
+++ b/redis/tests/test_script.rs
@@ -9,7 +9,7 @@ mod script {
 
     #[test]
     fn test_script() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let script = redis::Script::new(r"return {redis.call('GET', KEYS[1]), ARGV[1]}");
@@ -26,7 +26,7 @@ mod script {
 
     #[test]
     fn test_script_load() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let script = redis::Script::new("return 'Hello World'");
@@ -38,7 +38,7 @@ mod script {
 
     #[test]
     fn test_script_load_through_invocation() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let script = redis::Script::new("return 'Hello World'");
@@ -50,7 +50,7 @@ mod script {
 
     #[test]
     fn test_script_that_is_not_loaded_fails_on_pipeline_invocation() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let script = redis::Script::new(r"return tonumber(ARGV[1]) + tonumber(ARGV[2]);");
@@ -62,7 +62,7 @@ mod script {
 
     #[test]
     fn test_script_pipeline() {
-        let ctx = TestContext::new();
+        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let script = redis::Script::new(r"return tonumber(ARGV[1]) + tonumber(ARGV[2]);");

--- a/redis/tests/test_streams.rs
+++ b/redis/tests/test_streams.rs
@@ -102,7 +102,7 @@ fn test_assorted_1() {
     // xread
     // xlen
 
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     xadd(&mut con);
@@ -171,7 +171,7 @@ fn test_xgroup_create() {
     // xgroup_create
     // xinfo_groups
 
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     xadd(&mut con);
@@ -210,7 +210,7 @@ fn test_xgroup_createconsumer() {
     // Tests the following command....
     // xgroup_createconsumer
 
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     xadd(&mut con);
@@ -275,7 +275,7 @@ fn test_assorted_2() {
     // xpending_count
     // xpending_consumer_count
 
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     xadd(&mut con);
@@ -414,7 +414,7 @@ fn assert_stream_pending_data(data: StreamPendingData) {
 
 #[test]
 fn test_xadd_maxlen_map() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     for i in 0..10 {
@@ -435,7 +435,7 @@ fn test_xadd_maxlen_map() {
 
 #[test]
 fn test_xadd_options() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     // NoMKStream will return a nil when the stream does not exist
@@ -511,7 +511,7 @@ fn test_xadd_options() {
 #[test]
 fn test_xread_options_deleted_pel_entry() {
     // Test xread_options behaviour with deleted entry
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
     let result = con.xgroup_create_mkstream("k1", "g1", "$");
     assert_matches!(result, Ok(_));
@@ -568,7 +568,7 @@ fn create_group_add_and_read(con: &mut Connection) -> StreamReadReply {
 fn test_xautoclaim() {
     // Tests the following command....
     // xautoclaim_options
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     // xautoclaim test basic idea:
@@ -634,7 +634,7 @@ fn test_xclaim() {
     // Tests the following commands....
     // xclaim
     // xclaim_options
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     // xclaim test basic idea:
@@ -719,7 +719,7 @@ fn test_xclaim() {
 
 #[test]
 fn test_xclaim_last_id() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     let result = con.xgroup_create_mkstream("k1", "g1", "$");
@@ -1106,7 +1106,7 @@ fn test_xreadgroup_claim_multiple_streams() {
 fn test_xdel() {
     // Tests the following commands....
     // xdel
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     // add some keys
@@ -2103,7 +2103,7 @@ fn test_xack_del() {
 fn test_xtrim() {
     // Tests the following commands....
     // xtrim
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     // add some keys
@@ -2122,7 +2122,7 @@ fn test_xtrim() {
 fn test_xtrim_options() {
     // Tests the following commands....
     // xtrim_options
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     // add some keys
@@ -2171,7 +2171,7 @@ fn test_xgroup() {
     // xgroup_destroy
     // xgroup_delconsumer
 
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     // test xgroup create w/ mkstream @ 0
@@ -2215,7 +2215,7 @@ fn test_xrange() {
     // xrange_all
     // xrange_count
 
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     xadd(&mut con);
@@ -2241,7 +2241,7 @@ fn test_xrevrange() {
     // xrevrange_all
     // xrevrange_count
 
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     xadd(&mut con);
@@ -2269,7 +2269,7 @@ fn test_xautoclaim_invalid_pel_entries_claiming_full_entries() {
     // See https://github.com/redis-rs/redis-rs/issues/1798
     // Note that this issue also applies to xclaim.
 
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     // xautoclaim-invalid basic idea:
@@ -2321,7 +2321,7 @@ fn test_xautoclaim_invalid_pel_entries_claiming_just_ids() {
     // See https://github.com/redis-rs/redis-rs/issues/1798
     // Note that this issue also applies to xclaim.
 
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     // xautoclaim-invalid basic idea:

--- a/redis/tests/test_support.rs
+++ b/redis/tests/test_support.rs
@@ -179,7 +179,7 @@ baz_version: 23.0.0
 /// Tries to assure that the current server allows to parse the versions
 #[test]
 fn ctx_live_test_server() {
-    let ctx = TestContext::new();
+    let ctx = TestContext::default();
     let mut conn = ctx.connection();
 
     let components = AvailableComponents::from(&mut conn);

--- a/test-macros/src/lib.rs
+++ b/test-macros/src/lib.rs
@@ -38,7 +38,7 @@ pub fn async_test(_: TokenStream, input: TokenStream) -> TokenStream {
                     #[cfg_attr(feature = "tokio-comp", case::tokio(support::RuntimeType::Tokio))]
                     #[cfg_attr(feature = "smol-comp", case::smol(support::RuntimeType::Smol))]
                     fn multiplexed_connection (#[case]runtime: support::RuntimeType) {
-                        let ctx = TestContext::new();
+                        let ctx = TestContext::default();
                         support::block_on_all(async move {
                             let conn = ctx.async_connection().await.unwrap();
                             #function_name (conn).await
@@ -50,7 +50,7 @@ pub fn async_test(_: TokenStream, input: TokenStream) -> TokenStream {
                     #[cfg_attr(feature = "smol-comp", case::smol(support::RuntimeType::Smol))]
                     #[cfg(feature = "connection-manager")]
                     fn connection_manager (#[case]runtime: support::RuntimeType) {
-                        let ctx = TestContext::new();
+                        let ctx = TestContext::default();
                         support::block_on_all(async move {
                             let conn = ctx.client.get_connection_manager().await.unwrap();
                             #function_name (conn).await


### PR DESCRIPTION
With all `TestContext::new*` functions gone, it should be clear to use `TestContextBuilder` (or `::default()`) to build instances.