### PR TITLE
redis-test: Allow to re-use existing TLS keys (4/5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,29 @@ If the fuzzer finds a crash, in order to reproduce it, run:
     $ cd afl/<target>/
     $ cargo run --bin reproduce -- out/crashes/<crashfile>
 
+### Speeding up TLS tests
+
+TLS tests per-default create fresh keys for each tests. On entropy/resource-limited hosts, this might be time consuming.
+
+To instead re-use the same keys, first generate the needed keys beforehand (this needs to be done only once):
+
+```sh
+mkdir -p "$HOME/redis-rs-keys"
+openssl genrsa -out "$HOME/redis-rs-keys/ca.key" 4096
+openssl genrsa -out "$HOME/redis-rs-keys/client.key" 2048
+openssl genrsa -out "$HOME/redis-rs-keys/server.key" 2048
+```
+
+Then tell your environment to use them for testing (this needs to be executed in each terminal that runs the tests):
+
+```sh
+export REDISRS_TLS_KEY_CA="$HOME/redis-rs-keys/ca.key"
+export REDISRS_TLS_KEY_CLIENT="$HOME/redis-rs-keys/client.key"
+export REDISRS_TLS_KEY_SERVER="$HOME/redis-rs-keys/server.key"
+```
+
+Now `make test` will pick the pre-generated keys up, and TLS tests should breeze through.
+
 ### AI contributions
 
 This is not a firm policy, but for the time being, PRs get evaluated on their

--- a/redis-test/src/lib.rs
+++ b/redis-test/src/lib.rs
@@ -30,6 +30,34 @@
 //! let result = my_exists(&mut mock_connection, "foo").unwrap();
 //! assert_eq!(result, true);
 //! ```
+//!
+//! # TLS helpers
+//!
+//! The TLS helpers [`utils::build_key_*`](utils::build_keys_and_certs_for_tls) and
+//! [`utils::build_client_cert_*`](utils::build_client_cert_with_custom_cn) generate new keys on
+//! each call. When using them heavily on entropy/resource-limited hosts, this quickly becomes time
+//! consuming.
+//!
+//! To instead re-use the same keys for each call, first generate the needed keys beforehand (this
+//! needs to be done only once):
+//!
+//! ```sh
+//! mkdir -p "$HOME/redis-rs-keys"
+//! openssl genrsa -out "$HOME/redis-rs-keys/ca.key" 4096
+//! openssl genrsa -out "$HOME/redis-rs-keys/client.key" 2048
+//! openssl genrsa -out "$HOME/redis-rs-keys/server.key" 2048
+//! ```
+//!
+//! Then tell your environment to use them for testing (this needs to be executed in each terminal
+//! that runs the tests):
+//!
+//! ```sh
+//! export REDISRS_TLS_KEY_CA="$HOME/redis-rs-keys/ca.key"
+//! export REDISRS_TLS_KEY_CLIENT="$HOME/redis-rs-keys/client.key"
+//! export REDISRS_TLS_KEY_SERVER="$HOME/redis-rs-keys/server.key"
+//! ```
+//!
+//! Now the TLS helpers will pick the pre-generated keys up, and perform better.
 
 pub mod cluster;
 pub mod sentinel;

--- a/redis-test/src/utils.rs
+++ b/redis-test/src/utils.rs
@@ -143,7 +143,35 @@ impl CommandMultiArgs for OpensslCommand {
     }
 }
 
-fn generate_key<S: AsRef<std::ffi::OsStr>>(file: S, size: usize, purpose: &str) {
+/// Generate an RSA key
+///
+/// # Arguments:
+///
+/// * `file` - The key gets written to this file
+/// * `size` - Generate a key with this bit size
+/// * `purpose` - The name to use for this key in error messages
+/// * `env_name` - If there is an environment variable of this name that has a non-empty value, load
+///   the key from the file at this value instead of generating the key afresh.
+// The `env_name` could get inferred from `purpose`. But we don't infer it to allow grepping for the
+// full environment variable and landing at the callers.
+fn generate_key(file: &PathBuf, size: usize, purpose: &str, env_name: &str) {
+    if let Ok(env_value) = std::env::var(env_name)
+        && !env_value.is_empty()
+    {
+        // The environment signals to re-use an existing key instead of generating a new one.
+
+        // Read the key data
+        let key = fs::read_to_string(&env_value)
+            .unwrap_or_else(|e| panic!("failed to read {purpose} key from '{env_value}': {e}"));
+
+        // Write the key data to the expected place
+        fs::write(file, key)
+            .unwrap_or_else(|e| panic!("failed to write {purpose} key to '{file:?}': {e}"));
+
+        return;
+    }
+
+    // Call OpenSSL to generate the key
     OpensslCommand::new(&format!("generate {purpose} key"))
         .arg("genrsa")
         .arg2("-out", file)
@@ -151,14 +179,42 @@ fn generate_key<S: AsRef<std::ffi::OsStr>>(file: S, size: usize, purpose: &str) 
         .spawn();
 }
 
+/// Builds CA and server certs keys etc. for TLS connections with `CN` and `alt_names`
+///
+/// The server certificate will have a `CN` and `alt_name` `DNS.1` of `localhost.example.com`
+///
+/// # Caveat
+///
+/// This function creates new keys for each call. On entropy/resource-limited hosts, this quickly
+/// becomes time consuming. See the [TLS helpers section](crate#tls-helpers) on how to precompute
+/// keys once and then re-use them to speed up calls.
 pub fn build_keys_and_certs_for_tls(tempdir: &TempDir) -> TlsFilePaths {
     build_keys_and_certs_for_tls_ext(tempdir, true)
 }
 
+/// Builds CA and server certs keys etc. for TLS connections and optional `alt_names`/`CN`
+///
+/// If `with_ip_alts` is `true`, the server certificate will have a `CN` and `alt_name` `DNS.1` of
+/// localhost.example.com`. Otherwise, only `alt_names` `IP.1` of `127.0.0.1`.
+///
+/// # Caveat
+///
+/// This function creates new keys for each call. On entropy/resource-limited hosts, this quickly
+/// becomes time consuming. See the [TLS helpers section](crate#tls-helpers) on how to precompute
+/// keys once and then re-use them to speed up calls.
 pub fn build_keys_and_certs_for_tls_ext(tempdir: &TempDir, with_ip_alts: bool) -> TlsFilePaths {
     build_keys_and_certs_for_tls_with_hostname(tempdir, with_ip_alts, None)
 }
 
+/// Builds CA and server certs keys etc. for TLS connections and optional `alt_names` and `hostname`
+///
+/// The given `dns_hostname` is only respected if `with_ip_alts` is `true`.
+///
+/// # Caveat
+///
+/// This function creates new keys for each call. On entropy/resource-limited hosts, this quickly
+/// becomes time consuming. See the [TLS helpers section](crate#tls-helpers) on how to precompute
+/// keys once and then re-use them to speed up calls.
 pub fn build_keys_and_certs_for_tls_with_hostname(
     tempdir: &TempDir,
     with_ip_alts: bool,
@@ -174,10 +230,10 @@ pub fn build_keys_and_certs_for_tls_with_hostname(
     let ext_file = tempdir.path().join("openssl.cnf");
 
     // Generate the key for the CA
-    generate_key(&ca_key, 4096, "CA");
+    generate_key(&ca_key, 4096, "CA", "REDISRS_TLS_KEY_CA");
 
     // Generate the key for the Redis server
-    generate_key(&redis_key, 2048, "server");
+    generate_key(&redis_key, 2048, "server", "REDISRS_TLS_KEY_SERVER");
 
     // Build CA Cert
     OpensslCommand::new("self-certify CA")
@@ -263,8 +319,15 @@ pub fn build_keys_and_certs_for_tls_with_hostname(
 }
 
 /// Build a client certificate with a custom common name (CN) field
+///
 /// Redis 8.6+ allows certificate-based authentication where the common name (CN)
 /// is mapped to an ACL username
+///
+/// # Caveat
+///
+/// This function creates new keys for each call. On entropy/resource-limited hosts, this quickly
+/// becomes time consuming. See the [TLS helpers section](crate#tls-helpers) on how to precompute
+/// keys once and then re-use them to speed up calls.
 pub fn build_client_cert_with_custom_cn(
     tempdir: &TempDir,
     common_name: &str,
@@ -276,7 +339,7 @@ pub fn build_client_cert_with_custom_cn(
     let ca_serial = tempdir.path().join("ca.txt");
 
     // Generate client private key
-    generate_key(&client_key, 2048, "client");
+    generate_key(&client_key, 2048, "client", "REDISRS_TLS_KEY_CLIENT");
 
     // Create a basic extensions file for X.509 v3 client certificate
     let client_ext_file = tempdir.path().join("client_ext.cnf");


### PR DESCRIPTION
As generating TLS keys for each test is time consuming, we allow to optionally skip generating new keys by re-use existing keys.

Set any of the environment variables

* `REDISRS_TLS_KEY_CA`
* `REDISRS_TLS_KEY_SERVER`
* `REDISRS_TLS_KEY_CLIENT`

to the file name of a TLS key, and the test will pick their data for the respective kind of key instead of generating a new one.

This allows to shave ~75% runtime off when running TLS tests and helps to improve the development cycle.

This re-use is not a security changes, as we only re-use the keys (certs etc are still computed afresh for each test).

Also, users have to opt-in. The default is still to generate fresh keys for each test.

This commit is part of #2254.