### PR TITLE
redis-test: Downgrade to release candidate version `2.0.0-rc.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "redis-test"
-version = "2.0.0"
+version = "2.0.0-rc.1"
 dependencies = [
  "bytes",
  "futures",

--- a/redis-test/Cargo.toml
+++ b/redis-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-test"
-version = "2.0.0"
+version = "2.0.0-rc.1"
 edition = "2024"
 description = "Testing helpers for the `redis` crate"
 homepage = "https://github.com/redis-rs/redis-rs"


### PR DESCRIPTION
When buming `redis` from `1.3.0` to `2.0.0-rc.1` (with `rc`), `redis-test` got bumped from `1.0.4` to `2.0.0` (without `rc`) in 7a950cd.

As `redis-test` is not yet a full `2.0.0` release, we downgrade it to `rc` again to match `redis`.