### PR TITLE
redis/tests: Require `tokio-comp` instead of `aio` for `parser` test

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -200,7 +200,7 @@ required-features = ["tokio-comp"]
 
 [[test]]
 name = "parser"
-required-features = ["aio"]
+required-features = ["tokio-comp"]
 
 [[test]]
 name = "test_acl"


### PR DESCRIPTION
`aio` on its own does not work, as it requires a runtime. The test passed only because we never try to compile with minimum required features.

However, when reworking features around testing (e.g.: like the `RedisServer` re-factoring), listing the wrong minimally required features hurts manual verification. So we set the requirement straight nonetheless.