### PR TITLE
redis-test: Convert dev-dependency on redis to feature synchronization (18.5/19)

### DIFF
--- a/redis-test/Cargo.toml
+++ b/redis-test/Cargo.toml
@@ -21,11 +21,7 @@ socket2 = "0.6"
 rand = "0.10"
 
 [features]
-aio = ["futures", "redis/aio"]
+aio = ["futures", "redis/aio", "redis/tokio-comp"]
 
 [dev-dependencies]
-redis = { version = "2.0.0-rc.1", path = "../redis", features = [
-    "aio",
-    "tokio-comp",
-] }
 tokio = { workspace = true }


### PR DESCRIPTION
`redis-test` has a plain dependency on `redis`.

The additional dev-dependency on it with `aio` and `tokio-comp` is
currently not needed for CI, and get's confused Rust about features and
available libraries when trying to move `TestContext` into `redis-test`
(#2261).

There, (with the above dependency still in place) the examples compiled
`redis-test` with `aio` flag. The corresponding `rustc` command had the
required guards for `future` (`--cfg 'feature="futures"'`), but missed
the `--extern futures=...rlib`.

Hence, compiling the examples failed.

(Adding `-p redis` made the `--extern futures=...rlib` appear again.)

It seems something about the additional `redis` dev-dependency in
`redis-test` confused Rust..

So we convert the unconditional `redis` with `aio` and `tokio-comp`
dev-dependency to feature synchronization.

By that, `redis` is only once a dependency for `redis-test` and Rust can
figure things out better.

CI works before and after this change, running the same tests.

When running manually, now both of the following work:

* `cargo nextest run --locked -p redis-test`
* `cargo nextest run --locked -p redis-test --all-features`

So we can manually run also the async test.

(Switching CI to run the async test is unrelated and hence left to
follow-up commits. cf #2272)
