### PR TITLE
ci: Run `redis-test` tests with both no and all features (18.75/19)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,14 @@ test:
 	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features --profile unix
 
 	@echo "===================================================================="
-	@echo "Testing redis-test"
+	@echo "Testing redis-test without features"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" RUST_BACKTRACE=1 cargo nextest run --locked -p redis-test
+	@RUSTFLAGS="-D warnings" RUST_BACKTRACE=1 cargo nextest run --locked -p redis-test --no-default-features
+
+	@echo "===================================================================="
+	@echo "Testing redis-test with all features"
+	@echo "===================================================================="
+	@RUSTFLAGS="-D warnings" RUST_BACKTRACE=1 cargo nextest run --locked -p redis-test --all-features
 
 test-module-json:
 	@echo "===================================================================="

--- a/redis-test/Cargo.toml
+++ b/redis-test/Cargo.toml
@@ -21,11 +21,7 @@ socket2 = "0.6"
 rand = "0.10"
 
 [features]
-aio = ["futures", "redis/aio"]
+aio = ["futures", "redis/aio", "redis/tokio-comp"]
 
 [dev-dependencies]
-redis = { version = "2.0.0-rc.1", path = "../redis", features = [
-    "aio",
-    "tokio-comp",
-] }
 tokio = { workspace = true }


### PR DESCRIPTION
CI uses `make test`, which ran `redis-test` tests without features, as
there were no default features.

We now make this clearer by adding the `--no-default-features` flag.

To cover also `redis-test` tests that rely on a feature, we add a second
test run with `--all-features`.

This increases test coverage and should help with detecting issues earlier.

Fixes #2272
