### PR TITLE
Add the `FT.CREATE` command builder and index schema [2/8]

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -3,6 +3,8 @@
 use crate::cmd::{Cmd, Iter, cmd};
 use crate::connection::{Connection, ConnectionLike, Msg, RedisConnectionInfo};
 use crate::pipeline::Pipeline;
+#[cfg(feature = "search_unfinished")]
+use crate::search::{CreateOptions, NonEmpty, SearchSchema};
 use crate::types::{
     ExistenceCheck, ExpireOption, Expiry, FieldExistenceCheck, FromRedisValue, IntegerReplyOrNoOp,
     NumericBehavior, RedisResult, RedisWrite, SetExpiry, ToRedisArgs, ToSingleRedisArg,
@@ -2944,6 +2946,54 @@ implement_commands! {
         options: &'a streams::StreamConfigOptions
     ) -> String {
         cmd("XCFGSET").arg(key).arg(options).take()
+    }
+
+    // Search commands
+
+    /// Create a search index.
+    ///
+    /// ```text
+    /// FT.CREATE index [ON HASH | JSON] [PREFIX count prefix [prefix ...]] [FILTER {filter}]
+    /// [LANGUAGE default_lang] [LANGUAGE_FIELD lang_attribute]
+    /// [SCORE default_score] [SCORE_FIELD score_attribute]
+    /// [PAYLOAD_FIELD payload_attribute] [MAXTEXTFIELDS] [TEMPORARY seconds]
+    /// [NOOFFSETS] [NOHL] [NOFIELDS] [NOFREQS]
+    /// [STOPWORDS count [stopword ...]] [SKIPINITIALSCAN]
+    /// SCHEMA field_name [AS alias] TEXT | TAG | NUMERIC | GEO | VECTOR | GEOSHAPE [ SORTABLE [UNF]]
+    /// [NOINDEX] [ field_name [AS alias] TEXT | TAG | NUMERIC | GEO | VECTOR | GEOSHAPE [ SORTABLE [UNF]] [NOINDEX] ...]
+    /// ```
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use redis::{schema, Commands, search::*};
+    ///
+    /// # fn example() -> redis::RedisResult<String> {
+    /// # let client = redis::Client::open("redis://127.0.0.1/")?;
+    /// # let mut con = client.get_connection()?;
+    /// let schema = schema! {
+    ///     "title" => SchemaTextField::new().weight(2.0),
+    ///     "subtitle" => SchemaTextField::new()
+    /// };
+    ///
+    /// let options = CreateOptions::new()
+    ///     .on(IndexDataType::Hash)
+    ///     .prefix("product:");
+    ///
+    /// let result: String = con.ft_create("products", &options, &schema)?;
+    /// # Ok(result)
+    /// # }
+    /// ```
+    ///
+    /// [Redis Docs](https://redis.io/commands/ft.create)
+    #[cfg(feature = "search_unfinished")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "search_unfinished")))]
+    fn ft_create<K: ToSingleRedisArg>(
+        index_name: K,
+        options: &'a CreateOptions,
+        schema: &'a SearchSchema<NonEmpty>
+    ) -> (String) {
+        cmd("FT.CREATE").arg(index_name).arg(options).arg("SCHEMA").arg(schema).take()
     }
 
     // script commands

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -4,7 +4,7 @@ use crate::cmd::{Cmd, Iter, cmd};
 use crate::connection::{Connection, ConnectionLike, Msg, RedisConnectionInfo};
 use crate::pipeline::Pipeline;
 #[cfg(feature = "search_unfinished")]
-use crate::search::{CreateOptions, NonEmpty, SearchSchema};
+use crate::search::{CreateOptions, SearchSchema};
 use crate::types::{
     ExistenceCheck, ExpireOption, Expiry, FieldExistenceCheck, FromRedisValue, IntegerReplyOrNoOp,
     NumericBehavior, RedisResult, RedisWrite, SetExpiry, ToRedisArgs, ToSingleRedisArg,
@@ -2991,7 +2991,7 @@ implement_commands! {
     fn ft_create<K: ToSingleRedisArg>(
         index_name: K,
         options: &'a CreateOptions,
-        schema: &'a SearchSchema<NonEmpty>
+        schema: &'a SearchSchema
     ) -> (String) {
         cmd("FT.CREATE").arg(index_name).arg(options).arg("SCHEMA").arg(schema).take()
     }

--- a/redis/src/commands/search/create/fields.rs
+++ b/redis/src/commands/search/create/fields.rs
@@ -76,13 +76,13 @@ impl ToRedisArgs for Sortable {
 #[non_exhaustive]
 pub enum Phonetic {
     /// Double metaphone for English
-    DmEn,
+    DmEnglish,
     /// Double metaphone for French
-    DmFr,
+    DmFrench,
     /// Double metaphone for Portuguese
-    DmPt,
+    DmPortuguese,
     /// Double metaphone for Spanish
-    DmEs,
+    DmSpanish,
 }
 
 impl ToRedisArgs for Phonetic {
@@ -91,10 +91,10 @@ impl ToRedisArgs for Phonetic {
         W: ?Sized + RedisWrite,
     {
         out.write_arg(match self {
-            Self::DmEn => b"dm:en",
-            Self::DmFr => b"dm:fr",
-            Self::DmPt => b"dm:pt",
-            Self::DmEs => b"dm:es",
+            Self::DmEnglish => b"dm:en",
+            Self::DmFrench => b"dm:fr",
+            Self::DmPortuguese => b"dm:pt",
+            Self::DmSpanish => b"dm:es",
         });
     }
 }
@@ -341,7 +341,7 @@ mod tests {
         let schema = schema! {
             TEXT_FIELD_NAME => SchemaTextField::new(),
         };
-        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
         assert_eq!(ft_create.into_args(), "FT.CREATE index SCHEMA title TEXT");
     }
 
@@ -350,7 +350,7 @@ mod tests {
         let schema = schema! {
             TEXT_FIELD_NAME => SchemaTextField::new().no_stem(true),
         };
-        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
         assert_eq!(
             ft_create.into_args(),
             "FT.CREATE index SCHEMA title TEXT NOSTEM"
@@ -362,7 +362,7 @@ mod tests {
         let schema = schema! {
             TEXT_FIELD_NAME => SchemaTextField::new().weight(1.0),
         };
-        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
         assert_eq!(
             ft_create.into_args(),
             "FT.CREATE index SCHEMA title TEXT WEIGHT 1.0"
@@ -372,9 +372,9 @@ mod tests {
     #[test]
     fn test_text_field_with_phonetic() {
         let schema = schema! {
-            TEXT_FIELD_NAME => SchemaTextField::new().phonetic(Phonetic::DmEn),
+            TEXT_FIELD_NAME => SchemaTextField::new().phonetic(Phonetic::DmEnglish),
         };
-        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
         assert_eq!(
             ft_create.into_args(),
             "FT.CREATE index SCHEMA title TEXT PHONETIC dm:en"
@@ -386,7 +386,7 @@ mod tests {
         let schema = schema! {
             TEXT_FIELD_NAME => SchemaTextField::new().with_suffix_trie(true),
         };
-        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
         assert_eq!(
             ft_create.into_args(),
             "FT.CREATE index SCHEMA title TEXT WITHSUFFIXTRIE"
@@ -398,7 +398,7 @@ mod tests {
         let schema = schema! {
             TEXT_FIELD_NAME => SchemaTextField::new().index_empty(true),
         };
-        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
         assert_eq!(
             ft_create.into_args(),
             "FT.CREATE index SCHEMA title TEXT INDEXEMPTY"
@@ -410,7 +410,7 @@ mod tests {
         let schema = schema! {
             TEXT_FIELD_NAME => SchemaTextField::new().alias(CUSTOM_ALIAS),
         };
-        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
         assert_eq!(
             ft_create.into_args(),
             "FT.CREATE index SCHEMA title AS custom_alias TEXT"
@@ -422,7 +422,7 @@ mod tests {
         let schema = schema! {
             TEXT_FIELD_NAME => SchemaTextField::new().index_missing(true),
         };
-        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
         assert_eq!(
             ft_create.into_args(),
             "FT.CREATE index SCHEMA title TEXT INDEXMISSING"
@@ -434,7 +434,7 @@ mod tests {
         let schema = schema! {
             TEXT_FIELD_NAME => SchemaTextField::new().sortable(Sortable::Yes),
         };
-        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
         assert_eq!(
             ft_create.into_args(),
             "FT.CREATE index SCHEMA title TEXT SORTABLE"
@@ -446,7 +446,7 @@ mod tests {
         let schema = schema! {
             TEXT_FIELD_NAME => SchemaTextField::new().sortable(Sortable::Unf),
         };
-        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
         assert_eq!(
             ft_create.into_args(),
             "FT.CREATE index SCHEMA title TEXT SORTABLE UNF"
@@ -458,7 +458,7 @@ mod tests {
         let schema = schema! {
             TEXT_FIELD_NAME => SchemaTextField::new().no_index(true),
         };
-        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
         assert_eq!(
             ft_create.into_args(),
             "FT.CREATE index SCHEMA title TEXT NOINDEX"
@@ -470,23 +470,29 @@ mod tests {
         let field = SchemaTextField::new()
             .no_stem(true)
             .weight(1.0)
-            .phonetic(Phonetic::DmEn)
+            .phonetic(Phonetic::DmEnglish)
             .with_suffix_trie(true)
             .index_empty(true)
             .alias(CUSTOM_ALIAS)
             .index_missing(true)
             .sortable(Sortable::Unf);
-        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema! {
-            TEXT_FIELD_NAME => field.clone(),
-        });
+        let ft_create = FtCreateCommand::new(
+            INDEX_NAME,
+            schema! {
+                TEXT_FIELD_NAME => field.clone(),
+            },
+        );
         assert_eq!(
             ft_create.into_args(),
             "FT.CREATE index SCHEMA title AS custom_alias TEXT INDEXMISSING NOSTEM WEIGHT 1.0 PHONETIC dm:en WITHSUFFIXTRIE INDEXEMPTY SORTABLE UNF"
         );
         // Index missing and no index are mutually exclusive
-        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema! {
-            TEXT_FIELD_NAME => field.index_missing(false).no_index(true),
-        });
+        let ft_create = FtCreateCommand::new(
+            INDEX_NAME,
+            schema! {
+                TEXT_FIELD_NAME => field.index_missing(false).no_index(true),
+            },
+        );
         assert_eq!(
             ft_create.into_args(),
             "FT.CREATE index SCHEMA title AS custom_alias TEXT NOSTEM WEIGHT 1.0 PHONETIC dm:en WITHSUFFIXTRIE INDEXEMPTY SORTABLE UNF NOINDEX"

--- a/redis/src/commands/search/create/fields.rs
+++ b/redis/src/commands/search/create/fields.rs
@@ -1,0 +1,495 @@
+//! Defines the schema field types used with the FT.CREATE command.
+use crate::{RedisWrite, ToRedisArgs};
+
+/// Field type for schema definition.
+/// More information at: <https://redis.io/docs/latest/commands/ft.create/#required-arguments>
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub enum FieldType {
+    /// Allows full-text search queries against the value in this attribute.
+    Text,
+    /// Allows exact-match queries, such as categories or primary keys, against the value in this attribute.
+    Tag,
+    /// Allows numeric range queries against the value in this attribute.
+    Numeric,
+    /// Allows radius range queries against the value (point) in this attribute.
+    Geo,
+    /// Allows vector queries against the value in this attribute. This requires query dialect 2 or above (introduced in RediSearch v2.4).
+    Vector,
+    /// Allows polygon queries against the value in this attribute.
+    GeoShape,
+}
+
+impl ToRedisArgs for FieldType {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        out.write_arg(match self {
+            Self::Text => b"TEXT",
+            Self::Tag => b"TAG",
+            Self::Numeric => b"NUMERIC",
+            Self::Geo => b"GEO",
+            Self::Vector => b"VECTOR",
+            Self::GeoShape => b"GEOSHAPE",
+        });
+    }
+}
+
+impl FieldType {
+    /// Returns whether the field type is sortable.
+    pub fn is_sortable(&self) -> bool {
+        matches!(self, Self::Text | Self::Tag | Self::Numeric | Self::Geo)
+    }
+}
+
+/// Enumeration for sortable fields
+/// <https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/sorting/>
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum Sortable {
+    /// Apply sortable
+    Yes,
+    /// Apply sortable with un-normalized form
+    Unf,
+}
+
+impl ToRedisArgs for Sortable {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        match self {
+            Self::Yes => out.write_arg(b"SORTABLE"),
+            Self::Unf => {
+                out.write_arg(b"SORTABLE");
+                out.write_arg(b"UNF");
+            }
+        }
+    }
+}
+
+/// Declaring a text attribute as PHONETIC will perform phonetic matching on it in searches by default.
+/// The obligatory argument specifies the phonetic algorithm and language used.
+/// <https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/phonetic_matching/>
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum Phonetic {
+    /// Double metaphone for English
+    DmEn,
+    /// Double metaphone for French
+    DmFr,
+    /// Double metaphone for Portuguese
+    DmPt,
+    /// Double metaphone for Spanish
+    DmEs,
+}
+
+impl ToRedisArgs for Phonetic {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        out.write_arg(match self {
+            Self::DmEn => b"dm:en",
+            Self::DmFr => b"dm:fr",
+            Self::DmPt => b"dm:pt",
+            Self::DmEs => b"dm:es",
+        });
+    }
+}
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub(crate) struct BaseSchemaField {
+    pub field_type: FieldType,
+    pub alias: Option<String>,
+    pub index_missing: bool,
+}
+
+impl BaseSchemaField {
+    pub(crate) fn new(field_type: FieldType) -> Self {
+        Self {
+            field_type,
+            alias: None,
+            index_missing: false,
+        }
+    }
+
+    pub fn alias(mut self, alias: impl Into<String>) -> Self {
+        self.alias = Some(alias.into());
+        self
+    }
+
+    pub fn index_missing(mut self, index_missing: bool) -> Self {
+        self.index_missing = index_missing;
+        self
+    }
+}
+
+impl ToRedisArgs for BaseSchemaField {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        if let Some(alias) = &self.alias {
+            out.write_arg(b"AS");
+            alias.write_redis_args(out);
+        }
+
+        self.field_type.write_redis_args(out);
+
+        if self.index_missing {
+            out.write_arg(b"INDEXMISSING");
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub(crate) struct SchemaCommonField {
+    pub base: BaseSchemaField,
+    pub sortable: Option<Sortable>,
+    pub no_index: bool,
+}
+
+impl SchemaCommonField {
+    pub(crate) fn new(field_type: FieldType) -> Self {
+        Self {
+            base: BaseSchemaField::new(field_type),
+            sortable: None,
+            no_index: false,
+        }
+    }
+
+    pub fn sortable(mut self, sortable: Sortable) -> Self {
+        if self.base.field_type.is_sortable() {
+            self.sortable = Some(sortable);
+        } else {
+            unreachable!("Field type {:?} is not sortable", self.base.field_type);
+        }
+        self
+    }
+
+    pub fn no_index(mut self, no_index: bool) -> Self {
+        self.no_index = no_index;
+        self
+    }
+
+    pub fn alias(mut self, alias: impl Into<String>) -> Self {
+        self.base = self.base.alias(alias);
+        self
+    }
+
+    pub fn index_missing(mut self, index_missing: bool) -> Self {
+        self.base = self.base.index_missing(index_missing);
+        self
+    }
+}
+
+impl ToRedisArgs for SchemaCommonField {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        if let Some(sortable) = &self.sortable {
+            sortable.write_redis_args(out);
+        }
+
+        if self.no_index {
+            out.write_arg(b"NOINDEX");
+        }
+    }
+}
+
+/// Represents a text field in the schema.
+#[must_use = "Text field has no effect unless inserted into a schema"]
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SchemaTextField {
+    pub(crate) common: SchemaCommonField,
+    no_stem: bool,
+    weight: Option<f64>,
+    phonetic: Option<Phonetic>,
+    with_suffix_trie: bool,
+    index_empty: bool,
+}
+
+impl SchemaTextField {
+    /// Create a new TEXT field.
+    pub fn new() -> Self {
+        Self {
+            common: SchemaCommonField::new(FieldType::Text),
+            no_stem: false,
+            weight: None,
+            phonetic: None,
+            with_suffix_trie: false,
+            index_empty: false,
+        }
+    }
+
+    /// Disables stemming when indexing the text field's values. This may be ideal for things like proper names.
+    /// <https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/stemming/>
+    pub fn no_stem(mut self, no_stem: bool) -> Self {
+        self.no_stem = no_stem;
+        self
+    }
+
+    /// Declares the importance of this attribute when calculating result accuracy.
+    /// This is a multiplication factor and defaults to 1 if not specified.
+    pub fn weight(mut self, weight: f64) -> Self {
+        self.weight = Some(weight);
+        self
+    }
+
+    /// Declaring a text attribute as PHONETIC will perform phonetic matching on it in searches by default.
+    /// <https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/phonetic_matching/>
+    pub fn phonetic(mut self, phonetic: Phonetic) -> Self {
+        self.phonetic = Some(phonetic);
+        self
+    }
+
+    /// Keeps a suffix trie with all terms which match the suffix. It is used to optimize contains (foo) and suffix (*foo) queries.
+    /// Otherwise, a brute-force search on the trie is performed. If suffix trie exists for some fields, these queries will be disabled for other fields.
+    pub fn with_suffix_trie(mut self, with_suffix_trie: bool) -> Self {
+        self.with_suffix_trie = with_suffix_trie;
+        self
+    }
+
+    /// Index empty strings. This allows searching for empty values - documents that do not contain a specific field.
+    /// By default, empty strings are not indexed.
+    pub fn index_empty(mut self, index_empty: bool) -> Self {
+        self.index_empty = index_empty;
+        self
+    }
+
+    /// Mark the field as sortable.
+    pub fn sortable(mut self, sortable: Sortable) -> Self {
+        self.common = self.common.sortable(sortable);
+        self
+    }
+
+    /// Mark the field as no index. This means that the field will not be indexed.
+    pub fn no_index(mut self, no_index: bool) -> Self {
+        self.common = self.common.no_index(no_index);
+        self
+    }
+
+    /// Set the alias for the field.
+    pub fn alias(mut self, alias: impl Into<String>) -> Self {
+        self.common = self.common.alias(alias);
+        self
+    }
+
+    /// Set index missing. This allows searching for missing values - documents that do not contain a specific field.
+    pub fn index_missing(mut self, index_missing: bool) -> Self {
+        self.common = self.common.index_missing(index_missing);
+        self
+    }
+}
+
+impl ToRedisArgs for SchemaTextField {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        self.common.base.write_redis_args(out);
+
+        if self.no_stem {
+            out.write_arg(b"NOSTEM");
+        }
+        if let Some(weight) = self.weight {
+            out.write_arg(b"WEIGHT");
+            weight.write_redis_args(out);
+        }
+        if let Some(phonetic) = &self.phonetic {
+            out.write_arg(b"PHONETIC");
+            phonetic.write_redis_args(out);
+        }
+        if self.with_suffix_trie {
+            out.write_arg(b"WITHSUFFIXTRIE");
+        }
+        if self.index_empty {
+            out.write_arg(b"INDEXEMPTY");
+        }
+
+        self.common.write_redis_args(out);
+    }
+}
+
+impl Default for SchemaTextField {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema;
+    use crate::search::FtCreateCommand;
+
+    static INDEX_NAME: &str = "index";
+    static TEXT_FIELD_NAME: &str = "title";
+    static CUSTOM_ALIAS: &str = "custom_alias";
+
+    // ============================================================================
+    // TEXT Field Tests
+    // ============================================================================
+    #[test]
+    fn test_text_field() {
+        let schema = schema! {
+            TEXT_FIELD_NAME => SchemaTextField::new(),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        assert_eq!(ft_create.into_args(), "FT.CREATE index SCHEMA title TEXT");
+    }
+
+    #[test]
+    fn test_text_field_with_nostem() {
+        let schema = schema! {
+            TEXT_FIELD_NAME => SchemaTextField::new().no_stem(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA title TEXT NOSTEM"
+        );
+    }
+
+    #[test]
+    fn test_text_field_with_weight() {
+        let schema = schema! {
+            TEXT_FIELD_NAME => SchemaTextField::new().weight(1.0),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA title TEXT WEIGHT 1.0"
+        );
+    }
+
+    #[test]
+    fn test_text_field_with_phonetic() {
+        let schema = schema! {
+            TEXT_FIELD_NAME => SchemaTextField::new().phonetic(Phonetic::DmEn),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA title TEXT PHONETIC dm:en"
+        );
+    }
+
+    #[test]
+    fn test_text_field_with_withsuffixtrie() {
+        let schema = schema! {
+            TEXT_FIELD_NAME => SchemaTextField::new().with_suffix_trie(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA title TEXT WITHSUFFIXTRIE"
+        );
+    }
+
+    #[test]
+    fn test_text_field_with_indexempty() {
+        let schema = schema! {
+            TEXT_FIELD_NAME => SchemaTextField::new().index_empty(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA title TEXT INDEXEMPTY"
+        );
+    }
+
+    #[test]
+    fn test_text_field_with_alias() {
+        let schema = schema! {
+            TEXT_FIELD_NAME => SchemaTextField::new().alias(CUSTOM_ALIAS),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA title AS custom_alias TEXT"
+        );
+    }
+
+    #[test]
+    fn test_text_field_with_indexmissing() {
+        let schema = schema! {
+            TEXT_FIELD_NAME => SchemaTextField::new().index_missing(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA title TEXT INDEXMISSING"
+        );
+    }
+
+    #[test]
+    fn test_text_field_with_sortable() {
+        let schema = schema! {
+            TEXT_FIELD_NAME => SchemaTextField::new().sortable(Sortable::Yes),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA title TEXT SORTABLE"
+        );
+    }
+
+    #[test]
+    fn test_text_field_with_sortable_unf() {
+        let schema = schema! {
+            TEXT_FIELD_NAME => SchemaTextField::new().sortable(Sortable::Unf),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA title TEXT SORTABLE UNF"
+        );
+    }
+
+    #[test]
+    fn test_text_field_with_noindex() {
+        let schema = schema! {
+            TEXT_FIELD_NAME => SchemaTextField::new().no_index(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA title TEXT NOINDEX"
+        );
+    }
+
+    #[test]
+    fn test_text_field_with_all_options() {
+        let field = SchemaTextField::new()
+            .no_stem(true)
+            .weight(1.0)
+            .phonetic(Phonetic::DmEn)
+            .with_suffix_trie(true)
+            .index_empty(true)
+            .alias(CUSTOM_ALIAS)
+            .index_missing(true)
+            .sortable(Sortable::Unf);
+        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema! {
+            TEXT_FIELD_NAME => field.clone(),
+        });
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA title AS custom_alias TEXT INDEXMISSING NOSTEM WEIGHT 1.0 PHONETIC dm:en WITHSUFFIXTRIE INDEXEMPTY SORTABLE UNF"
+        );
+        // Index missing and no index are mutually exclusive
+        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema! {
+            TEXT_FIELD_NAME => field.index_missing(false).no_index(true),
+        });
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA title AS custom_alias TEXT NOSTEM WEIGHT 1.0 PHONETIC dm:en WITHSUFFIXTRIE INDEXEMPTY SORTABLE UNF NOINDEX"
+        );
+    }
+}

--- a/redis/src/commands/search/create/mod.rs
+++ b/redis/src/commands/search/create/mod.rs
@@ -1,5 +1,225 @@
-//! Types to use with the [FT.CREATE](https://redis.io/docs/latest/commands/ft.create/) command.
-
+//! Provides a type-safe way to generate [FT.CREATE](https://redis.io/docs/latest/commands/ft.create/) commands programmatically.
+//!
+//! The pieces fit together as follows:
+//!
+//! ```text
+//! SchemaTextField (and the other field builders)
+//!       │ into()
+//!       ▼
+//! FieldDefinition
+//!       │ inserted by the schema! macro or by insert()
+//!       ▼
+//! SearchSchema<Empty> ──insert()──> SearchSchema<NonEmpty>
+//!       │
+//!       │ every type along the way implements ToRedisArgs
+//!       ▼
+//! FtCreateCommand<NoSchema> ──schema()──> FtCreateCommand<SearchSchema<NonEmpty>>
+//!       │
+//!       └── into_cmd() yields a redis::Cmd
+//! ```
+//!
+//! # Examples
+//!
+//! ```rust
+//! use redis::{schema, search::*};
+//!
+//! // Build a schema using the schema! macro
+//! let schema = schema! {
+//!     "title" => SchemaTextField::new().weight(2.0),
+//!     "subtitle" => SchemaTextField::new()
+//! };
+//!
+//! // Create an FT.CREATE command
+//! let ft_create = FtCreateCommand::new("index")
+//!     .options(
+//!         CreateOptions::new()
+//!             .on(IndexDataType::Hash)
+//!             .prefix("doc:")
+//!     )
+//!     .schema(schema);
+//! ```
+mod fields;
 mod options;
+mod schema;
 
+pub use fields::*;
 pub use options::*;
+pub use schema::*;
+
+use crate::Cmd;
+
+/// Marker type indicating no schema has been set yet.
+pub struct NoSchema;
+
+/// FT.CREATE command builder.
+///
+/// Uses the typestate pattern to enforce at compile time that a schema
+/// is set before the command can be built. The schema state is encoded
+/// directly in the generic parameter: before a schema is set the builder
+/// holds a [`NoSchema`] marker, and after the schema is set it holds the
+/// [`SearchSchema<NonEmpty>`] itself.
+///
+/// # Type States
+/// - `FtCreateCommand<NoSchema>` - No schema set yet, `into_cmd()` not available
+/// - `FtCreateCommand<SearchSchema<NonEmpty>>` - Schema set, `into_cmd()` available
+///
+/// # Example
+/// ```rust
+/// use redis::{schema, search::*};
+///
+/// let cmd = FtCreateCommand::new("my_index")
+///     .options(CreateOptions::new().on(IndexDataType::Hash))
+///     .schema(schema! { "title" => SchemaTextField::new() })
+///     .into_cmd();
+/// ```
+pub struct FtCreateCommand<S = NoSchema> {
+    index: String,
+    options: CreateOptions,
+    schema: S,
+}
+
+impl FtCreateCommand<NoSchema> {
+    /// Create a new FT.CREATE command for the given index
+    pub fn new<S: Into<String>>(index: S) -> Self {
+        Self {
+            index: index.into(),
+            options: CreateOptions::default(),
+            schema: NoSchema,
+        }
+    }
+
+    /// Set the options for the command
+    pub fn options(mut self, options: CreateOptions) -> Self {
+        self.options = options;
+        self
+    }
+
+    /// Set the schema for the command.
+    ///
+    /// The schema must be non-empty (contain at least one field).
+    /// This is enforced at compile time by the type system.
+    ///
+    /// This transitions the builder from `FtCreateCommand<NoSchema>` to
+    /// `FtCreateCommand<SearchSchema<NonEmpty>>`, making `into_cmd()` available.
+    pub fn schema(self, schema: SearchSchema<NonEmpty>) -> FtCreateCommand<SearchSchema<NonEmpty>> {
+        FtCreateCommand {
+            index: self.index,
+            options: self.options,
+            schema,
+        }
+    }
+}
+
+impl FtCreateCommand<SearchSchema<NonEmpty>> {
+    /// Set the options for the command
+    pub fn options(mut self, options: CreateOptions) -> Self {
+        self.options = options;
+        self
+    }
+
+    /// Consume the builder and convert it into a `redis::Cmd`.
+    pub fn into_cmd(self) -> Cmd {
+        let mut cmd = crate::cmd("FT.CREATE");
+        cmd.arg(&self.index);
+        cmd.arg(&self.options);
+        cmd.arg("SCHEMA");
+        cmd.arg(self.schema);
+
+        cmd
+    }
+
+    /// Consume the builder and convert it into a string for testing purposes.
+    #[cfg(test)]
+    pub(crate) fn into_args(self) -> String {
+        use crate::cmd::Arg;
+        self.into_cmd()
+            .args_iter()
+            .map(|arg| match arg {
+                Arg::Simple(bytes) => bytes.to_vec(),
+                Arg::Cursor => panic!("Cursor not expected in FT.CREATE command"),
+            })
+            .map(|arg| String::from_utf8_lossy(&arg).to_string())
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema;
+
+    static INDEX_NAME: &str = "index";
+    static TEXT_FIELD_NAME: &str = "title";
+
+    #[test]
+    fn test_empty_index_name() {
+        // Empty index names are valid in Redis
+        let ft_create = FtCreateCommand::new("").schema(schema! {
+            TEXT_FIELD_NAME => SchemaTextField::new()
+        });
+        assert_eq!(ft_create.into_args(), "FT.CREATE  SCHEMA title TEXT");
+    }
+
+    #[test]
+    fn test_options_can_be_set_after_the_schema() {
+        let ft_create = FtCreateCommand::new(INDEX_NAME)
+            .schema(schema! {
+                TEXT_FIELD_NAME => SchemaTextField::new()
+            })
+            .options(CreateOptions::new().on(IndexDataType::Hash));
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index ON HASH SCHEMA title TEXT"
+        );
+    }
+
+    // ============================================================================
+    // Website examples
+    // <https://redis.io/docs/latest/commands/ft.create/#examples>
+    // ============================================================================
+    #[test]
+    fn test_index_with_filter() {
+        // In this example, keys for author data use the key pattern author:details:<id> while keys for book data use the pattern book:details:<id>.
+
+        /*
+        Index authors whose names start with G.
+        FT.CREATE g-authors-idx ON HASH PREFIX 1 author:details FILTER 'startswith(@name, "G")' SCHEMA name TEXT
+        */
+        let ft_create = FtCreateCommand::new("g-authors-idx")
+            .options(
+                CreateOptions::new()
+                    .on(IndexDataType::Hash)
+                    .prefix("author:details")
+                    .filter("startswith(@name, \"G\")"),
+            )
+            .schema(schema! {
+                "name" =>  SchemaTextField::new(),
+            });
+
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE g-authors-idx ON HASH PREFIX 1 author:details FILTER 'startswith(@name, \"G\")' SCHEMA name TEXT"
+        );
+
+        /*
+        Index only books that have a subtitle.
+        FT.CREATE subtitled-books-idx ON HASH PREFIX 1 book:details FILTER '@subtitle != ""' SCHEMA title TEXT
+        */
+        let ft_create = FtCreateCommand::new("subtitled-books-idx")
+            .options(
+                CreateOptions::new()
+                    .on(IndexDataType::Hash)
+                    .prefix("book:details")
+                    .filter("@subtitle != \"\""),
+            )
+            .schema(schema! {
+                "title" =>  SchemaTextField::new(),
+            });
+
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE subtitled-books-idx ON HASH PREFIX 1 book:details FILTER '@subtitle != \"\"' SCHEMA title TEXT"
+        );
+    }
+}

--- a/redis/src/commands/search/create/mod.rs
+++ b/redis/src/commands/search/create/mod.rs
@@ -9,11 +9,11 @@
 //! FieldDefinition
 //!       │ inserted by the schema! macro or by insert()
 //!       ▼
-//! SearchSchema<Empty> ──insert()──> SearchSchema<NonEmpty>
+//! SearchSchema (always holds at least one field)
 //!       │
 //!       │ every type along the way implements ToRedisArgs
 //!       ▼
-//! FtCreateCommand<NoSchema> ──schema()──> FtCreateCommand<SearchSchema<NonEmpty>>
+//! FtCreateCommand
 //!       │
 //!       └── into_cmd() yields a redis::Cmd
 //! ```
@@ -30,13 +30,12 @@
 //! };
 //!
 //! // Create an FT.CREATE command
-//! let ft_create = FtCreateCommand::new("index")
+//! let ft_create = FtCreateCommand::new("index", schema)
 //!     .options(
 //!         CreateOptions::new()
 //!             .on(IndexDataType::Hash)
 //!             .prefix("doc:")
-//!     )
-//!     .schema(schema);
+//!     );
 //! ```
 mod fields;
 mod options;
@@ -48,69 +47,38 @@ pub use schema::*;
 
 use crate::Cmd;
 
-/// Marker type indicating no schema has been set yet.
-pub struct NoSchema;
-
 /// FT.CREATE command builder.
 ///
-/// Uses the typestate pattern to enforce at compile time that a schema
-/// is set before the command can be built. The schema state is encoded
-/// directly in the generic parameter: before a schema is set the builder
-/// holds a [`NoSchema`] marker, and after the schema is set it holds the
-/// [`SearchSchema<NonEmpty>`] itself.
-///
-/// # Type States
-/// - `FtCreateCommand<NoSchema>` - No schema set yet, `into_cmd()` not available
-/// - `FtCreateCommand<SearchSchema<NonEmpty>>` - Schema set, `into_cmd()` available
+/// The schema is required by `FT.CREATE`, so [`FtCreateCommand::new`] takes it
+/// as a mandatory argument rather than exposing it through a builder method.
+/// Together with [`SearchSchema`] requiring at least one field, this makes the
+/// server's requirements compile-time guarantees: the schema is always present
+/// and never empty.
 ///
 /// # Example
 /// ```rust
 /// use redis::{schema, search::*};
 ///
-/// let cmd = FtCreateCommand::new("my_index")
+/// let cmd = FtCreateCommand::new("my_index", schema! { "title" => SchemaTextField::new() })
 ///     .options(CreateOptions::new().on(IndexDataType::Hash))
-///     .schema(schema! { "title" => SchemaTextField::new() })
 ///     .into_cmd();
 /// ```
-pub struct FtCreateCommand<S = NoSchema> {
+pub struct FtCreateCommand {
     index: String,
     options: CreateOptions,
-    schema: S,
+    schema: SearchSchema,
 }
 
-impl FtCreateCommand<NoSchema> {
-    /// Create a new FT.CREATE command for the given index
-    pub fn new<S: Into<String>>(index: S) -> Self {
+impl FtCreateCommand {
+    /// Create a new FT.CREATE command for the given index and schema.
+    pub fn new<S: Into<String>>(index: S, schema: SearchSchema) -> Self {
         Self {
             index: index.into(),
             options: CreateOptions::default(),
-            schema: NoSchema,
-        }
-    }
-
-    /// Set the options for the command
-    pub fn options(mut self, options: CreateOptions) -> Self {
-        self.options = options;
-        self
-    }
-
-    /// Set the schema for the command.
-    ///
-    /// The schema must be non-empty (contain at least one field).
-    /// This is enforced at compile time by the type system.
-    ///
-    /// This transitions the builder from `FtCreateCommand<NoSchema>` to
-    /// `FtCreateCommand<SearchSchema<NonEmpty>>`, making `into_cmd()` available.
-    pub fn schema(self, schema: SearchSchema<NonEmpty>) -> FtCreateCommand<SearchSchema<NonEmpty>> {
-        FtCreateCommand {
-            index: self.index,
-            options: self.options,
             schema,
         }
     }
-}
 
-impl FtCreateCommand<SearchSchema<NonEmpty>> {
     /// Set the options for the command
     pub fn options(mut self, options: CreateOptions) -> Self {
         self.options = options;
@@ -155,19 +123,24 @@ mod tests {
     #[test]
     fn test_empty_index_name() {
         // Empty index names are valid in Redis
-        let ft_create = FtCreateCommand::new("").schema(schema! {
-            TEXT_FIELD_NAME => SchemaTextField::new()
-        });
+        let ft_create = FtCreateCommand::new(
+            "",
+            schema! {
+                TEXT_FIELD_NAME => SchemaTextField::new()
+            },
+        );
         assert_eq!(ft_create.into_args(), "FT.CREATE  SCHEMA title TEXT");
     }
 
     #[test]
-    fn test_options_can_be_set_after_the_schema() {
-        let ft_create = FtCreateCommand::new(INDEX_NAME)
-            .schema(schema! {
+    fn test_options_are_emitted_before_the_schema() {
+        let ft_create = FtCreateCommand::new(
+            INDEX_NAME,
+            schema! {
                 TEXT_FIELD_NAME => SchemaTextField::new()
-            })
-            .options(CreateOptions::new().on(IndexDataType::Hash));
+            },
+        )
+        .options(CreateOptions::new().on(IndexDataType::Hash));
         assert_eq!(
             ft_create.into_args(),
             "FT.CREATE index ON HASH SCHEMA title TEXT"
@@ -186,16 +159,18 @@ mod tests {
         Index authors whose names start with G.
         FT.CREATE g-authors-idx ON HASH PREFIX 1 author:details FILTER 'startswith(@name, "G")' SCHEMA name TEXT
         */
-        let ft_create = FtCreateCommand::new("g-authors-idx")
-            .options(
-                CreateOptions::new()
-                    .on(IndexDataType::Hash)
-                    .prefix("author:details")
-                    .filter("startswith(@name, \"G\")"),
-            )
-            .schema(schema! {
+        let ft_create = FtCreateCommand::new(
+            "g-authors-idx",
+            schema! {
                 "name" =>  SchemaTextField::new(),
-            });
+            },
+        )
+        .options(
+            CreateOptions::new()
+                .on(IndexDataType::Hash)
+                .prefix("author:details")
+                .filter("startswith(@name, \"G\")"),
+        );
 
         assert_eq!(
             ft_create.into_args(),
@@ -206,16 +181,18 @@ mod tests {
         Index only books that have a subtitle.
         FT.CREATE subtitled-books-idx ON HASH PREFIX 1 book:details FILTER '@subtitle != ""' SCHEMA title TEXT
         */
-        let ft_create = FtCreateCommand::new("subtitled-books-idx")
-            .options(
-                CreateOptions::new()
-                    .on(IndexDataType::Hash)
-                    .prefix("book:details")
-                    .filter("@subtitle != \"\""),
-            )
-            .schema(schema! {
+        let ft_create = FtCreateCommand::new(
+            "subtitled-books-idx",
+            schema! {
                 "title" =>  SchemaTextField::new(),
-            });
+            },
+        )
+        .options(
+            CreateOptions::new()
+                .on(IndexDataType::Hash)
+                .prefix("book:details")
+                .filter("@subtitle != \"\""),
+        );
 
         assert_eq!(
             ft_create.into_args(),

--- a/redis/src/commands/search/create/schema.rs
+++ b/redis/src/commands/search/create/schema.rs
@@ -1,7 +1,6 @@
 //! Defines the schema passed to the FT.CREATE command.
 use super::fields::SchemaTextField;
 use crate::{RedisWrite, ToRedisArgs};
-use std::marker::PhantomData;
 
 /// Field definition for schema
 #[derive(Debug, Clone)]
@@ -28,20 +27,11 @@ impl From<SchemaTextField> for FieldDefinition {
     }
 }
 
-/// Marker type indicating an empty schema (no fields added yet).
-pub struct Empty;
-
-/// Marker type indicating a non-empty schema (at least one field added).
-pub struct NonEmpty;
-
 /// The search schema declaring which fields to index.
 ///
-/// Uses the typestate pattern to enforce at compile time that a schema
-/// has at least one field before it can be used with a command.
-///
-/// # Type States
-/// - `SearchSchema<Empty>` - No fields added yet, cannot be used with commands
-/// - `SearchSchema<NonEmpty>` - At least one field added, can be used with commands
+/// A schema must contain at least one field.
+/// [`SearchSchema::new`] takes the first field, so an empty schema cannot be constructed.
+/// This is required by the server - `FT.CREATE` rejects a `SCHEMA` with no fields.
 ///
 /// # Example
 /// ```rust
@@ -54,49 +44,23 @@ pub struct NonEmpty;
 /// };
 ///
 /// // Using the builder pattern
-/// let schema = SearchSchema::new()
-///     .insert("title", SchemaTextField::new())
+/// let schema = SearchSchema::new("title", SchemaTextField::new())
 ///     .insert("subtitle", SchemaTextField::new());
 /// ```
 #[must_use = "Schema has no effect unless passed to a command"]
 #[derive(Debug, Clone)]
-pub struct SearchSchema<State = Empty> {
+pub struct SearchSchema {
     fields: Vec<(String, FieldDefinition)>,
-    _state: PhantomData<State>,
 }
 
-impl SearchSchema<Empty> {
-    /// Create a new empty schema.
-    pub fn new() -> Self {
+impl SearchSchema {
+    /// Create a new schema with a field.
+    pub fn new<K: Into<String>, V: Into<FieldDefinition>>(key: K, value: V) -> Self {
         Self {
-            fields: Vec::new(),
-            _state: PhantomData,
+            fields: vec![(key.into(), value.into())],
         }
     }
 
-    /// Insert the first field into the schema.
-    ///
-    /// This transitions the schema from `Empty` to `NonEmpty` state.
-    pub fn insert<K: Into<String>, V: Into<FieldDefinition>>(
-        mut self,
-        key: K,
-        value: V,
-    ) -> SearchSchema<NonEmpty> {
-        self.fields.push((key.into(), value.into()));
-        SearchSchema {
-            fields: self.fields,
-            _state: PhantomData,
-        }
-    }
-}
-
-impl Default for SearchSchema<Empty> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl SearchSchema<NonEmpty> {
     /// Insert an additional field into the schema.
     pub fn insert<K: Into<String>, V: Into<FieldDefinition>>(mut self, key: K, value: V) -> Self {
         self.fields.push((key.into(), value.into()));
@@ -104,7 +68,7 @@ impl SearchSchema<NonEmpty> {
     }
 }
 
-impl ToRedisArgs for SearchSchema<NonEmpty> {
+impl ToRedisArgs for SearchSchema {
     fn write_redis_args<W>(&self, out: &mut W)
     where
         W: ?Sized + RedisWrite,
@@ -116,7 +80,7 @@ impl ToRedisArgs for SearchSchema<NonEmpty> {
     }
 }
 
-/// Creates a non-empty [`SearchSchema`].
+/// Creates a [`SearchSchema`].
 ///
 /// This macro offers a concise syntax for defining schemas and guarantees
 /// at compile time that at least one field is specified. Empty schemas are
@@ -134,12 +98,13 @@ impl ToRedisArgs for SearchSchema<NonEmpty> {
 /// ```
 #[macro_export]
 macro_rules! schema {
-    // The `+` repetition requires at least one field - empty invocation won't match
-    ($($key:expr => $value:expr),+ $(,)?) => {{
-        $crate::search::SearchSchema::new()
+    // The first field is matched outside the repetition so it can be passed to `new`,
+    // which is also what makes an empty invocation fail to match.
+    ($first_key:expr => $first_value:expr $(, $key:expr => $value:expr)* $(,)?) => {{
+        $crate::search::SearchSchema::new($first_key, $first_value)
             $(
                 .insert($key, $value)
-            )+
+            )*
     }};
 }
 
@@ -153,11 +118,10 @@ mod tests {
 
     #[test]
     fn test_multiple_fields() {
-        let schema = SearchSchema::new()
-            .insert(TEXT_FIELD_NAME, SchemaTextField::new().weight(2.0))
+        let schema = SearchSchema::new(TEXT_FIELD_NAME, SchemaTextField::new().weight(2.0))
             .insert("subtitle", SchemaTextField::new());
 
-        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
         assert_eq!(
             ft_create.into_args(),
             "FT.CREATE index SCHEMA title TEXT WEIGHT 2.0 subtitle TEXT"
@@ -166,13 +130,16 @@ mod tests {
 
     #[test]
     fn test_macro_and_builder_produce_the_same_schema() {
-        let from_macro = FtCreateCommand::new(INDEX_NAME).schema(schema! {
-            TEXT_FIELD_NAME => SchemaTextField::new().weight(2.0),
-            "subtitle" => SchemaTextField::new(),
-        });
-        let from_builder = FtCreateCommand::new(INDEX_NAME).schema(
-            SearchSchema::new()
-                .insert(TEXT_FIELD_NAME, SchemaTextField::new().weight(2.0))
+        let from_macro = FtCreateCommand::new(
+            INDEX_NAME,
+            schema! {
+                TEXT_FIELD_NAME => SchemaTextField::new().weight(2.0),
+                "subtitle" => SchemaTextField::new(),
+            },
+        );
+        let from_builder = FtCreateCommand::new(
+            INDEX_NAME,
+            SearchSchema::new(TEXT_FIELD_NAME, SchemaTextField::new().weight(2.0))
                 .insert("subtitle", SchemaTextField::new()),
         );
 
@@ -181,19 +148,36 @@ mod tests {
 
     #[test]
     fn test_macro_accepts_a_single_field_without_a_trailing_comma() {
-        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema! {
-            TEXT_FIELD_NAME => SchemaTextField::new()
-        });
+        let ft_create = FtCreateCommand::new(
+            INDEX_NAME,
+            schema! {
+                TEXT_FIELD_NAME => SchemaTextField::new()
+            },
+        );
+        assert_eq!(ft_create.into_args(), "FT.CREATE index SCHEMA title TEXT");
+    }
+
+    #[test]
+    fn test_macro_accepts_a_single_field_with_a_trailing_comma() {
+        let ft_create = FtCreateCommand::new(
+            INDEX_NAME,
+            schema! {
+                TEXT_FIELD_NAME => SchemaTextField::new(),
+            },
+        );
         assert_eq!(ft_create.into_args(), "FT.CREATE index SCHEMA title TEXT");
     }
 
     /// The same attribute may be indexed more than once under different aliases.
     #[test]
     fn test_the_same_field_name_can_be_inserted_twice() {
-        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema! {
-            "sku" => SchemaTextField::new().alias("sku_text"),
-            "sku" => SchemaTextField::new().alias("sku_other"),
-        });
+        let ft_create = FtCreateCommand::new(
+            INDEX_NAME,
+            schema! {
+                "sku" => SchemaTextField::new().alias("sku_text"),
+                "sku" => SchemaTextField::new().alias("sku_other"),
+            },
+        );
         assert_eq!(
             ft_create.into_args(),
             "FT.CREATE index SCHEMA sku AS sku_text TEXT sku AS sku_other TEXT"

--- a/redis/src/commands/search/create/schema.rs
+++ b/redis/src/commands/search/create/schema.rs
@@ -1,0 +1,202 @@
+//! Defines the schema passed to the FT.CREATE command.
+use super::fields::SchemaTextField;
+use crate::{RedisWrite, ToRedisArgs};
+use std::marker::PhantomData;
+
+/// Field definition for schema
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum FieldDefinition {
+    /// Text field
+    Text(SchemaTextField),
+}
+
+impl ToRedisArgs for FieldDefinition {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        match self {
+            Self::Text(tf) => tf.write_redis_args(out),
+        }
+    }
+}
+
+impl From<SchemaTextField> for FieldDefinition {
+    fn from(field: SchemaTextField) -> Self {
+        Self::Text(field)
+    }
+}
+
+/// Marker type indicating an empty schema (no fields added yet).
+pub struct Empty;
+
+/// Marker type indicating a non-empty schema (at least one field added).
+pub struct NonEmpty;
+
+/// The search schema declaring which fields to index.
+///
+/// Uses the typestate pattern to enforce at compile time that a schema
+/// has at least one field before it can be used with a command.
+///
+/// # Type States
+/// - `SearchSchema<Empty>` - No fields added yet, cannot be used with commands
+/// - `SearchSchema<NonEmpty>` - At least one field added, can be used with commands
+///
+/// # Example
+/// ```rust
+/// use redis::{schema, search::*};
+///
+/// // Using the macro (recommended)
+/// let schema = schema! {
+///     "title" => SchemaTextField::new(),
+///     "subtitle" => SchemaTextField::new()
+/// };
+///
+/// // Using the builder pattern
+/// let schema = SearchSchema::new()
+///     .insert("title", SchemaTextField::new())
+///     .insert("subtitle", SchemaTextField::new());
+/// ```
+#[must_use = "Schema has no effect unless passed to a command"]
+#[derive(Debug, Clone)]
+pub struct SearchSchema<State = Empty> {
+    fields: Vec<(String, FieldDefinition)>,
+    _state: PhantomData<State>,
+}
+
+impl SearchSchema<Empty> {
+    /// Create a new empty schema.
+    pub fn new() -> Self {
+        Self {
+            fields: Vec::new(),
+            _state: PhantomData,
+        }
+    }
+
+    /// Insert the first field into the schema.
+    ///
+    /// This transitions the schema from `Empty` to `NonEmpty` state.
+    pub fn insert<K: Into<String>, V: Into<FieldDefinition>>(
+        mut self,
+        key: K,
+        value: V,
+    ) -> SearchSchema<NonEmpty> {
+        self.fields.push((key.into(), value.into()));
+        SearchSchema {
+            fields: self.fields,
+            _state: PhantomData,
+        }
+    }
+}
+
+impl Default for SearchSchema<Empty> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SearchSchema<NonEmpty> {
+    /// Insert an additional field into the schema.
+    pub fn insert<K: Into<String>, V: Into<FieldDefinition>>(mut self, key: K, value: V) -> Self {
+        self.fields.push((key.into(), value.into()));
+        self
+    }
+}
+
+impl ToRedisArgs for SearchSchema<NonEmpty> {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        for (key, field) in &self.fields {
+            key.write_redis_args(out);
+            field.write_redis_args(out);
+        }
+    }
+}
+
+/// Creates a non-empty [`SearchSchema`].
+///
+/// This macro offers a concise syntax for defining schemas and guarantees
+/// at compile time that at least one field is specified. Empty schemas are
+/// not allowed, and invoking the macro with no fields (`schema! {}`) will
+/// result in a compile-time error.
+///
+/// # Example
+/// ```rust
+/// use redis::{schema, search::*};
+///
+/// let schema = schema! {
+///     "title" => SchemaTextField::new().weight(2.0),
+///     "subtitle" => SchemaTextField::new(),
+/// };
+/// ```
+#[macro_export]
+macro_rules! schema {
+    // The `+` repetition requires at least one field - empty invocation won't match
+    ($($key:expr => $value:expr),+ $(,)?) => {{
+        $crate::search::SearchSchema::new()
+            $(
+                .insert($key, $value)
+            )+
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::search::FtCreateCommand;
+
+    static INDEX_NAME: &str = "index";
+    static TEXT_FIELD_NAME: &str = "title";
+
+    #[test]
+    fn test_multiple_fields() {
+        let schema = SearchSchema::new()
+            .insert(TEXT_FIELD_NAME, SchemaTextField::new().weight(2.0))
+            .insert("subtitle", SchemaTextField::new());
+
+        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA title TEXT WEIGHT 2.0 subtitle TEXT"
+        );
+    }
+
+    #[test]
+    fn test_macro_and_builder_produce_the_same_schema() {
+        let from_macro = FtCreateCommand::new(INDEX_NAME).schema(schema! {
+            TEXT_FIELD_NAME => SchemaTextField::new().weight(2.0),
+            "subtitle" => SchemaTextField::new(),
+        });
+        let from_builder = FtCreateCommand::new(INDEX_NAME).schema(
+            SearchSchema::new()
+                .insert(TEXT_FIELD_NAME, SchemaTextField::new().weight(2.0))
+                .insert("subtitle", SchemaTextField::new()),
+        );
+
+        assert_eq!(from_macro.into_args(), from_builder.into_args());
+    }
+
+    #[test]
+    fn test_macro_accepts_a_single_field_without_a_trailing_comma() {
+        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema! {
+            TEXT_FIELD_NAME => SchemaTextField::new()
+        });
+        assert_eq!(ft_create.into_args(), "FT.CREATE index SCHEMA title TEXT");
+    }
+
+    /// The same attribute may be indexed more than once under different aliases.
+    #[test]
+    fn test_the_same_field_name_can_be_inserted_twice() {
+        let ft_create = FtCreateCommand::new(INDEX_NAME).schema(schema! {
+            "sku" => SchemaTextField::new().alias("sku_text"),
+            "sku" => SchemaTextField::new().alias("sku_other"),
+        });
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA sku AS sku_text TEXT sku AS sku_other TEXT"
+        );
+    }
+}


### PR DESCRIPTION
# Add the `FT.CREATE` command builder and index schema

## Summary

Adds `FtCreateCommand`, `SearchSchema`, the `schema!` macro, the `TEXT` field type and the `ft_create` command. 
Together with the options from the previous part, this makes `FT.CREATE` usable end to end.
`FtCreateCommand` and `SearchSchema` both use the typestate pattern, so a command cannot be built without a schema and a schema cannot be empty both are compile-time errors rather than server-side ones.

This is **part 2 of the series that supersedes #2015**, where the design is described in full.

## Changes relative to #2015

Some review comments from #2015 were addressed here rather than carried over:

| Change | Why |
|---|---|
| `RediSearchSchema` renamed to `SearchSchema` | It was planned for a rename in the future anyway. |
| `FieldDefinition::JustType` and `From<FieldType> for FieldDefinition` removed | They gave every field type a second serialization path. Fields are now always built through their own builder, e.g. `SchemaTextField::new()` |
| `schema!` uses `+` repetition | Replaces the first-element-plus-`*` form; the non-empty guarantee is unchanged |

Dropping `JustType` also removes a case that type-checked but could not work. `FieldType::Vector` has no valid zero-argument form, so `schema! { "v" => FieldType::Vector }` used to serialize to a bare `VECTOR` token that the server rejects.

Everything else is a direct extraction from `types.rs` and `command.rs`, including all comments. The doc examples use `TEXT` only, since `SchemaNumericField` and `SchemaTagField` do not exist yet; they will be restored to the #2015 wording in the part that adds them.