### PR TITLE
fix: use a dedicated cached connection per candidate

### DIFF
--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -1209,15 +1209,17 @@ impl SentinelClient {
             "Couldn't open connection to a sentinel node.",
         )));
 
-        for connection_info in &self.sentinel.sentinels_connection_info {
+        for (connection_info, cached_connection) in self
+            .sentinel
+            .sentinels_connection_info
+            .iter()
+            .zip(self.sentinel.connections_cache.iter_mut())
+        {
             if let Ok(client) = Client::open(connection_info.clone()) {
                 match try_single_sentinel::<Role>(
                     cmd::cmd("ROLE"),
                     connection_info,
-                    self.sentinel
-                        .connections_cache
-                        .first_mut()
-                        .unwrap_or(&mut None),
+                    cached_connection,
                 ) {
                     Ok(Role::Sentinel { .. }) => {
                         return Ok(client);
@@ -1288,15 +1290,17 @@ impl SentinelClient {
             "Couldn't open connection to a sentinel node.",
         )));
 
-        for connection_info in &self.sentinel.sentinels_connection_info {
+        for (connection_info, cached_connection) in self
+            .sentinel
+            .sentinels_connection_info
+            .iter()
+            .zip(self.sentinel.async_connections_cache.iter_mut())
+        {
             if let Ok(client) = Client::open(connection_info.clone()) {
                 match async_try_single_sentinel::<Role>(
                     cmd::cmd("ROLE"),
                     connection_info,
-                    self.sentinel
-                        .async_connections_cache
-                        .first_mut()
-                        .unwrap_or(&mut None),
+                    cached_connection,
                 )
                 .await
                 {

--- a/redis/tests/regression_sentinel_candidate_cache.rs
+++ b/redis/tests/regression_sentinel_candidate_cache.rs
@@ -1,0 +1,56 @@
+#![cfg(feature = "sentinel")]
+
+mod support;
+
+use redis::sentinel::{SentinelClient, SentinelServerType};
+use test_macros::async_test;
+
+use crate::support::TestSentinelContext;
+
+fn client_with_non_sentinel_first(context: &TestSentinelContext) -> (SentinelClient, redis::ConnectionInfo) {
+    let non_sentinel = context.cluster.servers[0].connection_info();
+    let healthy_sentinel = context.sentinels_connection_info()[0].clone();
+    let client = SentinelClient::build(
+        vec![non_sentinel, healthy_sentinel.clone()],
+        String::from("master1"),
+        Some(context.sentinel_node_connection_info()),
+        SentinelServerType::Master,
+    )
+    .unwrap();
+
+    (client, healthy_sentinel)
+}
+
+#[test]
+fn sentinel_candidate_uses_matching_cached_connection() {
+    let context = TestSentinelContext::new(2, 3, 3);
+    let (mut client, healthy_sentinel) = client_with_non_sentinel_first(&context);
+
+    let selected = client
+        .get_sentinel_client()
+        .expect("the second configured candidate is a valid Sentinel");
+
+    assert_eq!(
+        selected.get_connection_info().addr(),
+        healthy_sentinel.addr(),
+        "candidate validation must use the cache entry belonging to that candidate"
+    );
+}
+
+#[cfg(feature = "aio")]
+#[async_test]
+async fn async_sentinel_candidate_uses_matching_cached_connection() {
+    let context = TestSentinelContext::new(2, 3, 3);
+    let (mut client, healthy_sentinel) = client_with_non_sentinel_first(&context);
+
+    let selected = client
+        .async_get_sentinel_client()
+        .await
+        .expect("the second configured candidate is a valid Sentinel");
+
+    assert_eq!(
+        selected.get_connection_info().addr(),
+        healthy_sentinel.addr(),
+        "async candidate validation must use the cache entry belonging to that candidate"
+    );
+}


### PR DESCRIPTION
## Summary

Use each Sentinel candidate's matching cached connection when validating candidates with `ROLE`.

Previously, both the synchronous and asynchronous `get_sentinel_client` paths always used the first cache entry while iterating over every configured Sentinel address. If the first reachable endpoint was not a Sentinel, later iterations reused that same connection instead of contacting subsequent candidates, preventing failover to a healthy Sentinel.

This change zips configured Sentinel addresses with their corresponding connection-cache entries, so each candidate is independently connected and validated in both sync and async paths.

## Testing

- `cargo check -p redis --features cluster-async,tokio-comp --lib`