### PR TITLE
Add the remaining simple field types for `FT.CREATE` [3/8]

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -2973,7 +2973,8 @@ implement_commands! {
     /// # let mut con = client.get_connection()?;
     /// let schema = schema! {
     ///     "title" => SchemaTextField::new().weight(2.0),
-    ///     "subtitle" => SchemaTextField::new()
+    ///     "price" => SchemaNumericField::new(),
+    ///     "condition" => SchemaTagField::new().separator(',')
     /// };
     ///
     /// let options = CreateOptions::new()

--- a/redis/src/commands/search/create/fields.rs
+++ b/redis/src/commands/search/create/fields.rs
@@ -323,6 +323,324 @@ impl Default for SchemaTextField {
     }
 }
 
+/// Represents a tag field in the schema.
+#[must_use = "Tag field has no effect unless inserted into a schema"]
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SchemaTagField {
+    pub(crate) common: SchemaCommonField,
+    separator: Option<char>,
+    case_sensitive: bool,
+    with_suffix_trie: bool,
+    index_empty: bool,
+}
+
+impl SchemaTagField {
+    /// Create a new TAG field.
+    pub fn new() -> Self {
+        Self {
+            common: SchemaCommonField::new(FieldType::Tag),
+            separator: None,
+            case_sensitive: false,
+            with_suffix_trie: false,
+            index_empty: false,
+        }
+    }
+
+    /// Indicates how the text contained in the attribute is to be split into individual tags.
+    /// The value must be a single character.
+    /// The default is ','.
+    pub fn separator(mut self, separator: char) -> Self {
+        self.separator = Some(separator);
+        self
+    }
+
+    /// Keeps the original letter cases of the tags. If not specified, the characters are converted to lowercase.
+    pub fn case_sensitive(mut self, case_sensitive: bool) -> Self {
+        self.case_sensitive = case_sensitive;
+        self
+    }
+
+    /// Keeps a suffix trie with all terms which match the suffix. It is used to optimize contains (foo) and suffix (*foo) queries.
+    /// Otherwise, a brute-force search on the trie is performed. If suffix trie exists for some fields, these queries will be disabled for other fields.
+    pub fn with_suffix_trie(mut self, with_suffix_trie: bool) -> Self {
+        self.with_suffix_trie = with_suffix_trie;
+        self
+    }
+
+    /// Index empty strings. This allows searching for empty values - documents that do not contain a specific field. By default, empty strings are not indexed.
+    pub fn index_empty(mut self, index_empty: bool) -> Self {
+        self.index_empty = index_empty;
+        self
+    }
+
+    /// Mark the field as sortable.
+    pub fn sortable(mut self, sortable: Sortable) -> Self {
+        self.common = self.common.sortable(sortable);
+        self
+    }
+
+    /// Mark the field as no index. This means that the field will not be indexed.
+    pub fn no_index(mut self, no_index: bool) -> Self {
+        self.common = self.common.no_index(no_index);
+        self
+    }
+
+    /// Set the alias for the field.
+    pub fn alias(mut self, alias: impl Into<String>) -> Self {
+        self.common = self.common.alias(alias);
+        self
+    }
+
+    /// Set index missing. This allows searching for missing values - documents that do not contain a specific field.
+    pub fn index_missing(mut self, index_missing: bool) -> Self {
+        self.common = self.common.index_missing(index_missing);
+        self
+    }
+}
+
+impl ToRedisArgs for SchemaTagField {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        self.common.base.write_redis_args(out);
+
+        if let Some(separator) = self.separator {
+            out.write_arg(b"SEPARATOR");
+            out.write_arg(separator.to_string().as_bytes());
+        }
+        if self.case_sensitive {
+            out.write_arg(b"CASESENSITIVE");
+        }
+        if self.with_suffix_trie {
+            out.write_arg(b"WITHSUFFIXTRIE");
+        }
+        if self.index_empty {
+            out.write_arg(b"INDEXEMPTY");
+        }
+
+        self.common.write_redis_args(out);
+    }
+}
+
+impl Default for SchemaTagField {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Represents a numeric field in the schema.
+#[must_use = "Numeric field has no effect unless inserted into a schema"]
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SchemaNumericField {
+    pub(crate) common: SchemaCommonField,
+}
+
+impl SchemaNumericField {
+    /// Create a new NUMERIC field.
+    pub fn new() -> Self {
+        Self {
+            common: SchemaCommonField::new(FieldType::Numeric),
+        }
+    }
+
+    /// Mark the field as sortable.
+    pub fn sortable(mut self, sortable: Sortable) -> Self {
+        self.common = self.common.sortable(sortable);
+        self
+    }
+
+    /// Mark the field as no index. This means that the field will not be indexed.
+    pub fn no_index(mut self, no_index: bool) -> Self {
+        self.common = self.common.no_index(no_index);
+        self
+    }
+
+    /// Set the alias for the field.
+    pub fn alias(mut self, alias: impl Into<String>) -> Self {
+        self.common = self.common.alias(alias);
+        self
+    }
+
+    /// Set index missing. This allows searching for missing values - documents that do not contain a specific field.
+    pub fn index_missing(mut self, index_missing: bool) -> Self {
+        self.common = self.common.index_missing(index_missing);
+        self
+    }
+}
+
+impl ToRedisArgs for SchemaNumericField {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        self.common.base.write_redis_args(out);
+        self.common.write_redis_args(out);
+    }
+}
+
+impl Default for SchemaNumericField {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Represents a geo field in the schema.
+#[must_use = "Geo field has no effect unless inserted into a schema"]
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SchemaGeoField {
+    pub(crate) common: SchemaCommonField,
+}
+
+impl SchemaGeoField {
+    /// Create a new GEO field.
+    pub fn new() -> Self {
+        Self {
+            common: SchemaCommonField::new(FieldType::Geo),
+        }
+    }
+
+    /// Mark the field as sortable.
+    pub fn sortable(mut self, sortable: Sortable) -> Self {
+        self.common = self.common.sortable(sortable);
+        self
+    }
+
+    /// Mark the field as no index. This means that the field will not be indexed.
+    pub fn no_index(mut self, no_index: bool) -> Self {
+        self.common = self.common.no_index(no_index);
+        self
+    }
+
+    /// Set the alias for the field.
+    pub fn alias(mut self, alias: impl Into<String>) -> Self {
+        self.common = self.common.alias(alias);
+        self
+    }
+
+    /// Set index missing. This allows searching for missing values - documents that do not contain a specific field.
+    pub fn index_missing(mut self, index_missing: bool) -> Self {
+        self.common = self.common.index_missing(index_missing);
+        self
+    }
+}
+
+impl ToRedisArgs for SchemaGeoField {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        self.common.base.write_redis_args(out);
+        self.common.write_redis_args(out);
+    }
+}
+
+impl Default for SchemaGeoField {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Coordinate system for geo shape fields
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum CoordSystem {
+    /// Geographic longitude and latitude coordinates
+    Spherical,
+    /// Cartesian X Y coordinates
+    Flat,
+}
+
+impl ToRedisArgs for CoordSystem {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        out.write_arg(match self {
+            Self::Spherical => b"SPHERICAL",
+            Self::Flat => b"FLAT",
+        });
+    }
+}
+
+/// Represents a geo shape field in the schema.
+#[must_use = "Geo shape field has no effect unless inserted into a schema"]
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SchemaGeoShapeField {
+    pub(crate) common: SchemaCommonField,
+    coord_system: CoordSystem,
+}
+
+impl SchemaGeoShapeField {
+    /// Create a new GEO SHAPE field.
+    pub fn new() -> Self {
+        Self {
+            common: SchemaCommonField::new(FieldType::GeoShape),
+            // The default coordinate system is SPHERICAL.
+            coord_system: CoordSystem::Spherical,
+        }
+    }
+
+    /// Set the coordinate system for the field.
+    pub fn coord_system(mut self, coord_system: CoordSystem) -> Self {
+        self.coord_system = coord_system;
+        self
+    }
+
+    /// Set the alias for the field.
+    pub fn alias(mut self, alias: impl Into<String>) -> Self {
+        self.common = self.common.alias(alias);
+        self
+    }
+
+    /// Set index missing. This allows searching for missing values - documents that do not contain a specific field.
+    pub fn index_missing(mut self, index_missing: bool) -> Self {
+        self.common = self.common.index_missing(index_missing);
+        self
+    }
+
+    // Sortable is not applicable to geo shape fields.
+
+    /// Mark the field as no index. This means that the field will not be indexed.
+    pub fn no_index(mut self, no_index: bool) -> Self {
+        self.common = self.common.no_index(no_index);
+        self
+    }
+}
+
+impl ToRedisArgs for SchemaGeoShapeField {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        // The coordinate system has to be placed immediately after the field type,
+        // which prevents the use of the common base implementation.
+        if let Some(alias) = &self.common.base.alias {
+            out.write_arg(b"AS");
+            alias.write_redis_args(out);
+        }
+
+        self.common.base.field_type.write_redis_args(out);
+        self.coord_system.write_redis_args(out);
+
+        if self.common.base.index_missing {
+            out.write_arg(b"INDEXMISSING");
+        }
+
+        self.common.write_redis_args(out);
+    }
+}
+
+impl Default for SchemaGeoShapeField {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -331,6 +649,10 @@ mod tests {
 
     static INDEX_NAME: &str = "index";
     static TEXT_FIELD_NAME: &str = "title";
+    static NUMERIC_FIELD_NAME: &str = "price";
+    static TAG_FIELD_NAME: &str = "condition";
+    static GEO_FIELD_NAME: &str = "location";
+    static GEOSHAPE_FIELD_NAME: &str = "area";
     static CUSTOM_ALIAS: &str = "custom_alias";
 
     // ============================================================================
@@ -496,6 +818,429 @@ mod tests {
         assert_eq!(
             ft_create.into_args(),
             "FT.CREATE index SCHEMA title AS custom_alias TEXT NOSTEM WEIGHT 1.0 PHONETIC dm:en WITHSUFFIXTRIE INDEXEMPTY SORTABLE UNF NOINDEX"
+        );
+    }
+
+    // ============================================================================
+    // NUMERIC Field Tests
+    // ============================================================================
+    #[test]
+    fn test_numeric_field() {
+        let schema = schema! {
+            NUMERIC_FIELD_NAME => SchemaNumericField::new(),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA price NUMERIC"
+        );
+    }
+
+    #[test]
+    fn test_numeric_field_with_alias() {
+        let schema = schema! {
+            NUMERIC_FIELD_NAME => SchemaNumericField::new().alias(CUSTOM_ALIAS),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA price AS custom_alias NUMERIC"
+        );
+    }
+
+    #[test]
+    fn test_numeric_field_with_indexmissing() {
+        let schema = schema! {
+            NUMERIC_FIELD_NAME => SchemaNumericField::new().index_missing(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA price NUMERIC INDEXMISSING"
+        );
+    }
+
+    #[test]
+    fn test_numeric_field_with_sortable() {
+        let schema = schema! {
+            NUMERIC_FIELD_NAME => SchemaNumericField::new().sortable(Sortable::Yes),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA price NUMERIC SORTABLE"
+        );
+    }
+
+    #[test]
+    fn test_numeric_field_with_sortable_unf() {
+        let schema = schema! {
+            NUMERIC_FIELD_NAME => SchemaNumericField::new().sortable(Sortable::Unf),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA price NUMERIC SORTABLE UNF"
+        );
+    }
+
+    #[test]
+    fn test_numeric_field_with_noindex() {
+        let schema = schema! {
+            NUMERIC_FIELD_NAME => SchemaNumericField::new().no_index(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA price NUMERIC NOINDEX"
+        );
+    }
+
+    #[test]
+    fn test_numeric_field_with_all_options() {
+        let field = SchemaNumericField::new()
+            .alias(CUSTOM_ALIAS)
+            .index_missing(true)
+            .sortable(Sortable::Unf);
+        let ft_create = FtCreateCommand::new(
+            INDEX_NAME,
+            schema! {
+                NUMERIC_FIELD_NAME => field.clone(),
+            },
+        );
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA price AS custom_alias NUMERIC INDEXMISSING SORTABLE UNF"
+        );
+        // Index missing and no index are mutually exclusive
+        let ft_create = FtCreateCommand::new(
+            INDEX_NAME,
+            schema! {
+                NUMERIC_FIELD_NAME => field.index_missing(false).no_index(true),
+            },
+        );
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA price AS custom_alias NUMERIC SORTABLE UNF NOINDEX"
+        );
+    }
+
+    // ============================================================================
+    // GEO Field Tests
+    // ============================================================================
+    #[test]
+    fn test_geo_field() {
+        let schema = schema! {
+            GEO_FIELD_NAME => SchemaGeoField::new(),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(ft_create.into_args(), "FT.CREATE index SCHEMA location GEO");
+    }
+
+    #[test]
+    fn test_geo_field_with_alias() {
+        let schema = schema! {
+            GEO_FIELD_NAME => SchemaGeoField::new().alias(CUSTOM_ALIAS),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA location AS custom_alias GEO"
+        );
+    }
+
+    #[test]
+    fn test_geo_field_with_indexmissing() {
+        let schema = schema! {
+            GEO_FIELD_NAME => SchemaGeoField::new().index_missing(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA location GEO INDEXMISSING"
+        );
+    }
+
+    #[test]
+    fn test_geo_field_with_sortable() {
+        let schema = schema! {
+            GEO_FIELD_NAME => SchemaGeoField::new().sortable(Sortable::Yes),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA location GEO SORTABLE"
+        );
+    }
+
+    #[test]
+    fn test_geo_field_with_sortable_unf() {
+        let schema = schema! {
+            GEO_FIELD_NAME => SchemaGeoField::new().sortable(Sortable::Unf),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA location GEO SORTABLE UNF"
+        );
+    }
+
+    #[test]
+    fn test_geo_field_with_noindex() {
+        let schema = schema! {
+            GEO_FIELD_NAME => SchemaGeoField::new().no_index(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA location GEO NOINDEX"
+        );
+    }
+
+    #[test]
+    fn test_geo_field_with_all_options() {
+        let field = SchemaGeoField::new()
+            .alias(CUSTOM_ALIAS)
+            .index_missing(true)
+            .sortable(Sortable::Unf);
+        let ft_create = FtCreateCommand::new(
+            INDEX_NAME,
+            schema! {
+                GEO_FIELD_NAME => field.clone(),
+            },
+        );
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA location AS custom_alias GEO INDEXMISSING SORTABLE UNF"
+        );
+        // Index missing and no index are mutually exclusive
+        let ft_create = FtCreateCommand::new(
+            INDEX_NAME,
+            schema! {
+                GEO_FIELD_NAME => field.index_missing(false).no_index(true),
+            },
+        );
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA location AS custom_alias GEO SORTABLE UNF NOINDEX"
+        );
+    }
+
+    // ============================================================================
+    // TAG Field Tests
+    // ============================================================================
+    #[test]
+    fn test_tag_field() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new(),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition TAG"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_separator() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new().separator(','),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition TAG SEPARATOR ,"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_casesensitive() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new().case_sensitive(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition TAG CASESENSITIVE"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_withsuffixtrie() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new().with_suffix_trie(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition TAG WITHSUFFIXTRIE"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_indexempty() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new().index_empty(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition TAG INDEXEMPTY"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_alias() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new().alias(CUSTOM_ALIAS),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition AS custom_alias TAG"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_indexmissing() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new().index_missing(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition TAG INDEXMISSING"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_sortable() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new().sortable(Sortable::Yes),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition TAG SORTABLE"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_sortable_unf() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new().sortable(Sortable::Unf),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition TAG SORTABLE UNF"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_noindex() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new().no_index(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition TAG NOINDEX"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_all_options() {
+        let field = SchemaTagField::new()
+            .alias(CUSTOM_ALIAS)
+            .separator(',')
+            .case_sensitive(true)
+            .with_suffix_trie(true)
+            .index_empty(true)
+            .sortable(Sortable::Unf);
+        let ft_create = FtCreateCommand::new(
+            INDEX_NAME,
+            schema! {
+                TAG_FIELD_NAME => field.clone(),
+            },
+        );
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition AS custom_alias TAG SEPARATOR , CASESENSITIVE WITHSUFFIXTRIE INDEXEMPTY SORTABLE UNF"
+        );
+        // Index missing and no index are mutually exclusive
+        let ft_create = FtCreateCommand::new(
+            INDEX_NAME,
+            schema! {
+                TAG_FIELD_NAME => field.index_missing(false).no_index(true),
+            },
+        );
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition AS custom_alias TAG SEPARATOR , CASESENSITIVE WITHSUFFIXTRIE INDEXEMPTY SORTABLE UNF NOINDEX"
+        );
+    }
+
+    // ============================================================================
+    // GEOSHAPE Field Tests
+    // ============================================================================
+    #[test]
+    fn test_geoshape_field_without_options_defaults_coord_system_to_spherical() {
+        let schema = schema! {
+            GEOSHAPE_FIELD_NAME => SchemaGeoShapeField::new(),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA area GEOSHAPE SPHERICAL"
+        );
+    }
+
+    #[test]
+    fn test_geoshape_field_with_flat_coord_system() {
+        let schema = schema! {
+            GEOSHAPE_FIELD_NAME => SchemaGeoShapeField::new().coord_system(CoordSystem::Flat),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA area GEOSHAPE FLAT"
+        );
+    }
+
+    #[test]
+    fn test_geoshape_field_with_alias() {
+        let schema = schema! {
+            GEOSHAPE_FIELD_NAME => SchemaGeoShapeField::new().alias(CUSTOM_ALIAS),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA area AS custom_alias GEOSHAPE SPHERICAL"
+        );
+    }
+
+    #[test]
+    fn test_geoshape_field_with_indexmissing() {
+        let schema = schema! {
+            GEOSHAPE_FIELD_NAME => SchemaGeoShapeField::new().index_missing(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA area GEOSHAPE SPHERICAL INDEXMISSING"
+        );
+    }
+
+    #[test]
+    fn test_geoshape_field_with_noindex() {
+        let schema = schema! {
+            GEOSHAPE_FIELD_NAME => SchemaGeoShapeField::new().no_index(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA area GEOSHAPE SPHERICAL NOINDEX"
         );
     }
 }

--- a/redis/src/commands/search/create/mod.rs
+++ b/redis/src/commands/search/create/mod.rs
@@ -26,7 +26,8 @@
 //! // Build a schema using the schema! macro
 //! let schema = schema! {
 //!     "title" => SchemaTextField::new().weight(2.0),
-//!     "subtitle" => SchemaTextField::new()
+//!     "price" => SchemaNumericField::new(),
+//!     "condition" => SchemaTagField::new().separator(',')
 //! };
 //!
 //! // Create an FT.CREATE command
@@ -152,6 +153,84 @@ mod tests {
     // <https://redis.io/docs/latest/commands/ft.create/#examples>
     // ============================================================================
     #[test]
+    fn test_create_blog_post_index() {
+        /*
+        Create an index that stores the title, publication date, and categories of blog post hashes whose keys start with blog:post: (for example, blog:post:1).
+        FT.CREATE idx ON HASH PREFIX 1 blog:post: SCHEMA title TEXT SORTABLE published_at NUMERIC SORTABLE category TAG SORTABLE
+        */
+        let schema = schema! {
+            "title" =>  SchemaTextField::new().sortable(Sortable::Yes),
+            "published_at" => SchemaNumericField::new().sortable(Sortable::Yes),
+            "category" => SchemaTagField::new().sortable(Sortable::Yes),
+        };
+        let options = CreateOptions::new()
+            .on(IndexDataType::Hash)
+            .prefix("blog:post:");
+
+        let ft_create = FtCreateCommand::new("idx", schema).options(options);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE idx ON HASH PREFIX 1 blog:post: SCHEMA title TEXT SORTABLE published_at NUMERIC SORTABLE category TAG SORTABLE"
+        );
+    }
+
+    #[test]
+    fn test_attribute_with_alias_and_dual_index() {
+        /*
+        Index the sku attribute from a hash as both a TAG and as TEXT.
+        FT.CREATE idx ON HASH PREFIX 1 blog:post: SCHEMA sku AS sku_text TEXT sku AS sku_tag TAG SORTABLE
+        */
+        let sku_text_field = SchemaTextField::new().alias("sku_text");
+
+        let sku_tag_field = SchemaTagField::new()
+            .alias("sku_tag")
+            .sortable(Sortable::Yes);
+
+        let schema = schema! {
+            "sku" => sku_text_field,
+            "sku" => sku_tag_field,
+        };
+
+        let options = CreateOptions::new()
+            .on(IndexDataType::Hash)
+            .prefix("blog:post:");
+
+        let ft_create = FtCreateCommand::new("idx", schema).options(options);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE idx ON HASH PREFIX 1 blog:post: SCHEMA sku AS sku_text TEXT sku AS sku_tag TAG SORTABLE"
+        );
+    }
+
+    #[test]
+    fn test_index_two_hashes_within_the_same_index() {
+        /*
+        Index two different hashes, one containing author data and one containing books, in the same index.
+        FT.CREATE author-books-idx ON HASH PREFIX 2 author:details: book:details: SCHEMA author_id TAG SORTABLE author_ids TAG title TEXT name TEXT
+        */
+        let ft_create = FtCreateCommand::new(
+            "author-books-idx",
+            schema! {
+                "author_id" =>  SchemaTagField::new().sortable(Sortable::Yes),
+                "author_ids" => SchemaTagField::new(),
+                "title" => SchemaTextField::new(),
+                "name" => SchemaTextField::new(),
+            },
+        )
+        .options(
+            CreateOptions::new()
+                .on(IndexDataType::Hash)
+                .prefix("author:details:")
+                .prefix("book:details:"),
+        );
+
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE author-books-idx ON HASH PREFIX 2 author:details: book:details: SCHEMA author_id TAG SORTABLE author_ids TAG title TEXT name TEXT"
+        );
+    }
+
+    #[test]
     fn test_index_with_filter() {
         // In this example, keys for author data use the key pattern author:details:<id> while keys for book data use the pattern book:details:<id>.
 
@@ -197,6 +276,54 @@ mod tests {
         assert_eq!(
             ft_create.into_args(),
             "FT.CREATE subtitled-books-idx ON HASH PREFIX 1 book:details FILTER '@subtitle != \"\"' SCHEMA title TEXT"
+        );
+    }
+
+    #[test]
+    fn test_index_with_separator() {
+        /*
+        In this example, keys for author data use the key pattern author:details:<id> while keys for book data use the pattern book:details:<id>.
+        Index books that have a "categories" attribute where each category is separated by a ; character.
+        FT.CREATE books-idx ON HASH PREFIX 1 book:details SCHEMA title TEXT categories TAG SEPARATOR ;
+        */
+        let ft_create = FtCreateCommand::new(
+            "books-idx",
+            schema! {
+                "title" =>  SchemaTextField::new(),
+                "categories" => SchemaTagField::new().separator(';'),
+            },
+        )
+        .options(
+            CreateOptions::new()
+                .on(IndexDataType::Hash)
+                .prefix("book:details"),
+        );
+
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE books-idx ON HASH PREFIX 1 book:details SCHEMA title TEXT categories TAG SEPARATOR ;"
+        );
+    }
+
+    #[test]
+    fn test_index_json() {
+        /*
+        Index a JSON document using a JSON Path expression
+        The following example uses data similar to the hash examples above but uses JSON instead.
+        FT.CREATE idx ON JSON SCHEMA $.title AS title TEXT $.categories AS categories TAG
+        */
+        let ft_create = FtCreateCommand::new(
+            "idx",
+            schema! {
+                "$.title" =>  SchemaTextField::new().alias("title"),
+                "$.categories" => SchemaTagField::new().alias("categories"),
+            },
+        )
+        .options(CreateOptions::new().on(IndexDataType::Json));
+
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE idx ON JSON SCHEMA $.title AS title TEXT $.categories AS categories TAG"
         );
     }
 }

--- a/redis/src/commands/search/create/schema.rs
+++ b/redis/src/commands/search/create/schema.rs
@@ -1,5 +1,7 @@
 //! Defines the schema passed to the FT.CREATE command.
-use super::fields::SchemaTextField;
+use super::fields::{
+    SchemaGeoField, SchemaGeoShapeField, SchemaNumericField, SchemaTagField, SchemaTextField,
+};
 use crate::{RedisWrite, ToRedisArgs};
 
 /// Field definition for schema
@@ -8,6 +10,14 @@ use crate::{RedisWrite, ToRedisArgs};
 pub enum FieldDefinition {
     /// Text field
     Text(SchemaTextField),
+    /// Numeric field
+    Numeric(SchemaNumericField),
+    /// Geo field
+    Geo(SchemaGeoField),
+    /// Tag field
+    Tag(SchemaTagField),
+    /// Geo shape field
+    GeoShape(SchemaGeoShapeField),
 }
 
 impl ToRedisArgs for FieldDefinition {
@@ -17,6 +27,10 @@ impl ToRedisArgs for FieldDefinition {
     {
         match self {
             Self::Text(tf) => tf.write_redis_args(out),
+            Self::Numeric(nf) => nf.write_redis_args(out),
+            Self::Geo(gf) => gf.write_redis_args(out),
+            Self::Tag(tf) => tf.write_redis_args(out),
+            Self::GeoShape(gs) => gs.write_redis_args(out),
         }
     }
 }
@@ -24,6 +38,30 @@ impl ToRedisArgs for FieldDefinition {
 impl From<SchemaTextField> for FieldDefinition {
     fn from(field: SchemaTextField) -> Self {
         Self::Text(field)
+    }
+}
+
+impl From<SchemaNumericField> for FieldDefinition {
+    fn from(field: SchemaNumericField) -> Self {
+        Self::Numeric(field)
+    }
+}
+
+impl From<SchemaGeoField> for FieldDefinition {
+    fn from(field: SchemaGeoField) -> Self {
+        Self::Geo(field)
+    }
+}
+
+impl From<SchemaTagField> for FieldDefinition {
+    fn from(field: SchemaTagField) -> Self {
+        Self::Tag(field)
+    }
+}
+
+impl From<SchemaGeoShapeField> for FieldDefinition {
+    fn from(field: SchemaGeoShapeField) -> Self {
+        Self::GeoShape(field)
     }
 }
 
@@ -40,12 +78,12 @@ impl From<SchemaTextField> for FieldDefinition {
 /// // Using the macro (recommended)
 /// let schema = schema! {
 ///     "title" => SchemaTextField::new(),
-///     "subtitle" => SchemaTextField::new()
+///     "price" => SchemaNumericField::new()
 /// };
 ///
 /// // Using the builder pattern
 /// let schema = SearchSchema::new("title", SchemaTextField::new())
-///     .insert("subtitle", SchemaTextField::new());
+///     .insert("price", SchemaNumericField::new());
 /// ```
 #[must_use = "Schema has no effect unless passed to a command"]
 #[derive(Debug, Clone)]
@@ -93,7 +131,8 @@ impl ToRedisArgs for SearchSchema {
 ///
 /// let schema = schema! {
 ///     "title" => SchemaTextField::new().weight(2.0),
-///     "subtitle" => SchemaTextField::new(),
+///     "price" => SchemaNumericField::new(),
+///     "tags" => SchemaTagField::new().separator(','),
 /// };
 /// ```
 #[macro_export]
@@ -115,16 +154,19 @@ mod tests {
 
     static INDEX_NAME: &str = "index";
     static TEXT_FIELD_NAME: &str = "title";
+    static NUMERIC_FIELD_NAME: &str = "price";
+    static TAG_FIELD_NAME: &str = "condition";
 
     #[test]
     fn test_multiple_fields() {
         let schema = SearchSchema::new(TEXT_FIELD_NAME, SchemaTextField::new().weight(2.0))
-            .insert("subtitle", SchemaTextField::new());
+            .insert(NUMERIC_FIELD_NAME, SchemaNumericField::new())
+            .insert(TAG_FIELD_NAME, SchemaTagField::new().separator(','));
 
         let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
         assert_eq!(
             ft_create.into_args(),
-            "FT.CREATE index SCHEMA title TEXT WEIGHT 2.0 subtitle TEXT"
+            "FT.CREATE index SCHEMA title TEXT WEIGHT 2.0 price NUMERIC condition TAG SEPARATOR ,"
         );
     }
 


### PR DESCRIPTION
# Add the remaining simple field types for `FT.CREATE`

## Summary

Adds the `TAG`, `NUMERIC`, `GEO` and `GEOSHAPE` schema field types.

This is **part 3 of the series that supersedes #2015**, where the design is described in full.