### PR TITLE
Add FLAT vector field support for `FT.CREATE` [5/8]

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -25,3 +25,6 @@ default-filter = 'binary(test_module_bloom*)'
 
 [profile.module_json]
 default-filter = 'test(test_module_json)'
+
+[profile.module_search]
+default-filter = 'binary(test_module_search*)'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   REDISRS_REDIS_JSON_PATH: "/tmp/librejson.so"
   REDISRS_REDIS_BLOOM_PATH: "/tmp/redisbloom.so"
+  REDISRS_REDIS_SEARCH_PATH: "/tmp/redisearch.so"
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.run_id || github.ref }}"
@@ -34,8 +35,8 @@ jobs:
             {  db-org: redis, db-name: redis, db-version: 6.2.22 },
             {  db-org: redis, db-name: redis, db-version: 7.0.15, json-module-version: v2.6.22 },
             {  db-org: redis, db-name: redis, db-version: 7.4.9, json-module-version: v2.6.22 },
-            {  db-org: redis, db-name: redis, db-version: 8.0.6, json-module-version: bundled, bloom-module-version: bundled },
-            {  db-org: redis, db-name: redis, db-version: 8.8.0, json-module-version: bundled, bloom-module-version: bundled },
+            {  db-org: redis, db-name: redis, db-version: 8.0.6, json-module-version: bundled, bloom-module-version: bundled, search-module-version: bundled },
+            {  db-org: redis, db-name: redis, db-version: 8.8.0, json-module-version: bundled, bloom-module-version: bundled, search-module-version: bundled },
             # valkey-bloom has some quirks with Valkey <8.1, so we only test it on >=8.1
             {  db-org: valkey-io, db-name: valkey, db-version: 7.2.13, json-module-version: v2.6.22 },
             {  db-org: valkey-io, db-name: valkey, db-version: 8.0.9, json-module-version: v2.6.22 },
@@ -74,6 +75,11 @@ jobs:
         if: matrix.config.bloom-module-version == 'bundled'
         run: |
           cp "$HOME/db/redisbloom.so" "$REDISRS_REDIS_BLOOM_PATH"
+
+      - name: Copy bundled RediSearch into place
+        if: matrix.config.search-module-version == 'bundled'
+        run: |
+          cp "$HOME/db/redisearch.so" "$REDISRS_REDIS_SEARCH_PATH"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
@@ -188,6 +194,10 @@ jobs:
       - name: Run RedisBloom tests
         if: matrix.config.bloom-module-version != ''
         run: make test-module-bloom
+
+      - name: Run Search module tests
+        if: matrix.config.search-module-version != ''
+        run: make test-module-search
 
       - name: Cache RedisJSON
         if: matrix.config.json-module-version != '' && matrix.config.json-module-version != 'bundled'

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,18 @@ test-module-bloom:
 	@echo "===================================================================="
 	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --locked --all-features --profile module_bloom
 
-test-modules: test-module-json test-module-bloom
+test-module-search:
+	@echo "===================================================================="
+	@echo "Testing RESP2 with RediSearch module"
+	@echo "===================================================================="
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features --profile module_search
+
+	@echo "===================================================================="
+	@echo "Testing RESP3 with RediSearch module"
+	@echo "===================================================================="
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --locked --all-features --profile module_search
+
+test-modules: test-module-json test-module-bloom test-module-search
 
 test-single: test
 

--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -34,6 +34,7 @@ enum ServerType {
 pub enum Module {
     Bloom,
     Json,
+    Search,
 }
 
 /// A standalone Redis server instance for testing.
@@ -211,6 +212,13 @@ impl RedisServer {
                 Module::Bloom => {
                     let path = env::var("REDISRS_REDIS_BLOOM_PATH").expect(
                         "Unable to find path to RedisBloom at REDISRS_REDIS_BLOOM_PATH, is it set?",
+                    );
+
+                    redis_cmd.arg("--loadmodule").arg(path);
+                }
+                Module::Search => {
+                    let path = env::var("REDISRS_REDIS_SEARCH_PATH").expect(
+                        "Unable to find path to RediSearch at REDISRS_REDIS_SEARCH_PATH, is it set?",
                     );
 
                     redis_cmd.arg("--loadmodule").arg(path);

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -215,6 +215,10 @@ name = "test_module_json"
 required-features = ["json", "serde/derive"]
 
 [[test]]
+name = "test_module_search"
+required-features = ["search_unfinished"]
+
+[[test]]
 name = "test_cluster_async"
 required-features = ["cluster-async"]
 

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -2973,7 +2973,8 @@ implement_commands! {
     /// # let mut con = client.get_connection()?;
     /// let schema = schema! {
     ///     "title" => SchemaTextField::new().weight(2.0),
-    ///     "subtitle" => SchemaTextField::new()
+    ///     "price" => SchemaNumericField::new(),
+    ///     "condition" => SchemaTagField::new().separator(',')
     /// };
     ///
     /// let options = CreateOptions::new()

--- a/redis/src/commands/search/create/fields.rs
+++ b/redis/src/commands/search/create/fields.rs
@@ -323,6 +323,324 @@ impl Default for SchemaTextField {
     }
 }
 
+/// Represents a tag field in the schema.
+#[must_use = "Tag field has no effect unless inserted into a schema"]
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SchemaTagField {
+    pub(crate) common: SchemaCommonField,
+    separator: Option<char>,
+    case_sensitive: bool,
+    with_suffix_trie: bool,
+    index_empty: bool,
+}
+
+impl SchemaTagField {
+    /// Create a new TAG field.
+    pub fn new() -> Self {
+        Self {
+            common: SchemaCommonField::new(FieldType::Tag),
+            separator: None,
+            case_sensitive: false,
+            with_suffix_trie: false,
+            index_empty: false,
+        }
+    }
+
+    /// Indicates how the text contained in the attribute is to be split into individual tags.
+    /// The value must be a single character.
+    /// The default is ','.
+    pub fn separator(mut self, separator: char) -> Self {
+        self.separator = Some(separator);
+        self
+    }
+
+    /// Keeps the original letter cases of the tags. If not specified, the characters are converted to lowercase.
+    pub fn case_sensitive(mut self, case_sensitive: bool) -> Self {
+        self.case_sensitive = case_sensitive;
+        self
+    }
+
+    /// Keeps a suffix trie with all terms which match the suffix. It is used to optimize contains (foo) and suffix (*foo) queries.
+    /// Otherwise, a brute-force search on the trie is performed. If suffix trie exists for some fields, these queries will be disabled for other fields.
+    pub fn with_suffix_trie(mut self, with_suffix_trie: bool) -> Self {
+        self.with_suffix_trie = with_suffix_trie;
+        self
+    }
+
+    /// Index empty strings. This allows searching for empty values - documents that do not contain a specific field. By default, empty strings are not indexed.
+    pub fn index_empty(mut self, index_empty: bool) -> Self {
+        self.index_empty = index_empty;
+        self
+    }
+
+    /// Mark the field as sortable.
+    pub fn sortable(mut self, sortable: Sortable) -> Self {
+        self.common = self.common.sortable(sortable);
+        self
+    }
+
+    /// Mark the field as no index. This means that the field will not be indexed.
+    pub fn no_index(mut self, no_index: bool) -> Self {
+        self.common = self.common.no_index(no_index);
+        self
+    }
+
+    /// Set the alias for the field.
+    pub fn alias(mut self, alias: impl Into<String>) -> Self {
+        self.common = self.common.alias(alias);
+        self
+    }
+
+    /// Set index missing. This allows searching for missing values - documents that do not contain a specific field.
+    pub fn index_missing(mut self, index_missing: bool) -> Self {
+        self.common = self.common.index_missing(index_missing);
+        self
+    }
+}
+
+impl ToRedisArgs for SchemaTagField {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        self.common.base.write_redis_args(out);
+
+        if let Some(separator) = self.separator {
+            out.write_arg(b"SEPARATOR");
+            out.write_arg(separator.to_string().as_bytes());
+        }
+        if self.case_sensitive {
+            out.write_arg(b"CASESENSITIVE");
+        }
+        if self.with_suffix_trie {
+            out.write_arg(b"WITHSUFFIXTRIE");
+        }
+        if self.index_empty {
+            out.write_arg(b"INDEXEMPTY");
+        }
+
+        self.common.write_redis_args(out);
+    }
+}
+
+impl Default for SchemaTagField {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Represents a numeric field in the schema.
+#[must_use = "Numeric field has no effect unless inserted into a schema"]
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SchemaNumericField {
+    pub(crate) common: SchemaCommonField,
+}
+
+impl SchemaNumericField {
+    /// Create a new NUMERIC field.
+    pub fn new() -> Self {
+        Self {
+            common: SchemaCommonField::new(FieldType::Numeric),
+        }
+    }
+
+    /// Mark the field as sortable.
+    pub fn sortable(mut self, sortable: Sortable) -> Self {
+        self.common = self.common.sortable(sortable);
+        self
+    }
+
+    /// Mark the field as no index. This means that the field will not be indexed.
+    pub fn no_index(mut self, no_index: bool) -> Self {
+        self.common = self.common.no_index(no_index);
+        self
+    }
+
+    /// Set the alias for the field.
+    pub fn alias(mut self, alias: impl Into<String>) -> Self {
+        self.common = self.common.alias(alias);
+        self
+    }
+
+    /// Set index missing. This allows searching for missing values - documents that do not contain a specific field.
+    pub fn index_missing(mut self, index_missing: bool) -> Self {
+        self.common = self.common.index_missing(index_missing);
+        self
+    }
+}
+
+impl ToRedisArgs for SchemaNumericField {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        self.common.base.write_redis_args(out);
+        self.common.write_redis_args(out);
+    }
+}
+
+impl Default for SchemaNumericField {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Represents a geo field in the schema.
+#[must_use = "Geo field has no effect unless inserted into a schema"]
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SchemaGeoField {
+    pub(crate) common: SchemaCommonField,
+}
+
+impl SchemaGeoField {
+    /// Create a new GEO field.
+    pub fn new() -> Self {
+        Self {
+            common: SchemaCommonField::new(FieldType::Geo),
+        }
+    }
+
+    /// Mark the field as sortable.
+    pub fn sortable(mut self, sortable: Sortable) -> Self {
+        self.common = self.common.sortable(sortable);
+        self
+    }
+
+    /// Mark the field as no index. This means that the field will not be indexed.
+    pub fn no_index(mut self, no_index: bool) -> Self {
+        self.common = self.common.no_index(no_index);
+        self
+    }
+
+    /// Set the alias for the field.
+    pub fn alias(mut self, alias: impl Into<String>) -> Self {
+        self.common = self.common.alias(alias);
+        self
+    }
+
+    /// Set index missing. This allows searching for missing values - documents that do not contain a specific field.
+    pub fn index_missing(mut self, index_missing: bool) -> Self {
+        self.common = self.common.index_missing(index_missing);
+        self
+    }
+}
+
+impl ToRedisArgs for SchemaGeoField {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        self.common.base.write_redis_args(out);
+        self.common.write_redis_args(out);
+    }
+}
+
+impl Default for SchemaGeoField {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Coordinate system for geo shape fields
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum CoordSystem {
+    /// Geographic longitude and latitude coordinates
+    Spherical,
+    /// Cartesian X Y coordinates
+    Flat,
+}
+
+impl ToRedisArgs for CoordSystem {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        out.write_arg(match self {
+            Self::Spherical => b"SPHERICAL",
+            Self::Flat => b"FLAT",
+        });
+    }
+}
+
+/// Represents a geo shape field in the schema.
+#[must_use = "Geo shape field has no effect unless inserted into a schema"]
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SchemaGeoShapeField {
+    pub(crate) common: SchemaCommonField,
+    coord_system: CoordSystem,
+}
+
+impl SchemaGeoShapeField {
+    /// Create a new GEO SHAPE field.
+    pub fn new() -> Self {
+        Self {
+            common: SchemaCommonField::new(FieldType::GeoShape),
+            // The default coordinate system is SPHERICAL.
+            coord_system: CoordSystem::Spherical,
+        }
+    }
+
+    /// Set the coordinate system for the field.
+    pub fn coord_system(mut self, coord_system: CoordSystem) -> Self {
+        self.coord_system = coord_system;
+        self
+    }
+
+    /// Set the alias for the field.
+    pub fn alias(mut self, alias: impl Into<String>) -> Self {
+        self.common = self.common.alias(alias);
+        self
+    }
+
+    /// Set index missing. This allows searching for missing values - documents that do not contain a specific field.
+    pub fn index_missing(mut self, index_missing: bool) -> Self {
+        self.common = self.common.index_missing(index_missing);
+        self
+    }
+
+    // Sortable is not applicable to geo shape fields.
+
+    /// Mark the field as no index. This means that the field will not be indexed.
+    pub fn no_index(mut self, no_index: bool) -> Self {
+        self.common = self.common.no_index(no_index);
+        self
+    }
+}
+
+impl ToRedisArgs for SchemaGeoShapeField {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        // The coordinate system has to be placed immediately after the field type,
+        // which prevents the use of the common base implementation.
+        if let Some(alias) = &self.common.base.alias {
+            out.write_arg(b"AS");
+            alias.write_redis_args(out);
+        }
+
+        self.common.base.field_type.write_redis_args(out);
+        self.coord_system.write_redis_args(out);
+
+        if self.common.base.index_missing {
+            out.write_arg(b"INDEXMISSING");
+        }
+
+        self.common.write_redis_args(out);
+    }
+}
+
+impl Default for SchemaGeoShapeField {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -331,6 +649,10 @@ mod tests {
 
     static INDEX_NAME: &str = "index";
     static TEXT_FIELD_NAME: &str = "title";
+    static NUMERIC_FIELD_NAME: &str = "price";
+    static TAG_FIELD_NAME: &str = "condition";
+    static GEO_FIELD_NAME: &str = "location";
+    static GEOSHAPE_FIELD_NAME: &str = "area";
     static CUSTOM_ALIAS: &str = "custom_alias";
 
     // ============================================================================
@@ -496,6 +818,429 @@ mod tests {
         assert_eq!(
             ft_create.into_args(),
             "FT.CREATE index SCHEMA title AS custom_alias TEXT NOSTEM WEIGHT 1.0 PHONETIC dm:en WITHSUFFIXTRIE INDEXEMPTY SORTABLE UNF NOINDEX"
+        );
+    }
+
+    // ============================================================================
+    // NUMERIC Field Tests
+    // ============================================================================
+    #[test]
+    fn test_numeric_field() {
+        let schema = schema! {
+            NUMERIC_FIELD_NAME => SchemaNumericField::new(),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA price NUMERIC"
+        );
+    }
+
+    #[test]
+    fn test_numeric_field_with_alias() {
+        let schema = schema! {
+            NUMERIC_FIELD_NAME => SchemaNumericField::new().alias(CUSTOM_ALIAS),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA price AS custom_alias NUMERIC"
+        );
+    }
+
+    #[test]
+    fn test_numeric_field_with_indexmissing() {
+        let schema = schema! {
+            NUMERIC_FIELD_NAME => SchemaNumericField::new().index_missing(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA price NUMERIC INDEXMISSING"
+        );
+    }
+
+    #[test]
+    fn test_numeric_field_with_sortable() {
+        let schema = schema! {
+            NUMERIC_FIELD_NAME => SchemaNumericField::new().sortable(Sortable::Yes),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA price NUMERIC SORTABLE"
+        );
+    }
+
+    #[test]
+    fn test_numeric_field_with_sortable_unf() {
+        let schema = schema! {
+            NUMERIC_FIELD_NAME => SchemaNumericField::new().sortable(Sortable::Unf),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA price NUMERIC SORTABLE UNF"
+        );
+    }
+
+    #[test]
+    fn test_numeric_field_with_noindex() {
+        let schema = schema! {
+            NUMERIC_FIELD_NAME => SchemaNumericField::new().no_index(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA price NUMERIC NOINDEX"
+        );
+    }
+
+    #[test]
+    fn test_numeric_field_with_all_options() {
+        let field = SchemaNumericField::new()
+            .alias(CUSTOM_ALIAS)
+            .index_missing(true)
+            .sortable(Sortable::Unf);
+        let ft_create = FtCreateCommand::new(
+            INDEX_NAME,
+            schema! {
+                NUMERIC_FIELD_NAME => field.clone(),
+            },
+        );
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA price AS custom_alias NUMERIC INDEXMISSING SORTABLE UNF"
+        );
+        // Index missing and no index are mutually exclusive
+        let ft_create = FtCreateCommand::new(
+            INDEX_NAME,
+            schema! {
+                NUMERIC_FIELD_NAME => field.index_missing(false).no_index(true),
+            },
+        );
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA price AS custom_alias NUMERIC SORTABLE UNF NOINDEX"
+        );
+    }
+
+    // ============================================================================
+    // GEO Field Tests
+    // ============================================================================
+    #[test]
+    fn test_geo_field() {
+        let schema = schema! {
+            GEO_FIELD_NAME => SchemaGeoField::new(),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(ft_create.into_args(), "FT.CREATE index SCHEMA location GEO");
+    }
+
+    #[test]
+    fn test_geo_field_with_alias() {
+        let schema = schema! {
+            GEO_FIELD_NAME => SchemaGeoField::new().alias(CUSTOM_ALIAS),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA location AS custom_alias GEO"
+        );
+    }
+
+    #[test]
+    fn test_geo_field_with_indexmissing() {
+        let schema = schema! {
+            GEO_FIELD_NAME => SchemaGeoField::new().index_missing(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA location GEO INDEXMISSING"
+        );
+    }
+
+    #[test]
+    fn test_geo_field_with_sortable() {
+        let schema = schema! {
+            GEO_FIELD_NAME => SchemaGeoField::new().sortable(Sortable::Yes),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA location GEO SORTABLE"
+        );
+    }
+
+    #[test]
+    fn test_geo_field_with_sortable_unf() {
+        let schema = schema! {
+            GEO_FIELD_NAME => SchemaGeoField::new().sortable(Sortable::Unf),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA location GEO SORTABLE UNF"
+        );
+    }
+
+    #[test]
+    fn test_geo_field_with_noindex() {
+        let schema = schema! {
+            GEO_FIELD_NAME => SchemaGeoField::new().no_index(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA location GEO NOINDEX"
+        );
+    }
+
+    #[test]
+    fn test_geo_field_with_all_options() {
+        let field = SchemaGeoField::new()
+            .alias(CUSTOM_ALIAS)
+            .index_missing(true)
+            .sortable(Sortable::Unf);
+        let ft_create = FtCreateCommand::new(
+            INDEX_NAME,
+            schema! {
+                GEO_FIELD_NAME => field.clone(),
+            },
+        );
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA location AS custom_alias GEO INDEXMISSING SORTABLE UNF"
+        );
+        // Index missing and no index are mutually exclusive
+        let ft_create = FtCreateCommand::new(
+            INDEX_NAME,
+            schema! {
+                GEO_FIELD_NAME => field.index_missing(false).no_index(true),
+            },
+        );
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA location AS custom_alias GEO SORTABLE UNF NOINDEX"
+        );
+    }
+
+    // ============================================================================
+    // TAG Field Tests
+    // ============================================================================
+    #[test]
+    fn test_tag_field() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new(),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition TAG"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_separator() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new().separator(','),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition TAG SEPARATOR ,"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_casesensitive() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new().case_sensitive(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition TAG CASESENSITIVE"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_withsuffixtrie() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new().with_suffix_trie(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition TAG WITHSUFFIXTRIE"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_indexempty() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new().index_empty(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition TAG INDEXEMPTY"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_alias() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new().alias(CUSTOM_ALIAS),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition AS custom_alias TAG"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_indexmissing() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new().index_missing(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition TAG INDEXMISSING"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_sortable() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new().sortable(Sortable::Yes),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition TAG SORTABLE"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_sortable_unf() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new().sortable(Sortable::Unf),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition TAG SORTABLE UNF"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_noindex() {
+        let schema = schema! {
+            TAG_FIELD_NAME => SchemaTagField::new().no_index(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition TAG NOINDEX"
+        );
+    }
+
+    #[test]
+    fn test_tag_field_with_all_options() {
+        let field = SchemaTagField::new()
+            .alias(CUSTOM_ALIAS)
+            .separator(',')
+            .case_sensitive(true)
+            .with_suffix_trie(true)
+            .index_empty(true)
+            .sortable(Sortable::Unf);
+        let ft_create = FtCreateCommand::new(
+            INDEX_NAME,
+            schema! {
+                TAG_FIELD_NAME => field.clone(),
+            },
+        );
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition AS custom_alias TAG SEPARATOR , CASESENSITIVE WITHSUFFIXTRIE INDEXEMPTY SORTABLE UNF"
+        );
+        // Index missing and no index are mutually exclusive
+        let ft_create = FtCreateCommand::new(
+            INDEX_NAME,
+            schema! {
+                TAG_FIELD_NAME => field.index_missing(false).no_index(true),
+            },
+        );
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA condition AS custom_alias TAG SEPARATOR , CASESENSITIVE WITHSUFFIXTRIE INDEXEMPTY SORTABLE UNF NOINDEX"
+        );
+    }
+
+    // ============================================================================
+    // GEOSHAPE Field Tests
+    // ============================================================================
+    #[test]
+    fn test_geoshape_field_without_options_defaults_coord_system_to_spherical() {
+        let schema = schema! {
+            GEOSHAPE_FIELD_NAME => SchemaGeoShapeField::new(),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA area GEOSHAPE SPHERICAL"
+        );
+    }
+
+    #[test]
+    fn test_geoshape_field_with_flat_coord_system() {
+        let schema = schema! {
+            GEOSHAPE_FIELD_NAME => SchemaGeoShapeField::new().coord_system(CoordSystem::Flat),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA area GEOSHAPE FLAT"
+        );
+    }
+
+    #[test]
+    fn test_geoshape_field_with_alias() {
+        let schema = schema! {
+            GEOSHAPE_FIELD_NAME => SchemaGeoShapeField::new().alias(CUSTOM_ALIAS),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA area AS custom_alias GEOSHAPE SPHERICAL"
+        );
+    }
+
+    #[test]
+    fn test_geoshape_field_with_indexmissing() {
+        let schema = schema! {
+            GEOSHAPE_FIELD_NAME => SchemaGeoShapeField::new().index_missing(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA area GEOSHAPE SPHERICAL INDEXMISSING"
+        );
+    }
+
+    #[test]
+    fn test_geoshape_field_with_noindex() {
+        let schema = schema! {
+            GEOSHAPE_FIELD_NAME => SchemaGeoShapeField::new().no_index(true),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA area GEOSHAPE SPHERICAL NOINDEX"
         );
     }
 }

--- a/redis/src/commands/search/create/mod.rs
+++ b/redis/src/commands/search/create/mod.rs
@@ -26,7 +26,8 @@
 //! // Build a schema using the schema! macro
 //! let schema = schema! {
 //!     "title" => SchemaTextField::new().weight(2.0),
-//!     "subtitle" => SchemaTextField::new()
+//!     "price" => SchemaNumericField::new(),
+//!     "condition" => SchemaTagField::new().separator(',')
 //! };
 //!
 //! // Create an FT.CREATE command
@@ -152,6 +153,84 @@ mod tests {
     // <https://redis.io/docs/latest/commands/ft.create/#examples>
     // ============================================================================
     #[test]
+    fn test_create_blog_post_index() {
+        /*
+        Create an index that stores the title, publication date, and categories of blog post hashes whose keys start with blog:post: (for example, blog:post:1).
+        FT.CREATE idx ON HASH PREFIX 1 blog:post: SCHEMA title TEXT SORTABLE published_at NUMERIC SORTABLE category TAG SORTABLE
+        */
+        let schema = schema! {
+            "title" =>  SchemaTextField::new().sortable(Sortable::Yes),
+            "published_at" => SchemaNumericField::new().sortable(Sortable::Yes),
+            "category" => SchemaTagField::new().sortable(Sortable::Yes),
+        };
+        let options = CreateOptions::new()
+            .on(IndexDataType::Hash)
+            .prefix("blog:post:");
+
+        let ft_create = FtCreateCommand::new("idx", schema).options(options);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE idx ON HASH PREFIX 1 blog:post: SCHEMA title TEXT SORTABLE published_at NUMERIC SORTABLE category TAG SORTABLE"
+        );
+    }
+
+    #[test]
+    fn test_attribute_with_alias_and_dual_index() {
+        /*
+        Index the sku attribute from a hash as both a TAG and as TEXT.
+        FT.CREATE idx ON HASH PREFIX 1 blog:post: SCHEMA sku AS sku_text TEXT sku AS sku_tag TAG SORTABLE
+        */
+        let sku_text_field = SchemaTextField::new().alias("sku_text");
+
+        let sku_tag_field = SchemaTagField::new()
+            .alias("sku_tag")
+            .sortable(Sortable::Yes);
+
+        let schema = schema! {
+            "sku" => sku_text_field,
+            "sku" => sku_tag_field,
+        };
+
+        let options = CreateOptions::new()
+            .on(IndexDataType::Hash)
+            .prefix("blog:post:");
+
+        let ft_create = FtCreateCommand::new("idx", schema).options(options);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE idx ON HASH PREFIX 1 blog:post: SCHEMA sku AS sku_text TEXT sku AS sku_tag TAG SORTABLE"
+        );
+    }
+
+    #[test]
+    fn test_index_two_hashes_within_the_same_index() {
+        /*
+        Index two different hashes, one containing author data and one containing books, in the same index.
+        FT.CREATE author-books-idx ON HASH PREFIX 2 author:details: book:details: SCHEMA author_id TAG SORTABLE author_ids TAG title TEXT name TEXT
+        */
+        let ft_create = FtCreateCommand::new(
+            "author-books-idx",
+            schema! {
+                "author_id" =>  SchemaTagField::new().sortable(Sortable::Yes),
+                "author_ids" => SchemaTagField::new(),
+                "title" => SchemaTextField::new(),
+                "name" => SchemaTextField::new(),
+            },
+        )
+        .options(
+            CreateOptions::new()
+                .on(IndexDataType::Hash)
+                .prefix("author:details:")
+                .prefix("book:details:"),
+        );
+
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE author-books-idx ON HASH PREFIX 2 author:details: book:details: SCHEMA author_id TAG SORTABLE author_ids TAG title TEXT name TEXT"
+        );
+    }
+
+    #[test]
     fn test_index_with_filter() {
         // In this example, keys for author data use the key pattern author:details:<id> while keys for book data use the pattern book:details:<id>.
 
@@ -197,6 +276,54 @@ mod tests {
         assert_eq!(
             ft_create.into_args(),
             "FT.CREATE subtitled-books-idx ON HASH PREFIX 1 book:details FILTER '@subtitle != \"\"' SCHEMA title TEXT"
+        );
+    }
+
+    #[test]
+    fn test_index_with_separator() {
+        /*
+        In this example, keys for author data use the key pattern author:details:<id> while keys for book data use the pattern book:details:<id>.
+        Index books that have a "categories" attribute where each category is separated by a ; character.
+        FT.CREATE books-idx ON HASH PREFIX 1 book:details SCHEMA title TEXT categories TAG SEPARATOR ;
+        */
+        let ft_create = FtCreateCommand::new(
+            "books-idx",
+            schema! {
+                "title" =>  SchemaTextField::new(),
+                "categories" => SchemaTagField::new().separator(';'),
+            },
+        )
+        .options(
+            CreateOptions::new()
+                .on(IndexDataType::Hash)
+                .prefix("book:details"),
+        );
+
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE books-idx ON HASH PREFIX 1 book:details SCHEMA title TEXT categories TAG SEPARATOR ;"
+        );
+    }
+
+    #[test]
+    fn test_index_json() {
+        /*
+        Index a JSON document using a JSON Path expression
+        The following example uses data similar to the hash examples above but uses JSON instead.
+        FT.CREATE idx ON JSON SCHEMA $.title AS title TEXT $.categories AS categories TAG
+        */
+        let ft_create = FtCreateCommand::new(
+            "idx",
+            schema! {
+                "$.title" =>  SchemaTextField::new().alias("title"),
+                "$.categories" => SchemaTagField::new().alias("categories"),
+            },
+        )
+        .options(CreateOptions::new().on(IndexDataType::Json));
+
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE idx ON JSON SCHEMA $.title AS title TEXT $.categories AS categories TAG"
         );
     }
 }

--- a/redis/src/commands/search/create/mod.rs
+++ b/redis/src/commands/search/create/mod.rs
@@ -41,10 +41,12 @@
 mod fields;
 mod options;
 mod schema;
+mod vector;
 
 pub use fields::*;
 pub use options::*;
 pub use schema::*;
+pub use vector::*;
 
 use crate::Cmd;
 

--- a/redis/src/commands/search/create/schema.rs
+++ b/redis/src/commands/search/create/schema.rs
@@ -1,5 +1,7 @@
 //! Defines the schema passed to the FT.CREATE command.
-use super::fields::SchemaTextField;
+use super::fields::{
+    SchemaGeoField, SchemaGeoShapeField, SchemaNumericField, SchemaTagField, SchemaTextField,
+};
 use crate::{RedisWrite, ToRedisArgs};
 
 /// Field definition for schema
@@ -8,6 +10,14 @@ use crate::{RedisWrite, ToRedisArgs};
 pub enum FieldDefinition {
     /// Text field
     Text(SchemaTextField),
+    /// Numeric field
+    Numeric(SchemaNumericField),
+    /// Geo field
+    Geo(SchemaGeoField),
+    /// Tag field
+    Tag(SchemaTagField),
+    /// Geo shape field
+    GeoShape(SchemaGeoShapeField),
 }
 
 impl ToRedisArgs for FieldDefinition {
@@ -17,6 +27,10 @@ impl ToRedisArgs for FieldDefinition {
     {
         match self {
             Self::Text(tf) => tf.write_redis_args(out),
+            Self::Numeric(nf) => nf.write_redis_args(out),
+            Self::Geo(gf) => gf.write_redis_args(out),
+            Self::Tag(tf) => tf.write_redis_args(out),
+            Self::GeoShape(gs) => gs.write_redis_args(out),
         }
     }
 }
@@ -24,6 +38,30 @@ impl ToRedisArgs for FieldDefinition {
 impl From<SchemaTextField> for FieldDefinition {
     fn from(field: SchemaTextField) -> Self {
         Self::Text(field)
+    }
+}
+
+impl From<SchemaNumericField> for FieldDefinition {
+    fn from(field: SchemaNumericField) -> Self {
+        Self::Numeric(field)
+    }
+}
+
+impl From<SchemaGeoField> for FieldDefinition {
+    fn from(field: SchemaGeoField) -> Self {
+        Self::Geo(field)
+    }
+}
+
+impl From<SchemaTagField> for FieldDefinition {
+    fn from(field: SchemaTagField) -> Self {
+        Self::Tag(field)
+    }
+}
+
+impl From<SchemaGeoShapeField> for FieldDefinition {
+    fn from(field: SchemaGeoShapeField) -> Self {
+        Self::GeoShape(field)
     }
 }
 
@@ -40,12 +78,12 @@ impl From<SchemaTextField> for FieldDefinition {
 /// // Using the macro (recommended)
 /// let schema = schema! {
 ///     "title" => SchemaTextField::new(),
-///     "subtitle" => SchemaTextField::new()
+///     "price" => SchemaNumericField::new()
 /// };
 ///
 /// // Using the builder pattern
 /// let schema = SearchSchema::new("title", SchemaTextField::new())
-///     .insert("subtitle", SchemaTextField::new());
+///     .insert("price", SchemaNumericField::new());
 /// ```
 #[must_use = "Schema has no effect unless passed to a command"]
 #[derive(Debug, Clone)]
@@ -93,7 +131,8 @@ impl ToRedisArgs for SearchSchema {
 ///
 /// let schema = schema! {
 ///     "title" => SchemaTextField::new().weight(2.0),
-///     "subtitle" => SchemaTextField::new(),
+///     "price" => SchemaNumericField::new(),
+///     "tags" => SchemaTagField::new().separator(','),
 /// };
 /// ```
 #[macro_export]
@@ -115,16 +154,19 @@ mod tests {
 
     static INDEX_NAME: &str = "index";
     static TEXT_FIELD_NAME: &str = "title";
+    static NUMERIC_FIELD_NAME: &str = "price";
+    static TAG_FIELD_NAME: &str = "condition";
 
     #[test]
     fn test_multiple_fields() {
         let schema = SearchSchema::new(TEXT_FIELD_NAME, SchemaTextField::new().weight(2.0))
-            .insert("subtitle", SchemaTextField::new());
+            .insert(NUMERIC_FIELD_NAME, SchemaNumericField::new())
+            .insert(TAG_FIELD_NAME, SchemaTagField::new().separator(','));
 
         let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
         assert_eq!(
             ft_create.into_args(),
-            "FT.CREATE index SCHEMA title TEXT WEIGHT 2.0 subtitle TEXT"
+            "FT.CREATE index SCHEMA title TEXT WEIGHT 2.0 price NUMERIC condition TAG SEPARATOR ,"
         );
     }
 

--- a/redis/src/commands/search/create/schema.rs
+++ b/redis/src/commands/search/create/schema.rs
@@ -2,6 +2,7 @@
 use super::fields::{
     SchemaGeoField, SchemaGeoShapeField, SchemaNumericField, SchemaTagField, SchemaTextField,
 };
+use super::vector::VectorField;
 use crate::{RedisWrite, ToRedisArgs};
 
 /// Field definition for schema
@@ -16,6 +17,8 @@ pub enum FieldDefinition {
     Geo(SchemaGeoField),
     /// Tag field
     Tag(SchemaTagField),
+    /// Vector field
+    Vector(VectorField),
     /// Geo shape field
     GeoShape(SchemaGeoShapeField),
 }
@@ -30,6 +33,7 @@ impl ToRedisArgs for FieldDefinition {
             Self::Numeric(nf) => nf.write_redis_args(out),
             Self::Geo(gf) => gf.write_redis_args(out),
             Self::Tag(tf) => tf.write_redis_args(out),
+            Self::Vector(v) => v.write_redis_args(out),
             Self::GeoShape(gs) => gs.write_redis_args(out),
         }
     }
@@ -56,6 +60,12 @@ impl From<SchemaGeoField> for FieldDefinition {
 impl From<SchemaTagField> for FieldDefinition {
     fn from(field: SchemaTagField) -> Self {
         Self::Tag(field)
+    }
+}
+
+impl From<VectorField> for FieldDefinition {
+    fn from(field: VectorField) -> Self {
+        Self::Vector(field)
     }
 }
 

--- a/redis/src/commands/search/create/vector/flat.rs
+++ b/redis/src/commands/search/create/vector/flat.rs
@@ -1,0 +1,205 @@
+//! Defines the options and builder for vector fields using the FLAT indexing algorithm.
+use super::{SchemaVectorField, VectorField};
+use crate::{RedisWrite, ToRedisArgs};
+
+/// Options for vectors using the FLAT indexing algorithm
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct FlatVectorOptions {
+    block_size: Option<u32>,
+}
+
+impl ToRedisArgs for FlatVectorOptions {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        if let Some(block_size) = self.block_size {
+            out.write_arg(b"BLOCK_SIZE");
+            block_size.write_redis_args(out);
+        }
+    }
+
+    fn num_of_args(&self) -> usize {
+        let mut count = 0;
+        if self.block_size.is_some() {
+            count += 2;
+        }
+        count
+    }
+}
+
+/// Builder for FLAT vector fields
+#[must_use = "The builder has no effect until .build() is called"]
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct FlatVectorFieldBuilder {
+    base: SchemaVectorField,
+    block_size: Option<u32>,
+}
+
+impl FlatVectorFieldBuilder {
+    pub(super) fn new(base: SchemaVectorField) -> Self {
+        Self {
+            base,
+            block_size: None,
+        }
+    }
+
+    /// Sets the block size for the FLAT index.
+    ///
+    /// The block size determines how vectors are organized in memory. BLOCK_SIZE amount of vectors are stored in a contiguous array.
+    /// This is useful when the index is dynamic with respect to addition and deletion.
+    /// The default block size is 1024.
+    pub fn block_size(mut self, block_size: u32) -> Self {
+        self.block_size = Some(block_size);
+        self
+    }
+
+    /// Set the alias for the field.
+    pub fn alias(mut self, alias: impl Into<String>) -> Self {
+        self.base.base = self.base.base.alias(alias);
+        self
+    }
+
+    /// Set index missing. This allows searching for missing values - documents that do not contain a specific field.
+    pub fn index_missing(mut self, index_missing: bool) -> Self {
+        self.base.base = self.base.base.index_missing(index_missing);
+        self
+    }
+
+    /// Build the vector field.
+    pub fn build(self) -> VectorField {
+        VectorField::Flat(
+            self.base,
+            FlatVectorOptions {
+                block_size: self.block_size,
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{DistanceMetric, VectorType};
+    use super::*;
+    use crate::schema;
+    use crate::search::FtCreateCommand;
+
+    static INDEX_NAME: &str = "index";
+    static VECTOR_FIELD_NAME: &str = "embedding";
+    static CUSTOM_ALIAS: &str = "custom_alias";
+
+    // ============================================================================
+    // VECTOR Field Tests
+    // ============================================================================
+    #[test]
+    #[should_panic(expected = "Vector dimension must be positive (greater than 0)")]
+    fn test_flat_vector_zero_dimension_panics() {
+        let _ = VectorField::flat(VectorType::Float32, 0, DistanceMetric::Cosine);
+    }
+
+    #[test]
+    fn test_vector_field_with_valid_dimension_one() {
+        let schema = schema! {
+            VECTOR_FIELD_NAME => VectorField::flat(VectorType::Float32, 1, DistanceMetric::Cosine)
+                .build(),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA embedding VECTOR FLAT 6 TYPE FLOAT32 DIM 1 DISTANCE_METRIC COSINE"
+        );
+    }
+
+    #[test]
+    fn test_vector_field_with_alias() {
+        let schema = schema! {
+            VECTOR_FIELD_NAME => VectorField::flat(VectorType::Float32, 2, DistanceMetric::L2)
+                .alias(CUSTOM_ALIAS)
+                .build(),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA embedding AS custom_alias VECTOR FLAT 6 TYPE FLOAT32 DIM 2 DISTANCE_METRIC L2"
+        );
+    }
+
+    #[test]
+    fn test_vector_field_with_indexmissing() {
+        let schema = schema! {
+            VECTOR_FIELD_NAME => VectorField::flat(VectorType::Float32, 2, DistanceMetric::L2)
+                .index_missing(true)
+                .build(),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA embedding VECTOR FLAT 6 TYPE FLOAT32 DIM 2 DISTANCE_METRIC L2 INDEXMISSING"
+        );
+    }
+
+    #[test]
+    fn test_vector_field_flat_algorithm() {
+        let schema = schema! {
+            VECTOR_FIELD_NAME => VectorField::flat(VectorType::Float32, 2, DistanceMetric::L2)
+                .block_size(1000)
+                .build(),
+        };
+        let ft_create = FtCreateCommand::new(INDEX_NAME, schema);
+        assert_eq!(
+            ft_create.into_args(),
+            "FT.CREATE index SCHEMA embedding VECTOR FLAT 8 TYPE FLOAT32 DIM 2 DISTANCE_METRIC L2 BLOCK_SIZE 1000"
+        );
+    }
+
+    /// Every vector type must serialize to the token FT.CREATE expects.
+    #[test]
+    fn test_vector_types() {
+        for (vector_type, expected) in [
+            (VectorType::Float32, "FLOAT32"),
+            (VectorType::Float64, "FLOAT64"),
+            (VectorType::BFloat16, "BFLOAT16"),
+            (VectorType::Float16, "FLOAT16"),
+            (VectorType::Int8, "INT8"),
+            (VectorType::UInt8, "UINT8"),
+        ] {
+            let ft_create = FtCreateCommand::new(
+                INDEX_NAME,
+                schema! {
+                    VECTOR_FIELD_NAME => VectorField::flat(vector_type, 2, DistanceMetric::L2).build(),
+                },
+            );
+            assert_eq!(
+                ft_create.into_args(),
+                format!(
+                    "FT.CREATE index SCHEMA embedding VECTOR FLAT 6 TYPE {expected} DIM 2 DISTANCE_METRIC L2"
+                )
+            );
+        }
+    }
+
+    /// Every distance metric must serialize to the token FT.CREATE expects.
+    #[test]
+    fn test_distance_metrics() {
+        for (distance_metric, expected) in [
+            (DistanceMetric::L2, "L2"),
+            (DistanceMetric::IP, "IP"),
+            (DistanceMetric::Cosine, "COSINE"),
+        ] {
+            let ft_create = FtCreateCommand::new(
+                INDEX_NAME,
+                schema! {
+                    VECTOR_FIELD_NAME => VectorField::flat(VectorType::Float32, 2, distance_metric).build(),
+                },
+            );
+            assert_eq!(
+                ft_create.into_args(),
+                format!(
+                    "FT.CREATE index SCHEMA embedding VECTOR FLAT 6 TYPE FLOAT32 DIM 2 DISTANCE_METRIC {expected}"
+                )
+            );
+        }
+    }
+}

--- a/redis/src/commands/search/create/vector/mod.rs
+++ b/redis/src/commands/search/create/vector/mod.rs
@@ -1,0 +1,232 @@
+//! Defines the vector field types used with the FT.CREATE command.
+//!
+//! A vector field is written as `VECTOR <algorithm> <attribute_count> <attributes...>`, where the
+//! count covers the shared attributes (`TYPE`, `DIM`, `DISTANCE_METRIC`) plus whichever
+//! algorithm-specific ones were set. Each algorithm's options and builder therefore live in their
+//! own module and report their argument count through `ToRedisArgs::num_of_args`, which
+//! [`VectorField`] sums to produce the count written on the wire.
+use super::fields::{BaseSchemaField, FieldType};
+use crate::{RedisWrite, ToRedisArgs};
+
+mod flat;
+
+pub use flat::*;
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub(crate) enum VectorAlgorithm {
+    Flat,
+}
+
+impl ToRedisArgs for VectorAlgorithm {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        out.write_arg(match self {
+            Self::Flat => b"FLAT",
+        });
+    }
+}
+
+/// Vector type for vector fields
+#[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
+#[allow(missing_docs)]
+pub enum VectorType {
+    Float32,
+    Float64,
+    BFloat16,
+    Float16,
+    Int8,
+    UInt8,
+}
+
+impl ToRedisArgs for VectorType {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        out.write_arg(match self {
+            Self::Float32 => b"FLOAT32",
+            Self::Float64 => b"FLOAT64",
+            Self::BFloat16 => b"BFLOAT16",
+            Self::Float16 => b"FLOAT16",
+            Self::Int8 => b"INT8",
+            Self::UInt8 => b"UINT8",
+        });
+    }
+}
+
+/// [Distance metric](https://redis.io/docs/latest/develop/ai/search-and-query/vectors/#distance-metrics/) for vector fields
+#[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
+pub enum DistanceMetric {
+    /// Euclidean distance between two vectors.
+    L2,
+    /// Inner product of two vectors.
+    IP,
+    /// Cosine distance of two vectors.
+    Cosine,
+}
+
+impl ToRedisArgs for DistanceMetric {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        out.write_arg(match self {
+            Self::L2 => b"L2",
+            Self::IP => b"IP",
+            Self::Cosine => b"COSINE",
+        });
+    }
+}
+
+/// Represents a vector field in the schema.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SchemaVectorField {
+    pub(crate) base: BaseSchemaField,
+    algorithm: VectorAlgorithm,
+    vector_type: VectorType,
+    dim: u32,
+    distance_metric: DistanceMetric,
+}
+
+impl ToRedisArgs for SchemaVectorField {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        if let Some(alias) = &self.base.alias {
+            out.write_arg(b"AS");
+            alias.write_redis_args(out);
+        }
+
+        self.base.field_type.write_redis_args(out);
+
+        self.algorithm.write_redis_args(out);
+        // Note: The attribute count will be written by the VectorField implementation
+        // which knows about both base and algorithm-specific attributes
+        // That is:
+        /*
+            out.write_arg(b"TYPE");
+            self.vector_type.write_redis_args(out);
+            out.write_arg(b"DIM");
+            self.dim.write_redis_args(out);
+            out.write_arg(b"DISTANCE_METRIC");
+            self.distance_metric.write_redis_args(out);
+        */
+    }
+
+    fn num_of_args(&self) -> usize {
+        // Count the number of attribute pairs (key-value pairs) for this vector field.
+        // Base attributes are: TYPE, DIM, DISTANCE_METRIC (3 pairs = 6 args)
+        6
+    }
+}
+
+/// Represents a vector field in the schema, built through a per-algorithm builder.
+///
+/// # Algorithms
+///
+/// - **FLAT**: Brute-force exact search. Best for small datasets (< 1M vectors) where perfect accuracy is required.
+///
+/// # Examples
+///
+/// ```rust
+/// use redis::search::*;
+///
+/// // FLAT index for exact search
+/// let flat_field = VectorField::flat(VectorType::Float32, 128, DistanceMetric::Cosine)
+///     .block_size(1000)
+///     .build();
+/// ```
+#[must_use = "Vector field has no effect unless inserted into a schema"]
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum VectorField {
+    /// FLAT (brute-force) vector index for exact nearest neighbor search.
+    /// Best for small datasets (< 1M vectors) where perfect accuracy is required.
+    Flat(SchemaVectorField, FlatVectorOptions),
+}
+
+impl VectorField {
+    /// Set the alias for the field.
+    pub fn alias(mut self, alias: impl Into<String>) -> Self {
+        match self {
+            Self::Flat(ref mut base, _) => base.base = base.base.clone().alias(alias),
+        }
+        self
+    }
+
+    /// Set index missing. This allows searching for missing values - documents that do not contain a specific field.
+    pub fn index_missing(mut self, index_missing: bool) -> Self {
+        match self {
+            Self::Flat(ref mut base, _) => {
+                base.base = base.base.clone().index_missing(index_missing);
+            }
+        }
+        self
+    }
+}
+
+impl ToRedisArgs for VectorField {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        let base = match self {
+            Self::Flat(base, _) => base,
+        };
+        base.write_redis_args(out);
+
+        let attributes_count = match self {
+            Self::Flat(base, flat_vector_options) => {
+                base.num_of_args() + flat_vector_options.num_of_args()
+            }
+        };
+        attributes_count.write_redis_args(out);
+
+        out.write_arg(b"TYPE");
+        base.vector_type.write_redis_args(out);
+        out.write_arg(b"DIM");
+        base.dim.write_redis_args(out);
+        out.write_arg(b"DISTANCE_METRIC");
+        base.distance_metric.write_redis_args(out);
+
+        // Write algorithm-specific attributes
+        match self {
+            Self::Flat(_, flat_vector_options) => {
+                flat_vector_options.write_redis_args(out);
+            }
+        }
+
+        if base.base.index_missing {
+            out.write_arg(b"INDEXMISSING");
+        }
+    }
+}
+
+impl VectorField {
+    /// Create a new FLAT vector field
+    pub fn flat(
+        vector_type: VectorType,
+        dim: u32,
+        distance_metric: DistanceMetric,
+    ) -> FlatVectorFieldBuilder {
+        assert!(
+            dim > 0,
+            "Vector dimension must be positive (greater than 0)"
+        );
+
+        FlatVectorFieldBuilder::new(SchemaVectorField {
+            base: BaseSchemaField::new(FieldType::Vector),
+            algorithm: VectorAlgorithm::Flat,
+            vector_type,
+            dim,
+            distance_metric,
+        })
+    }
+}

--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -17,6 +17,8 @@ pub const REDIS_CE_8_8: Component = ("redis", (8, 8, 0));
 pub const REDIS_JSON_8_8: Component = ("ReJSON", (8, 8, 0));
 pub const REDIS_BLOOM_ANY: Component = ("redis:bf", (0, 0, 0));
 
+pub const REDIS_SEARCH_8_0: Component = ("search", (8, 0, 0));
+
 // Valkey forked off at Redis 7.2.4 and still reports its Redis version 7.2.4. So tests that run
 // on Redis<=7.2.4 automatically also run on any Valkey server, and we only need version guards for
 // later versions.
@@ -338,7 +340,7 @@ macro_rules! skip_if_context_does_not_support {
 /// ```
 #[macro_export]
 macro_rules! run_test_if_version_supported {
-    ($component:expr) => {{ run_test_if_version_supported!($component, &[]) }};
+    ($component:expr) => {{ $crate::run_test_if_version_supported!($component, &[]) }};
     ($component:expr, $modules:expr) => {{
         let ctx = $crate::support::TestContext::with_modules($modules);
 

--- a/redis/tests/test_module_search.rs
+++ b/redis/tests/test_module_search.rs
@@ -1,0 +1,638 @@
+#![cfg(feature = "search_unfinished")]
+
+mod support;
+use crate::support::*;
+use redis::Commands;
+use redis::schema;
+use redis::search::*;
+use redis_test::server::Module;
+
+static TEXT_FIELD_NAME: &str = "title";
+static NUMERIC_FIELD_NAME: &str = "price";
+static TAG_FIELD_NAME: &str = "condition";
+static GEO_FIELD_NAME: &str = "location";
+static GEOSHAPE_FIELD_NAME: &str = "area";
+
+fn assert_no_index_and_index_missing_exclusivity_for_field(
+    result: redis::RedisResult<String>,
+    field_name: &str,
+) {
+    let server_error = redis::ServerError::try_from(result.unwrap_err()).unwrap();
+    assert!(server_error.details().is_some_and(|details| {
+        details.contains(
+            format!("cannot be defined with both `NOINDEX` and `INDEXMISSING` `{field_name}`")
+                .as_str(),
+        )
+    }));
+}
+
+#[test]
+fn test_module_search_ft_create_with_an_empty_index_name() {
+    let ctx = run_test_if_version_supported!(
+        [&[REDIS_CE_8_0][..], &[REDIS_SEARCH_8_0]],
+        &[Module::Search]
+    );
+    let mut con = ctx.connection();
+    let empty_index_name = "";
+    let options = CreateOptions::new();
+    let schema = schema! {
+        TEXT_FIELD_NAME => SchemaTextField::new()
+    };
+    // Check that the first call succeeds but the second one fails because the index already exists
+    assert_eq!(
+        con.ft_create(empty_index_name, &options, &schema),
+        Ok("OK".to_string())
+    );
+    con.ft_create::<_, String>(empty_index_name, &options, &schema)
+        .unwrap_err();
+}
+
+fn run_simple_ft_create<C, F>(con: &mut C, index_name: &str, mut on_created: F)
+where
+    C: redis::ConnectionLike,
+    F: FnMut(&str),
+{
+    let options = CreateOptions::new();
+    let schema = schema! {
+        TEXT_FIELD_NAME => SchemaTextField::new()
+    };
+    // Check that the first call succeeds but the second one fails because the index already exists
+    assert_eq!(
+        con.ft_create(index_name, &options, &schema),
+        Ok("OK".to_string())
+    );
+    on_created(index_name);
+    con.ft_create::<_, String>(index_name, &options, &schema)
+        .unwrap_err();
+}
+
+#[test]
+fn test_module_search_simple_ft_create() {
+    let ctx = run_test_if_version_supported!(
+        [&[REDIS_CE_8_0][..], &[REDIS_SEARCH_8_0]],
+        &[Module::Search]
+    );
+    run_simple_ft_create(&mut ctx.connection(), "index", |_| {});
+}
+
+#[test]
+fn test_module_search_ft_create_create_options() {
+    let ctx = run_test_if_version_supported!(
+        [&[REDIS_CE_8_0][..], &[REDIS_SEARCH_8_0]],
+        &[Module::Search]
+    );
+    let mut con = ctx.connection();
+    let schema = schema! {
+        TEXT_FIELD_NAME => SchemaTextField::new()
+    };
+
+    type CreateOptionsModifier = fn(CreateOptions) -> CreateOptions;
+    let option_modifiers: Vec<(&'static str, CreateOptionsModifier)> = vec![
+        ("on_hash", |opts| opts.on(IndexDataType::Hash)),
+        ("single_prefix", |opts| opts.prefix("pref1")),
+        ("multiple_prefixes", |opts| {
+            opts.prefix("pref2").prefix("pref3")
+        }),
+        ("filter", |opts| opts.filter("@field: value")),
+        ("language", |opts| opts.language(SearchLanguage::English)),
+        ("language_field", |opts| {
+            opts.language_field("language_field")
+        }),
+        ("score", |opts| opts.score(1.0)),
+        ("score_field", |opts| opts.score_field("score_field")),
+        ("no_offsets", |opts| opts.no_offsets()),
+        ("temporary", |opts| opts.temporary(1)),
+        ("no_highlight", |opts| opts.no_highlight()),
+        ("no_freqs", |opts| opts.no_freqs()),
+        ("single_stopword", |opts| opts.stopword("stopword1")),
+        ("multiple_stopwords", |opts| {
+            opts.stopword("stopword2").stopword("stopword3")
+        }),
+        ("skip_initial_scan", |opts| opts.skip_initial_scan()),
+    ];
+
+    // `max_text_fields` (MAXTEXTFIELDS) and `no_fields` (NOFIELDS) are mutually exclusive on
+    // newer versions of RediSearch, so they are shouldn't be combined with each other.
+    let mutually_exclusive_modifiers: Vec<(&'static str, CreateOptionsModifier)> = vec![
+        ("max_text_fields", |opts| opts.max_text_fields()),
+        ("no_fields", |opts| opts.no_fields()),
+    ];
+
+    // Test each option individually
+    for (suffix, modifier) in option_modifiers.iter().chain(&mutually_exclusive_modifiers) {
+        let index_name = format!("index_with_{suffix}");
+        let options = modifier(CreateOptions::new());
+
+        assert_eq!(
+            con.ft_create(&index_name, &options, &schema),
+            Ok("OK".to_string())
+        );
+    }
+
+    // Combine all non-mutually-exclusive options cumulatively
+    let mut combined_options = CreateOptions::new();
+    for (suffix, modifier) in &option_modifiers {
+        let combined_index_name = format!("combined_index_until_{suffix}");
+        combined_options = modifier(combined_options);
+
+        assert_eq!(
+            con.ft_create(&combined_index_name, &combined_options, &schema),
+            Ok("OK".to_string())
+        );
+    }
+
+    // Add each mutually exclusive option onto the fully combined base individually
+    for (suffix, modifier) in &mutually_exclusive_modifiers {
+        let combined_index_name = format!("combined_index_with_{suffix}");
+        let options = modifier(combined_options.clone());
+
+        assert_eq!(
+            con.ft_create(&combined_index_name, &options, &schema),
+            Ok("OK".to_string())
+        );
+    }
+}
+
+fn run_ft_create_schema_text_field<C, F>(con: &mut C, mut on_created: F)
+where
+    C: redis::ConnectionLike,
+    F: FnMut(&str),
+{
+    type SchemaTextFieldModifier = fn(SchemaTextField) -> SchemaTextField;
+    let field_modifiers: Vec<(&'static str, SchemaTextFieldModifier)> = vec![
+        // Common modifiers
+        ("alias", |field| field.alias("text_alias")),
+        ("sortable", |field| field.sortable(Sortable::Yes)),
+        ("sortable_unf", |field| field.sortable(Sortable::Unf)),
+        // Text field modifiers
+        ("no_stem", |field| field.no_stem(true)),
+        ("weight", |field| field.weight(1.0)),
+        ("phonetic", |field| field.phonetic(Phonetic::DmEnglish)),
+        ("with_suffix_trie", |field| field.with_suffix_trie(true)),
+        ("index_empty", |field| field.index_empty(true)),
+    ];
+
+    // Common modifiers that are mutually exclusive
+    let mutually_exclusive_common_modifiers: Vec<(&'static str, SchemaTextFieldModifier)> = vec![
+        ("index_missing", |field| field.index_missing(true)),
+        ("no_index", |field| field.no_index(true)),
+    ];
+
+    // Test each common field modifier individually
+    for (suffix, modifier) in &field_modifiers {
+        let index_name = format!("index_for_text_field_with_{suffix}");
+        let schema = schema! {
+            TEXT_FIELD_NAME => modifier(SchemaTextField::new())
+        };
+        assert_eq!(
+            con.ft_create(&index_name, &CreateOptions::new(), &schema),
+            Ok("OK".to_string())
+        );
+        on_created(&index_name);
+    }
+
+    // Test each mutually exclusive modifier individually
+    for (suffix, modifier) in &mutually_exclusive_common_modifiers {
+        let index_name = format!("index_for_text_field_with_{suffix}");
+        let schema = schema! {
+            TEXT_FIELD_NAME => modifier(SchemaTextField::new())
+        };
+        assert_eq!(
+            con.ft_create(&index_name, &CreateOptions::new(), &schema),
+            Ok("OK".to_string())
+        );
+        on_created(&index_name);
+    }
+
+    // Test all combinations of field modifiers that are not mutually exclusive
+    let mut combined_schema_text_field = SchemaTextField::new();
+    for (suffix, modifier) in &field_modifiers {
+        let combined_index_name = format!("index_for_text_field_combined_until_{suffix}");
+        combined_schema_text_field = modifier(combined_schema_text_field);
+        let schema = schema! {
+            TEXT_FIELD_NAME => combined_schema_text_field.clone()
+        };
+        assert_eq!(
+            con.ft_create(&combined_index_name, &CreateOptions::new(), &schema),
+            Ok("OK".to_string())
+        );
+        on_created(&combined_index_name);
+    }
+
+    // After all of the modifiers above have been applied, add each of the mutually exclusive modifiers individually
+    for (suffix, modifier) in &mutually_exclusive_common_modifiers {
+        let combined_index_name = format!("index_for_text_field_all_combined_with_{suffix}");
+        let schema = schema! {
+            TEXT_FIELD_NAME =>  modifier(combined_schema_text_field.clone())
+        };
+        assert_eq!(
+            con.ft_create(&combined_index_name, &CreateOptions::new(), &schema),
+            Ok("OK".to_string())
+        );
+        on_created(&combined_index_name);
+    }
+    // Test that mutually exclusive modifiers are mutually exclusive indeed
+    assert_no_index_and_index_missing_exclusivity_for_field(
+        con.ft_create::<_, String>(
+            "invalid_index",
+            &CreateOptions::new(),
+            &schema! {
+                TEXT_FIELD_NAME => SchemaTextField::new().no_index(true).index_missing(true)
+            },
+        ),
+        TEXT_FIELD_NAME,
+    );
+}
+
+#[test]
+fn test_module_search_ft_create_schema_text_field() {
+    let ctx = run_test_if_version_supported!(
+        [&[REDIS_CE_8_0][..], &[REDIS_SEARCH_8_0]],
+        &[Module::Search]
+    );
+    run_ft_create_schema_text_field(&mut ctx.connection(), |_| {});
+}
+
+fn run_ft_create_schema_tag_field<C, F>(con: &mut C, mut on_created: F)
+where
+    C: redis::ConnectionLike,
+    F: FnMut(&str),
+{
+    type SchemaTagFieldModifier = fn(SchemaTagField) -> SchemaTagField;
+    let field_modifiers: Vec<(&'static str, SchemaTagFieldModifier)> = vec![
+        // Common modifiers
+        ("alias", |field| field.alias("tag_alias")),
+        ("sortable", |field| field.sortable(Sortable::Yes)),
+        ("sortable_unf", |field| field.sortable(Sortable::Unf)),
+        // Tag field modifiers
+        ("separator", |field| field.separator(',')),
+        ("case_sensitive", |field| field.case_sensitive(true)),
+        ("with_suffix_trie", |field| field.with_suffix_trie(true)),
+        ("index_empty", |field| field.index_empty(true)),
+    ];
+
+    // Common modifiers that are mutually exclusive
+    let mutually_exclusive_common_modifiers: Vec<(&'static str, SchemaTagFieldModifier)> = vec![
+        ("index_missing", |field| field.index_missing(true)),
+        ("no_index", |field| field.no_index(true)),
+    ];
+
+    // Test each common field modifier individually
+    for (suffix, modifier) in &field_modifiers {
+        let index_name = format!("index_for_tag_field_with_{suffix}");
+        let schema = schema! {
+            TAG_FIELD_NAME => modifier(SchemaTagField::new())
+        };
+        assert_eq!(
+            con.ft_create(&index_name, &CreateOptions::new(), &schema),
+            Ok("OK".to_string())
+        );
+        on_created(&index_name);
+    }
+
+    // Test each mutually exclusive modifier individually
+    for (suffix, modifier) in &mutually_exclusive_common_modifiers {
+        let index_name = format!("index_for_tag_field_with_{suffix}");
+        let schema = schema! {
+            TAG_FIELD_NAME => modifier(SchemaTagField::new())
+        };
+        assert_eq!(
+            con.ft_create(&index_name, &CreateOptions::new(), &schema),
+            Ok("OK".to_string())
+        );
+        on_created(&index_name);
+    }
+
+    // Test all combinations of field modifiers that are not mutually exclusive
+    let mut combined_schema_tag_field = SchemaTagField::new();
+    for (suffix, modifier) in &field_modifiers {
+        let combined_index_name = format!("index_for_tag_field_combined_until_{suffix}");
+        combined_schema_tag_field = modifier(combined_schema_tag_field);
+        let schema = schema! {
+            TAG_FIELD_NAME => combined_schema_tag_field.clone()
+        };
+        assert_eq!(
+            con.ft_create(&combined_index_name, &CreateOptions::new(), &schema),
+            Ok("OK".to_string())
+        );
+        on_created(&combined_index_name);
+    }
+
+    // After all of the modifiers above have been applied, add each of the mutually exclusive modifiers individually
+    for (suffix, modifier) in &mutually_exclusive_common_modifiers {
+        let combined_index_name = format!("index_for_tag_field_all_combined_with_{suffix}");
+        let schema = schema! {
+            TAG_FIELD_NAME =>  modifier(combined_schema_tag_field.clone())
+        };
+        assert_eq!(
+            con.ft_create(&combined_index_name, &CreateOptions::new(), &schema),
+            Ok("OK".to_string())
+        );
+        on_created(&combined_index_name);
+    }
+    // Test that mutually exclusive modifiers are mutually exclusive indeed
+    assert_no_index_and_index_missing_exclusivity_for_field(
+        con.ft_create::<_, String>(
+            "invalid_index",
+            &CreateOptions::new(),
+            &schema! {
+                TAG_FIELD_NAME => SchemaTagField::new().no_index(true).index_missing(true)
+            },
+        ),
+        TAG_FIELD_NAME,
+    );
+}
+
+#[test]
+fn test_module_search_ft_create_schema_tag_field() {
+    let ctx = run_test_if_version_supported!(
+        [&[REDIS_CE_8_0][..], &[REDIS_SEARCH_8_0]],
+        &[Module::Search]
+    );
+    run_ft_create_schema_tag_field(&mut ctx.connection(), |_| {});
+}
+
+fn run_ft_create_schema_numeric_field<C, F>(con: &mut C, mut on_created: F)
+where
+    C: redis::ConnectionLike,
+    F: FnMut(&str),
+{
+    type SchemaNumericFieldModifier = fn(SchemaNumericField) -> SchemaNumericField;
+    let field_modifiers: Vec<(&'static str, SchemaNumericFieldModifier)> = vec![
+        // Common modifiers
+        ("alias", |field| field.alias("numeric_alias")),
+        ("sortable", |field| field.sortable(Sortable::Yes)),
+        ("sortable_unf", |field| field.sortable(Sortable::Unf)),
+    ];
+
+    // Common modifiers that are mutually exclusive
+    let mutually_exclusive_common_modifiers: Vec<(&'static str, SchemaNumericFieldModifier)> = vec![
+        ("index_missing", |field| field.index_missing(true)),
+        ("no_index", |field| field.no_index(true)),
+    ];
+
+    // Test each common field modifier individually
+    for (suffix, modifier) in &field_modifiers {
+        let index_name = format!("index_for_numeric_field_with_{suffix}");
+        let schema = schema! {
+            NUMERIC_FIELD_NAME => modifier(SchemaNumericField::new())
+        };
+        assert_eq!(
+            con.ft_create(&index_name, &CreateOptions::new(), &schema),
+            Ok("OK".to_string())
+        );
+        on_created(&index_name);
+    }
+
+    // Test each mutually exclusive modifier individually
+    for (suffix, modifier) in &mutually_exclusive_common_modifiers {
+        let index_name = format!("index_for_numeric_field_with_{suffix}");
+        let schema = schema! {
+            NUMERIC_FIELD_NAME => modifier(SchemaNumericField::new())
+        };
+        assert_eq!(
+            con.ft_create(&index_name, &CreateOptions::new(), &schema),
+            Ok("OK".to_string())
+        );
+        on_created(&index_name);
+    }
+
+    // Test all combinations of field modifiers that are not mutually exclusive
+    let mut combined_schema_numeric_field = SchemaNumericField::new();
+    for (suffix, modifier) in &field_modifiers {
+        let combined_index_name = format!("index_for_numeric_field_combined_until_{suffix}");
+        combined_schema_numeric_field = modifier(combined_schema_numeric_field);
+        let schema = schema! {
+            NUMERIC_FIELD_NAME => combined_schema_numeric_field.clone()
+        };
+        assert_eq!(
+            con.ft_create(&combined_index_name, &CreateOptions::new(), &schema),
+            Ok("OK".to_string())
+        );
+        on_created(&combined_index_name);
+    }
+
+    // After all of the modifiers above have been applied, add each of the mutually exclusive modifiers individually
+    for (suffix, modifier) in &mutually_exclusive_common_modifiers {
+        let combined_index_name = format!("index_for_numeric_field_all_combined_with_{suffix}");
+        let schema = schema! {
+            NUMERIC_FIELD_NAME =>  modifier(combined_schema_numeric_field.clone())
+        };
+        assert_eq!(
+            con.ft_create(&combined_index_name, &CreateOptions::new(), &schema),
+            Ok("OK".to_string())
+        );
+        on_created(&combined_index_name);
+    }
+    // Test that mutually exclusive modifiers are mutually exclusive indeed
+    assert_no_index_and_index_missing_exclusivity_for_field(
+        con.ft_create::<_, String>(
+            "invalid_index",
+            &CreateOptions::new(),
+            &schema! {
+                NUMERIC_FIELD_NAME => SchemaNumericField::new().no_index(true).index_missing(true)
+            },
+        ),
+        NUMERIC_FIELD_NAME,
+    );
+}
+
+#[test]
+fn test_module_search_ft_create_schema_numeric_field() {
+    let ctx = run_test_if_version_supported!(
+        [&[REDIS_CE_8_0][..], &[REDIS_SEARCH_8_0]],
+        &[Module::Search]
+    );
+    run_ft_create_schema_numeric_field(&mut ctx.connection(), |_| {});
+}
+
+fn run_ft_create_schema_geo_field<C, F>(con: &mut C, mut on_created: F)
+where
+    C: redis::ConnectionLike,
+    F: FnMut(&str),
+{
+    type SchemaGeoFieldModifier = fn(SchemaGeoField) -> SchemaGeoField;
+    let field_modifiers: Vec<(&'static str, SchemaGeoFieldModifier)> = vec![
+        // Common modifiers
+        ("alias", |field| field.alias("geo_alias")),
+        ("sortable", |field| field.sortable(Sortable::Yes)),
+        ("sortable_unf", |field| field.sortable(Sortable::Unf)),
+    ];
+
+    // Common modifiers that are mutually exclusive
+    let mutually_exclusive_common_modifiers: Vec<(&'static str, SchemaGeoFieldModifier)> = vec![
+        ("index_missing", |field| field.index_missing(true)),
+        ("no_index", |field| field.no_index(true)),
+    ];
+
+    // Test each common field modifier individually
+    for (suffix, modifier) in &field_modifiers {
+        let index_name = format!("index_for_geo_field_with_{suffix}");
+        let schema = schema! {
+            GEO_FIELD_NAME => modifier(SchemaGeoField::new())
+        };
+        assert_eq!(
+            con.ft_create(&index_name, &CreateOptions::new(), &schema),
+            Ok("OK".to_string())
+        );
+        on_created(&index_name);
+    }
+
+    // Test each mutually exclusive modifier individually
+    for (suffix, modifier) in &mutually_exclusive_common_modifiers {
+        let index_name = format!("index_for_geo_field_with_{suffix}");
+        let schema = schema! {
+            GEO_FIELD_NAME => modifier(SchemaGeoField::new())
+        };
+        assert_eq!(
+            con.ft_create(&index_name, &CreateOptions::new(), &schema),
+            Ok("OK".to_string())
+        );
+        on_created(&index_name);
+    }
+
+    // Test all combinations of field modifiers that are not mutually exclusive
+    let mut combined_schema_geo_field = SchemaGeoField::new();
+    for (suffix, modifier) in &field_modifiers {
+        let combined_index_name = format!("index_for_geo_field_combined_until_{suffix}");
+        combined_schema_geo_field = modifier(combined_schema_geo_field);
+        let schema = schema! {
+            GEO_FIELD_NAME => combined_schema_geo_field.clone()
+        };
+        assert_eq!(
+            con.ft_create(&combined_index_name, &CreateOptions::new(), &schema),
+            Ok("OK".to_string())
+        );
+        on_created(&combined_index_name);
+    }
+
+    // After all of the modifiers above have been applied, add each of the mutually exclusive modifiers individually
+    for (suffix, modifier) in &mutually_exclusive_common_modifiers {
+        let combined_index_name = format!("index_for_geo_field_all_combined_with_{suffix}");
+        let schema = schema! {
+            GEO_FIELD_NAME =>  modifier(combined_schema_geo_field.clone())
+        };
+        assert_eq!(
+            con.ft_create(&combined_index_name, &CreateOptions::new(), &schema),
+            Ok("OK".to_string())
+        );
+        on_created(&combined_index_name);
+    }
+    // Test that mutually exclusive modifiers are mutually exclusive indeed
+    assert_no_index_and_index_missing_exclusivity_for_field(
+        con.ft_create::<_, String>(
+            "invalid_index",
+            &CreateOptions::new(),
+            &schema! {
+                GEO_FIELD_NAME => SchemaGeoField::new().no_index(true).index_missing(true)
+            },
+        ),
+        GEO_FIELD_NAME,
+    );
+}
+
+#[test]
+fn test_module_search_ft_create_schema_geo_field() {
+    let ctx = run_test_if_version_supported!(
+        [&[REDIS_CE_8_0][..], &[REDIS_SEARCH_8_0]],
+        &[Module::Search]
+    );
+    run_ft_create_schema_geo_field(&mut ctx.connection(), |_| {});
+}
+
+fn run_ft_create_schema_geoshape_field<C, F>(con: &mut C, mut on_created: F)
+where
+    C: redis::ConnectionLike,
+    F: FnMut(&str),
+{
+    type SchemaGeoShapeFieldModifier = fn(SchemaGeoShapeField) -> SchemaGeoShapeField;
+    let field_modifiers: Vec<(&'static str, SchemaGeoShapeFieldModifier)> = vec![
+        // Common modifiers
+        ("alias", |field| field.alias("geo_shape_alias")),
+    ];
+
+    // Common modifiers that are mutually exclusive
+    let mutually_exclusive_common_modifiers: Vec<(&'static str, SchemaGeoShapeFieldModifier)> = vec![
+        ("index_missing", |field| field.index_missing(true)),
+        ("no_index", |field| field.no_index(true)),
+    ];
+
+    // For each coordinate system
+    for coord_system in &[CoordSystem::Spherical, CoordSystem::Flat] {
+        // Test each common field modifier individually
+        for (suffix, modifier) in &field_modifiers {
+            let index_name = format!("index_for_geoshape_{coord_system:?}_field_with_{suffix}");
+            let schema = schema! {
+                GEOSHAPE_FIELD_NAME => modifier(SchemaGeoShapeField::new().coord_system(coord_system.clone()))
+            };
+            assert_eq!(
+                con.ft_create(&index_name, &CreateOptions::new(), &schema),
+                Ok("OK".to_string())
+            );
+            on_created(&index_name);
+        }
+
+        // Test each mutually exclusive modifier individually
+        for (suffix, modifier) in &mutually_exclusive_common_modifiers {
+            let index_name = format!("index_for_geoshape_{coord_system:?}_field_with_{suffix}");
+            let schema = schema! {
+                GEOSHAPE_FIELD_NAME => modifier(SchemaGeoShapeField::new().coord_system(coord_system.clone()))
+            };
+            assert_eq!(
+                con.ft_create(&index_name, &CreateOptions::new(), &schema),
+                Ok("OK".to_string())
+            );
+            on_created(&index_name);
+        }
+
+        // Test all modifiers that are not mutually exclusive
+        let mut combined_field = SchemaGeoShapeField::new().coord_system(coord_system.clone());
+        for (_suffix, modifier) in &field_modifiers {
+            combined_field = modifier(combined_field);
+        }
+        let combined_index_name = format!("index_for_geoshape_{coord_system:?}_field_all_combined");
+        let schema = schema! {
+            GEOSHAPE_FIELD_NAME => combined_field.clone()
+        };
+        assert_eq!(
+            con.ft_create(&combined_index_name, &CreateOptions::new(), &schema),
+            Ok("OK".to_string())
+        );
+        on_created(&combined_index_name);
+
+        // After all of the modifiers above have been applied, add each of the mutually exclusive modifiers individually
+        for (suffix, modifier) in &mutually_exclusive_common_modifiers {
+            let combined_index_name =
+                format!("index_for_geoshape_{coord_system:?}_field_all_combined_with_{suffix}");
+            let schema = schema! {
+                GEOSHAPE_FIELD_NAME =>  modifier(combined_field.clone())
+            };
+            assert_eq!(
+                con.ft_create(&combined_index_name, &CreateOptions::new(), &schema),
+                Ok("OK".to_string())
+            );
+            on_created(&combined_index_name);
+        }
+
+        // Test that mutually exclusive modifiers are mutually exclusive indeed
+        assert_no_index_and_index_missing_exclusivity_for_field(
+            con.ft_create::<_, String>(
+                "invalid_index",
+                &CreateOptions::new(),
+                &schema! {
+                    GEOSHAPE_FIELD_NAME => SchemaGeoShapeField::new().coord_system(coord_system.clone()).no_index(true).index_missing(true)
+                }
+            ),
+            GEOSHAPE_FIELD_NAME,
+        );
+    }
+}
+
+#[test]
+fn test_module_search_ft_create_schema_geoshape_field() {
+    let ctx = run_test_if_version_supported!(
+        [&[REDIS_CE_8_0][..], &[REDIS_SEARCH_8_0]],
+        &[Module::Search]
+    );
+    run_ft_create_schema_geoshape_field(&mut ctx.connection(), |_| {});
+}

--- a/redis/tests/test_module_search.rs
+++ b/redis/tests/test_module_search.rs
@@ -11,6 +11,7 @@ static TEXT_FIELD_NAME: &str = "title";
 static NUMERIC_FIELD_NAME: &str = "price";
 static TAG_FIELD_NAME: &str = "condition";
 static GEO_FIELD_NAME: &str = "location";
+static VECTOR_FIELD_NAME: &str = "embedding";
 static GEOSHAPE_FIELD_NAME: &str = "area";
 
 fn assert_no_index_and_index_missing_exclusivity_for_field(
@@ -538,6 +539,124 @@ fn test_module_search_ft_create_schema_geo_field() {
         &[Module::Search]
     );
     run_ft_create_schema_geo_field(&mut ctx.connection(), |_| {});
+}
+
+type VectorFieldModifier = fn(VectorField) -> VectorField;
+
+fn run_ft_create_schema_flat_vector_field<C, F>(con: &mut C, mut on_created: F)
+where
+    C: redis::ConnectionLike,
+    F: FnMut(&str),
+{
+    const DIM: u32 = 128;
+
+    type FlatVectorFieldBuilderModifier = fn(FlatVectorFieldBuilder) -> FlatVectorFieldBuilder;
+    // FLAT-specific builder modifiers (applied before .build())
+    let builder_modifiers: Vec<(&'static str, FlatVectorFieldBuilderModifier)> =
+        vec![("block_size", |builder| builder.block_size(1000))];
+
+    // Common field modifiers (applied after .build()) - not mutually exclusive
+    let field_modifiers: Vec<(&'static str, VectorFieldModifier)> = vec![
+        ("alias", |field| field.alias("vector_alias")),
+        ("index_missing", |field| field.index_missing(true)),
+    ];
+
+    // For each Vector type
+    for (vector_type_name, vector_type) in [
+        ("float32", VectorType::Float32),
+        ("float64", VectorType::Float64),
+        ("bfloat16", VectorType::BFloat16),
+        ("float16", VectorType::Float16),
+        ("int8", VectorType::Int8),
+        ("uint8", VectorType::UInt8),
+    ] {
+        // For each distance metric
+        for (distance_metric_name, distance_metric) in [
+            ("l2", DistanceMetric::L2),
+            ("ip", DistanceMetric::IP),
+            ("cosine", DistanceMetric::Cosine),
+        ] {
+            let base_name = format!("idx_flat_{vector_type_name}_{distance_metric_name}");
+
+            // 1. Test each builder modifier individually
+            for (builder_suffix, builder_modifier) in &builder_modifiers {
+                let index_name = format!("{base_name}_builder_{builder_suffix}");
+                let schema = schema! {
+                    VECTOR_FIELD_NAME => builder_modifier(VectorField::flat(vector_type, DIM, distance_metric)).build()
+                };
+                assert_eq!(
+                    con.ft_create(&index_name, &CreateOptions::new(), &schema),
+                    Ok("OK".to_string())
+                );
+                on_created(&index_name);
+            }
+
+            // 2. Test each common field modifier individually
+            for (field_suffix, field_modifier) in &field_modifiers {
+                let index_name = format!("{base_name}_field_{field_suffix}");
+                let schema = schema! {
+                    VECTOR_FIELD_NAME => field_modifier(VectorField::flat(vector_type, DIM, distance_metric).build())
+                };
+                assert_eq!(
+                    con.ft_create(&index_name, &CreateOptions::new(), &schema),
+                    Ok("OK".to_string())
+                );
+                on_created(&index_name);
+            }
+
+            // 3. Test all builder modifiers combined progressively
+            let mut combined_builder = VectorField::flat(vector_type, DIM, distance_metric);
+            for (builder_suffix, builder_modifier) in &builder_modifiers {
+                combined_builder = builder_modifier(combined_builder);
+                let index_name = format!("{base_name}_builders_until_{builder_suffix}");
+                let schema = schema! {
+                    VECTOR_FIELD_NAME => combined_builder.clone().build()
+                };
+                assert_eq!(
+                    con.ft_create(&index_name, &CreateOptions::new(), &schema),
+                    Ok("OK".to_string())
+                );
+                on_created(&index_name);
+            }
+
+            // 4. Test all builder modifiers + each field modifier
+            for (field_suffix, field_modifier) in &field_modifiers {
+                let index_name = format!("{base_name}_all_builders_with_{field_suffix}");
+                let schema = schema! {
+                    VECTOR_FIELD_NAME => field_modifier(combined_builder.clone().build())
+                };
+                assert_eq!(
+                    con.ft_create(&index_name, &CreateOptions::new(), &schema),
+                    Ok("OK".to_string())
+                );
+                on_created(&index_name);
+            }
+
+            // 5. Test all builder modifiers + all field modifiers combined progressively
+            let mut combined_field = combined_builder.clone().build();
+            for (field_suffix, field_modifier) in &field_modifiers {
+                combined_field = field_modifier(combined_field);
+                let index_name = format!("{base_name}_all_builders_fields_until_{field_suffix}");
+                let schema = schema! {
+                    VECTOR_FIELD_NAME => combined_field.clone()
+                };
+                assert_eq!(
+                    con.ft_create(&index_name, &CreateOptions::new(), &schema),
+                    Ok("OK".to_string())
+                );
+                on_created(&index_name);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_module_search_ft_create_schema_flat_vector_field() {
+    let ctx = run_test_if_version_supported!(
+        [&[REDIS_CE_8_0][..], &[REDIS_SEARCH_8_0]],
+        &[Module::Search]
+    );
+    run_ft_create_schema_flat_vector_field(&mut ctx.connection(), |_| {});
 }
 
 fn run_ft_create_schema_geoshape_field<C, F>(con: &mut C, mut on_created: F)


### PR DESCRIPTION
# Add FLAT vector field support for `FT.CREATE`

## Summary

Adds the vector field types shared by every indexing algorithm, along with the `FLAT` algorithm and its builder.
This is **part 5 of the series that supersedes #2015**, where the design is described in full.

## Behavior

A vector field is written as `VECTOR <algorithm> <attribute_count> <attributes...>`, where the count covers the three shared attributes (`TYPE`, `DIM`, `DISTANCE_METRIC`) plus whichever algorithm-specific ones were set:

```
embedding VECTOR FLAT 6 TYPE FLOAT32 DIM 128 DISTANCE_METRIC COSINE
embedding VECTOR FLAT 8 TYPE FLOAT32 DIM 128 DISTANCE_METRIC COSINE BLOCK_SIZE 1000
```

Vector fields differ from the other field types in two ways: they are built through a per-algorithm builder ending in `.build()` rather than by chaining directly, and they support only `AS` and `INDEXMISSING` from the shared modifiers - not `SORTABLE` or `NOINDEX`.

## What's included

| Path | Purpose |
|---|---|
| `search/create/vector/mod.rs` | `VectorType`, `DistanceMetric`, `SchemaVectorField`, `VectorField`, attribute counting, `VectorField::flat()` |
| `search/create/vector/flat.rs` | `FlatVectorOptions`, `FlatVectorFieldBuilder` |
| `search/create/schema.rs` | `FieldDefinition::Vector` and `From<VectorField>` |

Two changes are a consequence of splitting one file per algorithm rather than keeping everything in `types.rs`: `SchemaVectorField::base` is `pub(crate)` because `vector/` is a different module from `fields.rs`, and `FlatVectorFieldBuilder` gains a `pub(super) fn new`, because its fields are private to `flat.rs` while `VectorField::flat()` sits in `vector/mod.rs`.

## Testing

**7 unit tests**, five carried over verbatim from #2015 covering the zero-dimension panic, `BLOCK_SIZE`, `AS` and `INDEXMISSING`.

#2015's unit tests only ever exercised `VectorType::Float32` with `COSINE` and `L2`, leaving `FLOAT64`, `BFLOAT16`, `FLOAT16`, `INT8`, `UINT8` and `IP` without unit coverage. The two new tests (`test_vector_types` and `test_distance_metrics`) assert every variant. Both enums are shared by all three algorithms, so the later parts inherit the coverage.

**1 integration test**, carried over from #2015, creating **144** indexes: 6 vector types × 3 distance metrics × 8 variations per combination - each builder and field modifier individually, then cumulatively, then combined.