### PR TITLE
Switch to `combine` version with `opaque` fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,9 +700,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "futures-core",

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -34,7 +34,7 @@ url = "2.5"
 # We need this for script support
 sha1_smol = { version = "1.0", optional = true }
 
-combine = { version = "4.6", default-features = false, features = ["std"] }
+combine = { version = "4.6.8", default-features = false, features = ["std"] }
 
 # Only needed for AIO
 bytes = { version = "1", optional = true }

--- a/redis/src/parser.rs
+++ b/redis/src/parser.rs
@@ -1,11 +1,3 @@
-// TODO remove this `allow` once `combine` released a fix. Upstream bug: https://github.com/Marwes/combine/issues/372
-// `combine`'s foreign `opaque!` macro trips the nightly-only `semicolon_in_expressions_from_non_local_macros` lint.
-// `unknown_lints` is applied so the other toolchains, which do not know that lint, ignore it instead of failing under `-D warnings`.
-#![allow(unknown_lints)]
-#![allow(
-    semicolon_in_expressions_from_non_local_macros,
-    reason = "This lint is on in nightly since 2026-07-16, but `combine-4.6.7` violates it in `opaque`. As we cannot decorate directly, we allow it for the whole module for now"
-)]
 use std::{
     io::{self, Read},
     str,


### PR DESCRIPTION
`combine` had the `opaque` fix merged (Marwes/combine#377), but not yet seen a release.

As `combine` releases do not happen too often (last one was 2 years ago. The one before was another 2 years back), we for now switch to the unreleased commit.

This trades one fix-up for another. But the new one is a lesser pain than the old one. So the trade-off is worth it.