### PR TITLE
fix: reject out-of-range integer and double replies instead of wrapping them

### DIFF
--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1704,7 +1704,7 @@ fn get_owned_inner_value(v: Value) -> Value {
     }
 }
 
-macro_rules! from_redis_value_for_num_internal {
+macro_rules! from_redis_value_for_float_internal {
     ($t:ty, $v:expr) => {{
         let v = if let Value::Attribute {
             data,
@@ -1731,15 +1731,11 @@ macro_rules! from_redis_value_for_num_internal {
     }};
 }
 
-/// Same as `from_redis_value_for_num_internal`, but for integer types.
+/// Same as `from_redis_value_for_float_internal`, but for integer types.
 ///
-/// `Value::Int` holds an `i64` and `Value::Double` holds an `f64`. Neither can
-/// be converted to a narrower or differently signed integer with `as`, which
-/// wraps around for integers, and saturates (turning NaN into zero) for floats.
-/// Both do so silently, so `TTL` replying `:-1` used to be handed back as
-/// `u64::MAX` instead of as an error. These two arms are therefore
-/// range-checked, which is what the `SimpleString` and `BulkString` arms
-/// already get from `str::parse`.
+/// Every arm rejects a value that the requested type cannot represent, so that
+/// a reply converts to the same result whether the server sent it as a number
+/// or as a string.
 macro_rules! from_redis_value_for_int_internal {
     ($t:ty, $v:expr) => {{
         let v = if let Value::Attribute {
@@ -1768,18 +1764,17 @@ macro_rules! from_redis_value_for_int_internal {
                 Err(_) => crate::errors::invalid_type_error!(v, "Could not convert from string."),
             },
             Value::Double(val) => {
-                // Truncate towards zero, as `as` does, but reject anything that
-                // does not fit. `<$t>::MAX as f64` rounds *up* to the next power
-                // of two for the wider integer types, so the upper bound has to
-                // be a strict `<` against `MAX as f64 + 1.0`. NaN and the
-                // infinities fail both comparisons and are rejected too.
-                let truncated = val.trunc();
-                if truncated >= <$t>::MIN as f64 && truncated < <$t>::MAX as f64 + 1.0 {
-                    Ok(truncated as $t)
+                // `<$t>::MAX as f64` rounds *up* to the next power of two for the
+                // wider integer types, so the upper bound is a strict `<` against
+                // `MAX as f64 + 1.0`. NaN and the infinities fail both
+                // comparisons, and a fractional value is not an integer, so all
+                // three are rejected the same way `str::parse` rejects them.
+                if val.fract() == 0.0 && val >= <$t>::MIN as f64 && val < <$t>::MAX as f64 + 1.0 {
+                    Ok(val as $t)
                 } else {
                     crate::errors::invalid_type_error!(
                         v,
-                        "Double is out of range for the requested type."
+                        "Double is not an integer in range for the requested type."
                     )
                 }
             }
@@ -1788,11 +1783,11 @@ macro_rules! from_redis_value_for_int_internal {
     }};
 }
 
-macro_rules! from_redis_value_for_num {
+macro_rules! from_redis_value_for_float {
     ($t:ty) => {
         impl FromRedisValue for $t {
             fn from_redis_value_ref(v: &Value) -> Result<$t, ParsingError> {
-                from_redis_value_for_num_internal!($t, v)
+                from_redis_value_for_float_internal!($t, v)
             }
 
             fn from_redis_value(v: Value) -> Result<Self, ParsingError> {
@@ -1843,8 +1838,8 @@ from_redis_value_for_int!(i64);
 from_redis_value_for_int!(u64);
 from_redis_value_for_int!(i128);
 from_redis_value_for_int!(u128);
-from_redis_value_for_num!(f32);
-from_redis_value_for_num!(f64);
+from_redis_value_for_float!(f32);
+from_redis_value_for_float!(f64);
 from_redis_value_for_int!(isize);
 from_redis_value_for_int!(usize);
 

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1731,6 +1731,63 @@ macro_rules! from_redis_value_for_num_internal {
     }};
 }
 
+/// Same as `from_redis_value_for_num_internal`, but for integer types.
+///
+/// `Value::Int` holds an `i64` and `Value::Double` holds an `f64`. Neither can
+/// be converted to a narrower or differently signed integer with `as`, which
+/// wraps around for integers, and saturates (turning NaN into zero) for floats.
+/// Both do so silently, so `TTL` replying `:-1` used to be handed back as
+/// `u64::MAX` instead of as an error. These two arms are therefore
+/// range-checked, which is what the `SimpleString` and `BulkString` arms
+/// already get from `str::parse`.
+macro_rules! from_redis_value_for_int_internal {
+    ($t:ty, $v:expr) => {{
+        let v = if let Value::Attribute {
+            data,
+            attributes: _,
+        } = $v
+        {
+            data
+        } else {
+            $v
+        };
+        match *v {
+            Value::Int(val) => match <$t>::try_from(val) {
+                Ok(rv) => Ok(rv),
+                Err(_) => crate::errors::invalid_type_error!(
+                    v,
+                    "Integer is out of range for the requested type."
+                ),
+            },
+            Value::SimpleString(ref s) => match s.parse::<$t>() {
+                Ok(rv) => Ok(rv),
+                Err(_) => crate::errors::invalid_type_error!(v, "Could not convert from string."),
+            },
+            Value::BulkString(ref bytes) => match from_utf8(bytes)?.parse::<$t>() {
+                Ok(rv) => Ok(rv),
+                Err(_) => crate::errors::invalid_type_error!(v, "Could not convert from string."),
+            },
+            Value::Double(val) => {
+                // Truncate towards zero, as `as` does, but reject anything that
+                // does not fit. `<$t>::MAX as f64` rounds *up* to the next power
+                // of two for the wider integer types, so the upper bound has to
+                // be a strict `<` against `MAX as f64 + 1.0`. NaN and the
+                // infinities fail both comparisons and are rejected too.
+                let truncated = val.trunc();
+                if truncated >= <$t>::MIN as f64 && truncated < <$t>::MAX as f64 + 1.0 {
+                    Ok(truncated as $t)
+                } else {
+                    crate::errors::invalid_type_error!(
+                        v,
+                        "Double is out of range for the requested type."
+                    )
+                }
+            }
+            _ => crate::errors::invalid_type_error!(v, "Response type not convertible to numeric."),
+        }
+    }};
+}
+
 macro_rules! from_redis_value_for_num {
     ($t:ty) => {
         impl FromRedisValue for $t {
@@ -1745,9 +1802,23 @@ macro_rules! from_redis_value_for_num {
     };
 }
 
+macro_rules! from_redis_value_for_int {
+    ($t:ty) => {
+        impl FromRedisValue for $t {
+            fn from_redis_value_ref(v: &Value) -> Result<$t, ParsingError> {
+                from_redis_value_for_int_internal!($t, v)
+            }
+
+            fn from_redis_value(v: Value) -> Result<Self, ParsingError> {
+                Self::from_redis_value_ref(&v)
+            }
+        }
+    };
+}
+
 impl FromRedisValue for u8 {
     fn from_redis_value_ref(v: &Value) -> Result<Self, ParsingError> {
-        from_redis_value_for_num_internal!(Self, v)
+        from_redis_value_for_int_internal!(Self, v)
     }
 
     fn from_redis_value(v: Value) -> Result<Self, ParsingError> {
@@ -1763,19 +1834,19 @@ impl FromRedisValue for u8 {
     }
 }
 
-from_redis_value_for_num!(i8);
-from_redis_value_for_num!(i16);
-from_redis_value_for_num!(u16);
-from_redis_value_for_num!(i32);
-from_redis_value_for_num!(u32);
-from_redis_value_for_num!(i64);
-from_redis_value_for_num!(u64);
-from_redis_value_for_num!(i128);
-from_redis_value_for_num!(u128);
+from_redis_value_for_int!(i8);
+from_redis_value_for_int!(i16);
+from_redis_value_for_int!(u16);
+from_redis_value_for_int!(i32);
+from_redis_value_for_int!(u32);
+from_redis_value_for_int!(i64);
+from_redis_value_for_int!(u64);
+from_redis_value_for_int!(i128);
+from_redis_value_for_int!(u128);
 from_redis_value_for_num!(f32);
 from_redis_value_for_num!(f64);
-from_redis_value_for_num!(isize);
-from_redis_value_for_num!(usize);
+from_redis_value_for_int!(isize);
+from_redis_value_for_int!(usize);
 
 #[cfg(any(
     feature = "rust_decimal",

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -276,20 +276,20 @@ mod types {
                 quickcheck! {
                     fn $name(val: f64) -> bool {
                         let from_double = <$t>::from_redis_value(Value::Double(val));
-                        // Neither a non-finite nor a fractional double is an
-                        // integer, and no integer string spells one, so the only
-                        // thing to check is that both are refused.
-                        if !val.is_finite() || val.fract() != 0.0 {
-                            return from_double.is_err();
-                        }
-                        // For a whole number `{:.0}` writes the exact value, which
-                        // is what a server sending it as a string would write.
-                        // Negative zero is the one exception: it is zero, but it
-                        // writes as "-0", and `str::parse` refuses a sign on an
-                        // unsigned type.
+                        // Negative zero is zero, but it writes as "-0" and
+                        // `str::parse` refuses a sign on an unsigned type, so
+                        // compare against the spelling of the value itself.
                         let val = if val == 0.0 { 0.0 } else { val };
-                        let from_string =
-                            <$t>::from_redis_value(string_value(format!("{val:.0}")));
+                        // A whole number is written exactly by `{:.0}`, which is
+                        // what a server sending it as a string would write. Every
+                        // other double is spelled the way it prints, and none of
+                        // those spellings parse as an integer.
+                        let spelled = if val.is_finite() && val.fract() == 0.0 {
+                            format!("{val:.0}")
+                        } else {
+                            format!("{val}")
+                        };
+                        let from_string = <$t>::from_redis_value(string_value(spelled));
                         match (from_double, from_string) {
                             (Ok(a), Ok(b)) => a == b,
                             (Err(_), Err(_)) => true,

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -230,6 +230,86 @@ mod types {
         }
     }
 
+    /// A reply carries the same number whether the server encodes it as a
+    /// number or as a string, so both encodings have to convert to the same
+    /// result for every integer type.
+    mod numeric_and_string_replies_agree {
+        use quickcheck::quickcheck;
+        use redis::{FromRedisValue, Value};
+
+        fn string_value(s: String) -> Value {
+            Value::BulkString(s.into_bytes())
+        }
+
+        macro_rules! agree_on_int {
+            ($name:ident, $t:ty) => {
+                quickcheck! {
+                    fn $name(val: i64) -> bool {
+                        let from_int = <$t>::from_redis_value(Value::Int(val));
+                        let from_string =
+                            <$t>::from_redis_value(string_value(val.to_string()));
+                        match (from_int, from_string) {
+                            (Ok(a), Ok(b)) => a == b,
+                            (Err(_), Err(_)) => true,
+                            _ => false,
+                        }
+                    }
+                }
+            };
+        }
+
+        agree_on_int!(u8_agrees, u8);
+        agree_on_int!(i8_agrees, i8);
+        agree_on_int!(u16_agrees, u16);
+        agree_on_int!(i16_agrees, i16);
+        agree_on_int!(u32_agrees, u32);
+        agree_on_int!(i32_agrees, i32);
+        agree_on_int!(u64_agrees, u64);
+        agree_on_int!(i64_agrees, i64);
+        agree_on_int!(u128_agrees, u128);
+        agree_on_int!(i128_agrees, i128);
+        agree_on_int!(usize_agrees, usize);
+        agree_on_int!(isize_agrees, isize);
+
+        macro_rules! agree_on_double {
+            ($name:ident, $t:ty) => {
+                quickcheck! {
+                    fn $name(val: f64) -> bool {
+                        let from_double = <$t>::from_redis_value(Value::Double(val));
+                        // Neither a non-finite nor a fractional double is an
+                        // integer, and no integer string spells one, so the only
+                        // thing to check is that both are refused.
+                        if !val.is_finite() || val.fract() != 0.0 {
+                            return from_double.is_err();
+                        }
+                        // For a whole number `{:.0}` writes the exact value, which
+                        // is what a server sending it as a string would write.
+                        // Negative zero is the one exception: it is zero, but it
+                        // writes as "-0", and `str::parse` refuses a sign on an
+                        // unsigned type.
+                        let val = if val == 0.0 { 0.0 } else { val };
+                        let from_string =
+                            <$t>::from_redis_value(string_value(format!("{val:.0}")));
+                        match (from_double, from_string) {
+                            (Ok(a), Ok(b)) => a == b,
+                            (Err(_), Err(_)) => true,
+                            _ => false,
+                        }
+                    }
+                }
+            };
+        }
+
+        agree_on_double!(u8_agrees_on_double, u8);
+        agree_on_double!(i8_agrees_on_double, i8);
+        agree_on_double!(u32_agrees_on_double, u32);
+        agree_on_double!(i32_agrees_on_double, i32);
+        agree_on_double!(u64_agrees_on_double, u64);
+        agree_on_double!(i64_agrees_on_double, i64);
+        agree_on_double!(u128_agrees_on_double, u128);
+        agree_on_double!(i128_agrees_on_double, i128);
+    }
+
     #[test]
     fn test_out_of_range_integer_reply_is_an_error() {
         for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
@@ -298,9 +378,16 @@ mod types {
                 parse_mode.parse_redis_value(Value::Double(9223372036854775808.0));
             assert_matches!(bad, Err(_));
 
-            // In-range doubles still truncate towards zero, as before.
-            assert_eq!(parse_mode.parse_redis_value(Value::Double(1.9)), Ok(1i64));
-            assert_eq!(parse_mode.parse_redis_value(Value::Double(-1.9)), Ok(-1i64));
+            // A fractional double is not an integer, the same way "1.9" is not
+            // one for `str::parse`.
+            let bad: Result<i64, _> = parse_mode.parse_redis_value(Value::Double(1.9));
+            assert_matches!(bad, Err(_));
+            let bad: Result<i64, _> = parse_mode.parse_redis_value(Value::Double(-1.9));
+            assert_matches!(bad, Err(_));
+
+            // Doubles that are whole numbers in range convert as before.
+            assert_eq!(parse_mode.parse_redis_value(Value::Double(1.0)), Ok(1i64));
+            assert_eq!(parse_mode.parse_redis_value(Value::Double(-1.0)), Ok(-1i64));
             assert_eq!(
                 parse_mode.parse_redis_value(Value::Double(255.0)),
                 Ok(255u8)

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -231,6 +231,91 @@ mod types {
     }
 
     #[test]
+    fn test_out_of_range_integer_reply_is_an_error() {
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            // `TTL` replies with `:-1` when the key has no expiry and with `:-2`
+            // when it does not exist. Neither fits in an unsigned type, and used
+            // to wrap around to `u64::MAX` / `u64::MAX - 1` instead of erroring.
+            let bad: Result<u64, _> = parse_mode.parse_redis_value(Value::Int(-1));
+            assert_matches!(bad, Err(_));
+            let bad: Result<usize, _> = parse_mode.parse_redis_value(Value::Int(-2));
+            assert_matches!(bad, Err(_));
+            let bad: Result<u32, _> = parse_mode.parse_redis_value(Value::Int(-1));
+            assert_matches!(bad, Err(_));
+
+            // Too large for the narrower types.
+            let bad: Result<u8, _> = parse_mode.parse_redis_value(Value::Int(300));
+            assert_matches!(bad, Err(_));
+            let bad: Result<i8, _> = parse_mode.parse_redis_value(Value::Int(128));
+            assert_matches!(bad, Err(_));
+            let bad: Result<i32, _> = parse_mode.parse_redis_value(Value::Int(i64::MAX));
+            assert_matches!(bad, Err(_));
+
+            // An integer reply and the equivalent string reply must agree: the
+            // same command can reply with either depending on the protocol
+            // version in use.
+            let bad: Result<u8, _> =
+                parse_mode.parse_redis_value(Value::BulkString(b"300".to_vec()));
+            assert_matches!(bad, Err(_));
+
+            // Values that do fit still convert, including the exact boundaries.
+            assert_eq!(parse_mode.parse_redis_value(Value::Int(-1)), Ok(-1i64));
+            assert_eq!(parse_mode.parse_redis_value(Value::Int(255)), Ok(255u8));
+            assert_eq!(parse_mode.parse_redis_value(Value::Int(-128)), Ok(-128i8));
+            assert_eq!(parse_mode.parse_redis_value(Value::Int(127)), Ok(127i8));
+            assert_eq!(
+                parse_mode.parse_redis_value(Value::Int(i64::MAX)),
+                Ok(i64::MAX)
+            );
+            assert_eq!(
+                parse_mode.parse_redis_value(Value::Int(i64::MIN)),
+                Ok(i64::MIN as i128)
+            );
+        }
+    }
+
+    #[test]
+    fn test_out_of_range_double_reply_is_an_error() {
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            // RESP3 replies with a double where RESP2 replies with a bulk
+            // string, e.g. for `ZSCORE`. A score that does not fit used to
+            // saturate to `i64::MAX` (and NaN used to become `0`) rather than
+            // producing the error the string reply produces.
+            let bad: Result<i64, _> = parse_mode.parse_redis_value(Value::Double(3e40));
+            assert_matches!(bad, Err(_));
+            let bad: Result<u64, _> = parse_mode.parse_redis_value(Value::Double(-5.0));
+            assert_matches!(bad, Err(_));
+            let bad: Result<i64, _> = parse_mode.parse_redis_value(Value::Double(f64::NAN));
+            assert_matches!(bad, Err(_));
+            let bad: Result<i64, _> = parse_mode.parse_redis_value(Value::Double(f64::INFINITY));
+            assert_matches!(bad, Err(_));
+            let bad: Result<i64, _> =
+                parse_mode.parse_redis_value(Value::Double(f64::NEG_INFINITY));
+            assert_matches!(bad, Err(_));
+
+            // `i64::MAX as f64` rounds up to 2^63, which is out of range.
+            let bad: Result<i64, _> =
+                parse_mode.parse_redis_value(Value::Double(9223372036854775808.0));
+            assert_matches!(bad, Err(_));
+
+            // In-range doubles still truncate towards zero, as before.
+            assert_eq!(parse_mode.parse_redis_value(Value::Double(1.9)), Ok(1i64));
+            assert_eq!(parse_mode.parse_redis_value(Value::Double(-1.9)), Ok(-1i64));
+            assert_eq!(
+                parse_mode.parse_redis_value(Value::Double(255.0)),
+                Ok(255u8)
+            );
+            assert_eq!(parse_mode.parse_redis_value(Value::Double(0.0)), Ok(0u64));
+
+            // Floating point targets are unaffected.
+            assert_eq!(
+                parse_mode.parse_redis_value(Value::Double(f64::INFINITY)),
+                Ok(f64::INFINITY)
+            );
+        }
+    }
+
+    #[test]
     fn test_parse_boxed() {
         for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
             let simple_string_exp = "Simple string".to_string();

--- a/version2.md
+++ b/version2.md
@@ -311,7 +311,7 @@ let ttl: u64 = con.ttl("key")?; // 18446744073709551615, no error
 
 The same value arriving as a string already errored, so the outcome depended on how the reply happened to be encoded. RESP3 makes the same split reachable for scores, since `ZSCORE` replies with a double under RESP3 and a bulk string under RESP2.
 
-The numeric arms are now range-checked, matching what the `SimpleString` and `BulkString` arms already got from `str::parse`. `Value::Int` goes through `try_from`, and `Value::Double` is bounds-checked before it truncates towards zero, which also rejects `NaN` and the infinities. In-range values, including the exact type boundaries and fractional doubles, convert exactly as before, and `f32`/`f64` are untouched.
+Every arm now rejects a value the requested type cannot represent, so a reply converts to the same result whether the server sent it as a number or as a string. `Value::Int` goes through `try_from`, and for the integer types `Value::Double` accepts only whole numbers in range, which also rejects `NaN`, the infinities, and fractional values such as `1.9` that previously truncated to `1`. Whole numbers in range, including the exact type boundaries, convert exactly as before, and `f32`/`f64` are untouched.
 
 **Migration:** Handle the error, or parse into a type that covers the full range of the reply.
 

--- a/version2.md
+++ b/version2.md
@@ -298,3 +298,32 @@ Their return types are now updated to:
 - `hget_ex`: `Vec<Option<String>>` (was `Vec<String>`)
 - `zscore_multiple`: `Vec<Option<f64>>` (was `Option<Vec<f64>>`)
 - `geo_hash`: `Vec<Option<String>>` (was `Vec<String>`)
+
+### Out-of-range integer and double replies are rejected instead of wrapping (Breaking Change)
+
+`FromRedisValue` for the integer types converted `Value::Int` and `Value::Double` with `as`, which wraps around for integers and saturates for floats, turning `NaN` into zero. Both did so silently, so a reply outside the target type's range produced a wrong number rather than an error.
+
+The most visible case is `TTL`, which replies `-2` for a missing key and `-1` for a key without an expiry:
+
+```rust
+let ttl: u64 = con.ttl("key")?; // 18446744073709551615, no error
+```
+
+The same value arriving as a string already errored, so the outcome depended on how the reply happened to be encoded. RESP3 makes the same split reachable for scores, since `ZSCORE` replies with a double under RESP3 and a bulk string under RESP2.
+
+The numeric arms are now range-checked, matching what the `SimpleString` and `BulkString` arms already got from `str::parse`. `Value::Int` goes through `try_from`, and `Value::Double` is bounds-checked before it truncates towards zero, which also rejects `NaN` and the infinities. In-range values, including the exact type boundaries and fractional doubles, convert exactly as before, and `f32`/`f64` are untouched.
+
+**Migration:** Handle the error, or parse into a type that covers the full range of the reply.
+
+```rust
+// Before: silently wrapped to 18446744073709551615
+let ttl: u64 = con.ttl("key")?;
+
+// After: use a signed type that can represent the -1 and -2 sentinels
+let ttl: i64 = con.ttl("key")?;
+match ttl {
+    -2 => { /* key does not exist */ }
+    -1 => { /* key exists but has no expiry */ }
+    secs => { /* seconds remaining */ }
+}
+```


### PR DESCRIPTION
### Does your PR solve an issue?

Not formally, but #1159 ("Redis TTL command returns overflow values on unsigned int") is the same defect. It was closed by the reporter within ten minutes after they worked around it with a signed type, so the underlying problem was never fixed.

### Is this a breaking change?

Yes, in the Hyrum's Law sense: conversions that used to silently produce a wrong number now return an error. No conversion that previously produced a *correct* number changes. Retargeted at `2.0.x` and described in `version2.md`.

---

`FromRedisValue` for the integer types converts `Value::Int` (an `i64`) and `Value::Double` (an `f64`) with `as`. `as` wraps around for integers, and saturates (turning NaN into zero) for floats. Both do so silently.

The most visible consequence is `TTL`, which is documented to reply `-2` when the key does not exist and `-1` when it exists without an expiry:

```rust
let ttl: u64 = con.ttl("key")?;   // 18446744073709551615, no error
```

The same value parsed from a string reply already errors, so the outcome depended purely on how the reply happened to be encoded:

```rust
u64::from_redis_value(Value::Int(-1))                      // Ok(18446744073709551615)
u64::from_redis_value(Value::BulkString(b"-1".to_vec()))   // Err(...)
```

RESP3 makes the same split reachable for scores. `ZSCORE` replies with a double under RESP3 and a bulk string under RESP2, so the identical score converted differently depending on the negotiated protocol version:

```rust
i64::from_redis_value(Value::Double(3e40))                    // Ok(i64::MAX)
i64::from_redis_value(Value::BulkString(b"3e+40".to_vec()))   // Err(...)
i64::from_redis_value(Value::Double(f64::NAN))                // Ok(0)
```

`test_u32` already asserts that `-1` must be an error for a `u32`, but only covered the string arm, so the numeric arms were never checked.

This splits the numeric macro so the integer types range-check both numeric arms, which is what the `SimpleString` and `BulkString` arms already get from `str::parse`. `Value::Int` goes through `try_from`. `Value::Double` still truncates towards zero, but is bounds-checked first; the upper bound is a strict `<` against `MAX as f64 + 1.0` because `<int>::MAX as f64` rounds up to the next power of two for the wider types, and NaN and the infinities fall out of the same comparison. `f32` and `f64` are untouched, and in-range values, including the exact type boundaries, convert as before.

Two regression tests cover the integer and double arms; both fail before this change. Verified against a local redis 8.10.1: `test_types`, `test_basic`, `parser`, `test_bignum`, `test_script`, `test_geospatial` and `test_streams` all pass.

Disclosure: this was AI assisted — an agent found the inconsistency by differential-testing the numeric and string arms of `FromRedisValue` against each other, and drafted the patch; I verified the behaviour and the reasoning before submitting.

