### PR TITLE
redis-test/RedisServer: Stop trying to load a dump during startup

### DIFF
--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -271,9 +271,12 @@ impl RedisServer {
             redis_cmd.arg(config_path);
         }
 
-        // Disable snapshotting
-        // This stops littering `dump.rdb` files during testing/development.
+        // Disable basic disk operations
+        // This stops littering or loading `dump.rdb` files during testing/development.
         redis_cmd.arg2("--save", "");
+        redis_cmd.arg2("--dbfilename", "");
+        // We'd prefer `flushdb` here, but this is only available on Redis 8.6+.
+        redis_cmd.arg2("--repl-diskless-load", "on-empty-db");
 
         redis_cmd.load_modules(modules);
 


### PR DESCRIPTION
If there's a `dump.rdb` from some manual experiments in `redis`, the tests will try to load it.

As the tests should start with an empty database, we turn off the default dump loading.