### PR TITLE
fix: accept the RESP3 array-of-pairs shape in map conversions

### DIFF
--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -392,10 +392,23 @@ impl fmt::Display for PushKind {
     }
 }
 
+/// RESP3 returns key/value replies that RESP2 flattened into a single array as an
+/// array of two-element pairs instead (`ZRANGE ... WITHSCORES` and friends). Detect
+/// that shape so it converts into a map type just like the RESP2 shape does. This
+/// mirrors the check `<(K, V)>::from_redis_values` already makes via
+/// `Value::is_collection_of_len`.
+fn is_nested_pairs(items: &[Value]) -> bool {
+    !items.is_empty() && items.iter().all(|item| item.is_collection_of_len(2))
+}
+
 #[non_exhaustive]
 pub enum MapIter<'a> {
     Array(std::slice::Iter<'a, Value>),
     Map(std::slice::Iter<'a, (Value, Value)>),
+    /// An array whose every element is itself a two-element collection. This is
+    /// the shape RESP3 uses where RESP2 used a flat key/value array, e.g. for
+    /// `ZRANGE ... WITHSCORES`.
+    NestedPairs(std::slice::Iter<'a, Value>),
 }
 
 impl<'a> Iterator for MapIter<'a> {
@@ -408,13 +421,14 @@ impl<'a> Iterator for MapIter<'a> {
                 let (k, v) = iter.next()?;
                 Some((k, v))
             }
+            MapIter::NestedPairs(iter) => iter.next()?.as_pair(),
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         match self {
-            MapIter::Array(iter) => iter.size_hint(),
             MapIter::Map(iter) => iter.size_hint(),
+            MapIter::Array(iter) | MapIter::NestedPairs(iter) => iter.size_hint(),
         }
     }
 }
@@ -423,6 +437,10 @@ impl<'a> Iterator for MapIter<'a> {
 pub enum OwnedMapIter {
     Array(std::vec::IntoIter<Value>),
     Map(std::vec::IntoIter<(Value, Value)>),
+    /// An array whose every element is itself a two-element collection. This is
+    /// the shape RESP3 uses where RESP2 used a flat key/value array, e.g. for
+    /// `ZRANGE ... WITHSCORES`.
+    NestedPairs(std::vec::IntoIter<Value>),
 }
 
 impl Iterator for OwnedMapIter {
@@ -432,6 +450,7 @@ impl Iterator for OwnedMapIter {
         match self {
             Self::Array(iter) => Some((iter.next()?, iter.next()?)),
             Self::Map(iter) => iter.next(),
+            Self::NestedPairs(iter) => iter.next()?.into_pair().ok(),
         }
     }
 
@@ -442,6 +461,7 @@ impl Iterator for OwnedMapIter {
                 (low / 2, high.map(|h| h / 2))
             }
             Self::Map(iter) => iter.size_hint(),
+            Self::NestedPairs(iter) => iter.size_hint(),
         }
     }
 }
@@ -492,9 +512,39 @@ impl Value {
     /// Returns an iterator of `(&Value, &Value)` if `self` is compatible with a map type
     pub fn as_map_iter(&self) -> Option<MapIter<'_>> {
         match self {
-            Self::Array(items) => (items.len() % 2 == 0).then(|| MapIter::Array(items.iter())),
+            Self::Array(items) => {
+                if is_nested_pairs(items) {
+                    Some(MapIter::NestedPairs(items.iter()))
+                } else {
+                    (items.len() % 2 == 0).then(|| MapIter::Array(items.iter()))
+                }
+            }
             Self::Map(items) => Some(MapIter::Map(items.iter())),
             _ => None,
+        }
+    }
+
+    /// If `self` is a two-element collection, return its two elements.
+    fn as_pair(&self) -> Option<(&Self, &Self)> {
+        match self {
+            Self::Array(items) | Self::Set(items) if items.len() == 2 => {
+                Some((&items[0], &items[1]))
+            }
+            Self::Map(items) if items.len() == 1 => Some((&items[0].0, &items[0].1)),
+            _ => None,
+        }
+    }
+
+    /// Owned counterpart of [`Self::as_pair`].
+    fn into_pair(self) -> Result<(Self, Self), Self> {
+        match self {
+            Self::Array(items) | Self::Set(items) if items.len() == 2 => {
+                let mut it = items.into_iter();
+                let (a, b) = (it.next().unwrap(), it.next().unwrap());
+                Ok((a, b))
+            }
+            Self::Map(items) if items.len() == 1 => Ok(items.into_iter().next().unwrap()),
+            other => Err(other),
         }
     }
 
@@ -503,7 +553,9 @@ impl Value {
     pub fn into_map_iter(self) -> Result<OwnedMapIter, Self> {
         match self {
             Self::Array(items) => {
-                if items.len() % 2 == 0 {
+                if is_nested_pairs(&items) {
+                    Ok(OwnedMapIter::NestedPairs(items.into_iter()))
+                } else if items.len() % 2 == 0 {
                     Ok(OwnedMapIter::Array(items.into_iter()))
                 } else {
                     Err(Self::Array(items))

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -640,11 +640,9 @@ mod types {
     /// into a map type identically. `Vec<(K, V)>` already handled both.
     #[test]
     fn test_map_from_resp3_array_of_pairs() {
-        use std::collections::HashMap;
+        type MapType = HashMap<String, f64>;
 
-        type Hm = HashMap<String, f64>;
-
-        let expected: Hm = [("a".to_string(), 1.0), ("b".to_string(), 2.5)]
+        let expected: MapType = [("a".to_string(), 1.0), ("b".to_string(), 2.5)]
             .into_iter()
             .collect();
 
@@ -663,11 +661,11 @@ mod types {
 
         for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
             assert_eq!(
-                parse_mode.parse_redis_value::<Hm>(resp2.clone()),
+                parse_mode.parse_redis_value::<MapType>(resp2.clone()),
                 Ok(expected.clone())
             );
             assert_eq!(
-                parse_mode.parse_redis_value::<Hm>(resp3.clone()),
+                parse_mode.parse_redis_value::<MapType>(resp3.clone()),
                 Ok(expected.clone())
             );
 
@@ -682,12 +680,12 @@ mod types {
                 Value::Array(vec![Value::BulkString("c".into()), Value::Double(3.0)]),
                 Value::Array(vec![Value::BulkString("d".into()), Value::Double(4.0)]),
             ]);
-            let m: Hm = parse_mode.parse_redis_value(four).unwrap();
+            let m: MapType = parse_mode.parse_redis_value(four).unwrap();
             assert_eq!(m.len(), 4);
             assert_eq!(m["d"], 4.0);
 
             // An empty array is still an empty map, not a "nested pairs" array.
-            let empty: Hm = parse_mode.parse_redis_value(Value::Array(vec![])).unwrap();
+            let empty: MapType = parse_mode.parse_redis_value(Value::Array(vec![])).unwrap();
             assert!(empty.is_empty());
 
             // A flat array of non-collections keeps the old pairwise behaviour.

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -634,6 +634,73 @@ mod types {
         }
     }
 
+    /// RESP3 replaces the flat `[member, score, member, score]` array RESP2 used
+    /// for `ZRANGE ... WITHSCORES` (and ZPOPMIN/ZPOPMAX/ZRANDMEMBER/ZDIFF/ZUNION/
+    /// ZINTER) with an array of `[member, score]` pairs. Both shapes must convert
+    /// into a map type identically. `Vec<(K, V)>` already handled both.
+    #[test]
+    fn test_map_from_resp3_array_of_pairs() {
+        use std::collections::HashMap;
+
+        type Hm = HashMap<String, f64>;
+
+        let expected: Hm = [("a".to_string(), 1.0), ("b".to_string(), 2.5)]
+            .into_iter()
+            .collect();
+
+        // RESP2: flat array.
+        let resp2 = Value::Array(vec![
+            Value::BulkString("a".into()),
+            Value::BulkString("1".into()),
+            Value::BulkString("b".into()),
+            Value::BulkString("2.5".into()),
+        ]);
+        // RESP3: array of two-element pairs.
+        let resp3 = Value::Array(vec![
+            Value::Array(vec![Value::BulkString("a".into()), Value::Double(1.0)]),
+            Value::Array(vec![Value::BulkString("b".into()), Value::Double(2.5)]),
+        ]);
+
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            assert_eq!(
+                parse_mode.parse_redis_value::<Hm>(resp2.clone()),
+                Ok(expected.clone())
+            );
+            assert_eq!(
+                parse_mode.parse_redis_value::<Hm>(resp3.clone()),
+                Ok(expected.clone())
+            );
+
+            // `Vec<(K, V)>` accepted both shapes before and must keep doing so.
+            let pairs: Vec<(String, f64)> = parse_mode.parse_redis_value(resp3.clone()).unwrap();
+            assert_eq!(pairs, vec![("a".to_string(), 1.0), ("b".to_string(), 2.5)]);
+
+            // An even-length array of pairs must not be paired up *as pairs*.
+            let four = Value::Array(vec![
+                Value::Array(vec![Value::BulkString("a".into()), Value::Double(1.0)]),
+                Value::Array(vec![Value::BulkString("b".into()), Value::Double(2.0)]),
+                Value::Array(vec![Value::BulkString("c".into()), Value::Double(3.0)]),
+                Value::Array(vec![Value::BulkString("d".into()), Value::Double(4.0)]),
+            ]);
+            let m: Hm = parse_mode.parse_redis_value(four).unwrap();
+            assert_eq!(m.len(), 4);
+            assert_eq!(m["d"], 4.0);
+
+            // An empty array is still an empty map, not a "nested pairs" array.
+            let empty: Hm = parse_mode.parse_redis_value(Value::Array(vec![])).unwrap();
+            assert!(empty.is_empty());
+
+            // A flat array of non-collections keeps the old pairwise behaviour.
+            let flat: HashMap<String, String> = parse_mode
+                .parse_redis_value(Value::Array(vec![
+                    Value::BulkString("k".into()),
+                    Value::BulkString("v".into()),
+                ]))
+                .unwrap();
+            assert_eq!(flat["k"], "v");
+        }
+    }
+
     #[cfg(feature = "hashbrown")]
     #[test]
     fn test_hashbrown_hashmap() {

--- a/version2.md
+++ b/version2.md
@@ -328,3 +328,22 @@ match ttl {
     secs => { /* seconds remaining */ }
 }
 ```
+
+### Map types accept the RESP3 array-of-pairs shape (Minor breaking Change)
+
+RESP3 returns `ZRANGE ... WITHSCORES` and its relatives as an array of `[member, score]` pairs where RESP2 returned one flat array. `Vec<(K, V)>` accepted both, because `from_redis_values` checks `Value::is_collection_of_len`, but the map types only accepted the flat one, so the same command on the same data parsed under RESP2 and errored under RESP3. `as_map_iter` and `into_map_iter` now recognise the nested shape using that same check.
+
+For the affected commands this turns an error into a map, which needs no migration. The breaking part is narrower: a key or value type that can itself absorb a two element array now sees the pairs split rather than combined.
+
+**Migration:** Expect one entry per pair for such a type.
+
+```rust
+// value: [[a, 1], [b, 2]]
+
+// Before:
+// {["a", "1"]: ["b", "2"]}
+
+// After:
+// {["a"]: ["1"], ["b"]: ["2"]}
+let map: HashMap<Vec<String>, Vec<String>> = con.zrange_withscores("z", 0, -1)?;
+```


### PR DESCRIPTION
RESP3 returns `ZRANGE ... WITHSCORES` as an array of `[member, score]` pairs where RESP2 returned one flat array. `Vec<(String, f64)>` handles both, because `from_redis_values` checks `is_collection_of_len`. `HashMap<String, f64>` only handles the flat one, so the same command on the same data parses under RESP2 and errors under RESP3.

```rust
let v = parse_redis_value(b"*2\r\n*2\r\n$1\r\na\r\n,1\r\n*2\r\n$1\r\nb\r\n,2\r\n").unwrap();
Vec::<(String, f64)>::from_redis_value(v.clone()); // Ok
HashMap::<String, f64>::from_redis_value(v);       // Err "Response type not string compatible."
```

Same for ZREVRANGE, ZRANGEBYSCORE, ZREVRANGEBYSCORE, ZPOPMIN/ZPOPMAX with a count, ZRANDMEMBER WITHSCORES, and ZDIFF/ZUNION/ZINTER WITHSCORES. I checked all ten against a live 8.10.1.

There is a structural bug underneath it too: on an even length reply `as_map_iter` pairs adjacent pairs with each other, so `[[a,1],[b,2]]` gives `key=["a",1], value=["b",2]`. It only avoids handing back wrong data because the leaf conversion errors afterwards. `HashMap<Vec<String>, Vec<String>>` does return `{["a","1"]: ["b","2"]}` today.

This teaches `as_map_iter`/`into_map_iter` the nested pair shape using the same `is_collection_of_len(2)` check the tuple path already uses. Both iterator enums are `#[non_exhaustive]`, so the new variant is not breaking. An empty array still parses as an empty map.

I found it by running each command on a RESP2 and a RESP3 connection against the same server state and diffing the parsed results, the same way as #2332.

One behaviour change worth naming: a key or value type that can absorb a two element array, like `HashMap<Vec<String>, Vec<String>>`, previously got `{["a","1"]: ["b","2"]}` from `[[a,1],[b,2]]` and now gets `{["a"]:["1"], ["b"]:["2"]}`. Happy to move this to `2.0.x` with a `version2.md` note if you would rather have it there.

AI assistance disclosure: I used Claude to build the differential harness and draft the patch. I ran and reviewed everything myself.
