### PR TITLE
test: Split encode parts out to make them usable from unit and int tests (8/15)

### DIFF
--- a/redis/benches/bench_basic.rs
+++ b/redis/benches/bench_basic.rs
@@ -286,7 +286,7 @@ fn bench_decode(c: &mut Criterion) {
     let mut group = c.benchmark_group("decode");
     {
         let mut input = Vec::new();
-        support::encode_value(&value, &mut input).unwrap();
+        support::shared::encode::encode_value(&value, &mut input).unwrap();
         assert_eq!(redis::parse_redis_value(&input).unwrap(), value);
         group.bench_function("decode", move |b| bench_decode_simple(b, &input));
     }

--- a/redis/tests/parser.rs
+++ b/redis/tests/parser.rs
@@ -12,7 +12,7 @@ use {
 };
 
 mod support;
-use crate::support::{current_thread_runtime, encode_value};
+use crate::support::{current_thread_runtime, shared::encode::encode_value};
 
 #[derive(Clone, Debug)]
 struct ArbitraryValue(Value);

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -20,7 +20,6 @@ use redis_test::utils::TlsFilePaths;
 #[cfg(feature = "tls-rustls")]
 use redis_test::utils::load_certs_from_file;
 
-use std::io;
 #[cfg(feature = "tls-rustls")]
 use std::{
     fs::File,
@@ -123,6 +122,7 @@ mod cluster;
 #[cfg(any(feature = "cluster", feature = "cluster-async"))]
 mod mock_cluster;
 
+pub mod shared;
 mod util;
 
 #[cfg(any(feature = "cluster", feature = "cluster-async"))]
@@ -189,95 +189,6 @@ impl TestContextExt for TestContext {
                 )
                 .await
         }
-    }
-}
-
-fn encode_iter<W>(values: &[Value], writer: &mut W, prefix: &str) -> io::Result<()>
-where
-    W: io::Write,
-{
-    write!(writer, "{}{}\r\n", prefix, values.len()).unwrap();
-    for val in values.iter() {
-        encode_value(val, writer).unwrap();
-    }
-    Ok(())
-}
-fn encode_map<W>(values: &[(Value, Value)], writer: &mut W, prefix: &str) -> io::Result<()>
-where
-    W: io::Write,
-{
-    write!(writer, "{}{}\r\n", prefix, values.len()).unwrap();
-    for (k, v) in values.iter() {
-        encode_value(k, writer).unwrap();
-        encode_value(v, writer).unwrap();
-    }
-    Ok(())
-}
-pub fn encode_value<W>(value: &Value, writer: &mut W) -> io::Result<()>
-where
-    W: io::Write,
-{
-    #![allow(clippy::write_with_newline)]
-    match *value {
-        Value::Nil => write!(writer, "$-1\r\n"),
-        Value::Int(val) => write!(writer, ":{val}\r\n"),
-        Value::BulkString(ref val) => {
-            write!(writer, "${}\r\n", val.len()).unwrap();
-            writer.write_all(val).unwrap();
-            writer.write_all(b"\r\n")
-        }
-        Value::Array(ref values) => encode_iter(values, writer, "*"),
-        Value::Okay => write!(writer, "+OK\r\n"),
-        Value::SimpleString(ref s) => write!(writer, "+{s}\r\n"),
-        Value::Map(ref values) => encode_map(values, writer, "%"),
-        Value::Attribute {
-            ref data,
-            ref attributes,
-        } => {
-            encode_map(attributes, writer, "|").unwrap();
-            encode_value(data, writer).unwrap();
-            Ok(())
-        }
-        Value::Set(ref values) => encode_iter(values, writer, "~"),
-        Value::Double(val) => write!(writer, ",{val}\r\n"),
-        Value::Boolean(v) => {
-            if v {
-                write!(writer, "#t\r\n")
-            } else {
-                write!(writer, "#f\r\n")
-            }
-        }
-        Value::VerbatimString {
-            ref format,
-            ref text,
-        } => {
-            // format is always 3 bytes
-            write!(writer, "={}\r\n{}:{}\r\n", 3 + text.len(), format, text)
-        }
-        Value::BigNumber(ref val) => {
-            #[cfg(feature = "num-bigint")]
-            return write!(writer, "({val}\r\n");
-            #[cfg(not(feature = "num-bigint"))]
-            {
-                write!(writer, "(").unwrap();
-                for byte in val {
-                    write!(writer, "{byte}").unwrap();
-                }
-                write!(writer, "\r\n")
-            }
-        }
-        Value::Push { ref kind, ref data } => {
-            write!(writer, ">{}\r\n+{kind}\r\n", data.len() + 1).unwrap();
-            for val in data.iter() {
-                encode_value(val, writer).unwrap();
-            }
-            Ok(())
-        }
-        Value::ServerError(ref err) => match err.details() {
-            Some(details) => write!(writer, "-{} {details}\r\n", err.code()),
-            None => write!(writer, "-{}\r\n", err.code()),
-        },
-        _ => panic!("unknown value {value:?}"),
     }
 }
 

--- a/redis/tests/support/shared/encode.rs
+++ b/redis/tests/support/shared/encode.rs
@@ -1,0 +1,96 @@
+//! Tooling to encode a [`Value`] as if it was sent by a Redis server
+
+// Importing `Value` via `super`, as that works both in unit and integration tests.
+use super::super::Value;
+use std::io;
+
+fn encode_iter<W>(values: &[Value], writer: &mut W, prefix: &str) -> io::Result<()>
+where
+    W: io::Write,
+{
+    write!(writer, "{}{}\r\n", prefix, values.len()).unwrap();
+    for val in values.iter() {
+        encode_value(val, writer).unwrap();
+    }
+    Ok(())
+}
+
+fn encode_map<W>(values: &[(Value, Value)], writer: &mut W, prefix: &str) -> io::Result<()>
+where
+    W: io::Write,
+{
+    write!(writer, "{}{}\r\n", prefix, values.len()).unwrap();
+    for (k, v) in values.iter() {
+        encode_value(k, writer).unwrap();
+        encode_value(v, writer).unwrap();
+    }
+    Ok(())
+}
+
+pub fn encode_value<W>(value: &Value, writer: &mut W) -> io::Result<()>
+where
+    W: io::Write,
+{
+    #![allow(clippy::write_with_newline)]
+    match *value {
+        Value::Nil => write!(writer, "$-1\r\n"),
+        Value::Int(val) => write!(writer, ":{val}\r\n"),
+        Value::BulkString(ref val) => {
+            write!(writer, "${}\r\n", val.len()).unwrap();
+            writer.write_all(val).unwrap();
+            writer.write_all(b"\r\n")
+        }
+        Value::Array(ref values) => encode_iter(values, writer, "*"),
+        Value::Okay => write!(writer, "+OK\r\n"),
+        Value::SimpleString(ref s) => write!(writer, "+{s}\r\n"),
+        Value::Map(ref values) => encode_map(values, writer, "%"),
+        Value::Attribute {
+            ref data,
+            ref attributes,
+        } => {
+            encode_map(attributes, writer, "|").unwrap();
+            encode_value(data, writer).unwrap();
+            Ok(())
+        }
+        Value::Set(ref values) => encode_iter(values, writer, "~"),
+        Value::Double(val) => write!(writer, ",{val}\r\n"),
+        Value::Boolean(v) => {
+            if v {
+                write!(writer, "#t\r\n")
+            } else {
+                write!(writer, "#f\r\n")
+            }
+        }
+        Value::VerbatimString {
+            ref format,
+            ref text,
+        } => {
+            // format is always 3 bytes
+            write!(writer, "={}\r\n{}:{}\r\n", 3 + text.len(), format, text)
+        }
+        Value::BigNumber(ref val) => {
+            #[cfg(feature = "num-bigint")]
+            return write!(writer, "({val}\r\n");
+            #[cfg(not(feature = "num-bigint"))]
+            {
+                write!(writer, "(").unwrap();
+                for byte in val {
+                    write!(writer, "{byte}").unwrap();
+                }
+                write!(writer, "\r\n")
+            }
+        }
+        Value::Push { ref kind, ref data } => {
+            write!(writer, ">{}\r\n+{kind}\r\n", data.len() + 1).unwrap();
+            for val in data.iter() {
+                encode_value(val, writer).unwrap();
+            }
+            Ok(())
+        }
+        Value::ServerError(ref err) => match err.details() {
+            Some(details) => write!(writer, "-{} {details}\r\n", err.code()),
+            None => write!(writer, "-{}\r\n", err.code()),
+        },
+        _ => panic!("unknown value {value:?}"),
+    }
+}

--- a/redis/tests/support/shared/mod.rs
+++ b/redis/tests/support/shared/mod.rs
@@ -1,0 +1,3 @@
+//! Tooling for tests that should be usable from both unit and integration tests
+
+pub mod encode;

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -1,6 +1,7 @@
 mod support;
 
 mod types {
+    use crate::support::shared::encode::encode_value;
     use std::{
         collections::{HashMap, HashSet},
         error::Error,
@@ -944,8 +945,6 @@ mod types {
 
     #[test]
     fn test_large_usize_array_to_redis_args_and_back() {
-        use crate::support::encode_value;
-
         let mut array = [0; 1000];
         for (i, item) in array.iter_mut().enumerate() {
             *item = i;
@@ -968,8 +967,6 @@ mod types {
 
     #[test]
     fn test_large_u8_array_to_redis_args_and_back() {
-        use crate::support::encode_value;
-
         let mut array: [u8; 1000] = [0; 1000];
         for (i, item) in array.iter_mut().enumerate() {
             *item = (i % 256) as u8;
@@ -989,8 +986,6 @@ mod types {
 
     #[test]
     fn test_large_string_array_to_redis_args_and_back() {
-        use crate::support::encode_value;
-
         let mut array: [String; 1000] = [(); 1000].map(|_| String::new());
         for (i, item) in array.iter_mut().enumerate() {
             *item = format!("{i}");
@@ -1013,8 +1008,6 @@ mod types {
 
     #[test]
     fn test_0_length_usize_array_to_redis_args_and_back() {
-        use crate::support::encode_value;
-
         let array: [usize; 0] = [0; 0];
 
         let vec = (&array).to_redis_args();


### PR DESCRIPTION
`test_types` is structurally an integration test. But effectively does not test the integration of services/components. Instead its tests are actually unit tests for `types.rs`. So the aim is to turn `test_types` into unit tests. But this is not possible, as they rely on `encode_values` which lives in `tests/support` and hence not accessible from unit tests.

But we cannot pull these `encode` functions into `types.rs`' unit tests, as they are also used parser integration tests and `bench_basic`.

In order to allow accessing the `encode` functions from both unit tests, integration tests, and benches, we move them into a `shared` module, which we can import from all these places.

This will allow to turn `test_types` into unit tests in follow-up commits.

This is part of #2249