### PR TITLE
Remove usage of env variables in CI testing

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -11,14 +11,8 @@ filter = 'test(cluster_async::test_async_cluster_basic_failover)'
 slow-timeout = { period = "20s", terminate-after = 2 }
 
 
-[profile.tcp_tls]
+[profile.no_module]
 default-filter = 'not (test(test_module))'
-
-[profile.tcp]
-default-filter = 'not (test(tls) | test(test_module))'
-
-[profile.unix]
-default-filter = 'not (test(cluster) | binary(test_sentinel) | test(tls) | test(test_module))'
 
 [profile.module_bloom]
 default-filter = 'binary(test_module_bloom*)'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2979,8 +2979,10 @@ dependencies = [
 name = "test-macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "rstest",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ test:
 	@RUSTFLAGS="-D warnings" cargo build --locked -p redis -p redis-test --all-features
 
 	@echo "===================================================================="
+	@echo "Testing test-macros unit tests"
+	@echo "===================================================================="
+	@RUSTFLAGS="-D warnings" cargo test --locked -p test-macros
+
+	@echo "===================================================================="
 	@echo "Testing Connection Type TCP without features"
 	@echo "===================================================================="
 	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run --locked -p redis --no-default-features --profile tcp

--- a/Makefile
+++ b/Makefile
@@ -13,71 +13,41 @@ test:
 	@RUSTFLAGS="-D warnings" cargo test --locked -p test-macros
 
 	@echo "===================================================================="
-	@echo "Testing Connection Type TCP without features"
+	@echo "Testing redis without default features"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run --locked -p redis --no-default-features --profile tcp
+	@RUSTFLAGS="-D warnings" RUST_BACKTRACE=1 cargo nextest run --locked -p redis --no-default-features --profile no_module
 
 	@echo "===================================================================="
-	@echo "Testing Connection Type TCP with all features and RESP2"
+	@echo "Testing redis with all features"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features --profile tcp
-
-	@echo "===================================================================="
-	@echo "Testing Connection Type TCP with all features and RESP3"
-	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run --locked -p redis --all-features --profile tcp
-
-	@echo "===================================================================="
-	@echo "Testing Connection Type TCP with all features and Rustls support"
-	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features --profile tcp_tls
+	@RUSTFLAGS="-D warnings" RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features --profile no_module
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with native-TLS support"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo nextest run --locked -p redis --features=json,tokio-native-tls-comp,smol-native-tls-comp,connection-manager,cluster-async --profile tcp_tls
-
-	@echo "===================================================================="
-	@echo "Testing Connection Type UNIX SOCKETS"
-	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features --profile unix
-
-	@echo "===================================================================="
-	@echo "Testing Connection Type UNIX SOCKETS and RESP3"
-	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=unix PROTOCOL=RESP3 RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features --profile unix	
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo nextest run --locked -p redis --features=json,tokio-native-tls-comp,smol-native-tls-comp,connection-manager,cluster-async --profile no_module
 
 	@echo "===================================================================="
 	@echo "Testing redis-test without features"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" RUST_BACKTRACE=1 cargo nextest run --locked -p redis-test --no-default-features
+	@RUSTFLAGS="-D warnings" RUST_BACKTRACE=1 cargo nextest run --locked -p redis-test --no-default-features --profile no_module
 
 	@echo "===================================================================="
 	@echo "Testing redis-test with all features"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" RUST_BACKTRACE=1 cargo nextest run --locked -p redis-test --all-features
+	@RUSTFLAGS="-D warnings" RUST_BACKTRACE=1 cargo nextest run --locked -p redis-test --all-features --profile no_module
 
 test-module-json:
 	@echo "===================================================================="
-	@echo "Testing RESP2 with RedisJSON module"
+	@echo "Testing RedisJSON module"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features --profile module_json
-
-	@echo "===================================================================="
-	@echo "Testing RESP3 with RedisJSON module"
-	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --locked --all-features --profile module_json
+	@RUSTFLAGS="-D warnings" RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features --profile module_json
 
 test-module-bloom:
 	@echo "===================================================================="
-	@echo "Testing RESP2 with RedisBloom module"
+	@echo "Testing RedisBloom module"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features --profile module_bloom
-
-	@echo "===================================================================="
-	@echo "Testing RESP3 with RedisBloom module"
-	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --locked --all-features --profile module_bloom
+	@RUSTFLAGS="-D warnings" RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features --profile module_bloom
 
 test-modules: test-module-json test-module-bloom
 

--- a/redis-test/src/cluster.rs
+++ b/redis-test/src/cluster.rs
@@ -26,6 +26,7 @@ pub struct RedisClusterConfiguration {
     cluster_databases: Option<u16>,
     /// Custom DNS hostname for TLS certificate SAN (used when `certs_with_ip_alts` is false).
     dns_hostname: Option<String>,
+    cluster_type: Option<ClusterType>,
 }
 
 impl RedisClusterConfiguration {
@@ -90,6 +91,17 @@ impl RedisClusterConfiguration {
         self
     }
 
+    pub fn cluster_type(mut self, cluster_type: ClusterType) -> Self {
+        self.cluster_type = Some(cluster_type);
+        self
+    }
+
+    pub fn get_cluster_type(&self) -> ClusterType {
+        self.cluster_type
+            .or_else(ClusterType::get_intended)
+            .unwrap_or(ClusterType::Tcp)
+    }
+
     pub fn get_require_secure_tls(&self) -> bool {
         self.require_secure_tls
     }
@@ -111,6 +123,7 @@ impl Default for RedisClusterConfiguration {
             certs_with_ip_alts: true,
             cluster_databases: None,
             dns_hostname: None,
+            cluster_type: None,
         }
     }
 }
@@ -124,22 +137,22 @@ pub enum ClusterType {
 }
 
 impl ClusterType {
-    pub fn get_intended() -> Self {
+    pub fn get_intended() -> Option<Self> {
         match env::var("REDISRS_SERVER_TYPE")
             .ok()
             .as_ref()
             .map(|x| &x[..])
         {
-            Some("tcp+tls") => Self::TcpTls,
-            Some("tcp") | None => Self::Tcp,
+            Some("tcp+tls") => Some(Self::TcpTls),
+            Some("tcp") | None => Some(Self::Tcp),
             Some(val) => {
                 panic!("Unknown server type {val:?}");
             }
         }
     }
 
-    fn build_addr(port: u16) -> redis::ConnectionAddr {
-        match Self::get_intended() {
+    pub fn build_addr(&self, port: u16) -> redis::ConnectionAddr {
+        match self {
             Self::Tcp => redis::ConnectionAddr::Tcp("127.0.0.1".into(), port),
             Self::TcpTls => redis::ConnectionAddr::TcpTls {
                 host: "127.0.0.1".into(),
@@ -197,6 +210,8 @@ impl RedisCluster {
     }
 
     pub fn new(configuration: RedisClusterConfiguration) -> Self {
+        let cluster_type = configuration.get_cluster_type();
+
         let RedisClusterConfiguration {
             num_nodes: nodes,
             num_replicas: replicas,
@@ -207,6 +222,7 @@ impl RedisCluster {
             certs_with_ip_alts,
             cluster_databases,
             dns_hostname,
+            ..
         } = configuration;
 
         let optional_ports = if ports.is_empty() {
@@ -223,7 +239,7 @@ impl RedisCluster {
 
         let mut is_tls = false;
 
-        if let ClusterType::TcpTls = ClusterType::get_intended() {
+        if let ClusterType::TcpTls = cluster_type {
             // Create a shared set of keys in cluster mode
             let tempdir = tempfile::Builder::new()
                 .prefix("redis")
@@ -243,7 +259,7 @@ impl RedisCluster {
 
         let mut make_server = |port| {
             RedisServerBuilder::new()
-                .address(ClusterType::build_addr(port))
+                .address(cluster_type.build_addr(port))
                 .tls_paths_opt(tls_paths.clone())
                 .mtls(mtls_enabled)
                 .modules(&modules)

--- a/redis-test/src/sentinel.rs
+++ b/redis-test/src/sentinel.rs
@@ -121,8 +121,8 @@ impl RedisSentinelCluster {
     }
 }
 
-fn get_addr(port: u16) -> ConnectionAddr {
-    let addr = RedisServer::get_addr(port);
+fn get_addr_for_type(port: u16, server_type: crate::server::ServerType) -> ConnectionAddr {
+    let addr = RedisServer::get_addr_for_type(port, server_type);
     if let ConnectionAddr::Unix(_) = addr {
         panic!("Sentinels are not supported on unix sockets");
     }
@@ -134,9 +134,10 @@ fn spawn_master_server(
     dir: &TempDir,
     tlspaths: &Option<TlsFilePaths>,
     modules: &[Module],
+    server_type: crate::server::ServerType,
 ) -> RedisServer {
     RedisServerBuilder::new()
-        .address(get_addr(port))
+        .address(get_addr_for_type(port, server_type))
         .tls_paths_opt(tlspaths.clone())
         .modules(modules)
         .refine_and_build(|cmd| {
@@ -155,12 +156,13 @@ fn spawn_replica_server(
     dir: &TempDir,
     tlspaths: &Option<TlsFilePaths>,
     modules: &[Module],
+    server_type: crate::server::ServerType,
 ) -> RedisServer {
     let config_file_path = dir.path().join("redis_config.conf");
     File::create(&config_file_path).unwrap();
 
     RedisServerBuilder::new()
-        .address(get_addr(port))
+        .address(get_addr_for_type(port, server_type))
         .config(config_file_path)
         .tls_paths_opt(tlspaths.clone())
         .modules(modules)
@@ -179,6 +181,7 @@ fn spawn_sentinel_server(
     dir: &TempDir,
     tlspaths: &Option<TlsFilePaths>,
     modules: &[Module],
+    server_type: crate::server::ServerType,
 ) -> RedisServer {
     let config_file_path = dir.path().join("redis_config.conf");
     let mut file = File::create(&config_file_path).unwrap();
@@ -191,7 +194,7 @@ fn spawn_sentinel_server(
     file.flush().unwrap();
 
     RedisServerBuilder::new()
-        .address(get_addr(port))
+        .address(get_addr_for_type(port, server_type))
         .config(config_file_path)
         .tls_paths_opt(tlspaths.clone())
         .modules(modules)
@@ -315,7 +318,29 @@ fn wait_for_replicas_to_sync(cluster: &RedisSentinelCluster, masters: u16) {
 
 impl RedisSentinelCluster {
     pub fn new(masters: u16, replicas_per_master: u16, sentinels: u16) -> Self {
-        Self::with_modules(masters, replicas_per_master, sentinels, &[])
+        Self::with_modules_and_server_type(
+            masters,
+            replicas_per_master,
+            sentinels,
+            &[],
+            crate::server::ServerType::get_intended()
+                .unwrap_or(crate::server::ServerType::Tcp { tls: false }),
+        )
+    }
+
+    pub fn new_with_server_type(
+        masters: u16,
+        replicas_per_master: u16,
+        sentinels: u16,
+        server_type: crate::server::ServerType,
+    ) -> Self {
+        Self::with_modules_and_server_type(
+            masters,
+            replicas_per_master,
+            sentinels,
+            &[],
+            server_type,
+        )
     }
 
     pub fn with_modules(
@@ -323,6 +348,23 @@ impl RedisSentinelCluster {
         replicas_per_master: u16,
         sentinels: u16,
         modules: &[Module],
+    ) -> Self {
+        Self::with_modules_and_server_type(
+            masters,
+            replicas_per_master,
+            sentinels,
+            modules,
+            crate::server::ServerType::get_intended()
+                .unwrap_or(crate::server::ServerType::Tcp { tls: false }),
+        )
+    }
+
+    pub fn with_modules_and_server_type(
+        masters: u16,
+        replicas_per_master: u16,
+        sentinels: u16,
+        modules: &[Module],
+        server_type: crate::server::ServerType,
     ) -> Self {
         let mut servers = vec![];
         let mut folders = vec![];
@@ -336,7 +378,7 @@ impl RedisSentinelCluster {
         let mut available_ports: Vec<_> = available_ports.into_iter().collect();
 
         let tlspaths = matches!(
-            RedisServer::get_addr(available_ports[0]),
+            RedisServer::get_addr_for_type(available_ports[0], server_type),
             ConnectionAddr::TcpTls { .. }
         )
         .then(|| {
@@ -355,7 +397,13 @@ impl RedisSentinelCluster {
                 .prefix("redis")
                 .tempdir()
                 .expect("failed to create tempdir");
-            servers.push(spawn_master_server(port, &tempdir, &tlspaths, modules));
+            servers.push(spawn_master_server(
+                port,
+                &tempdir,
+                &tlspaths,
+                modules,
+                server_type,
+            ));
             folders.push(tempdir);
             master_ports.push(port);
 
@@ -371,6 +419,7 @@ impl RedisSentinelCluster {
                     &tempdir,
                     &tlspaths,
                     modules,
+                    server_type,
                 ));
                 folders.push(tempdir);
             }
@@ -390,6 +439,7 @@ impl RedisSentinelCluster {
                 &tempdir,
                 &tlspaths,
                 modules,
+                server_type,
             ));
             folders.push(tempdir);
         }

--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -9,16 +9,17 @@ use crate::utils::{
     CommandMultiArgs, TlsFilePaths, build_keys_and_certs_for_tls, get_random_available_port,
 };
 
-pub fn use_protocol() -> ProtocolVersion {
-    if env::var("PROTOCOL").unwrap_or_default() == "RESP3" {
-        ProtocolVersion::RESP3
-    } else {
-        ProtocolVersion::RESP2
+pub fn use_protocol() -> Option<ProtocolVersion> {
+    match env::var("PROTOCOL").ok().as_deref() {
+        Some("RESP2") => Some(ProtocolVersion::RESP2),
+        Some("RESP3") => Some(ProtocolVersion::RESP3),
+        Some(val) => panic!("Unknown protocol {val:?}"),
+        None => None,
     }
 }
 
 pub fn redis_settings() -> RedisConnectionInfo {
-    RedisConnectionInfo::default().set_protocol(use_protocol())
+    RedisConnectionInfo::default().set_protocol(use_protocol().unwrap_or(ProtocolVersion::RESP2))
 }
 
 /// Get the default host to use for TCP connections.
@@ -26,8 +27,9 @@ pub fn get_default_host() -> String {
     "127.0.0.1".to_string()
 }
 
-#[derive(PartialEq)]
-enum ServerType {
+#[derive(PartialEq, Clone, Copy, Debug)]
+#[non_exhaustive]
+pub enum ServerType {
     Tcp { tls: bool },
     Unix,
 }
@@ -56,6 +58,7 @@ pub enum Module {
 // considerations.
 #[derive(Default)]
 pub struct RedisServerBuilder {
+    server_type: Option<ServerType>,
     address: Option<ConnectionAddr>,
     config_file: Option<PathBuf>,
     cert_auth_field: Option<String>,
@@ -68,6 +71,11 @@ impl RedisServerBuilder {
     /// Starts a fresh builder
     pub fn new() -> Self {
         Default::default()
+    }
+
+    pub fn server_type(mut self, server_type: ServerType) -> Self {
+        self.server_type = Some(server_type);
+        self
     }
 
     pub fn address(mut self, address: ConnectionAddr) -> Self {
@@ -131,7 +139,11 @@ impl RedisServerBuilder {
             // This is technically a race, but we can't do better with
             // the tools that redis gives us :(
             let redis_port = get_random_available_port();
-            RedisServer::get_addr(redis_port)
+            let st = self
+                .server_type
+                .or_else(ServerType::get_intended)
+                .unwrap_or(ServerType::Tcp { tls: false });
+            RedisServer::get_addr_for_type(redis_port, st)
         });
 
         RedisServer::new(
@@ -192,18 +204,19 @@ pub struct RedisServer {
 }
 
 impl ServerType {
-    fn get_intended() -> Self {
+    pub fn get_intended() -> Option<Self> {
         match env::var("REDISRS_SERVER_TYPE")
             .ok()
             .as_ref()
             .map(|x| &x[..])
         {
-            Some("tcp+tls") => Self::Tcp { tls: true },
-            Some("unix") => Self::Unix,
-            Some("tcp") | None => Self::Tcp { tls: false },
+            Some("tcp+tls") => Some(Self::Tcp { tls: true }),
+            Some("unix") => Some(Self::Unix),
+            Some("tcp") => Some(Self::Tcp { tls: false }),
             Some(val) => {
                 panic!("Unknown server type {val:?}");
             }
+            None => None,
         }
     }
 }
@@ -226,7 +239,13 @@ impl RedisServer {
     }
 
     pub fn get_addr(port: u16) -> ConnectionAddr {
-        let server_type = ServerType::get_intended();
+        Self::get_addr_for_type(
+            port,
+            ServerType::get_intended().unwrap_or(ServerType::Tcp { tls: false }),
+        )
+    }
+
+    pub fn get_addr_for_type(port: u16, server_type: ServerType) -> ConnectionAddr {
         match server_type {
             ServerType::Tcp { tls } => {
                 if tls {
@@ -380,11 +399,18 @@ impl RedisServer {
     }
 
     pub fn connection_info(&self) -> redis::ConnectionInfo {
+        self.connection_info_with_protocol(use_protocol().unwrap_or(ProtocolVersion::RESP2))
+    }
+
+    pub fn connection_info_with_protocol(
+        &self,
+        protocol: ProtocolVersion,
+    ) -> redis::ConnectionInfo {
         self.client_addr()
             .clone()
             .into_connection_info()
             .unwrap()
-            .set_redis_settings(redis_settings())
+            .set_redis_settings(redis::RedisConnectionInfo::default().set_protocol(protocol))
     }
 
     /// Stops the server (if running) and optionally yields formatted process information

--- a/redis-test/src/test_context.rs
+++ b/redis-test/src/test_context.rs
@@ -26,6 +26,7 @@ use std::time::Duration;
 #[derive(Default)]
 pub struct TestContextBuilder {
     server_builder: RedisServerBuilder,
+    protocol: Option<redis::ProtocolVersion>,
 }
 
 impl TestContextBuilder {
@@ -36,6 +37,16 @@ impl TestContextBuilder {
 
     pub fn address(mut self, address: ConnectionAddr) -> Self {
         self.server_builder = self.server_builder.address(address);
+        self
+    }
+
+    pub fn server_type(mut self, server_type: crate::server::ServerType) -> Self {
+        self.server_builder = self.server_builder.server_type(server_type);
+        self
+    }
+
+    pub fn protocol(mut self, protocol: redis::ProtocolVersion) -> Self {
+        self.protocol = Some(protocol);
         self
     }
 
@@ -91,7 +102,7 @@ impl TestContextBuilder {
     /// * `refiner` - See [`RedisServerBuilder::refine_and_build`]
     pub fn refine_and_build(self, refiner: impl FnOnce(&mut RedisServerCommand)) -> TestContext {
         let server = self.server_builder.refine_and_build(refiner);
-        TestContext::from_server(server)
+        TestContext::from_server(server, self.protocol)
     }
 }
 
@@ -146,9 +157,16 @@ impl TestContext {
     //
     // Instead, users should to go through `TestContextBuilder` to limit the points of entry and
     // hence help us with maintenance.
-    fn from_server(mut server: RedisServer) -> Self {
-        let client =
-            build_single_client(server.connection_info(), &server.tls_paths, server.mtls).unwrap();
+    fn from_server(mut server: RedisServer, protocol: Option<ProtocolVersion>) -> Self {
+        let protocol = protocol
+            .or_else(use_protocol)
+            .unwrap_or(ProtocolVersion::RESP2);
+        let client = build_single_client(
+            server.connection_info_with_protocol(protocol),
+            &server.tls_paths,
+            server.mtls,
+        )
+        .unwrap();
 
         if server.tls_paths.is_some() {
             crate::utils::start_tls_crypto_provider();
@@ -218,7 +236,7 @@ impl TestContext {
         Self {
             server,
             client,
-            protocol: use_protocol(),
+            protocol,
         }
     }
 

--- a/redis/benches/bench_cache.rs
+++ b/redis/benches/bench_cache.rs
@@ -95,7 +95,7 @@ fn prepare_benchmark(
 }
 
 fn bench_cache(c: &mut Criterion) {
-    if !use_protocol().supports_resp3() {
+    if use_protocol() != Some(redis::ProtocolVersion::RESP3) {
         return;
     }
     let is_cache_enabled = env::var("ENABLE_CLIENT_SIDE_CACHE").unwrap_or_default() == "true";

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -13,8 +13,6 @@ use redis::RedisResult;
 use redis::aio::ConnectionLike;
 #[cfg(feature = "cluster-async")]
 use redis::cluster_async::Connect;
-#[cfg(feature = "tls-rustls")]
-use redis_test::cluster::ClusterType;
 use redis_test::cluster::{RedisCluster, RedisClusterConfiguration};
 use redis_test::server::{RedisServer, use_protocol};
 use redis_test::utils::{build_single_client, start_tls_crypto_provider};
@@ -37,12 +35,13 @@ impl TestClusterContext {
     }
 
     pub fn new_with_mtls() -> Self {
-        Self::new_with_config_and_builder(
-            RedisClusterConfiguration::default()
-                .mtls_enabled()
-                .insecure_tls(),
-            identity,
-        )
+        let cfg = RedisClusterConfiguration::default()
+            .mtls_enabled()
+            .insecure_tls();
+        #[cfg(feature = "tls-rustls")]
+        let cfg = cfg.cluster_type(redis_test::cluster::ClusterType::TcpTls);
+
+        Self::new_with_config_and_builder(cfg, identity)
     }
 
     pub fn new_without_ip_alts() -> Self {
@@ -75,6 +74,13 @@ impl TestClusterContext {
         Self::new_with_config_and_builder(RedisClusterConfiguration::default(), initializer)
     }
 
+    pub fn new_with_config_and_protocol(
+        cluster_config: RedisClusterConfiguration,
+        protocol: ProtocolVersion,
+    ) -> Self {
+        Self::new_with_config_and_builder_and_protocol(cluster_config, identity, protocol)
+    }
+
     pub fn new_with_config_and_builder<F>(
         cluster_config: RedisClusterConfiguration,
         initializer: F,
@@ -82,20 +88,36 @@ impl TestClusterContext {
     where
         F: FnOnce(redis::cluster::ClusterClientBuilder) -> redis::cluster::ClusterClientBuilder,
     {
+        Self::new_with_config_and_builder_and_protocol(
+            cluster_config,
+            initializer,
+            use_protocol().unwrap_or(ProtocolVersion::RESP2),
+        )
+    }
+
+    pub fn new_with_config_and_builder_and_protocol<F>(
+        cluster_config: RedisClusterConfiguration,
+        initializer: F,
+        protocol: ProtocolVersion,
+    ) -> Self
+    where
+        F: FnOnce(redis::cluster::ClusterClientBuilder) -> redis::cluster::ClusterClientBuilder,
+    {
         start_tls_crypto_provider();
         #[cfg(feature = "tls-rustls")]
-        let secure_tls = cluster_config.get_require_secure_tls();
+        let _secure_tls = cluster_config.get_require_secure_tls();
         let mtls_enabled = cluster_config.get_mtls_enabled();
+        let _cluster_type = cluster_config.get_cluster_type();
         let cluster = RedisCluster::new(cluster_config);
         let initial_nodes: Vec<ConnectionInfo> = cluster
             .iter_servers()
             .map(RedisServer::connection_info)
             .collect();
-        let mut builder = redis::cluster::ClusterClientBuilder::new(initial_nodes.clone())
-            .use_protocol(use_protocol());
+        let mut builder =
+            redis::cluster::ClusterClientBuilder::new(initial_nodes.clone()).use_protocol(protocol);
 
         #[cfg(feature = "tls-rustls")]
-        if (mtls_enabled || (ClusterType::get_intended() == ClusterType::TcpTls && !secure_tls))
+        if (mtls_enabled || cluster.tls_paths.is_some())
             && let Some(tls_file_paths) = &cluster.tls_paths
         {
             builder = builder.certs(load_certs_from_file(tls_file_paths));
@@ -110,7 +132,7 @@ impl TestClusterContext {
             client,
             mtls_enabled,
             nodes: initial_nodes,
-            protocol: use_protocol(),
+            protocol,
         }
     }
 
@@ -124,13 +146,29 @@ impl TestClusterContext {
             .use_protocol(self.protocol);
 
         #[cfg(feature = "tls-rustls")]
-        if (self.mtls_enabled || ClusterType::get_intended() == ClusterType::TcpTls)
+        if (self.mtls_enabled || self.cluster.tls_paths.is_some())
             && let Some(tls_file_paths) = &self.cluster.tls_paths
         {
             builder = builder.certs(load_certs_from_file(tls_file_paths));
         }
 
         initializer(builder).build().unwrap()
+    }
+
+    /// Returns a new context against the same (already-running) servers, but with
+    /// the cluster client rebuilt through the given builder initializer.
+    pub fn with_cluster_client_builder<F>(self, initializer: F) -> Self
+    where
+        F: FnOnce(redis::cluster::ClusterClientBuilder) -> redis::cluster::ClusterClientBuilder,
+    {
+        let client = self.new_client_with_builder(initializer);
+        Self {
+            cluster: self.cluster,
+            client,
+            mtls_enabled: self.mtls_enabled,
+            nodes: self.nodes,
+            protocol: self.protocol,
+        }
     }
 
     pub fn connection(&self) -> redis::cluster::ClusterConnection {

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -14,11 +14,28 @@ use redis::{ClientTlsConfig, TlsCertificates};
 use redis::{Pipeline, Value};
 #[cfg(feature = "aio")]
 use redis::{aio, cmd};
-use redis_test::TestContext;
+#[allow(unused_imports)]
+pub use redis_test::run_test_if_version_supported;
+#[allow(unused_imports)]
+pub use redis_test::skip_if_context_does_not_support;
 #[cfg(feature = "tls-rustls")]
 use redis_test::utils::TlsFilePaths;
+#[allow(unused_imports)]
+pub use redis_test::utils::build_single_client;
 #[cfg(feature = "tls-rustls")]
-use redis_test::utils::load_certs_from_file;
+pub use redis_test::utils::load_certs_from_file;
+#[allow(unused_imports)]
+pub use redis_test::utils::start_tls_crypto_provider;
+#[allow(unused_imports)]
+pub use redis_test::version::TestContextVersioning;
+#[allow(unused_imports)]
+pub use redis_test::version::{
+    REDIS_BLOOM_ANY, REDIS_CE_6_0, REDIS_CE_7_0, REDIS_CE_7_2, REDIS_CE_7_4, REDIS_CE_8_0,
+    REDIS_CE_8_2, REDIS_CE_8_4, REDIS_CE_8_6, REDIS_CE_8_8, REDIS_JSON_8_8, VALKEY_8_1, VALKEY_9_0,
+    VALKEY_9_1,
+};
+#[allow(unused_imports)]
+pub use redis_test::{TestContext, TestContextBuilder};
 
 use std::io;
 #[cfg(feature = "tls-rustls")]
@@ -97,13 +114,14 @@ where
     res.unwrap()
 }
 
+// With both `tokio-comp` and `smol-comp` enabled, the tests of both runtimes run
+// in the same process. Setting a preferred runtime here would poison the process
+// for the other runtime, so we rely on `Runtime::locate`'s auto-detection instead.
 #[cfg(feature = "tokio-comp")]
 fn block_on_all_using_tokio<F>(f: F) -> F::Output
 where
     F: Future,
 {
-    #[cfg(feature = "smol-comp")]
-    redis::aio::prefer_tokio().unwrap();
     current_thread_runtime().block_on(f)
 }
 
@@ -112,8 +130,6 @@ fn block_on_all_using_smol<F>(f: F) -> F::Output
 where
     F: Future,
 {
-    #[cfg(feature = "tokio-comp")]
-    redis::aio::prefer_smol().unwrap();
     smol::block_on(f)
 }
 

--- a/redis/tests/support/sentinel.rs
+++ b/redis/tests/support/sentinel.rs
@@ -1,10 +1,12 @@
 use redis::ConnectionAddr;
 use redis::ConnectionInfo;
+use redis::ProtocolVersion;
 use redis::TlsMode;
 use redis::sentinel::SentinelNodeConnectionInfo;
 use redis_test::sentinel::{RedisSentinelCluster, wait_for_master_server, wait_for_replica};
-use redis_test::server::RedisServer;
-use redis_test::utils::start_tls_crypto_provider;
+use redis_test::server::{RedisServer, use_protocol};
+
+use crate::support::start_tls_crypto_provider;
 
 const MTLS_NOT_ENABLED: bool = false;
 
@@ -12,12 +14,40 @@ pub struct TestSentinelContext {
     pub cluster: RedisSentinelCluster,
     pub sentinel: redis::sentinel::Sentinel,
     pub sentinels_connection_info: Vec<ConnectionInfo>,
+    pub protocol: ProtocolVersion,
     mtls_enabled: bool, // for future tests
 }
 
 impl TestSentinelContext {
     pub fn new(nodes: u16, replicas: u16, sentinels: u16) -> Self {
         Self::new_with_cluster_client_builder(nodes, replicas, sentinels)
+    }
+
+    pub fn new_with_server_type_and_protocol(
+        nodes: u16,
+        replicas: u16,
+        sentinels: u16,
+        server_type: redis_test::server::ServerType,
+        protocol: redis::ProtocolVersion,
+    ) -> Self {
+        start_tls_crypto_provider();
+        let cluster =
+            RedisSentinelCluster::new_with_server_type(nodes, replicas, sentinels, server_type);
+        let initial_nodes: Vec<ConnectionInfo> = cluster
+            .iter_sentinel_servers()
+            .map(|s| s.connection_info_with_protocol(protocol))
+            .collect();
+        let sentinel = redis::sentinel::Sentinel::build(initial_nodes.clone()).unwrap();
+
+        let mut context = Self {
+            cluster,
+            sentinel,
+            sentinels_connection_info: initial_nodes,
+            protocol,
+            mtls_enabled: MTLS_NOT_ENABLED,
+        };
+        context.wait_for_cluster_up();
+        context
     }
 
     pub fn new_with_cluster_client_builder(nodes: u16, replicas: u16, sentinels: u16) -> Self {
@@ -34,6 +64,7 @@ impl TestSentinelContext {
             cluster,
             sentinel,
             sentinels_connection_info: initial_nodes,
+            protocol: use_protocol().unwrap_or(ProtocolVersion::RESP2),
             mtls_enabled: MTLS_NOT_ENABLED,
         };
         context.wait_for_cluster_up();

--- a/redis/tests/test_acl.rs
+++ b/redis/tests/test_acl.rs
@@ -4,29 +4,100 @@ use redis::TypedCommands;
 use redis::acl::Rule;
 use redis_test::REDIS_CE_7_2;
 use redis_test::TestContext;
-use redis_test::run_test_if_version_supported;
 use std::collections::HashSet;
 
 mod support;
+use crate::support::*;
+use test_macros::single_server_test;
 
-#[test]
-fn test_acl_whoami() {
-    let ctx = TestContext::default();
+#[single_server_test]
+fn test_acl_whoami(ctx: TestContext) {
     let mut con = ctx.connection();
     assert_eq!(con.acl_whoami(), Ok("default".to_owned()));
 }
 
-#[test]
-fn test_acl_help() {
-    let ctx = TestContext::default();
+#[single_server_test]
+fn test_acl_help(ctx: TestContext) {
     let mut con = ctx.connection();
     let res = con.acl_help().expect("Got help manual");
     assert!(!res.is_empty());
 }
 
-#[test]
-fn test_acl_cat() {
-    let ctx = TestContext::default();
+//TODO: do we need this test?
+#[single_server_test]
+#[ignore]
+fn test_acl_getsetdel_users(ctx: TestContext) {
+    let mut con = ctx.connection();
+    assert_eq!(
+        con.acl_list(),
+        Ok(vec!["user default on nopass ~* +@all".to_owned()])
+    );
+    assert_eq!(con.acl_users(), Ok(vec!["default".to_owned()]));
+    // bob
+    assert_eq!(con.acl_setuser("bob"), Ok(()));
+    assert_eq!(
+        con.acl_users(),
+        Ok(vec!["bob".to_owned(), "default".to_owned()])
+    );
+
+    // ACL SETUSER bob on ~redis:* +set
+    assert_eq!(
+        con.acl_setuser_rules(
+            "bob",
+            &[
+                Rule::On,
+                Rule::AddHashedPass(
+                    "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2".to_owned()
+                ),
+                Rule::Pattern("redis:*".to_owned()),
+                Rule::AddCommand("set".to_owned())
+            ],
+        ),
+        Ok(())
+    );
+    let acl_info = con.acl_getuser("bob").expect("Got user").unwrap();
+    assert_eq!(acl_info.flags, vec![Rule::On]);
+    assert_eq!(
+        acl_info.passwords,
+        vec![Rule::AddHashedPass(
+            "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2".to_owned()
+        )]
+    );
+    assert_eq!(
+        acl_info.commands,
+        vec![
+            Rule::RemoveCategory("all".to_owned()),
+            Rule::AddCommand("set".to_owned())
+        ]
+    );
+    assert_eq!(acl_info.keys, vec![Rule::Pattern("redis:*".to_owned())]);
+    assert_eq!(acl_info.channels, vec![]);
+    assert_eq!(acl_info.selectors, vec![]);
+
+    assert_eq!(
+        con.acl_list(),
+        Ok(vec![
+            "user bob on #c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2 ~redis:* -@all +set".to_owned(),
+            "user default on nopass ~* +@all".to_owned(),
+        ])
+    );
+
+    // ACL SETUSER eve
+    assert_eq!(con.acl_setuser("eve"), Ok(()));
+    assert_eq!(
+        con.acl_users(),
+        Ok(vec![
+            "bob".to_owned(),
+            "default".to_owned(),
+            "eve".to_owned()
+        ])
+    );
+    assert_eq!(con.acl_deluser(&["bob", "eve"]), Ok(2));
+    assert_eq!(con.acl_users(), Ok(vec!["default".to_owned()]));
+}
+
+#[single_server_test]
+fn test_acl_cat(ctx: TestContext) {
     let mut con = ctx.connection();
     let res: HashSet<String> = con.acl_cat().expect("Got categories");
     let expects = vec![
@@ -65,9 +136,8 @@ fn test_acl_cat() {
     }
 }
 
-#[test]
-fn test_acl_genpass() {
-    let ctx = TestContext::default();
+#[single_server_test]
+fn test_acl_genpass(ctx: TestContext) {
     let mut con = ctx.connection();
     let pass: String = con.acl_genpass().expect("Got password");
     assert_eq!(pass.len(), 64);
@@ -76,19 +146,18 @@ fn test_acl_genpass() {
     assert_eq!(pass.len(), 256);
 }
 
-#[test]
-fn test_acl_log() {
-    let ctx = TestContext::default();
+#[single_server_test]
+fn test_acl_log(ctx: TestContext) {
     let mut con = ctx.connection();
     let logs: Vec<String> = con.acl_log(1).expect("Got logs");
     assert_eq!(logs.len(), 0);
     assert_eq!(con.acl_log_reset(), Ok(()));
 }
 
-#[test]
-fn test_acl_dryrun() {
+#[single_server_test]
+fn test_acl_dryrun(ctx: TestContext) {
     // Skip the test <7.2, as the error message at the end was different before 7.2
-    let ctx = run_test_if_version_supported!(REDIS_CE_7_2);
+    skip_if_context_does_not_support!(ctx, REDIS_CE_7_2);
 
     let mut con = ctx.connection();
 
@@ -114,9 +183,9 @@ fn test_acl_dryrun() {
         "User VIRGINIA has no permissions to run the 'get' command"
     );
 }
-#[test]
-fn test_acl_info() {
-    let ctx = run_test_if_version_supported!(REDIS_CE_7_2);
+#[single_server_test]
+fn test_acl_info(ctx: TestContext) {
+    skip_if_context_does_not_support!(ctx, REDIS_CE_7_2);
     let mut conn = ctx.connection();
     let username = "tenant";
     let password = "securepassword123";
@@ -191,9 +260,9 @@ fn test_acl_info() {
     );
     assert_eq!(info.selectors, vec![]);
 }
-#[test]
-fn test_acl_sample_info() {
-    let ctx = run_test_if_version_supported!(REDIS_CE_7_2);
+#[single_server_test]
+fn test_acl_sample_info(ctx: TestContext) {
+    skip_if_context_does_not_support!(ctx, REDIS_CE_7_2);
     let mut conn = ctx.connection();
     let sample_rule = vec![
         Rule::On,
@@ -253,13 +322,12 @@ mod token_based_authentication_acl_tests {
         aio::ConnectionLike,
         auth::{BasicAuth, StreamingCredentialsProvider},
     };
-    use redis_test::TestContext;
     use std::{
         pin::Pin,
         sync::{Arc, Mutex, Once, RwLock},
         time::Duration,
     };
-    use test_macros::async_test;
+    use test_macros::{async_single_server_test, async_test};
     use tokio::sync::mpsc::Sender;
 
     static INIT_LOGGER: Once = Once::new();
@@ -555,10 +623,9 @@ mod token_based_authentication_acl_tests {
         }
     }
 
-    #[async_test]
-    async fn test_authentication_with_mock_streaming_credentials_provider() {
+    #[async_single_server_test]
+    async fn test_authentication_with_mock_streaming_credentials_provider(ctx: TestContext) {
         init_logger();
-        let ctx = TestContext::default();
         // Set up a Redis user that expects a JWT token as password
         let mut admin_con = ctx.async_connection().await.unwrap();
         let expected_username = OID_CLAIM_VALUE;
@@ -636,9 +703,8 @@ mod token_based_authentication_acl_tests {
     }
 
     #[async_test]
-    async fn token_rotation_with_mock_streaming_credentials_provider() {
+    async fn token_rotation_with_mock_streaming_credentials_provider(ctx: TestContext) {
         init_logger();
-        let ctx = TestContext::default();
         let users_cmd = redis::cmd("ACL").arg("USERS").clone();
         let whoami_cmd = redis::cmd("ACL").arg("WHOAMI").clone();
 
@@ -696,9 +762,11 @@ mod token_based_authentication_acl_tests {
     }
 
     #[async_test]
-    async fn test_authentication_error_handling_with_mock_streaming_credentials_provider() {
+    async fn test_authentication_error_handling_with_mock_streaming_credentials_provider(
+        ctx: TestContext,
+    ) {
         init_logger();
-        let ctx = TestContext::default();
+
         let whoami_cmd = redis::cmd("ACL").arg("WHOAMI").clone();
 
         // Create a user with the JWT token as password and full permissions for each token
@@ -755,9 +823,10 @@ mod token_based_authentication_acl_tests {
     }
 
     #[async_test]
-    async fn test_multiple_connections_from_one_client_sharing_a_single_credentials_provider() {
+    async fn test_multiple_connections_from_one_client_sharing_a_single_credentials_provider(
+        ctx: TestContext,
+    ) {
         init_logger();
-        let ctx = TestContext::default();
         let whoami_cmd = redis::cmd("ACL").arg("WHOAMI").clone();
 
         // Create a user with the JWT token as password and full permissions for each token
@@ -822,9 +891,8 @@ mod token_based_authentication_acl_tests {
     }
 
     #[async_test]
-    async fn test_multiple_clients_sharing_a_single_credentials_provider() {
+    async fn test_multiple_clients_sharing_a_single_credentials_provider(ctx1: TestContext) {
         init_logger();
-        let ctx1 = TestContext::default();
         let whoami_cmd = redis::cmd("ACL").arg("WHOAMI").clone();
 
         // Create a user with the JWT token as password and full permissions for each token
@@ -893,9 +961,8 @@ mod token_based_authentication_acl_tests {
     /// 4. Admin invalidates Alice via ACL DELUSER
     /// 5. The server rejects the next command — proving we rely on the server for auth enforcement
     #[async_test]
-    async fn test_server_rejects_after_user_invalidated() {
+    async fn test_server_rejects_after_user_invalidated(ctx: TestContext) {
         init_logger();
-        let ctx = TestContext::default();
 
         // Create a user with the JWT token as password and full permissions for each token
         println!("Setting up Redis users for re-authentication failure test...");
@@ -959,6 +1026,7 @@ mod token_based_authentication_acl_tests {
     mod cluster {
         use super::*;
         use redis::cluster::ClusterClientBuilder;
+        use test_macros::async_cluster_test;
 
         /// Sets up a single ACL user on every node in the cluster.
         async fn add_user_on_all_nodes(cluster: &TestClusterContext, username: &str, token: &str) {
@@ -985,20 +1053,20 @@ mod token_based_authentication_acl_tests {
             }
         }
 
-        #[async_test]
-        async fn test_cluster_authentication_with_mock_streaming_credentials_provider() {
+        #[async_cluster_test]
+        async fn test_cluster_authentication_with_mock_streaming_credentials_provider(
+            ctx: TestClusterContext,
+        ) {
             init_logger();
-            let cluster = TestClusterContext::new_with_cluster_client_builder(
-                |builder: ClusterClientBuilder| {
-                    let mut mock_provider = MockStreamingCredentialsProvider::new();
-                    mock_provider.start();
-                    builder.set_credentials_provider(mock_provider)
-                },
-            );
+            let ctx = ctx.with_cluster_client_builder(|builder: ClusterClientBuilder| {
+                let mut mock_provider = MockStreamingCredentialsProvider::new();
+                mock_provider.start();
+                builder.set_credentials_provider(mock_provider)
+            });
 
-            add_user_on_all_nodes(&cluster, OID_CLAIM_VALUE, &MOCKED_TOKEN).await;
+            add_user_on_all_nodes(&ctx, OID_CLAIM_VALUE, &MOCKED_TOKEN).await;
 
-            let mut connection = cluster.async_connection().await;
+            let mut connection = ctx.async_connection().await;
 
             let current_user: String = redis::cmd("ACL")
                 .arg("WHOAMI")
@@ -1023,21 +1091,21 @@ mod token_based_authentication_acl_tests {
             assert_eq!(result, "test_value");
         }
 
-        #[async_test]
-        async fn test_cluster_token_rotation_with_mock_streaming_credentials_provider() {
+        #[async_cluster_test]
+        async fn test_cluster_token_rotation_with_mock_streaming_credentials_provider(
+            ctx: TestClusterContext,
+        ) {
             init_logger();
-            let cluster = TestClusterContext::new_with_cluster_client_builder(
-                |builder: ClusterClientBuilder| {
-                    let mut mock_provider = MockStreamingCredentialsProvider::multiple_tokens();
-                    mock_provider.start();
-                    builder.set_credentials_provider(mock_provider)
-                },
-            );
+            let ctx = ctx.with_cluster_client_builder(|builder: ClusterClientBuilder| {
+                let mut mock_provider = MockStreamingCredentialsProvider::multiple_tokens();
+                mock_provider.start();
+                builder.set_credentials_provider(mock_provider)
+            });
 
-            add_users_with_jwt_tokens_on_all_nodes(&cluster).await;
+            add_users_with_jwt_tokens_on_all_nodes(&ctx).await;
 
             let whoami_cmd = redis::cmd("ACL").arg("WHOAMI").clone();
-            let mut con = cluster.async_connection().await;
+            let mut con = ctx.async_connection().await;
 
             let current_user: String = whoami_cmd.query_async(&mut con).await.unwrap();
             assert_eq!(current_user, ALICE_OID_CLAIM);
@@ -1053,23 +1121,22 @@ mod token_based_authentication_acl_tests {
             assert_eq!(current_user, CHARLIE_OID_CLAIM);
         }
 
-        #[async_test]
-        async fn test_cluster_authentication_error_handling_with_mock_streaming_credentials_provider()
-         {
+        #[async_cluster_test]
+        async fn test_cluster_authentication_error_handling_with_mock_streaming_credentials_provider(
+            ctx: TestClusterContext,
+        ) {
             init_logger();
-            let cluster = TestClusterContext::new_with_cluster_client_builder(
-                |builder: ClusterClientBuilder| {
-                    let mut mock_provider =
-                        MockStreamingCredentialsProvider::multiple_tokens_with_errors(vec![1]);
-                    mock_provider.start();
-                    builder.set_credentials_provider(mock_provider)
-                },
-            );
+            let ctx = ctx.with_cluster_client_builder(|builder: ClusterClientBuilder| {
+                let mut mock_provider =
+                    MockStreamingCredentialsProvider::multiple_tokens_with_errors(vec![1]);
+                mock_provider.start();
+                builder.set_credentials_provider(mock_provider)
+            });
 
-            add_users_with_jwt_tokens_on_all_nodes(&cluster).await;
+            add_users_with_jwt_tokens_on_all_nodes(&ctx).await;
 
             let whoami_cmd = redis::cmd("ACL").arg("WHOAMI").clone();
-            let mut con = cluster.async_connection().await;
+            let mut con = ctx.async_connection().await;
 
             let current_user: String = whoami_cmd.query_async(&mut con).await.unwrap();
             assert_eq!(current_user, ALICE_OID_CLAIM);
@@ -1090,22 +1157,22 @@ mod token_based_authentication_acl_tests {
             assert_eq!(current_user, ALICE_OID_CLAIM);
         }
 
-        #[async_test]
-        async fn test_cluster_multiple_connections_sharing_a_single_credentials_provider() {
+        #[async_cluster_test]
+        async fn test_cluster_multiple_connections_sharing_a_single_credentials_provider(
+            ctx: TestClusterContext,
+        ) {
             init_logger();
-            let cluster = TestClusterContext::new_with_cluster_client_builder(
-                |builder: ClusterClientBuilder| {
-                    let mut mock_provider = MockStreamingCredentialsProvider::multiple_tokens();
-                    mock_provider.start();
-                    builder.set_credentials_provider(mock_provider)
-                },
-            );
+            let ctx = ctx.with_cluster_client_builder(|builder: ClusterClientBuilder| {
+                let mut mock_provider = MockStreamingCredentialsProvider::multiple_tokens();
+                mock_provider.start();
+                builder.set_credentials_provider(mock_provider)
+            });
 
-            add_users_with_jwt_tokens_on_all_nodes(&cluster).await;
+            add_users_with_jwt_tokens_on_all_nodes(&ctx).await;
 
             let whoami_cmd = redis::cmd("ACL").arg("WHOAMI").clone();
-            let mut con1 = cluster.client.get_async_connection().await.unwrap();
-            let mut con2 = cluster.client.get_async_connection().await.unwrap();
+            let mut con1 = ctx.client.get_async_connection().await.unwrap();
+            let mut con2 = ctx.client.get_async_connection().await.unwrap();
 
             for (i, con) in [&mut con1, &mut con2].into_iter().enumerate() {
                 let current_user: String = whoami_cmd.query_async(con).await.unwrap();
@@ -1132,10 +1199,11 @@ mod token_based_authentication_acl_tests {
             }
         }
 
-        #[async_test]
-        async fn test_cluster_multiple_clients_sharing_a_single_credentials_provider() {
+        #[async_cluster_test]
+        async fn test_cluster_multiple_clients_sharing_a_single_credentials_provider(
+            cluster: TestClusterContext,
+        ) {
             init_logger();
-            let cluster = TestClusterContext::new();
 
             add_users_with_jwt_tokens_on_all_nodes(&cluster).await;
 
@@ -1201,23 +1269,21 @@ mod token_based_authentication_acl_tests {
         /// 3. Connection should still work because the previous auth session is unaffected
         /// 4. Admin invalidates Alice via ACL DELUSER on all nodes
         /// 5. The server rejects the next command — proving we rely on the server for auth enforcement
-        #[async_test]
-        async fn test_cluster_server_rejects_after_user_invalidated() {
+        #[async_cluster_test]
+        async fn test_cluster_server_rejects_after_user_invalidated(ctx: TestClusterContext) {
             init_logger();
-            let cluster = TestClusterContext::new_with_cluster_client_builder(
-                |builder: ClusterClientBuilder| {
-                    let mut mock_provider = MockStreamingCredentialsProvider::with_config(
-                        MockProviderConfig::valid_then_invalid_credentials(),
-                    );
-                    mock_provider.start();
-                    builder.set_credentials_provider(mock_provider)
-                },
-            );
+            let ctx = ctx.with_cluster_client_builder(|builder: ClusterClientBuilder| {
+                let mut mock_provider = MockStreamingCredentialsProvider::with_config(
+                    MockProviderConfig::valid_then_invalid_credentials(),
+                );
+                mock_provider.start();
+                builder.set_credentials_provider(mock_provider)
+            });
 
-            add_users_with_jwt_tokens_on_all_nodes(&cluster).await;
+            add_users_with_jwt_tokens_on_all_nodes(&ctx).await;
 
             let whoami_cmd = redis::cmd("ACL").arg("WHOAMI").clone();
-            let mut con = cluster.async_connection().await;
+            let mut con = ctx.async_connection().await;
 
             // Verify initial authentication succeeded
             let current_user: String = whoami_cmd.query_async(&mut con).await.unwrap();
@@ -1231,7 +1297,7 @@ mod token_based_authentication_acl_tests {
             assert_eq!(current_user, ALICE_OID_CLAIM);
 
             // Now simulate token expiry on the server side by deleting Alice's user on all nodes
-            delete_user_on_all_nodes(&cluster, ALICE_OID_CLAIM).await;
+            delete_user_on_all_nodes(&ctx, ALICE_OID_CLAIM).await;
 
             // The server should reject the next command since Alice no longer exists
             // and no credential update can fix it (the re-auth task already exited)

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -4,7 +4,6 @@ mod support;
 mod basic_async {
     use std::{collections::HashMap, time::Duration};
 
-    use super::*;
     use crate::support::*;
     use assert_matches::assert_matches;
     use futures::{StreamExt, prelude::*};

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -19,9 +19,7 @@ mod basic_async {
     #[cfg(any(feature = "json", feature = "connection-manager"))]
     use redis_test::TestContextBuilder;
     use redis_test::redis_value;
-    #[cfg(feature = "json")]
-    use redis_test::server::Module;
-    use redis_test::server::{redis_settings, use_protocol};
+    use redis_test::server::redis_settings;
     use std::sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -157,8 +155,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn test_set_write_backpressure_boundary_does_not_break_connection() {
-        let ctx = TestContext::default();
+    async fn test_set_write_backpressure_boundary_does_not_break_connection(ctx: TestContext) {
         let config =
             redis::AsyncConnectionConfig::new().set_write_backpressure_boundary(16 * 1024 * 1024);
         let mut conn = ctx
@@ -172,8 +169,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn test_can_authenticate_with_username_and_password() {
-        let ctx = TestContext::default();
+    async fn test_can_authenticate_with_username_and_password(ctx: TestContext) {
         let mut con = ctx.async_connection().await.unwrap();
 
         let username = "foo";
@@ -247,27 +243,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn test_async_typed_hmget(mut con: impl redis::AsyncTypedCommands) {
-        let _: usize = con.hset("my_hash", "f1", "1").await.unwrap();
-        let data: Vec<String> = con
-            .hmget("my_hash", &["f1"])
-            .await
-            .unwrap()
-            .into_iter()
-            .map(|s| s.unwrap())
-            .collect();
-        assert_eq!(data, vec!["1"]);
-
-        let data: Vec<Option<String>> = con.hmget("my_hash", &["f1", "f2"]).await.unwrap();
-        assert_eq!(data, vec![Some("1".to_string()), None]);
-
-        let data: Vec<Option<String>> = con.hmget("non_existing_hash", &["f1"]).await.unwrap();
-        assert_eq!(data, vec![None]);
-    }
-
-    #[async_test]
-    async fn test_dont_panic_on_closed_multiplexed_connection() {
-        let ctx = TestContext::default();
+    async fn test_dont_panic_on_closed_multiplexed_connection(ctx: TestContext) {
         let client = ctx.client.clone();
         let connect = client.get_multiplexed_async_connection();
         drop(ctx);
@@ -374,10 +350,9 @@ mod basic_async {
         assert_eq!(x, 42);
     }
 
-    #[async_test]
     #[cfg(feature = "json")]
-    async fn test_module_json_and_pipeline_transaction_with_ignore_errors() {
-        let ctx = TestContextBuilder::new().module(Module::Json).build();
+    #[async_test(module = "json")]
+    async fn test_module_json_and_pipeline_transaction_with_ignore_errors(ctx: TestContext) {
         let mut con = ctx.async_connection().await.unwrap();
         con.set::<_, _, ()>("x", 42).await.unwrap();
         con.json_set::<_, _, _, ()>("y", "$", &serde_json::json!({"path": "value"}))
@@ -659,9 +634,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn test_response_timeout_multiplexed_connection() {
-        let ctx = TestContext::default();
-
+    async fn test_response_timeout_multiplexed_connection(ctx: TestContext) {
         let mut connection = ctx.async_connection().await.unwrap();
         connection.set_response_timeout(Duration::from_millis(1));
         let mut cmd = redis::Cmd::new();
@@ -729,9 +702,7 @@ mod basic_async {
     // Allowing `let ()` as `query_async` requires the type it converts the result to.
     #[allow(clippy::let_unit_value, clippy::iter_nth_zero)]
     #[async_test]
-    async fn test_io_error_on_kill_issue_320() {
-        let ctx = TestContext::default();
-
+    async fn test_io_error_on_kill_issue_320(ctx: TestContext) {
         let mut conn_to_kill = ctx.async_connection().await.unwrap();
         kill_client_async(&mut conn_to_kill, &ctx.client)
             .await
@@ -749,9 +720,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn test_invalid_password_issue_343() {
-        let ctx = TestContext::default();
-
+    async fn test_invalid_password_issue_343(ctx: TestContext) {
         let redis = RedisConnectionInfo::default().set_password("asdcasc");
         let connection_info = ctx
             .server
@@ -842,9 +811,7 @@ mod basic_async {
         use super::*;
 
         #[async_test]
-        async fn test_pub_sub_subscription() {
-            let ctx = TestContext::default();
-
+        async fn test_pub_sub_subscription(ctx: TestContext) {
             let mut pubsub_conn = ctx.async_pubsub().await.unwrap();
             let _: () = pubsub_conn.subscribe("phonewave").await.unwrap();
             let mut pubsub_stream = pubsub_conn.on_message();
@@ -864,9 +831,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn test_pub_sub_subscription_to_multiple_channels() {
-            let ctx = TestContext::default();
-
+        async fn test_pub_sub_subscription_to_multiple_channels(ctx: TestContext) {
             let mut pubsub_conn = ctx.async_pubsub().await.unwrap();
             let _: () = pubsub_conn
                 .subscribe(&["phonewave", "foo", "bar"])
@@ -945,10 +910,8 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn test_pub_sub_unsubscription() {
+        async fn test_pub_sub_unsubscription(ctx: TestContext) {
             const SUBSCRIPTION_KEY: &str = "phonewave-pub-sub-unsubscription";
-
-            let ctx = TestContext::default();
 
             let mut pubsub_conn = ctx.async_pubsub().await.unwrap();
             pubsub_conn.subscribe(SUBSCRIPTION_KEY).await.unwrap();
@@ -966,9 +929,9 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn test_can_receive_messages_while_sending_requests_from_split_pub_sub() {
-            let ctx = TestContext::default();
-
+        async fn test_can_receive_messages_while_sending_requests_from_split_pub_sub(
+            ctx: TestContext,
+        ) {
             let (mut sink, mut stream) = ctx.async_pubsub().await.unwrap().split();
             let mut publish_conn = ctx.async_connection().await.unwrap();
 
@@ -986,9 +949,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn test_can_send_ping_on_split_pubsub() {
-            let ctx = TestContext::default();
-
+        async fn test_can_send_ping_on_split_pubsub(ctx: TestContext) {
             let (mut sink, mut stream) = ctx.async_pubsub().await.unwrap().split();
             let mut publish_conn = ctx.async_connection().await.unwrap();
 
@@ -1029,9 +990,9 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn test_can_receive_messages_from_split_pub_sub_after_sink_was_dropped() {
-            let ctx = TestContext::default();
-
+        async fn test_can_receive_messages_from_split_pub_sub_after_sink_was_dropped(
+            ctx: TestContext,
+        ) {
             let (mut sink, mut stream) = ctx.async_pubsub().await.unwrap().split();
             let mut publish_conn = ctx.async_connection().await.unwrap();
 
@@ -1050,9 +1011,9 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn test_can_receive_messages_from_split_pub_sub_after_into_on_message() {
-            let ctx = TestContext::default();
-
+        async fn test_can_receive_messages_from_split_pub_sub_after_into_on_message(
+            ctx: TestContext,
+        ) {
             let mut pubsub = ctx.async_pubsub().await.unwrap();
             let mut publish_conn = ctx.async_connection().await.unwrap();
 
@@ -1073,9 +1034,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn test_cannot_subscribe_on_split_pub_sub_after_stream_was_dropped() {
-            let ctx = TestContext::default();
-
+        async fn test_cannot_subscribe_on_split_pub_sub_after_stream_was_dropped(ctx: TestContext) {
             let (mut sink, stream) = ctx.async_pubsub().await.unwrap().split();
             drop(stream);
 
@@ -1083,10 +1042,8 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn test_automatic_unsubscription() {
+        async fn test_automatic_unsubscription(ctx: TestContext) {
             const SUBSCRIPTION_KEY: &str = "phonewave-automatic-unsubscription";
-
-            let ctx = TestContext::default();
 
             let mut pubsub_conn = ctx.async_pubsub().await.unwrap();
             pubsub_conn.subscribe(SUBSCRIPTION_KEY).await.unwrap();
@@ -1113,10 +1070,8 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn test_automatic_unsubscription_on_split() {
+        async fn test_automatic_unsubscription_on_split(ctx: TestContext) {
             const SUBSCRIPTION_KEY: &str = "phonewave-automatic-unsubscription-on-split";
-
-            let ctx = TestContext::default();
 
             let (mut sink, stream) = ctx.async_pubsub().await.unwrap().split();
             sink.subscribe(SUBSCRIPTION_KEY).await.unwrap();
@@ -1172,8 +1127,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn test_multiplexed_pub_sub_subscribe_on_multiple_channels() {
-            let ctx = TestContext::default();
+        async fn test_multiplexed_pub_sub_subscribe_on_multiple_channels(ctx: TestContext) {
             if !ctx.protocol.supports_resp3() {
                 return;
             }
@@ -1223,8 +1177,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn test_pub_sub_multiple() {
-            let ctx = TestContext::default();
+        async fn test_pub_sub_multiple(ctx: TestContext) {
             let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
             let connection_info = ctx.server.connection_info().set_redis_settings(redis);
             let client = redis::Client::open(connection_info).unwrap();
@@ -1287,14 +1240,10 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn test_pub_sub_requires_resp3() {
-            if use_protocol()
-                .unwrap_or(ProtocolVersion::RESP2)
-                .supports_resp3()
-            {
+        async fn test_pub_sub_requires_resp3(ctx: TestContext) {
+            if ctx.protocol.supports_resp3() {
                 return;
             }
-            let ctx = TestContext::default();
             let mut conn = ctx.async_connection().await.unwrap();
 
             let res = conn.subscribe("foo").await;
@@ -1306,8 +1255,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn test_push_sender_send_on_disconnect() {
-            let ctx = TestContext::default();
+        async fn test_push_sender_send_on_disconnect(ctx: TestContext) {
             let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
             let connection_info = ctx.server.connection_info().set_redis_settings(redis);
             let client = redis::Client::open(connection_info).unwrap();
@@ -1328,8 +1276,9 @@ mod basic_async {
 
         #[cfg(feature = "connection-manager")]
         #[async_test]
-        async fn test_manager_should_resubscribe_to_pubsub_channels_after_disconnect() {
-            let ctx = TestContext::default();
+        async fn test_manager_should_resubscribe_to_pubsub_channels_after_disconnect(
+            ctx: TestContext,
+        ) {
             if !ctx.protocol.supports_resp3() {
                 return;
             }
@@ -1339,7 +1288,8 @@ mod basic_async {
             let config = redis::aio::ConnectionManagerConfig::new()
                 .set_push_sender(tx)
                 .set_automatic_resubscription()
-                .set_max_delay(max_delay_between_attempts);
+                .set_max_delay(max_delay_between_attempts)
+                .set_number_of_retries(10_000);
 
             let mut pubsub_conn = ctx
                 .client
@@ -1453,13 +1403,12 @@ mod basic_async {
 
     #[async_test]
     #[cfg(feature = "connection-manager")]
-    async fn test_connection_manager_reconnect_after_delay() {
+    async fn test_connection_manager_reconnect_after_delay(ctx: TestContext) {
         let max_delay_between_attempts = Duration::from_millis(2);
         let mut config = redis::aio::ConnectionManagerConfig::new()
             .set_exponent_base(10000.0)
             .set_max_delay(max_delay_between_attempts);
 
-        let ctx = TestContext::default();
         let protocol = ctx.protocol;
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -1501,8 +1450,7 @@ mod basic_async {
 
     #[cfg(feature = "connection-manager")]
     #[async_test]
-    async fn test_manager_should_reconnect_without_actions_if_resp3_is_set() {
-        let ctx = TestContext::default();
+    async fn test_manager_should_reconnect_without_actions_if_resp3_is_set(ctx: TestContext) {
         if !ctx.protocol.supports_resp3() {
             return;
         }
@@ -1510,7 +1458,8 @@ mod basic_async {
         let max_delay_between_attempts = Duration::from_millis(2);
         let config = redis::aio::ConnectionManagerConfig::new()
             .set_exponent_base(10000.0)
-            .set_max_delay(max_delay_between_attempts);
+            .set_max_delay(max_delay_between_attempts)
+            .set_number_of_retries(10_000);
 
         let mut conn = ctx
             .client
@@ -1529,8 +1478,7 @@ mod basic_async {
 
     #[cfg(feature = "connection-manager")]
     #[async_test]
-    async fn test_manager_should_completely_disconnect_when_drop() {
-        let ctx = TestContext::default();
+    async fn test_manager_should_completely_disconnect_when_drop(ctx: TestContext) {
         let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
         let connection_info = ctx.server.connection_info().set_redis_settings(redis);
         let client = redis::Client::open(connection_info).unwrap();
@@ -1570,9 +1518,9 @@ mod basic_async {
 
     #[cfg(feature = "connection-manager")]
     #[async_test]
-    async fn test_manager_should_reconnect_without_actions_if_push_sender_is_set_even_after_sender_returns_error()
-     {
-        let ctx = TestContext::default();
+    async fn test_manager_should_reconnect_without_actions_if_push_sender_is_set_even_after_sender_returns_error(
+        ctx: TestContext,
+    ) {
         if !ctx.protocol.supports_resp3() {
             return;
         }
@@ -1583,7 +1531,8 @@ mod basic_async {
         let config = redis::aio::ConnectionManagerConfig::new()
             .set_exponent_base(10000.0)
             .set_push_sender(tx)
-            .set_max_delay(max_delay_between_attempts);
+            .set_max_delay(max_delay_between_attempts)
+            .set_number_of_retries(10_000);
 
         let mut conn = ctx
             .client
@@ -1613,9 +1562,9 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn test_multiplexed_connection_kills_connection_on_drop_even_when_blocking() {
-        let ctx = TestContext::default();
-
+    async fn test_multiplexed_connection_kills_connection_on_drop_even_when_blocking(
+        ctx: TestContext,
+    ) {
         let mut conn = ctx.async_connection().await.unwrap();
         let mut connection_to_dispose_of = ctx.async_connection().await.unwrap();
         connection_to_dispose_of.set_response_timeout(Duration::from_millis(1));
@@ -1650,9 +1599,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn test_monitor() {
-        let ctx = TestContext::default();
-
+    async fn test_monitor(ctx: TestContext) {
         let mut conn = ctx.async_connection().await.unwrap();
         let monitor_conn = ctx.client.get_async_monitor().await.unwrap();
         let mut stream = monitor_conn.into_on_message();
@@ -1676,7 +1623,10 @@ mod basic_async {
         #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn test_should_connect_mtls(#[case] runtime: RuntimeType) {
-            let ctx = TestContextBuilder::new().mtls(true).build();
+            let ctx = TestContextBuilder::new()
+                .server_type(redis_test::server::ServerType::Tcp { tls: true })
+                .mtls(true)
+                .build();
 
             let connect = ctx.client.get_multiplexed_async_connection();
             block_on_all(
@@ -1700,7 +1650,10 @@ mod basic_async {
         #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
         #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
         fn test_should_not_connect_if_tls_active(#[case] runtime: RuntimeType) {
-            let ctx = TestContextBuilder::new().mtls(true).build();
+            let ctx = TestContextBuilder::new()
+                .server_type(redis_test::server::ServerType::Tcp { tls: true })
+                .mtls(true)
+                .build();
 
             let client =
                 build_single_client(ctx.server.connection_info(), &ctx.server.tls_paths, false)
@@ -1744,8 +1697,7 @@ mod basic_async {
 
     #[async_test]
     #[cfg(feature = "connection-manager")]
-    async fn test_resp3_pushes_connection_manager() {
-        let ctx = TestContext::default();
+    async fn test_resp3_pushes_connection_manager(ctx: TestContext) {
         let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
         let connection_info = ctx.server.connection_info().set_redis_settings(redis);
         let client = redis::Client::open(connection_info).unwrap();
@@ -1770,8 +1722,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn test_select_db() {
-        let ctx = TestContext::default();
+    async fn test_select_db(ctx: TestContext) {
         let redis = redis_settings().set_db(5);
         let connection_info = ctx.server.connection_info().set_redis_settings(redis);
         let client = redis::Client::open(connection_info).unwrap();
@@ -1787,8 +1738,9 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn test_multiplexed_connection_send_single_disconnect_on_connection_failure() {
-        let mut ctx = TestContext::default();
+    async fn test_multiplexed_connection_send_single_disconnect_on_connection_failure(
+        mut ctx: TestContext,
+    ) {
         if !ctx.protocol.supports_resp3() {
             return;
         }
@@ -1810,8 +1762,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn test_fail_on_empty_command() {
-        let ctx = TestContext::default();
+    async fn test_fail_on_empty_command(ctx: TestContext) {
         let mut connection = ctx.async_connection().await.unwrap();
 
         let error: RedisError = redis::Pipeline::new()
@@ -1866,8 +1817,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn test_transaction_should_retry_on_watch() {
-            let ctx = TestContext::default();
+        async fn test_transaction_should_retry_on_watch(ctx: TestContext) {
             let con1 = ctx.async_connection().await.unwrap();
             let mut con2 = ctx.async_connection().await.unwrap();
 
@@ -1912,8 +1862,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn test_transaction_should_retry_on_none_from_closure() {
-            let ctx = TestContext::default();
+        async fn test_transaction_should_retry_on_none_from_closure(ctx: TestContext) {
             let con = ctx.async_connection().await.unwrap();
 
             let attempts = Arc::new(AtomicUsize::new(0));
@@ -1939,8 +1888,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn test_transaction_abort_if_internal_function_returns_error() {
-            let ctx = TestContext::default();
+        async fn test_transaction_abort_if_internal_function_returns_error(ctx: TestContext) {
             let con = ctx.async_connection().await.unwrap();
             let attempts = Arc::new(AtomicUsize::new(0));
 
@@ -1981,9 +1929,7 @@ mod basic_async {
         use super::*;
 
         #[async_test]
-        async fn test_lazy_connection_manager_can_be_created_synchronously() {
-            let ctx = TestContext::default();
-
+        async fn test_lazy_connection_manager_can_be_created_synchronously(ctx: TestContext) {
             let config = redis::aio::ConnectionManagerConfig::new()
                 .set_pipeline_buffer_size(100)
                 .set_number_of_retries(3);
@@ -1997,9 +1943,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn test_lazy_connection_manager_reconnects_after_disconnect() {
-            let ctx = TestContext::default();
-
+        async fn test_lazy_connection_manager_reconnects_after_disconnect(ctx: TestContext) {
             let max_delay_between_attempts = Duration::from_millis(2);
             let config = redis::aio::ConnectionManagerConfig::new()
                 .set_max_delay(max_delay_between_attempts);
@@ -2028,9 +1972,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn test_lazy_connection_manager_can_be_cloned_before_sending() {
-            let ctx = TestContext::default();
-
+        async fn test_lazy_connection_manager_can_be_cloned_before_sending(ctx: TestContext) {
             let config = redis::aio::ConnectionManagerConfig::new();
             let manager = ctx.client.get_connection_manager_lazy(config).unwrap();
             let mut manager1 = manager.clone();
@@ -2047,8 +1989,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn test_lazy_connection_manager_with_resp3_push() {
-            let ctx = TestContext::default();
+        async fn test_lazy_connection_manager_with_resp3_push(ctx: TestContext) {
             if !ctx.protocol.supports_resp3() {
                 return;
             }

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -1289,7 +1289,10 @@ mod basic_async {
 
         #[async_test]
         async fn test_pub_sub_requires_resp3() {
-            if use_protocol().supports_resp3() {
+            if use_protocol()
+                .unwrap_or(ProtocolVersion::RESP2)
+                .supports_resp3()
+            {
                 return;
             }
             let ctx = TestContext::default();

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -10,6 +10,7 @@ mod basic {
     use rand::distr::Alphanumeric;
     use rand::prelude::IndexedRandom;
     use rand::{RngExt, rng};
+    use test_macros::single_server_test;
 
     use redis::{
         Aggregate, Client, Connection, ConnectionInfo, ConnectionLike, ControlFlow, CopyOptions,
@@ -29,9 +30,9 @@ mod basic {
         EmbeddingInput, VAddOptions, VEmbOptions, VSimOptions, VectorAddInput, VectorQuantization,
         VectorSimilaritySearchInput,
     };
+    use redis_test::redis_value;
     use redis_test::server::redis_settings;
     use redis_test::utils::get_listener_on_free_port;
-    use redis_test::*;
 
     use assert_matches::assert_matches;
     #[cfg(feature = "vector-sets")]
@@ -85,9 +86,8 @@ mod basic {
         let _info: ConnectionInfo = "redis://127.0.0.1:1234/0".parse().unwrap();
     }
 
-    #[test]
-    fn test_args() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_args(ctx: TestContext) {
         let mut con = ctx.connection();
 
         redis::cmd("SET")
@@ -106,9 +106,8 @@ mod basic {
         );
     }
 
-    #[test]
-    fn test_can_authenticate_with_username_and_password() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_can_authenticate_with_username_and_password(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let username = "foo";
@@ -137,9 +136,8 @@ mod basic {
         assert_eq!(result, username);
     }
 
-    #[test]
-    fn test_getset() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_getset(ctx: TestContext) {
         let mut con = ctx.connection();
 
         redis::cmd("SET").arg("foo").arg(42).exec(&mut con).unwrap();
@@ -157,9 +155,8 @@ mod basic {
     }
 
     //unit test for key_type function
-    #[test]
-    fn test_key_type() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_key_type(ctx: TestContext) {
         let mut con = ctx.connection();
 
         // The key does not have a value
@@ -212,10 +209,9 @@ mod basic {
         assert_eq!(hash_key_type, ValueType::Hash);
     }
 
-    #[test]
-    fn test_client_tracking_doesnt_block_execution() {
+    #[single_server_test]
+    fn test_client_tracking_doesnt_block_execution(ctx: TestContext) {
         //It checks if the library distinguish a push-type message from the others and continues its normal operation.
-        let ctx = TestContext::default();
         let mut con = ctx.connection();
         let (k1, k2): (i32, i32) = redis::pipe()
             .cmd("CLIENT")
@@ -249,332 +245,16 @@ mod basic {
         assert_eq!(num, 45);
     }
 
-    #[test]
-    fn test_incr() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_incr(ctx: TestContext) {
         let mut con = ctx.connection();
 
         redis::cmd("SET").arg("foo").arg(42).exec(&mut con).unwrap();
         assert_eq!(redis::cmd("INCR").arg("foo").query(&mut con), Ok(43usize));
     }
 
-    #[test]
-    fn test_increx_options_args() {
-        assert_eq!(
-            ToRedisArgs::to_redis_args(&IncrexOptions::<i64>::default()).len(),
-            0
-        );
-
-        let opts = IncrexOptions::default()
-            .saturate()
-            .lower_bound(-5)
-            .upper_bound(100)
-            .with_expiration(Expiry::EX(60))
-            .enx();
-        assert_args!(
-            &opts, "SATURATE", "LBOUND", "-5", "UBOUND", "100", "EX", "60", "ENX"
-        );
-
-        let opts = IncrexOptions::default()
-            .saturate()
-            .upper_bound(2.5)
-            .with_expiration(Expiry::PERSIST);
-        assert_args!(&opts, "SATURATE", "UBOUND", "2.5", "PERSIST");
-    }
-
-    #[test]
-    fn test_increx_with_integers() {
-        let ctx = run_test_if_version_supported!([REDIS_CE_8_8]);
-        let mut con = ctx.connection();
-
-        // A fresh key starts at 0.
-        // A normal in-bounds increment applies fully.
-        let result = con.increx("counter", 5, IncrexOptions::default()).unwrap();
-        let (value, actual_increment) = result.as_i64().unwrap();
-        assert_eq!(value, 5);
-        assert_eq!(actual_increment, 5);
-
-        // The default policy rejects out-of-bounds operations.
-        // The reply is a regular successful `Ok`, reporting the unchanged current value and a zero applied increment.
-        let result = con
-            .increx("counter", 100, IncrexOptions::default().upper_bound(10))
-            .unwrap();
-        let (value, actual_increment) = result.as_i64().unwrap();
-        assert_eq!(value, 5);
-        assert_eq!(actual_increment, 0);
-
-        // SATURATE clamps the result to an explicit upper bound and reports the clamped delta (10 - 5 = 5), not the requested increment (100).
-        let result = con
-            .increx(
-                "counter",
-                100,
-                IncrexOptions::default().saturate().upper_bound(10),
-            )
-            .unwrap();
-        let (value, actual_increment) = result.as_i64().unwrap();
-        assert_eq!(value, 10);
-        assert_eq!(actual_increment, 5);
-
-        // SATURATE clamps to an explicit lower bound on underflow.
-        // The actual_increment is again the clamped delta (-10 - 5 = -15), not the requested -100.
-        con.set("underflow", 5).unwrap();
-        let result = con
-            .increx(
-                "underflow",
-                -100,
-                IncrexOptions::default().saturate().lower_bound(-10),
-            )
-            .unwrap();
-        let (value, actual_increment) = result.as_i64().unwrap();
-        assert_eq!(value, -10);
-        assert_eq!(actual_increment, -15);
-
-        // With no explicit bound, SATURATE clamps to the server's integer type limits,
-        // which are exactly i64::MAX / i64::MIN (the server operates on 64-bit `long long`).
-        con.set("hi", i64::MAX - 100).unwrap();
-        let result = con
-            .increx("hi", 200, IncrexOptions::default().saturate())
-            .unwrap();
-        let (value, actual_increment) = result.as_i64().unwrap();
-        assert_eq!(value, i64::MAX);
-        assert_eq!(actual_increment, 100);
-        con.set("lo", i64::MIN + 100).unwrap();
-        let result = con
-            .increx("lo", -200, IncrexOptions::default().saturate())
-            .unwrap();
-        let (value, actual_increment) = result.as_i64().unwrap();
-        assert_eq!(value, i64::MIN);
-        assert_eq!(actual_increment, -100);
-
-        // Expiration is applied alongside the increment.
-        let result = con
-            .increx(
-                "ttl_counter",
-                1,
-                IncrexOptions::default().with_expiration(Expiry::EX(100)),
-            )
-            .unwrap();
-        let (value, actual_increment) = result.as_i64().unwrap();
-        assert_eq!(value, 1);
-        assert_eq!(actual_increment, 1);
-        assert!((0..=100).contains(&con.ttl("ttl_counter").unwrap().raw()));
-
-        // Rejected operations leave the key's value *and* TTL untouched.
-        con.set_ex("bounded", 5, 100).unwrap();
-        let result = con
-            .increx(
-                "bounded",
-                100,
-                IncrexOptions::default()
-                    .upper_bound(10)
-                    .with_expiration(Expiry::EX(999)),
-            )
-            .unwrap();
-        let (value, actual_increment) = result.as_i64().unwrap();
-        assert_eq!(value, 5);
-        assert_eq!(actual_increment, 0);
-        assert_eq!(con.get("bounded").unwrap(), Some("5".to_string()));
-        assert!((0..=100).contains(&con.ttl("bounded").unwrap().raw()));
-
-        // A SATURATE clamp that lands on the current value has an effective delta of 0, yet it counts as an *applied* operation,
-        // which means that the supplied expiration still takes effect.
-        // This differs from the default policy rejection above, which leaves the TTL untouched.
-        con.set("at_bound", 10).unwrap();
-        let result = con
-            .increx(
-                "at_bound",
-                100,
-                IncrexOptions::default()
-                    .saturate() // Because of this, the operation is applied even though the value doesn't change.
-                    .upper_bound(10)
-                    .with_expiration(Expiry::EX(500)),
-            )
-            .unwrap();
-        let (value, actual_increment) = result.as_i64().unwrap();
-        assert_eq!(value, 10);
-        assert_eq!(actual_increment, 0);
-        // The key started with no TTL, so EX must have set one.
-        assert!((0..=500).contains(&con.ttl("at_bound").unwrap().raw()));
-
-        // ENX takes into account if a TTL is already present and blocks the update even though the clamp itself is applied.
-        con.set_ex("at_bound_enx", 10, 100).unwrap();
-        let result = con
-            .increx(
-                "at_bound_enx",
-                100,
-                IncrexOptions::default()
-                    .saturate()
-                    .upper_bound(10)
-                    .with_expiration(Expiry::EX(999))
-                    .enx(),
-            )
-            .unwrap();
-        let (value, actual_increment) = result.as_i64().unwrap();
-        assert_eq!(value, 10);
-        assert_eq!(actual_increment, 0);
-        assert!((0..=100).contains(&con.ttl("at_bound_enx").unwrap().raw()));
-    }
-
-    #[test]
-    fn test_increx_with_floats() {
-        let ctx = run_test_if_version_supported!([REDIS_CE_8_8]);
-        let mut con = ctx.connection();
-
-        // A normal in-bounds float increment applies fully.
-        let result = con
-            .increx("balance", 2.5, IncrexOptions::default())
-            .unwrap();
-        let (value, actual_increment) = result.as_f64().unwrap();
-        assert_approx_eq!(value, 2.5);
-        assert_approx_eq!(actual_increment, 2.5);
-
-        // SATURATE clamps to a floating-point upper bound.
-        // The actual_increment is the clamped delta (4.0 - 2.5 = 1.5), not the requested 5.5.
-        let result = con
-            .increx(
-                "balance",
-                5.5,
-                IncrexOptions::default().saturate().upper_bound(4.0),
-            )
-            .unwrap();
-        let (value, actual_increment) = result.as_f64().unwrap();
-        assert_approx_eq!(value, 4.0);
-        assert_approx_eq!(actual_increment, 1.5);
-
-        // The default policy rejects an out-of-bounds floating-point operation, leaving the value unchanged.
-        let result = con
-            .increx("balance", 5.5, IncrexOptions::default().upper_bound(4.0))
-            .unwrap();
-        let (value, actual_increment) = result.as_f64().unwrap();
-        assert_approx_eq!(value, 4.0);
-        assert_approx_eq!(actual_increment, 0.0);
-
-        // SATURATE clamps to a floating-point lower bound on underflow.
-        // From 0, -5.5 clamps to -1.5, so the clamped delta is -1.5 rather than the requested -5.5.
-        let result = con
-            .increx(
-                "debt",
-                -5.5,
-                IncrexOptions::default().saturate().lower_bound(-1.5),
-            )
-            .unwrap();
-        let (value, actual_increment) = result.as_f64().unwrap();
-        assert_approx_eq!(value, -1.5);
-        assert_approx_eq!(actual_increment, -1.5);
-
-        // Expiration is applied alongside the increment.
-        let result = con
-            .increx(
-                "ttl_counter",
-                1.0,
-                IncrexOptions::default().with_expiration(Expiry::EX(100)),
-            )
-            .unwrap();
-        let (value, actual_increment) = result.as_f64().unwrap();
-        assert_approx_eq!(value, 1.0);
-        assert_approx_eq!(actual_increment, 1.0);
-        assert!((0..=100).contains(&con.ttl("ttl_counter").unwrap().raw()));
-
-        // Rejected operations leave the key's value *and* TTL untouched.
-        con.set_ex("bounded", 5.0, 100).unwrap();
-        let result = con
-            .increx(
-                "bounded",
-                100.0,
-                IncrexOptions::default()
-                    .upper_bound(10.0)
-                    .with_expiration(Expiry::EX(999)),
-            )
-            .unwrap();
-        let (value, actual_increment) = result.as_f64().unwrap();
-        assert_approx_eq!(value, 5.0);
-        assert_approx_eq!(actual_increment, 0.0);
-        assert!((0..=100).contains(&con.ttl("bounded").unwrap().raw()));
-
-        // A SATURATE clamp that lands on the current value has an effective delta of 0, yet it counts as an *applied* operation,
-        // which means that the supplied expiration still takes effect.
-        con.set("at_bound", 10.0).unwrap();
-        let result = con
-            .increx(
-                "at_bound",
-                100.0,
-                IncrexOptions::default()
-                    .saturate() // Because of this, the operation is applied even though the value doesn't change.
-                    .upper_bound(10.0)
-                    .with_expiration(Expiry::EX(500)),
-            )
-            .unwrap();
-        let (value, actual_increment) = result.as_f64().unwrap();
-        assert_approx_eq!(value, 10.0);
-        assert_approx_eq!(actual_increment, 0.0);
-        assert!((0..=500).contains(&con.ttl("at_bound").unwrap().raw()));
-
-        // ENX takes into account if a TTL is already present and blocks the update even though the clamp itself is applied.
-        con.set_ex("at_bound_enx", 10.0, 100).unwrap();
-        let result = con
-            .increx(
-                "at_bound_enx",
-                100.0,
-                IncrexOptions::default()
-                    .saturate()
-                    .upper_bound(10.0)
-                    .with_expiration(Expiry::EX(999))
-                    .enx(),
-            )
-            .unwrap();
-        let (value, actual_increment) = result.as_f64().unwrap();
-        assert_approx_eq!(value, 10.0);
-        assert_approx_eq!(actual_increment, 0.0);
-        assert!((0..=100).contains(&con.ttl("at_bound_enx").unwrap().raw()));
-    }
-
-    #[test]
-    fn test_increx_server_errors_forwarded_verbatim() {
-        let ctx = run_test_if_version_supported!([REDIS_CE_8_8]);
-        let mut con = ctx.connection();
-
-        // Type mismatch: INCREX against a list key yields WRONGTYPE, surfaced with the server's exact code and detail.
-        con.rpush("list_key", "a").unwrap();
-        let err = con
-            .increx("list_key", 1, IncrexOptions::default())
-            .unwrap_err();
-        assert_eq!(err.code(), Some("WRONGTYPE"));
-        assert_eq!(
-            err.detail(),
-            Some("Operation against a key holding the wrong kind of value")
-        );
-
-        // Non-numeric value under BYINT / BYFLOAT.
-        // The server's value-type errors are forwarded verbatim.
-        // Note: The error message wording differs between BYINT and BYFLOAT.
-        con.set("str_key", "hello").unwrap();
-        let err = con
-            .increx("str_key", 1, IncrexOptions::default())
-            .unwrap_err();
-        assert_eq!(err.code(), Some("ERR"));
-        assert_eq!(
-            err.detail(),
-            Some("value is not an integer or out of range")
-        );
-
-        let err = con
-            .increx("str_key", 1.5, IncrexOptions::default())
-            .unwrap_err();
-        assert_eq!(err.code(), Some("ERR"));
-        assert_eq!(err.detail(), Some("value is not a valid float"));
-
-        // Malformed arguments reachable through the typed API - ENX with no expiration.
-        // The server's argument error is forwarded verbatim.
-        let err = con
-            .increx("misc", 1, IncrexOptions::default().enx())
-            .unwrap_err();
-        assert_eq!(err.code(), Some("ERR"));
-        assert_eq!(err.detail(), Some("ENX flag requires an expiration"));
-    }
-
-    #[test]
-    fn test_ping() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_ping(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let res: String = con.ping_message("foobar").unwrap();
@@ -583,9 +263,8 @@ mod basic {
         assert_eq!(&res, "PONG");
     }
 
-    #[test]
-    fn test_getdel() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_getdel(ctx: TestContext) {
         let mut con = ctx.connection();
 
         redis::cmd("SET").arg("foo").arg(42).exec(&mut con).unwrap();
@@ -598,9 +277,8 @@ mod basic {
         );
     }
 
-    #[test]
-    fn test_getex() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_getex(ctx: TestContext) {
         let mut con = ctx.connection();
 
         redis::cmd("SET")
@@ -641,9 +319,8 @@ mod basic {
         assert_eq!(delayed_get, Some(420));
     }
 
-    #[test]
-    fn test_info() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_info(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let info: redis::InfoDict = redis::cmd("INFO").query(&mut con).unwrap();
@@ -654,9 +331,8 @@ mod basic {
         assert!(info.contains_key(&"role"));
     }
 
-    #[test]
-    fn test_hash_ops() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_hash_ops(ctx: TestContext) {
         let mut con = ctx.connection();
 
         redis::cmd("HSET")
@@ -683,9 +359,9 @@ mod basic {
         assert_eq!(h.get("key_2"), Some(&2i32));
     }
 
-    #[test]
-    fn test_hash_expiration() {
-        let ctx = run_test_if_version_supported!([REDIS_CE_7_4, VALKEY_9_0]);
+    #[single_server_test]
+    fn test_hash_expiration(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, [REDIS_CE_7_4, VALKEY_9_0]);
 
         let mut con = ctx.connection();
         redis::cmd("HMSET")
@@ -797,9 +473,9 @@ mod basic {
     /// 3. It successfully deletes multiple fields from a given existing hash.
     /// 4. When used on a hash with only one field, it deletes the entire hash.
     /// 5. Attempting to delete a field from a non-existing hash results in a NIL response.
-    #[test]
-    fn test_hget_del() {
-        let ctx = run_test_if_version_supported!([REDIS_CE_8_0, VALKEY_9_1]);
+    #[single_server_test]
+    fn test_hget_del(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, [REDIS_CE_8_0, VALKEY_9_1]);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
@@ -874,9 +550,9 @@ mod basic {
     /// 5. It successfully retrieves multiple fields from a given existing hash and sets their expiration to 1 second.
     ///    It verifies that the fields have been set to expire and that they are no longer present in the hash after they expire.
     /// 6. Attempting to retrieve a field from a non-existing hash returns in a NIL response.
-    #[test]
-    fn test_hget_ex() {
-        let ctx = run_test_if_version_supported!([REDIS_CE_8_0, VALKEY_9_0]);
+    #[single_server_test]
+    fn test_hget_ex(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, [REDIS_CE_8_0, VALKEY_9_0]);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
@@ -945,10 +621,6 @@ mod basic {
             redis::Commands::hget_ex(&mut con, HASH_KEY, &expired_fields, Expiry::PERSIST),
             Ok([Value::Nil])
         );
-        assert_eq!(
-            con.hget_ex(HASH_KEY, &expired_fields, Expiry::PERSIST),
-            Ok(vec![None])
-        );
 
         // Scenario 5
         // Retrieve multiple fields and set their expiration to 1 second
@@ -991,19 +663,15 @@ mod basic {
             redis::Commands::hget_ex(&mut con, HASH_KEY, &expired_fields, Expiry::PERSIST),
             Ok(vec![Value::Nil; expired_fields.len()])
         );
-        assert_eq!(
-            con.hget_ex(HASH_KEY, &expired_fields, Expiry::PERSIST),
-            Ok(vec![None; expired_fields.len()])
-        );
     }
 
     /// The test validates the various expiration options for hash fields using the HGETEX command.
     ///
     /// It tests setting expiration using the EX, PX, EXAT, and PXAT options,
     /// as well as removing an existing expiration using the PERSIST option.
-    #[test]
-    fn test_hget_ex_field_expiration_options() {
-        let ctx = run_test_if_version_supported!([REDIS_CE_8_0, VALKEY_9_0]);
+    #[single_server_test]
+    fn test_hget_ex_field_expiration_options(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, [REDIS_CE_8_0, VALKEY_9_0]);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
@@ -1096,9 +764,9 @@ mod basic {
     ///        and verifies that the value has been modified and the field is set to expire.
     ///     7. It successfully sets all fields with an expiration
     ///        and verifies that their values have been modified and the fields are set to expire.
-    #[test]
-    fn test_hset_ex() {
-        let ctx = run_test_if_version_supported!([REDIS_CE_8_0, VALKEY_9_0]);
+    #[single_server_test]
+    fn test_hset_ex(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, [REDIS_CE_8_0, VALKEY_9_0]);
         let mut con = ctx.connection();
 
         let generated_hash_key = generate_random_testing_hash_key(&mut con);
@@ -1282,9 +950,9 @@ mod basic {
     ///
     /// It tests setting expiration using the EX, PX, EXAT, and PXAT options,
     /// as well as keeping an existing expiration using the KEEPTTL option.
-    #[test]
-    fn test_hsetex_field_expiration_options() {
-        let ctx = run_test_if_version_supported!([REDIS_CE_8_0, VALKEY_9_0]);
+    #[single_server_test]
+    fn test_hsetex_field_expiration_options(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, [REDIS_CE_8_0, VALKEY_9_0]);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
@@ -1344,9 +1012,11 @@ mod basic {
         assert_eq!(con.exists(HASH_KEY), Ok(false));
     }
 
-    #[test]
-    fn test_hsetex_can_update_the_expiration_of_a_field_that_has_already_been_set_to_expire() {
-        let ctx = run_test_if_version_supported!([REDIS_CE_8_0, VALKEY_9_0]);
+    #[single_server_test]
+    fn test_hsetex_can_update_the_expiration_of_a_field_that_has_already_been_set_to_expire(
+        ctx: TestContext,
+    ) {
+        skip_if_context_does_not_support!(ctx, [REDIS_CE_8_0, VALKEY_9_0]);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
@@ -1394,9 +1064,8 @@ mod basic {
     // Requires redis-server >= 4.0.0.
     // Not supported with the current appveyor/windows binary deployed.
     #[cfg(not(target_os = "windows"))]
-    #[test]
-    fn test_unlink() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_unlink(ctx: TestContext) {
         let mut con = ctx.connection();
 
         redis::cmd("SET").arg("foo").arg(42).exec(&mut con).unwrap();
@@ -1408,9 +1077,8 @@ mod basic {
         assert_eq!(con.unlink(&["foo", "bar"]), Ok(2));
     }
 
-    #[test]
-    fn test_set_ops() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_set_ops(ctx: TestContext) {
         let mut con = ctx.connection();
 
         assert_eq!(con.sadd("foo", &[1, 2, 3]), Ok(3));
@@ -1433,9 +1101,8 @@ mod basic {
         assert!(set.contains(&3i32));
     }
 
-    #[test]
-    fn test_scan() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_scan(ctx: TestContext) {
         let mut con = ctx.connection();
 
         assert_eq!(con.sadd("foo", &[1, 2, 3]), Ok(3));
@@ -1451,9 +1118,8 @@ mod basic {
         assert_eq!(&s, &[1, 2, 3]);
     }
 
-    #[test]
-    fn test_optionals() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_optionals(ctx: TestContext) {
         let mut con = ctx.connection();
 
         redis::cmd("SET").arg("foo").arg(1).exec(&mut con).unwrap();
@@ -1473,9 +1139,8 @@ mod basic {
         assert_eq!(a, 0i32);
     }
 
-    #[test]
-    fn test_scanning() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_scanning(ctx: TestContext) {
         let mut con = ctx.connection();
         let mut unseen = HashSet::new();
 
@@ -1501,11 +1166,9 @@ mod basic {
         assert_eq!(unseen.len(), 0);
     }
 
-    #[test]
-    fn test_checked_scanning_error() {
+    #[single_server_test]
+    fn test_checked_scanning_error(ctx: TestContext) {
         const KEY_COUNT: u32 = 1000;
-
-        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         // Insert a bunch of keys with legit UTF-8 first
@@ -1554,9 +1217,8 @@ mod basic {
         assert_eq!(error_kind, Some(ErrorKind::Parse));
     }
 
-    #[test]
-    fn test_filtered_scanning() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_filtered_scanning(ctx: TestContext) {
         let mut con = ctx.connection();
         let mut unseen = HashSet::new();
 
@@ -1581,9 +1243,8 @@ mod basic {
         assert_eq!(unseen.len(), 0);
     }
 
-    #[test]
-    fn test_scan_with_options_works() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_scan_with_options_works(ctx: TestContext) {
         let mut con = ctx.connection();
         for i in 0..20usize {
             con.append(format!("test/{i}"), i).unwrap();
@@ -1613,9 +1274,8 @@ mod basic {
         assert_eq!(values.len(), 1);
     }
 
-    #[test]
-    fn test_pipeline() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_pipeline(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let ((k1, k2),): ((i32, i32),) = redis::pipe()
@@ -1636,9 +1296,8 @@ mod basic {
         assert_eq!(k2, 43);
     }
 
-    #[test]
-    fn test_pipeline_with_err() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_pipeline_with_err(ctx: TestContext) {
         let mut con = ctx.connection();
 
         redis::cmd("SET")
@@ -1676,9 +1335,8 @@ mod basic {
         assert_eq!(res, "x-value");
     }
 
-    #[test]
-    fn test_pipeline_returns_server_errors() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_pipeline_returns_server_errors(ctx: TestContext) {
         let mut con = ctx.connection();
         let mut pipe = redis::pipe();
         pipe.set("x", "x-value")
@@ -1695,17 +1353,15 @@ mod basic {
         );
     }
 
-    #[test]
-    fn test_empty_pipeline() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_empty_pipeline(ctx: TestContext) {
         let mut con = ctx.connection();
 
         redis::pipe().cmd("PING").ignore().exec(&mut con).unwrap();
     }
 
-    #[test]
-    fn test_pipeline_transaction() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_pipeline_transaction(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let ((k1, k2),): ((i32, i32),) = redis::pipe()
@@ -1727,9 +1383,8 @@ mod basic {
         assert_eq!(k2, 43);
     }
 
-    #[test]
-    fn test_pipeline_transaction_with_errors() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_pipeline_transaction_with_errors(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let _: () = con.set("x", 42).unwrap();
@@ -1764,9 +1419,8 @@ mod basic {
         assert_eq!(x, 42);
     }
 
-    #[test]
-    fn test_pipeline_reuse_query() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_pipeline_reuse_query(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let mut pl = redis::pipe();
@@ -1802,9 +1456,8 @@ mod basic {
         assert_eq!(k3, 43);
     }
 
-    #[test]
-    fn test_pipeline_reuse_query_clear() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_pipeline_reuse_query_clear(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let mut pl = redis::pipe();
@@ -1857,9 +1510,8 @@ mod basic {
         assert!(!pl.is_empty());
     }
 
-    #[test]
-    fn test_real_transaction() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_real_transaction(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let key = "the_key";
@@ -1891,9 +1543,8 @@ mod basic {
         }
     }
 
-    #[test]
-    fn test_real_transaction_highlevel() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_real_transaction_highlevel(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let key = "the_key";
@@ -1914,10 +1565,9 @@ mod basic {
         assert_eq!(response, (43,));
     }
 
-    #[test]
-    fn test_pubsub() {
+    #[single_server_test]
+    fn test_pubsub(ctx: TestContext) {
         use std::sync::{Arc, Barrier};
-        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         // Connection for subscriber api
@@ -1959,26 +1609,35 @@ mod basic {
         if ctx.protocol.supports_resp3() {
             // We expect all push messages to be here, since sync connection won't read in background
             // we can't receive push messages without requesting some command
+            let PushInfo { kind, data, .. } = rx.try_recv().unwrap();
             assert_eq!(
-                rx.try_recv().unwrap(),
-                PushInfo::new(PushKind::Subscribe).data(vec![redis_value!("foo"), redis_value!(1)])
+                (
+                    PushKind::Subscribe,
+                    vec![redis_value!("foo"), redis_value!(1)]
+                ),
+                (kind, data)
             );
+            let PushInfo { kind, data, .. } = rx.try_recv().unwrap();
             assert_eq!(
-                rx.try_recv().unwrap(),
-                PushInfo::new(PushKind::Message)
-                    .data(vec![redis_value!("foo"), redis_value!("42")])
+                (
+                    PushKind::Message,
+                    vec![redis_value!("foo"), redis_value!("42")]
+                ),
+                (kind, data)
             );
+            let PushInfo { kind, data, .. } = rx.try_recv().unwrap();
             assert_eq!(
-                rx.try_recv().unwrap(),
-                PushInfo::new(PushKind::Message)
-                    .data(vec![redis_value!("foo"), redis_value!("23")])
+                (
+                    PushKind::Message,
+                    vec![redis_value!("foo"), redis_value!("23")]
+                ),
+                (kind, data)
             );
         }
     }
 
-    #[test]
-    fn test_pubsub_handles_timeout() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_pubsub_handles_timeout(ctx: TestContext) {
         let mut con = ctx.connection();
 
         // Connection for subscriber api
@@ -1999,10 +1658,9 @@ mod basic {
         assert_eq!(msg.get_payload(), Ok("bar".to_string()));
     }
 
-    #[test]
-    fn test_pubsub_send_ping() {
+    #[single_server_test]
+    fn test_pubsub_send_ping(ctx: TestContext) {
         use std::sync::{Arc, Barrier};
-        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         // Connection for subscriber api
@@ -2065,9 +1723,8 @@ mod basic {
         thread.join().expect("Something went wrong");
     }
 
-    #[test]
-    fn pub_sub_subscription_to_multiple_channels() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn pub_sub_subscription_to_multiple_channels(ctx: TestContext) {
         let mut conn = ctx.connection();
         let mut pubsub_conn = conn.as_pubsub();
         pubsub_conn.subscribe(&["phonewave", "foo", "bar"]).unwrap();
@@ -2082,9 +1739,8 @@ mod basic {
         assert_eq!("foobar".to_string(), msg_payload);
     }
 
-    #[test]
-    fn test_pubsub_unsubscribe() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_pubsub_unsubscribe(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let (tx, rx) = std::sync::mpsc::channel();
@@ -2123,10 +1779,10 @@ mod basic {
             ];
             let mut received_values = vec![];
             for _ in &expected_values {
-                let info = rx.try_recv().unwrap();
+                let PushInfo { kind, data, .. } = rx.try_recv().unwrap();
                 let channel_name: String =
-                    redis::from_redis_value_ref(info.data.first().unwrap()).unwrap();
-                received_values.push((info.kind, channel_name));
+                    redis::from_redis_value_ref(data.first().unwrap()).unwrap();
+                received_values.push((kind, channel_name));
             }
             for val in expected_values {
                 assert!(received_values.contains(&val));
@@ -2134,9 +1790,8 @@ mod basic {
         }
     }
 
-    #[test]
-    fn test_pubsub_subscribe_while_messages_are_sent() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_pubsub_subscribe_while_messages_are_sent(ctx: TestContext) {
         let mut conn_external = ctx.connection();
         let mut conn_internal = ctx.connection();
         let received = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
@@ -2192,9 +1847,8 @@ mod basic {
         );
     }
 
-    #[test]
-    fn test_pubsub_unsubscribe_no_subs() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_pubsub_unsubscribe_no_subs(ctx: TestContext) {
         let mut con = ctx.connection();
 
         {
@@ -2207,9 +1861,8 @@ mod basic {
         assert_eq!(&value[..], "bar");
     }
 
-    #[test]
-    fn test_pubsub_unsubscribe_one_sub() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_pubsub_unsubscribe_one_sub(ctx: TestContext) {
         let mut con = ctx.connection();
 
         {
@@ -2223,9 +1876,8 @@ mod basic {
         assert_eq!(&value[..], "bar");
     }
 
-    #[test]
-    fn test_pubsub_unsubscribe_one_sub_one_psub() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_pubsub_unsubscribe_one_sub_one_psub(ctx: TestContext) {
         let mut con = ctx.connection();
 
         {
@@ -2240,9 +1892,8 @@ mod basic {
         assert_eq!(&value[..], "bar");
     }
 
-    #[test]
-    fn scoped_pubsub() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn scoped_pubsub(ctx: TestContext) {
         let mut con = ctx.connection();
 
         // Connection for subscriber api
@@ -2292,9 +1943,8 @@ mod basic {
         assert_eq!(&value[..], "bar");
     }
 
-    #[test]
-    fn test_tuple_args() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_tuple_args(ctx: TestContext) {
         let mut con = ctx.connection();
 
         redis::cmd("HMSET")
@@ -2319,9 +1969,8 @@ mod basic {
         );
     }
 
-    #[test]
-    fn test_nice_api() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_nice_api(ctx: TestContext) {
         let mut con = ctx.connection();
 
         assert_matches!(con.set("my_key", 42), Ok(_));
@@ -2342,9 +1991,8 @@ mod basic {
         assert_eq!(k2, 43);
     }
 
-    #[test]
-    fn test_auto_m_versions() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_auto_m_versions(ctx: TestContext) {
         let mut con = ctx.connection();
 
         assert_matches!(con.mset(&[("key1", 1), ("key2", 2)]), Ok(_));
@@ -2359,9 +2007,8 @@ mod basic {
         );
     }
 
-    #[test]
-    fn test_nice_hash_api() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_nice_hash_api(ctx: TestContext) {
         let mut con = ctx.connection();
 
         assert_eq!(
@@ -2422,9 +2069,8 @@ mod basic {
         assert!(found.contains(&("f4".to_string(), 8)));
     }
 
-    #[test]
-    fn test_nice_list_api() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_nice_list_api(ctx: TestContext) {
         let mut con = ctx.connection();
 
         assert_eq!(con.rpush("my_list", &[1, 2, 3, 4]), Ok(4));
@@ -2457,9 +2103,8 @@ mod basic {
         }
     }
 
-    #[test]
-    fn test_tuple_decoding_regression() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_tuple_decoding_regression(ctx: TestContext) {
         let mut con = ctx.connection();
 
         assert_matches!(con.del("my_zset"), Ok(_));
@@ -2475,10 +2120,9 @@ mod basic {
         assert_eq!(vec.len(), 0);
     }
 
-    #[test]
-    fn test_tuple_decoding_from_iter() {
+    #[single_server_test]
+    fn test_tuple_decoding_from_iter(ctx: TestContext) {
         const KEY: &str = "my_iter_tuple";
-        let ctx = TestContext::default();
         let mut con = ctx.connection();
 
         let map = HashMap::from([("one", 1), ("two", 2), ("three", 3)]);
@@ -2509,18 +2153,16 @@ mod basic {
         assert_eq!(map.len(), counter);
     }
 
-    #[test]
-    fn test_setbit_and_getbit_single_offset() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_setbit_and_getbit_single_offset(ctx: TestContext) {
         let mut con = ctx.connection();
 
         assert_eq!(con.setbit("bitvec", 10, true), Ok(false));
         assert_eq!(con.getbit("bitvec", 10), Ok(true));
     }
 
-    #[test]
-    fn test_bit_operations() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_bit_operations(ctx: TestContext) {
         let mut con = ctx.connection();
 
         fn perform_bitwise_operation<F>(str1: &str, str2: &str, op: F) -> String
@@ -2626,9 +2268,8 @@ mod basic {
         assert_eq!(one_result, vec![0x00]); // 00000000
     }
 
-    #[test]
-    fn test_redis_server_down() {
-        let mut ctx = TestContext::default();
+    #[single_server_test]
+    fn test_redis_server_down(mut ctx: TestContext) {
         let mut con = ctx.connection();
 
         let ping = redis::cmd("PING").query::<String>(&mut con);
@@ -2643,9 +2284,8 @@ mod basic {
         assert!(!con.is_open());
     }
 
-    #[test]
-    fn test_zinterstore_zunionstore() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_zinterstore_zunionstore(ctx: TestContext) {
         let mut con = ctx.connection();
 
         // Shared members (one, two) have different scores in each set so that
@@ -2778,9 +2418,9 @@ mod basic {
         );
     }
 
-    #[test]
-    fn test_zinterstore_zunionstore_count() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
+    #[single_server_test]
+    fn test_zinterstore_zunionstore_count(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         con.zadd_multiple("s1", &[(1, "foo"), (1, "bar")]).unwrap();
@@ -2845,9 +2485,8 @@ mod basic {
         );
     }
 
-    #[test]
-    fn test_zinter_zunion() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_zinter_zunion(ctx: TestContext) {
         let mut con = ctx.connection();
 
         // Shared members (one, two) have different scores in each set so that
@@ -3029,9 +2668,9 @@ mod basic {
         );
     }
 
-    #[test]
-    fn test_zinter_zunion_count() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
+    #[single_server_test]
+    fn test_zinter_zunion_count(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         con.zadd_multiple("s1", &[(1, "foo"), (1, "bar")]).unwrap();
@@ -3079,9 +2718,8 @@ mod basic {
         );
     }
 
-    #[test]
-    fn test_zrembylex() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_zrembylex(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let setname = "myzset";
@@ -3111,9 +2749,8 @@ mod basic {
     // Requires redis-server >= 6.2.0.
     // Not supported with the current appveyor/windows binary deployed.
     #[cfg(not(target_os = "windows"))]
-    #[test]
-    fn test_zrandmember() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_zrandmember(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let setname = "myzrandset";
@@ -3159,9 +2796,8 @@ mod basic {
         assert_eq!(results.len(), 5);
     }
 
-    #[test]
-    fn test_sismember() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_sismember(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let setname = "myset";
@@ -3177,9 +2813,8 @@ mod basic {
     // Requires redis-server >= 6.2.0.
     // Not supported with the current appveyor/windows binary deployed.
     #[cfg(not(target_os = "windows"))]
-    #[test]
-    fn test_smismember() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_smismember(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let setname = "myset";
@@ -3188,9 +2823,8 @@ mod basic {
         assert_eq!(results, vec![false, true, true, true, false]);
     }
 
-    #[test]
-    fn test_object_freq_command() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_object_freq_command(ctx: TestContext) {
         let mut con = ctx.connection();
 
         // Enable an LFU `maxmemory-policy`. This is required for `OBJECT FREQ` to work.
@@ -3217,9 +2851,8 @@ mod basic {
         // test `redis-rs`, not Redis, we don't test further access frequency increases.
     }
 
-    #[test]
-    fn test_object_idletime_command() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_object_idletime_command(ctx: TestContext) {
         let mut con = ctx.connection();
 
         con.set("object_key_str", "object_value_str").unwrap();
@@ -3239,9 +2872,8 @@ mod basic {
         assert_eq!(con.object_refcount("object_key_str").unwrap().unwrap(), 1);
     }
 
-    #[test]
-    fn test_mget() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_mget(ctx: TestContext) {
         let mut con = ctx.connection();
 
         con.set(1, "1").unwrap();
@@ -3269,42 +2901,8 @@ mod basic {
         assert_eq!(data, vec![Some("2".to_string()), None]);
     }
 
-    #[test]
-    fn test_hmget() {
-        let ctx = TestContext::default();
-        let mut con = ctx.connection();
-
-        con.hset("my_hash", "f1", "1").unwrap();
-        let data: Vec<String> = con
-            .hmget("my_hash", &["f1"])
-            .unwrap()
-            .into_iter()
-            .map(|s| s.unwrap())
-            .collect();
-        assert_eq!(data, vec!["1"]);
-
-        con.hset("my_hash", "f2", "2").unwrap();
-        let data: Vec<String> = con
-            .hmget("my_hash", &["f1", "f2"])
-            .unwrap()
-            .into_iter()
-            .map(|s| s.unwrap())
-            .collect();
-        assert_eq!(data, vec!["1", "2"]);
-
-        let data: Vec<Option<String>> = con.hmget("my_hash", &["f4"]).unwrap();
-        assert_eq!(data, vec![None]);
-
-        let data: Vec<Option<String>> = con.hmget("my_hash", &["f2", "f4"]).unwrap();
-        assert_eq!(data, vec![Some("2".to_string()), None]);
-
-        let data: Vec<Option<String>> = con.hmget("non_existing_hash", &["f1", "f2"]).unwrap();
-        assert_eq!(data, vec![None, None]);
-    }
-
-    #[test]
-    fn test_variable_length_get() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_variable_length_get(ctx: TestContext) {
         let mut con = ctx.connection();
 
         con.set(1, "1").unwrap();
@@ -3314,9 +2912,8 @@ mod basic {
         assert_eq!(data, vec!["1"]);
     }
 
-    #[test]
-    fn test_multi_generics() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_multi_generics(ctx: TestContext) {
         let mut con = ctx.connection();
 
         assert_eq!(con.sadd(b"set1", vec![5, 42]), Ok(2));
@@ -3325,9 +2922,8 @@ mod basic {
         assert_eq!(con.sunionstore("res", &[b"set1", b"set2"]), Ok(3));
     }
 
-    #[test]
-    fn test_set_options_with_get() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_set_options_with_get(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let opts = SetOptions::default().get(true);
@@ -3420,9 +3016,9 @@ mod basic {
     }
 
     /// The test validates the IFEQ value comparison option for the SET command
-    #[test]
-    fn test_set_value_comparison_value_equals() {
-        let ctx = run_test_if_version_supported!([REDIS_CE_8_4, VALKEY_8_1]);
+    #[single_server_test]
+    fn test_set_value_comparison_value_equals(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, [REDIS_CE_8_4, VALKEY_8_1]);
         let mut con = ctx.connection();
 
         let key = "test_ifeq_key";
@@ -3479,10 +3075,10 @@ mod basic {
     }
 
     /// The test validates the IFNE value comparison option for the SET command
-    #[test]
-    fn test_set_value_comparison_value_not_equals() {
+    #[single_server_test]
+    fn test_set_value_comparison_value_not_equals(ctx: TestContext) {
         // `SET` option `IFNE` is only supported in Redis 8.4+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_4);
         let mut con = ctx.connection();
 
         let key = "test_ifne_key";
@@ -3545,10 +3141,10 @@ mod basic {
     }
 
     /// The test validates the DIGEST command
-    #[test]
-    fn test_digest_command() {
+    #[single_server_test]
+    fn test_digest_command(ctx: TestContext) {
         // `DIGEST` is only supported in Redis 8.4+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_4);
         let mut con = ctx.connection();
 
         let key = "test_digest_key";
@@ -3590,10 +3186,10 @@ mod basic {
     }
 
     /// The test validates the IFDEQ value comparison option for the SET command
-    #[test]
-    fn test_set_value_comparison_digest_equals() {
+    #[single_server_test]
+    fn test_set_value_comparison_digest_equals(ctx: TestContext) {
         // `SET` option `IFDEQ` is only supported in Redis 8.4+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_4);
         let mut con = ctx.connection();
 
         let key = "test_ifdeq_key";
@@ -3654,10 +3250,10 @@ mod basic {
     }
 
     /// The test validates the IFDNE value comparison option for the SET command
-    #[test]
-    fn test_set_value_comparison_digest_not_equals() {
+    #[single_server_test]
+    fn test_set_value_comparison_digest_not_equals(ctx: TestContext) {
         // `SET` option `IFDNE` is only supported in Redis 8.4+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_4);
         let mut con = ctx.connection();
 
         let key = "test_ifdne_key";
@@ -3723,10 +3319,10 @@ mod basic {
         assert_eq!(con.get(key).unwrap(), Some(updated_value.to_string()));
     }
 
-    #[test]
-    fn test_del_ex() {
+    #[single_server_test]
+    fn test_del_ex(ctx: TestContext) {
         // `DELEX` is only supported in Redis 8.4+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_4);
         let mut con = ctx.connection();
 
         let key = "test_del_ex_key";
@@ -3853,9 +3449,9 @@ mod basic {
     }
 
     /// Test the MSETEX command with the NX existence option
-    #[test]
-    fn test_mset_ex_nx() {
-        let ctx = run_test_if_version_supported!([REDIS_CE_8_4, VALKEY_9_1]);
+    #[single_server_test]
+    fn test_mset_ex_nx(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, [REDIS_CE_8_4, VALKEY_9_1]);
         let mut con = ctx.connection();
 
         let key1 = "mset_ex_nx_key1";
@@ -3899,9 +3495,9 @@ mod basic {
     }
 
     /// Test the MSETEX command with the XX existence option
-    #[test]
-    fn test_mset_ex_xx() {
-        let ctx = run_test_if_version_supported!([REDIS_CE_8_4, VALKEY_9_1]);
+    #[single_server_test]
+    fn test_mset_ex_xx(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, [REDIS_CE_8_4, VALKEY_9_1]);
         let mut con = ctx.connection();
 
         let key1 = "mset_ex_xx_key1";
@@ -3953,9 +3549,9 @@ mod basic {
     }
 
     /// Test the MSETEX command with all supported expiration options
-    #[test]
-    fn test_mset_ex_expiration_options() {
-        let ctx = run_test_if_version_supported!([REDIS_CE_8_4, VALKEY_9_1]);
+    #[single_server_test]
+    fn test_mset_ex_expiration_options(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, [REDIS_CE_8_4, VALKEY_9_1]);
         let mut con = ctx.connection();
 
         let current_timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
@@ -4033,9 +3629,8 @@ mod basic {
         assert_args!(&opts, "DB", "123", "REPLACE");
     }
 
-    #[test]
-    fn test_copy() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_copy(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let opts = CopyOptions::default();
@@ -4061,9 +3656,9 @@ mod basic {
         assert_eq!(con.get("key4").unwrap(), Some("value1".to_string()));
     }
 
-    #[test]
-    fn test_expire_time() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_7_0);
+    #[single_server_test]
+    fn test_expire_time(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, REDIS_CE_7_0);
 
         let mut con = ctx.connection();
 
@@ -4096,9 +3691,8 @@ mod basic {
         assert_eq!(expire_time_milliseconds, now * 1000 + 12_000);
     }
 
-    #[test]
-    fn test_timeout_leaves_usable_connection() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_timeout_leaves_usable_connection(ctx: TestContext) {
         let mut con = ctx.connection();
 
         con.set("key", "value").unwrap();
@@ -4193,9 +3787,8 @@ mod basic {
         assert_eq!(value, "key2");
     }
 
-    #[test]
-    fn test_blocking_sorted_set_api() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_blocking_sorted_set_api(ctx: TestContext) {
         let mut con = ctx.connection();
 
         assert_matches!(con.zadd("a", "1a", 1), Ok(_));
@@ -4228,9 +3821,8 @@ mod basic {
         }
     }
 
-    #[test]
-    fn test_sorted_set_add_options() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_sorted_set_add_options(ctx: TestContext) {
         let mut con = ctx.connection();
 
         // Scenario 1
@@ -4303,31 +3895,11 @@ mod basic {
         assert_eq!(con.zscore("6", "6a"), Ok(Some(12.0)));
     }
 
-    #[test]
-    fn test_zmscore() {
-        let ctx = TestContext::default();
-        let mut con = ctx.connection();
-
-        let _: usize = con.zadd("my_zset", "m1", 1.5).unwrap();
-        let _: usize = con.zadd("my_zset", "m2", 2.5).unwrap();
-
-        let scores: Vec<Option<f64>> = con.zscore_multiple("my_zset", &["m1", "m2"]).unwrap();
-        assert_eq!(scores, vec![Some(1.5), Some(2.5)]);
-
-        let scores: Vec<Option<f64>> = con.zscore_multiple("my_zset", &["m1", "m3"]).unwrap();
-        assert_eq!(scores, vec![Some(1.5), None]);
-
-        let scores: Vec<Option<f64>> = con
-            .zscore_multiple("non_existing_zset", &["m1", "m2"])
-            .unwrap();
-        assert_eq!(scores, vec![None, None]);
-    }
-
-    #[test]
     #[cfg(feature = "vector-sets")]
-    fn test_vector_sets_basic_operations() {
+    #[single_server_test]
+    fn test_vector_sets_basic_operations(ctx: TestContext) {
         // `VADD` is only supported in Redis 8.0+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_0);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_0);
         let mut con = ctx.connection();
 
         let key = "test_points";
@@ -4408,11 +3980,11 @@ mod basic {
         assert_eq!(con.vgetattr(key, attributes_target_point), Ok(None));
     }
 
-    #[test]
     #[cfg(feature = "vector-sets")]
-    fn test_vector_sets_similarity_search() {
+    #[single_server_test]
+    fn test_vector_sets_similarity_search(ctx: TestContext) {
         // `VADD` is only supported in Redis 8.0+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_0);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_0);
         let mut con = ctx.connection();
 
         let key = "test_points_for_similarity_search";
@@ -4590,11 +4162,11 @@ mod basic {
         }
     }
 
-    #[test]
     #[cfg(feature = "vector-sets")]
-    fn test_vector_sets_auxiliary_commands() {
+    #[single_server_test]
+    fn test_vector_sets_auxiliary_commands(ctx: TestContext) {
         // `VADD` is only supported in Redis 8.0+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_0);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_0);
         let mut con = ctx.connection();
 
         let key = "test_points_for_auxiliary_commands";
@@ -4822,11 +4394,11 @@ mod basic {
         assert_eq!(con.vgetattr(key, point_of_interest), Ok(None));
     }
 
-    #[test]
     #[cfg(feature = "vector-sets")]
-    fn test_vector_sets_edge_cases() {
+    #[single_server_test]
+    fn test_vector_sets_edge_cases(ctx: TestContext) {
         // `VADD` is only supported in Redis 8.0+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_0);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_0);
         let mut con = ctx.connection();
 
         let non_existent_key = "non_existent_key";
@@ -4951,9 +4523,8 @@ mod basic {
         assert_eq!(error.kind(), redis::ServerErrorKind::ResponseError.into());
     }
 
-    #[test]
-    fn test_push_manager() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_push_manager(ctx: TestContext) {
         let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
         let connection_info = ctx.server.connection_info().set_redis_settings(redis);
 
@@ -4971,9 +4542,10 @@ mod basic {
         for _ in 0..10 {
             let _: RedisResult<()> = pipe.query(&mut con);
             con.get_int("key_1").unwrap();
+            let PushInfo { kind, data, .. } = rx.try_recv().unwrap();
             assert_eq!(
-                rx.try_recv().unwrap(),
-                PushInfo::new(PushKind::Invalidate).data(vec![redis_value!(["key_1"])])
+                (PushKind::Invalidate, vec![redis_value!(["key_1"])]),
+                (kind, data)
             );
         }
         let (new_tx, new_rx) = std::sync::mpsc::channel();
@@ -4981,9 +4553,10 @@ mod basic {
         drop(rx);
         let _: RedisResult<()> = pipe.query(&mut con);
         con.get_int("key_1").unwrap();
+        let PushInfo { kind, data, .. } = new_rx.try_recv().unwrap();
         assert_eq!(
-            new_rx.try_recv().unwrap(),
-            PushInfo::new(PushKind::Invalidate).data(vec![redis_value!(["key_1"])])
+            (PushKind::Invalidate, vec![redis_value!(["key_1"])]),
+            (kind, data)
         );
 
         {
@@ -4996,9 +4569,8 @@ mod basic {
         }
     }
 
-    #[test]
-    fn test_push_manager_disconnection() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_push_manager_disconnection(ctx: TestContext) {
         let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
         let connection_info = ctx.server.connection_info().set_redis_settings(redis);
         let client = redis::Client::open(connection_info).unwrap();
@@ -5018,10 +4590,9 @@ mod basic {
         assert_eq!(rx.try_recv().unwrap().kind, PushKind::Disconnection);
     }
 
-    #[test]
-    fn test_raw_pubsub_with_push_manager() {
+    #[single_server_test]
+    fn test_raw_pubsub_with_push_manager(ctx: TestContext) {
         // Tests PubSub usage with raw connection.
-        let ctx = TestContext::default();
         if !ctx.protocol.supports_resp3() {
             return;
         }
@@ -5049,8 +4620,8 @@ mod basic {
         // we don't assume any order on the received messages, so we first receive them and them check that they exist regardless of order
         let mut messages = vec![];
         for _ in 0..4 {
-            let info = rx.try_recv().unwrap();
-            messages.push((info.kind, info.data));
+            let PushInfo { kind, data, .. } = rx.try_recv().unwrap();
+            messages.push((kind, data));
         }
         assert!(
             messages.contains(&(
@@ -5093,22 +4664,29 @@ mod basic {
         assert_eq!(con.publish("barvaz", 42), Ok(0));
 
         // We have received verification from Redis that it's unsubscribed to channel.
+        let PushInfo { kind, data, .. } = rx.try_recv().unwrap();
         assert_eq!(
-            rx.try_recv().unwrap(),
-            PushInfo::new(PushKind::Unsubscribe).data(vec![redis_value!("foo"), redis_value!(1)])
+            (
+                PushKind::Unsubscribe,
+                vec![redis_value!("foo"), redis_value!(1)]
+            ),
+            (kind, data)
         );
+        let PushInfo { kind, data, .. } = rx.try_recv().unwrap();
         assert_eq!(
-            rx.try_recv().unwrap(),
-            PushInfo::new(PushKind::PUnsubscribe).data(vec![redis_value!("bar*"), redis_value!(0)])
+            (
+                PushKind::PUnsubscribe,
+                vec![redis_value!("bar*"), redis_value!(0)]
+            ),
+            (kind, data)
         );
 
         // check that no additional message was sent.
         rx.try_recv().unwrap_err();
     }
 
-    #[test]
-    fn test_select_db() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_select_db(ctx: TestContext) {
         let redis = redis_settings().set_db(5);
         let connection_info = ctx.server.connection_info().set_redis_settings(redis);
 
@@ -5121,9 +4699,8 @@ mod basic {
         assert!(info.contains("db=5"));
     }
 
-    #[test]
-    fn test_client_getname() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_client_getname(ctx: TestContext) {
         let mut con = ctx.connection();
         redis::cmd("CLIENT")
             .arg("SETNAME")
@@ -5134,33 +4711,29 @@ mod basic {
         assert_eq!(res, "connection-name");
     }
 
-    #[test]
-    fn test_client_id() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_client_id(ctx: TestContext) {
         let mut con = ctx.connection();
         let _num = con.client_id().unwrap();
     }
 
-    #[test]
-    fn test_client_setname() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_client_setname(ctx: TestContext) {
         let mut con = ctx.connection();
         assert_eq!(con.client_setname("connection-name"), Ok(()));
         let res: String = redis::cmd("CLIENT").arg("GETNAME").query(&mut con).unwrap();
         assert_eq!(res, "connection-name");
     }
 
-    #[test]
-    fn test_role_primary() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_role_primary(ctx: TestContext) {
         let mut con = ctx.connection();
         let ret = redis::cmd("ROLE").query::<Role>(&mut con).unwrap();
         assert_matches!(ret, Role::Primary { .. });
     }
 
-    #[test]
-    fn test_connection_timeout_on_busy_server() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_connection_timeout_on_busy_server(ctx: TestContext) {
         let mut con = ctx.connection();
         // we stop the server on another thread, in order to move forwardd while the server is stopped.
         let handle = thread::spawn(move || {
@@ -5185,9 +4758,8 @@ mod basic {
         handle.join().unwrap();
     }
 
-    #[test]
-    fn fail_on_empty_command() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn fail_on_empty_command(ctx: TestContext) {
         let mut connection = ctx.connection();
 
         let error: RedisError = redis::Pipeline::new()
@@ -5203,9 +4775,9 @@ mod basic {
         assert_eq!(error.to_string(), "empty command - Client");
     }
 
-    #[test]
-    fn test_connection_info_lib_name() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_7_2);
+    #[single_server_test]
+    fn test_connection_info_lib_name(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, REDIS_CE_7_2);
 
         // Build a `ConnectionInfo` that sets lib_name etc
         let redis = redis_settings().set_lib_name("redis-rs-test-basic-lib-name", "42.4711");
@@ -5235,6 +4807,371 @@ mod basic {
             "42.4711"
         );
     }
+
+    #[test]
+    fn test_increx_options_args() {
+        assert_eq!(
+            ToRedisArgs::to_redis_args(&IncrexOptions::<i64>::default()).len(),
+            0
+        );
+
+        let opts = IncrexOptions::default()
+            .saturate()
+            .lower_bound(-5)
+            .upper_bound(100)
+            .with_expiration(Expiry::EX(60))
+            .enx();
+        assert_args!(
+            &opts, "SATURATE", "LBOUND", "-5", "UBOUND", "100", "EX", "60", "ENX"
+        );
+
+        let opts = IncrexOptions::default()
+            .saturate()
+            .upper_bound(2.5)
+            .with_expiration(Expiry::PERSIST);
+        assert_args!(&opts, "SATURATE", "UBOUND", "2.5", "PERSIST");
+    }
+
+    #[single_server_test]
+    fn test_increx_with_integers(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_8);
+        let mut con = ctx.connection();
+
+        // A fresh key starts at 0.
+        // A normal in-bounds increment applies fully.
+        let result = con.increx("counter", 5, IncrexOptions::default()).unwrap();
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, 5);
+        assert_eq!(actual_increment, 5);
+
+        // The default policy rejects out-of-bounds operations.
+        // The reply is a regular successful `Ok`, reporting the unchanged current value and a zero applied increment.
+        let result = con
+            .increx("counter", 100, IncrexOptions::default().upper_bound(10))
+            .unwrap();
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, 5);
+        assert_eq!(actual_increment, 0);
+
+        // SATURATE clamps the result to an explicit upper bound and reports the clamped delta (10 - 5 = 5), not the requested increment (100).
+        let result = con
+            .increx(
+                "counter",
+                100,
+                IncrexOptions::default().saturate().upper_bound(10),
+            )
+            .unwrap();
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, 10);
+        assert_eq!(actual_increment, 5);
+
+        // SATURATE clamps to an explicit lower bound on underflow.
+        // The actual_increment is again the clamped delta (-10 - 5 = -15), not the requested -100.
+        con.set("underflow", 5).unwrap();
+        let result = con
+            .increx(
+                "underflow",
+                -100,
+                IncrexOptions::default().saturate().lower_bound(-10),
+            )
+            .unwrap();
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, -10);
+        assert_eq!(actual_increment, -15);
+
+        // With no explicit bound, SATURATE clamps to the server's integer type limits,
+        // which are exactly i64::MAX / i64::MIN (the server operates on 64-bit `long long`).
+        con.set("hi", i64::MAX - 100).unwrap();
+        let result = con
+            .increx("hi", 200, IncrexOptions::default().saturate())
+            .unwrap();
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, i64::MAX);
+        assert_eq!(actual_increment, 100);
+        con.set("lo", i64::MIN + 100).unwrap();
+        let result = con
+            .increx("lo", -200, IncrexOptions::default().saturate())
+            .unwrap();
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, i64::MIN);
+        assert_eq!(actual_increment, -100);
+
+        // Expiration is applied alongside the increment.
+        let result = con
+            .increx(
+                "ttl_counter",
+                1,
+                IncrexOptions::default().with_expiration(Expiry::EX(100)),
+            )
+            .unwrap();
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, 1);
+        assert_eq!(actual_increment, 1);
+        assert!((0..=100).contains(&con.ttl("ttl_counter").unwrap().raw()));
+
+        // Rejected operations leave the key's value *and* TTL untouched.
+        con.set_ex("bounded", 5, 100).unwrap();
+        let result = con
+            .increx(
+                "bounded",
+                100,
+                IncrexOptions::default()
+                    .upper_bound(10)
+                    .with_expiration(Expiry::EX(999)),
+            )
+            .unwrap();
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, 5);
+        assert_eq!(actual_increment, 0);
+        assert_eq!(con.get("bounded").unwrap(), Some("5".to_string()));
+        assert!((0..=100).contains(&con.ttl("bounded").unwrap().raw()));
+
+        // A SATURATE clamp that lands on the current value has an effective delta of 0, yet it counts as an *applied* operation,
+        // which means that the supplied expiration still takes effect.
+        // This differs from the default policy rejection above, which leaves the TTL untouched.
+        con.set("at_bound", 10).unwrap();
+        let result = con
+            .increx(
+                "at_bound",
+                100,
+                IncrexOptions::default()
+                    .saturate() // Because of this, the operation is applied even though the value doesn't change.
+                    .upper_bound(10)
+                    .with_expiration(Expiry::EX(500)),
+            )
+            .unwrap();
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, 10);
+        assert_eq!(actual_increment, 0);
+        // The key started with no TTL, so EX must have set one.
+        assert!((0..=500).contains(&con.ttl("at_bound").unwrap().raw()));
+
+        // ENX takes into account if a TTL is already present and blocks the update even though the clamp itself is applied.
+        con.set_ex("at_bound_enx", 10, 100).unwrap();
+        let result = con
+            .increx(
+                "at_bound_enx",
+                100,
+                IncrexOptions::default()
+                    .saturate()
+                    .upper_bound(10)
+                    .with_expiration(Expiry::EX(999))
+                    .enx(),
+            )
+            .unwrap();
+        let (value, actual_increment) = result.as_i64().unwrap();
+        assert_eq!(value, 10);
+        assert_eq!(actual_increment, 0);
+        assert!((0..=100).contains(&con.ttl("at_bound_enx").unwrap().raw()));
+    }
+
+    #[single_server_test]
+    fn test_increx_with_floats(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_8);
+        let mut con = ctx.connection();
+
+        // A normal in-bounds float increment applies fully.
+        let result = con
+            .increx("balance", 2.5, IncrexOptions::default())
+            .unwrap();
+        let (value, actual_increment) = result.as_f64().unwrap();
+        assert_approx_eq!(value, 2.5);
+        assert_approx_eq!(actual_increment, 2.5);
+
+        // SATURATE clamps to a floating-point upper bound.
+        // The actual_increment is the clamped delta (4.0 - 2.5 = 1.5), not the requested 5.5.
+        let result = con
+            .increx(
+                "balance",
+                5.5,
+                IncrexOptions::default().saturate().upper_bound(4.0),
+            )
+            .unwrap();
+        let (value, actual_increment) = result.as_f64().unwrap();
+        assert_approx_eq!(value, 4.0);
+        assert_approx_eq!(actual_increment, 1.5);
+
+        // The default policy rejects an out-of-bounds floating-point operation, leaving the value unchanged.
+        let result = con
+            .increx("balance", 5.5, IncrexOptions::default().upper_bound(4.0))
+            .unwrap();
+        let (value, actual_increment) = result.as_f64().unwrap();
+        assert_approx_eq!(value, 4.0);
+        assert_approx_eq!(actual_increment, 0.0);
+
+        // SATURATE clamps to a floating-point lower bound on underflow.
+        // From 0, -5.5 clamps to -1.5, so the clamped delta is -1.5 rather than the requested -5.5.
+        let result = con
+            .increx(
+                "debt",
+                -5.5,
+                IncrexOptions::default().saturate().lower_bound(-1.5),
+            )
+            .unwrap();
+        let (value, actual_increment) = result.as_f64().unwrap();
+        assert_approx_eq!(value, -1.5);
+        assert_approx_eq!(actual_increment, -1.5);
+
+        // Expiration is applied alongside the increment.
+        let result = con
+            .increx(
+                "ttl_counter",
+                1.0,
+                IncrexOptions::default().with_expiration(Expiry::EX(100)),
+            )
+            .unwrap();
+        let (value, actual_increment) = result.as_f64().unwrap();
+        assert_approx_eq!(value, 1.0);
+        assert_approx_eq!(actual_increment, 1.0);
+        assert!((0..=100).contains(&con.ttl("ttl_counter").unwrap().raw()));
+
+        // Rejected operations leave the key's value *and* TTL untouched.
+        con.set_ex("bounded", 5.0, 100).unwrap();
+        let result = con
+            .increx(
+                "bounded",
+                100.0,
+                IncrexOptions::default()
+                    .upper_bound(10.0)
+                    .with_expiration(Expiry::EX(999)),
+            )
+            .unwrap();
+        let (value, actual_increment) = result.as_f64().unwrap();
+        assert_approx_eq!(value, 5.0);
+        assert_approx_eq!(actual_increment, 0.0);
+        assert!((0..=100).contains(&con.ttl("bounded").unwrap().raw()));
+
+        // A SATURATE clamp that lands on the current value has an effective delta of 0, yet it counts as an *applied* operation,
+        // which means that the supplied expiration still takes effect.
+        con.set("at_bound", 10.0).unwrap();
+        let result = con
+            .increx(
+                "at_bound",
+                100.0,
+                IncrexOptions::default()
+                    .saturate() // Because of this, the operation is applied even though the value doesn't change.
+                    .upper_bound(10.0)
+                    .with_expiration(Expiry::EX(500)),
+            )
+            .unwrap();
+        let (value, actual_increment) = result.as_f64().unwrap();
+        assert_approx_eq!(value, 10.0);
+        assert_approx_eq!(actual_increment, 0.0);
+        assert!((0..=500).contains(&con.ttl("at_bound").unwrap().raw()));
+
+        // ENX takes into account if a TTL is already present and blocks the update even though the clamp itself is applied.
+        con.set_ex("at_bound_enx", 10.0, 100).unwrap();
+        let result = con
+            .increx(
+                "at_bound_enx",
+                100.0,
+                IncrexOptions::default()
+                    .saturate()
+                    .upper_bound(10.0)
+                    .with_expiration(Expiry::EX(999))
+                    .enx(),
+            )
+            .unwrap();
+        let (value, actual_increment) = result.as_f64().unwrap();
+        assert_approx_eq!(value, 10.0);
+        assert_approx_eq!(actual_increment, 0.0);
+        assert!((0..=100).contains(&con.ttl("at_bound_enx").unwrap().raw()));
+    }
+
+    #[single_server_test]
+    fn test_increx_server_errors_forwarded_verbatim(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_8);
+        let mut con = ctx.connection();
+
+        // Type mismatch: INCREX against a list key yields WRONGTYPE, surfaced with the server's exact code and detail.
+        con.rpush("list_key", "a").unwrap();
+        let err = con
+            .increx("list_key", 1, IncrexOptions::default())
+            .unwrap_err();
+        assert_eq!(err.code(), Some("WRONGTYPE"));
+        assert_eq!(
+            err.detail(),
+            Some("Operation against a key holding the wrong kind of value")
+        );
+
+        // Non-numeric value under BYINT / BYFLOAT.
+        // The server's value-type errors are forwarded verbatim.
+        // Note: The error message wording differs between BYINT and BYFLOAT.
+        con.set("str_key", "hello").unwrap();
+        let err = con
+            .increx("str_key", 1, IncrexOptions::default())
+            .unwrap_err();
+        assert_eq!(err.code(), Some("ERR"));
+        assert_eq!(
+            err.detail(),
+            Some("value is not an integer or out of range")
+        );
+
+        let err = con
+            .increx("str_key", 1.5, IncrexOptions::default())
+            .unwrap_err();
+        assert_eq!(err.code(), Some("ERR"));
+        assert_eq!(err.detail(), Some("value is not a valid float"));
+
+        // Malformed arguments reachable through the typed API - ENX with no expiration.
+        // The server's argument error is forwarded verbatim.
+        let err = con
+            .increx("misc", 1, IncrexOptions::default().enx())
+            .unwrap_err();
+        assert_eq!(err.code(), Some("ERR"));
+        assert_eq!(err.detail(), Some("ENX flag requires an expiration"));
+    }
+
+    #[single_server_test]
+    fn test_hmget(ctx: TestContext) {
+        let mut con = ctx.connection();
+
+        con.hset("my_hash", "f1", "1").unwrap();
+        let data: Vec<String> = con
+            .hmget("my_hash", &["f1"])
+            .unwrap()
+            .into_iter()
+            .map(|s| s.unwrap())
+            .collect();
+        assert_eq!(data, vec!["1"]);
+
+        con.hset("my_hash", "f2", "2").unwrap();
+        let data: Vec<String> = con
+            .hmget("my_hash", &["f1", "f2"])
+            .unwrap()
+            .into_iter()
+            .map(|s| s.unwrap())
+            .collect();
+        assert_eq!(data, vec!["1", "2"]);
+
+        let data: Vec<Option<String>> = con.hmget("my_hash", &["f4"]).unwrap();
+        assert_eq!(data, vec![None]);
+
+        let data: Vec<Option<String>> = con.hmget("my_hash", &["f2", "f4"]).unwrap();
+        assert_eq!(data, vec![Some("2".to_string()), None]);
+
+        let data: Vec<Option<String>> = con.hmget("non_existing_hash", &["f1", "f2"]).unwrap();
+        assert_eq!(data, vec![None, None]);
+    }
+
+    #[single_server_test]
+    fn test_zmscore(ctx: TestContext) {
+        let mut con = ctx.connection();
+
+        let _: usize = con.zadd("my_zset", "m1", 1.5).unwrap();
+        let _: usize = con.zadd("my_zset", "m2", 2.5).unwrap();
+
+        let scores: Vec<Option<f64>> = con.zscore_multiple("my_zset", &["m1", "m2"]).unwrap();
+        assert_eq!(scores, vec![Some(1.5), Some(2.5)]);
+
+        let scores: Vec<Option<f64>> = con.zscore_multiple("my_zset", &["m1", "m3"]).unwrap();
+        assert_eq!(scores, vec![Some(1.5), None]);
+
+        let scores: Vec<Option<f64>> = con
+            .zscore_multiple("non_existing_zset", &["m1", "m2"])
+            .unwrap();
+        assert_eq!(scores, vec![None, None]);
+    }
 }
 
 #[cfg(feature = "r2d2")]
@@ -5242,10 +5179,10 @@ mod r2d2_pool {
     use r2d2::ManageConnection;
     use redis::{ErrorKind, ServerErrorKind};
     use redis_test::TestContext;
+    use test_macros::single_server_test;
 
-    #[test]
-    fn is_valid_reports_the_error_returned_by_the_server() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn is_valid_reports_the_error_returned_by_the_server(ctx: TestContext) {
         let mut con = ctx.connection();
 
         // Revoke `PING` from the default user, so that the health check fails

--- a/redis/tests/test_cache.rs
+++ b/redis/tests/test_cache.rs
@@ -7,12 +7,10 @@ use redis::CommandCacheConfig;
 use redis::cluster_routing::*;
 use redis::{AsyncCommands, RedisError, caching::CacheConfig};
 #[cfg(feature = "json")]
-use redis_test::server::Module;
-use redis_test::{REDIS_CE_7_2, TestContext, TestContextBuilder, run_test_if_version_supported};
-#[cfg(feature = "json")]
 use serde_json::json;
 use std::collections::HashMap;
 use std::time::Duration;
+use test_macros::async_cluster_test;
 use test_macros::async_test;
 
 mod support;
@@ -36,9 +34,7 @@ macro_rules! assert_invalidate {
 }
 
 // Basic testing should work with both CacheMode::All and CacheMode::OptIn if commands has called cache()
-#[async_test]
-async fn test_cache_basic(test_with_optin: bool) {
-    let ctx = TestContext::default();
+async fn test_cache_basic_impl(ctx: TestContext, test_with_optin: bool) {
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -95,8 +91,17 @@ async fn test_cache_basic(test_with_optin: bool) {
 }
 
 #[async_test]
-async fn test_cache_mget() {
-    let ctx = TestContext::default();
+async fn test_cache_basic_default(ctx: TestContext) {
+    test_cache_basic_impl(ctx, false).await;
+}
+
+#[async_test]
+async fn test_cache_basic_optin(ctx: TestContext) {
+    test_cache_basic_impl(ctx, true).await;
+}
+
+#[async_test]
+async fn test_cache_mget(ctx: TestContext) {
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -150,9 +155,8 @@ async fn test_cache_mget() {
 }
 
 #[cfg(feature = "json")]
-#[async_test]
-async fn test_module_json_cache_get_mget() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[async_test(module = "json")]
+async fn test_module_json_cache_get_mget(ctx: TestContext) {
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -220,9 +224,8 @@ async fn test_module_json_cache_get_mget() {
 }
 
 #[cfg(feature = "json")]
-#[async_test]
-async fn test_module_json_cache_get_mget_different_paths() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[async_test(module = "json")]
+async fn test_module_json_cache_get_mget_different_paths(ctx: TestContext) {
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -334,8 +337,7 @@ async fn test_module_json_cache_get_mget_different_paths() {
 }
 
 #[async_test]
-async fn test_cache_is_not_target_type_dependent() {
-    let ctx = TestContext::default();
+async fn test_cache_is_not_target_type_dependent(ctx: TestContext) {
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -353,56 +355,56 @@ async fn test_cache_is_not_target_type_dependent() {
 }
 
 #[async_test]
-async fn test_cache_with_pipeline(atomic: bool) {
-    let ctx = TestContext::default();
+async fn test_cache_with_pipeline(ctx: TestContext) {
     if !ctx.protocol.supports_resp3() {
         return;
     }
 
-    let mut con = ctx.async_connection_with_cache().await.unwrap();
-    // Test cache for both atomic and non-atomic Pipeline and mix MGET,GET,ignore in the pipeline.
-    let (mget_k1_k2,): ((i32, i32),) = get_pipe(atomic)
-        .cmd("SET")
-        .arg("key_1")
-        .arg(41)
-        .ignore()
-        .cmd("SET")
-        .arg("key_2")
-        .arg(42)
-        .ignore()
-        .cmd("MGET")
-        .arg(&["key_1", "key_2"])
-        .query_async(&mut con)
-        .await
-        .unwrap();
+    for atomic in [true, false] {
+        let mut con = ctx.async_connection_with_cache().await.unwrap();
+        // Test cache for both atomic and non-atomic Pipeline and mix MGET,GET,ignore in the pipeline.
+        let (mget_k1_k2,): ((i32, i32),) = get_pipe(atomic)
+            .cmd("SET")
+            .arg("key_1")
+            .arg(41)
+            .ignore()
+            .cmd("SET")
+            .arg("key_2")
+            .arg(42)
+            .ignore()
+            .cmd("MGET")
+            .arg(&["key_1", "key_2"])
+            .query_async(&mut con)
+            .await
+            .unwrap();
 
-    assert_eq!(mget_k1_k2, (41, 42));
-    // There are 2 miss for key_1, key_2 used with MGET
-    assert_hit!(&con, 0);
-    assert_miss!(&con, 2);
+        assert_eq!(mget_k1_k2, (41, 42));
+        // There are 2 miss for key_1, key_2 used with MGET
+        assert_hit!(&con, 0);
+        assert_miss!(&con, 2);
 
-    let (k1, mget_k1_k2, k_unknown): (i32, (i32, i32), Option<i32>) = get_pipe(atomic)
-        .cmd("GET")
-        .arg("key_1")
-        .cmd("MGET")
-        .arg(&["key_1", "key_2"])
-        .cmd("GET")
-        .arg("key_doesnt_exists")
-        .query_async(&mut con)
-        .await
-        .unwrap();
+        let (k1, mget_k1_k2, k_unknown): (i32, (i32, i32), Option<i32>) = get_pipe(atomic)
+            .cmd("GET")
+            .arg("key_1")
+            .cmd("MGET")
+            .arg(&["key_1", "key_2"])
+            .cmd("GET")
+            .arg("key_doesnt_exists")
+            .query_async(&mut con)
+            .await
+            .unwrap();
 
-    assert_eq!(k1, 41);
-    assert_eq!(mget_k1_k2, (41, 42));
-    assert_eq!(k_unknown, Option::None);
-    assert_hit!(&con, 3);
-    assert_miss!(&con, 3);
+        assert_eq!(k1, 41);
+        assert_eq!(mget_k1_k2, (41, 42));
+        assert_eq!(k_unknown, Option::None);
+        assert_hit!(&con, 3);
+        assert_miss!(&con, 3);
+    }
 }
 
 #[async_test]
-async fn test_cache_basic_partial_opt_in() {
+async fn test_cache_basic_partial_opt_in(ctx: TestContext) {
     // In OptIn mode cache must not be utilized without explicit per command configuration.
-    let ctx = TestContext::default();
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -466,128 +468,143 @@ async fn test_cache_basic_partial_opt_in() {
 }
 
 #[async_test]
-async fn test_cache_pipeline_partial_opt_in(atomic: bool) {
+async fn test_cache_pipeline_partial_opt_in(ctx: TestContext) {
     // In OptIn mode cache must not be utilized without explicit per command configuration.
-    let ctx = TestContext::default();
     if !ctx.protocol.supports_resp3() {
         return;
     }
 
-    let cache_config = CacheConfig::new().set_mode(redis::caching::CacheMode::OptIn);
-    let mut con = ctx
-        .async_connection_with_cache_config(cache_config)
-        .await
-        .unwrap();
-    // Test cache for both atomic and non-atomic Pipeline and mix MGET,GET,ignore in the pipeline.
-    let (mget_k1_k2,): ((i32, i32),) = get_pipe(atomic)
-        .cmd("SET")
-        .arg("key_1")
-        .arg(42)
-        .ignore()
-        .cmd("SET")
-        .arg("key_2")
-        .arg(43)
-        .ignore()
-        .cmd("MGET")
-        .arg(&["key_1", "key_2"])
-        .query_async(&mut con)
-        .await
-        .unwrap();
-
-    assert_eq!(mget_k1_k2, (42, 43));
-    // Since CacheMode::OptIn is enabled, so there should be no miss or hit
-    assert_hit!(&con, 0);
-    assert_miss!(&con, 0);
-
-    for _ in 0..2 {
-        let (mget_k1_k2, k1, k_unknown): ((i32, i32), i32, Option<i32>) = get_pipe(atomic)
-            .cmd("MGET")
-            .set_cache_config(CommandCacheConfig::new().set_enable_cache(true))
-            .arg(&["key_1", "key_2"])
-            .cmd("GET")
+    for atomic in [true, false] {
+        let cache_config = CacheConfig::new().set_mode(redis::caching::CacheMode::OptIn);
+        let mut con = ctx
+            .async_connection_with_cache_config(cache_config)
+            .await
+            .unwrap();
+        // Test cache for both atomic and non-atomic Pipeline and mix MGET,GET,ignore in the pipeline.
+        let (mget_k1_k2,): ((i32, i32),) = get_pipe(atomic)
+            .cmd("SET")
             .arg("key_1")
-            .cmd("GET")
-            .arg("key_doesnt_exists")
+            .arg(42)
+            .ignore()
+            .cmd("SET")
+            .arg("key_2")
+            .arg(43)
+            .ignore()
+            .cmd("MGET")
+            .arg(&["key_1", "key_2"])
             .query_async(&mut con)
             .await
             .unwrap();
 
         assert_eq!(mget_k1_k2, (42, 43));
-        assert_eq!(k1, 42);
-        assert_eq!(k_unknown, Option::None);
+        // Since CacheMode::OptIn is enabled, so there should be no miss or hit
+        assert_hit!(&con, 0);
+        assert_miss!(&con, 0);
+
+        for _ in 0..2 {
+            let (mget_k1_k2, k1, k_unknown): ((i32, i32), i32, Option<i32>) = get_pipe(atomic)
+                .cmd("MGET")
+                .set_cache_config(CommandCacheConfig::new().set_enable_cache(true))
+                .arg(&["key_1", "key_2"])
+                .cmd("GET")
+                .arg("key_1")
+                .cmd("GET")
+                .arg("key_doesnt_exists")
+                .query_async(&mut con)
+                .await
+                .unwrap();
+
+            assert_eq!(mget_k1_k2, (42, 43));
+            assert_eq!(k1, 42);
+            assert_eq!(k_unknown, Option::None);
+        }
+        // Only MGET should be use cache path, since pipeline used twice there should be one miss and one hit.
+        assert_hit!(&con, 2);
+        assert_miss!(&con, 2);
     }
-    // Only MGET should be use cache path, since pipeline used twice there should be one miss and one hit.
-    assert_hit!(&con, 2);
-    assert_miss!(&con, 2);
 }
 
 #[async_test]
-async fn test_cache_different_commands(test_with_opt_in: bool) {
-    let ctx = TestContext::default();
+async fn test_cache_different_commands(ctx: TestContext) {
     if !ctx.protocol.supports_resp3() {
         return;
     }
 
-    let cache_config = if test_with_opt_in {
-        CacheConfig::new().set_mode(redis::caching::CacheMode::OptIn)
-    } else {
-        CacheConfig::default()
-    };
-    let mut con = ctx
-        .async_connection_with_cache_config(cache_config)
-        .await
-        .unwrap();
-    let _: () = get_cmd("HSET", test_with_opt_in)
-        .arg("user")
-        .arg("health")
-        .arg("100")
-        .query_async(&mut con)
-        .await
-        .unwrap();
+    for test_with_opt_in in [true, false] {
+        let cache_config = if test_with_opt_in {
+            CacheConfig::new().set_mode(redis::caching::CacheMode::OptIn)
+        } else {
+            CacheConfig::default()
+        };
+        let mut con = ctx
+            .async_connection_with_cache_config(cache_config)
+            .await
+            .unwrap();
+        let _: () = get_cmd("HSET", test_with_opt_in)
+            .arg("user")
+            .arg("health")
+            .arg("100")
+            .query_async(&mut con)
+            .await
+            .unwrap();
 
-    let val: usize = get_cmd("HGET", test_with_opt_in)
-        .arg("user")
-        .arg("health")
-        .query_async(&mut con)
-        .await
-        .unwrap();
-    assert_eq!(val, 100);
-    assert_hit!(&con, 0);
-    assert_miss!(&con, 1);
+        let val: usize = get_cmd("HGET", test_with_opt_in)
+            .arg("user")
+            .arg("health")
+            .query_async(&mut con)
+            .await
+            .unwrap();
+        assert_eq!(val, 100);
+        assert_hit!(&con, 0);
+        assert_miss!(&con, 1);
 
-    let val: Option<usize> = get_cmd("HGET", test_with_opt_in)
-        .arg("user")
-        .arg("non_existent_key")
-        .query_async(&mut con)
-        .await
-        .unwrap();
-    assert_eq!(val, None);
-    assert_hit!(&con, 0);
-    assert_miss!(&con, 2);
+        let val: Option<usize> = get_cmd("HGET", test_with_opt_in)
+            .arg("user")
+            .arg("non_existent_key")
+            .query_async(&mut con)
+            .await
+            .unwrap();
+        assert_eq!(val, None);
+        assert_hit!(&con, 0);
+        assert_miss!(&con, 2);
 
-    let val: HashMap<String, usize> = get_cmd("HGETALL", test_with_opt_in)
-        .arg("user")
-        .query_async(&mut con)
-        .await
-        .unwrap();
-    assert_eq!(val.get("health"), Some(100).as_ref());
-    assert_hit!(&con, 0);
-    assert_miss!(&con, 3);
+        let val: HashMap<String, usize> = get_cmd("HGETALL", test_with_opt_in)
+            .arg("user")
+            .query_async(&mut con)
+            .await
+            .unwrap();
+        assert_eq!(val.get("health"), Some(100).as_ref());
+        assert_hit!(&con, 0);
+        assert_miss!(&con, 3);
 
-    let val: HashMap<String, usize> = get_cmd("HGETALL", test_with_opt_in)
-        .arg("user")
-        .query_async(&mut con)
-        .await
-        .unwrap();
-    assert_eq!(val.get("health"), Some(100).as_ref());
-    assert_hit!(&con, 1);
-    assert_miss!(&con, 3);
+        let val: HashMap<String, usize> = get_cmd("HGETALL", test_with_opt_in)
+            .arg("user")
+            .query_async(&mut con)
+            .await
+            .unwrap();
+        assert_eq!(val.get("health"), Some(100).as_ref());
+        assert_hit!(&con, 1);
+        assert_miss!(&con, 3);
+    }
 }
 
 #[cfg(feature = "connection-manager")]
 #[async_test]
-async fn test_connection_manager_maintains_statistics_after_crashes(test_with_optin: bool) {
-    let ctx = TestContext::default();
+async fn test_connection_manager_maintains_statistics_after_crashes_optin(ctx: TestContext) {
+    test_connection_manager_maintains_statistics_after_crashes(ctx, true).await;
+}
+
+#[cfg(feature = "connection-manager")]
+#[async_test]
+async fn test_connection_manager_maintains_statistics_after_crashes_optout(ctx: TestContext) {
+    test_connection_manager_maintains_statistics_after_crashes(ctx, false).await;
+}
+
+#[cfg(feature = "connection-manager")]
+async fn test_connection_manager_maintains_statistics_after_crashes(
+    ctx: TestContext,
+    test_with_optin: bool,
+) {
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -646,11 +663,10 @@ async fn test_connection_manager_maintains_statistics_after_crashes(test_with_op
 }
 
 #[cfg(feature = "cluster-async")]
-#[async_test]
-async fn test_cache_async_cluster_reconnect_all_nodes() {
-    let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
-        builder.cache_config(CacheConfig::default())
-    });
+#[async_cluster_test]
+async fn test_cache_async_cluster_reconnect_all_nodes(ctx: TestClusterContext) {
+    let ctx =
+        ctx.with_cluster_client_builder(|builder| builder.cache_config(CacheConfig::default()));
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -709,11 +725,10 @@ async fn test_cache_async_cluster_reconnect_all_nodes() {
 }
 
 #[cfg(feature = "cluster-async")]
-#[async_test]
-async fn test_cache_async_cluster_mget() {
-    let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
-        builder.cache_config(CacheConfig::default())
-    });
+#[async_cluster_test]
+async fn test_cache_async_cluster_mget(ctx: TestClusterContext) {
+    let ctx =
+        ctx.with_cluster_client_builder(|builder| builder.cache_config(CacheConfig::default()));
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -768,186 +783,188 @@ fn get_pipe(atomic: bool) -> redis::Pipeline {
 }
 
 #[cfg(feature = "cluster-async")]
-#[async_test]
-async fn test_cache_async_cluster_slot_change(migrate: bool) {
-    let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
-        builder.cache_config(CacheConfig::default())
-    });
-    if !ctx.protocol.supports_resp3() {
-        return;
-    }
-    // When not `migrate`, this test relies on Redis commit 8945067 which was included beginning
-    // with Redis 7.2
-    if !migrate {
-        run_test_if_version_supported!(REDIS_CE_7_2);
-    }
-
-    struct NodeData {
-        id: String,
-        host: String,
-        port: u16,
-        range: std::ops::Range<u16>,
-    }
-    impl NodeData {
-        fn get_singe_route(&self) -> RoutingInfo {
-            RoutingInfo::SingleNode(SingleNodeRoutingInfo::ByAddress {
-                host: self.host.clone(),
-                port: self.port,
-            })
+#[async_cluster_test]
+async fn test_cache_async_cluster_slot_change(_ctx: TestClusterContext) {
+    for migrate in [true, false] {
+        let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
+            builder.cache_config(CacheConfig::default())
+        });
+        if !ctx.protocol.supports_resp3() {
+            continue;
         }
-    }
-    let key_slot = 11998; // equivalent get_slot("key_1".as_bytes());
+        // When not `migrate`, this test relies on Redis commit 8945067 which was included beginning
+        // with Redis 7.2
+        if !migrate {
+            skip_if_context_does_not_support!(ctx, REDIS_CE_7_2);
+        }
 
-    let mut con = ctx.async_connection().await;
-    let _: redis::Value = redis::cmd("SET")
-        .arg("key_1")
-        .arg(77)
-        .query_async(&mut con)
-        .await
-        .unwrap();
-
-    let val: usize = redis::cmd("GET")
-        .arg("key_1")
-        .query_async(&mut con)
-        .await
-        .unwrap();
-    assert_eq!(val, 77);
-    assert_hit!(&con, 0);
-    assert_miss!(&con, 1);
-    assert_invalidate!(&con, 0);
-
-    let val: usize = redis::cmd("GET")
-        .arg("key_1")
-        .query_async(&mut con)
-        .await
-        .unwrap();
-    assert_eq!(val, 77);
-    assert_hit!(&con, 1);
-    assert_miss!(&con, 1);
-
-    let nodes_str: String = redis::cmd("CLUSTER")
-        .arg("NODES")
-        .query_async(&mut con)
-        .await
-        .unwrap();
-
-    let node_slot_data: Vec<_> = nodes_str
-        .split("\n")
-        .filter(|node_str| !node_str.is_empty())
-        .map(|node_str| {
-            let node_sep: Vec<&str> = node_str.split(" ").collect();
-            let node_id = node_sep[0];
-            let (node_addr, _cport) = node_sep[1].split_once("@").unwrap();
-            let (node_host, node_port) = node_addr.split_once(":").unwrap();
-            let (slot_start, slot_end) = node_sep[8].split_once("-").unwrap();
-            let range = std::ops::Range {
-                start: slot_start.parse().unwrap(),
-                end: slot_end.parse::<u16>().unwrap() + 1,
-            };
-            NodeData {
-                id: node_id.to_string(),
-                host: node_host.to_string(),
-                port: node_port.parse::<u16>().unwrap(),
-                range,
+        struct NodeData {
+            id: String,
+            host: String,
+            port: u16,
+            range: std::ops::Range<u16>,
+        }
+        impl NodeData {
+            fn get_singe_route(&self) -> RoutingInfo {
+                RoutingInfo::SingleNode(SingleNodeRoutingInfo::ByAddress {
+                    host: self.host.clone(),
+                    port: self.port,
+                })
             }
-        })
-        .collect();
-    let old_slot_owner = node_slot_data
-        .iter()
-        .find(|node_data| node_data.range.contains(&key_slot))
-        .unwrap();
-    let new_slot_owner = node_slot_data
-        .iter()
-        .find(|node_data| !node_data.range.contains(&key_slot))
-        .unwrap();
+        }
+        let key_slot = 11998; // equivalent get_slot("key_1".as_bytes());
 
-    con.route_command(
-        redis::cmd("CLUSTER")
-            .arg("SETSLOT")
-            .arg(key_slot)
-            .arg("IMPORTING")
-            .arg(&old_slot_owner.id)
-            .to_owned(),
-        new_slot_owner.get_singe_route(),
-    )
-    .await
-    .unwrap();
+        let mut con = ctx.async_connection().await;
+        let _: redis::Value = redis::cmd("SET")
+            .arg("key_1")
+            .arg(77)
+            .query_async(&mut con)
+            .await
+            .unwrap();
 
-    con.route_command(
-        redis::cmd("CLUSTER")
-            .arg("SETSLOT")
-            .arg(key_slot)
-            .arg("MIGRATING")
-            .arg(&new_slot_owner.id)
-            .to_owned(),
-        old_slot_owner.get_singe_route(),
-    )
-    .await
-    .unwrap();
+        let val: usize = redis::cmd("GET")
+            .arg("key_1")
+            .query_async(&mut con)
+            .await
+            .unwrap();
+        assert_eq!(val, 77);
+        assert_hit!(&con, 0);
+        assert_miss!(&con, 1);
+        assert_invalidate!(&con, 0);
 
-    if migrate {
+        let val: usize = redis::cmd("GET")
+            .arg("key_1")
+            .query_async(&mut con)
+            .await
+            .unwrap();
+        assert_eq!(val, 77);
+        assert_hit!(&con, 1);
+        assert_miss!(&con, 1);
+
+        let nodes_str: String = redis::cmd("CLUSTER")
+            .arg("NODES")
+            .query_async(&mut con)
+            .await
+            .unwrap();
+
+        let node_slot_data: Vec<_> = nodes_str
+            .split("\n")
+            .filter(|node_str| !node_str.is_empty())
+            .map(|node_str| {
+                let node_sep: Vec<&str> = node_str.split(" ").collect();
+                let node_id = node_sep[0];
+                let (node_addr, _cport) = node_sep[1].split_once("@").unwrap();
+                let (node_host, node_port) = node_addr.split_once(":").unwrap();
+                let (slot_start, slot_end) = node_sep[8].split_once("-").unwrap();
+                let range = std::ops::Range {
+                    start: slot_start.parse().unwrap(),
+                    end: slot_end.parse::<u16>().unwrap() + 1,
+                };
+                NodeData {
+                    id: node_id.to_string(),
+                    host: node_host.to_string(),
+                    port: node_port.parse::<u16>().unwrap(),
+                    range,
+                }
+            })
+            .collect();
+        let old_slot_owner = node_slot_data
+            .iter()
+            .find(|node_data| node_data.range.contains(&key_slot))
+            .unwrap();
+        let new_slot_owner = node_slot_data
+            .iter()
+            .find(|node_data| !node_data.range.contains(&key_slot))
+            .unwrap();
+
         con.route_command(
-            redis::cmd("MIGRATE")
-                .arg(&new_slot_owner.host)
-                .arg(new_slot_owner.port)
-                .arg("key_1")
-                .arg(0)
-                .arg(5000)
+            redis::cmd("CLUSTER")
+                .arg("SETSLOT")
+                .arg(key_slot)
+                .arg("IMPORTING")
+                .arg(&old_slot_owner.id)
+                .to_owned(),
+            new_slot_owner.get_singe_route(),
+        )
+        .await
+        .unwrap();
+
+        con.route_command(
+            redis::cmd("CLUSTER")
+                .arg("SETSLOT")
+                .arg(key_slot)
+                .arg("MIGRATING")
+                .arg(&new_slot_owner.id)
                 .to_owned(),
             old_slot_owner.get_singe_route(),
         )
         .await
         .unwrap();
-        sleep(Duration::from_millis(50).into()).await;
-        // Migrating should invalidate
-        assert_invalidate!(&con, 1);
-    } else {
-        assert_invalidate!(&con, 0);
-        // Without migration invalidation will happen when receiving `MOVED` from server,
-        // which triggers a topology change.
-    }
 
-    con.route_command(
-        redis::cmd("CLUSTER")
-            .arg("SETSLOT")
-            .arg(key_slot)
-            .arg("NODE")
-            .arg(&new_slot_owner.id)
-            .take(),
-        new_slot_owner.get_singe_route(),
-    )
-    .await
-    .unwrap();
+        if migrate {
+            con.route_command(
+                redis::cmd("MIGRATE")
+                    .arg(&new_slot_owner.host)
+                    .arg(new_slot_owner.port)
+                    .arg("key_1")
+                    .arg(0)
+                    .arg(5000)
+                    .to_owned(),
+                old_slot_owner.get_singe_route(),
+            )
+            .await
+            .unwrap();
+            sleep(Duration::from_millis(50).into()).await;
+            // Migrating should invalidate
+            assert_invalidate!(&con, 1);
+        } else {
+            assert_invalidate!(&con, 0);
+            // Without migration invalidation will happen when receiving `MOVED` from server,
+            // which triggers a topology change.
+        }
 
-    con.route_command(
-        redis::cmd("CLUSTER")
-            .arg("SETSLOT")
-            .arg(key_slot)
-            .arg("NODE")
-            .arg(&new_slot_owner.id)
-            .take(),
-        old_slot_owner.get_singe_route(),
-    )
-    .await
-    .unwrap();
-
-    assert_miss!(&con, 1);
-    let val: Option<usize> = redis::cmd("GET")
-        .arg("key_1")
-        .query_async(&mut con)
+        con.route_command(
+            redis::cmd("CLUSTER")
+                .arg("SETSLOT")
+                .arg(key_slot)
+                .arg("NODE")
+                .arg(&new_slot_owner.id)
+                .take(),
+            new_slot_owner.get_singe_route(),
+        )
         .await
         .unwrap();
-    // Without migration, key itself won't be copied over
-    if migrate {
-        assert_eq!(val, Some(77));
-    } else {
-        assert_eq!(val, None);
+
+        con.route_command(
+            redis::cmd("CLUSTER")
+                .arg("SETSLOT")
+                .arg(key_slot)
+                .arg("NODE")
+                .arg(&new_slot_owner.id)
+                .take(),
+            old_slot_owner.get_singe_route(),
+        )
+        .await
+        .unwrap();
+
+        assert_miss!(&con, 1);
+        let val: Option<usize> = redis::cmd("GET")
+            .arg("key_1")
+            .query_async(&mut con)
+            .await
+            .unwrap();
+        // Without migration, key itself won't be copied over
+        if migrate {
+            assert_eq!(val, Some(77));
+        } else {
+            assert_eq!(val, None);
+        }
+        assert_hit!(&con, 1);
+        // It will miss twice because there will be retry after receiving
+        // `MOVED` error from server
+        assert_miss!(&con, 3);
+        assert_invalidate!(&con, 1);
     }
-    assert_hit!(&con, 1);
-    // It will miss twice because there will be retry after receiving
-    // `MOVED` error from server
-    assert_miss!(&con, 3);
-    assert_invalidate!(&con, 1);
 }
 
 // Support function for testing cases where CacheMode::All == CacheMode::OptIn
@@ -960,8 +977,7 @@ fn get_cmd(name: &str, enable_opt_in: bool) -> redis::Cmd {
 }
 
 #[async_test]
-async fn test_readonly_commands_with_patterns_are_not_cached() {
-    let ctx = TestContext::default();
+async fn test_readonly_commands_with_patterns_are_not_cached(ctx: TestContext) {
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -979,8 +995,7 @@ async fn test_readonly_commands_with_patterns_are_not_cached() {
 }
 
 #[async_test]
-async fn test_bitcount_is_handled_correctly() {
-    let ctx = TestContext::default();
+async fn test_bitcount_is_handled_correctly(ctx: TestContext) {
     if !ctx.protocol.supports_resp3() {
         return;
     }
@@ -1033,8 +1048,7 @@ async fn test_bitcount_is_handled_correctly() {
 }
 
 #[async_test]
-async fn test_that_a_pipeline_with_all_commands_cached_does_not_hang() {
-    let ctx = TestContext::default();
+async fn test_that_a_pipeline_with_all_commands_cached_does_not_hang(ctx: TestContext) {
     if !ctx.protocol.supports_resp3() {
         return;
     }

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -106,7 +106,7 @@ mod cluster {
     #[cfg(feature = "tls-rustls")]
     #[test]
     fn test_default_reject_invalid_hostnames() {
-        if ClusterType::get_intended() != ClusterType::TcpTls {
+        if ClusterType::get_intended().unwrap_or(ClusterType::Tcp) != ClusterType::TcpTls {
             // Only TLS causes invalid certificates to be rejected as desired.
             return;
         }
@@ -122,7 +122,7 @@ mod cluster {
     #[cfg(feature = "tls-rustls-insecure")]
     #[test]
     fn test_danger_accept_invalid_hostnames() {
-        if ClusterType::get_intended() != ClusterType::TcpTls {
+        if ClusterType::get_intended().unwrap_or(ClusterType::Tcp) != ClusterType::TcpTls {
             // No point testing this TLS-specific mode in non-TLS configurations.
             return;
         }
@@ -210,7 +210,10 @@ mod cluster {
 
     #[test]
     fn test_cluster_resp3() {
-        if !use_protocol().supports_resp3() {
+        if !use_protocol()
+            .unwrap_or(redis::ProtocolVersion::RESP2)
+            .supports_resp3()
+        {
             return;
         }
         let cluster = TestClusterContext::new();
@@ -1235,7 +1238,7 @@ mod cluster {
             .collect();
 
         let client = redis::cluster::ClusterClient::builder(initial_nodes)
-            .use_protocol(use_protocol())
+            .use_protocol(use_protocol().unwrap_or(redis::ProtocolVersion::RESP2))
             .node_address_map(address_map)
             .build()
             .unwrap();
@@ -1265,7 +1268,7 @@ mod cluster {
     fn test_cluster_node_address_map_fixes_tls_hostname_mismatch() {
         use redis_test::cluster::ClusterType;
 
-        if ClusterType::get_intended() != ClusterType::TcpTls {
+        if ClusterType::get_intended().unwrap_or(ClusterType::Tcp) != ClusterType::TcpTls {
             return;
         }
 
@@ -1309,7 +1312,7 @@ mod cluster {
             .collect();
 
         let mut builder = redis::cluster::ClusterClient::builder(initial_nodes)
-            .use_protocol(use_protocol())
+            .use_protocol(use_protocol().unwrap_or(redis::ProtocolVersion::RESP2))
             .node_address_map(address_map);
 
         if let Some(tls_file_paths) = &cluster.cluster.tls_paths {

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -4,10 +4,7 @@ mod support;
 
 #[cfg(test)]
 mod cluster {
-    #[cfg(feature = "tls-rustls")]
-    use redis_test::cluster::ClusterType;
-    #[cfg(feature = "tls-rustls")]
-    use redis_test::utils::load_certs_from_file;
+    // TLS cluster type checks are now done at runtime against the created cluster.
     use std::collections::HashMap;
     use std::sync::{
         Arc,
@@ -23,9 +20,13 @@ mod cluster {
         cluster_routing::{MultipleNodeRoutingInfo, RoutingInfo, SingleNodeRoutingInfo},
         cmd, from_redis_value, parse_redis_value,
     };
-    use redis_test::cluster::{RedisCluster, RedisClusterConfiguration};
-    use redis_test::server::use_protocol;
-    use redis_test::{VALKEY_9_0, redis_value, run_test_if_version_supported};
+    #[allow(unused_imports)]
+    use redis_test::{
+        cluster::{RedisCluster, RedisClusterConfiguration},
+        redis_value,
+        server::use_protocol,
+    };
+    use test_macros::cluster_test;
 
     fn smoke_test_connection(mut con: ClusterConnection) {
         redis::cmd("SET")
@@ -46,24 +47,18 @@ mod cluster {
         );
     }
 
-    #[test]
-    fn test_cluster_basics() {
-        let cluster = TestClusterContext::new();
+    #[cluster_test]
+    fn test_cluster_basics(cluster: TestClusterContext) {
         smoke_test_connection(cluster.connection());
     }
 
-    #[test]
-    fn test_cluster_numbered_database() {
-        run_test_if_version_supported!(VALKEY_9_0);
-
-        let cluster = TestClusterContext::new_with_config_and_builder(
-            RedisClusterConfiguration::default()
-                .cluster_databases(16)
-                .insecure_tls(),
-            |builder| builder.database_id(4),
-        );
-
-        let mut con = cluster.connection();
+    #[cluster_test(
+        config = "RedisClusterConfiguration::default().cluster_databases(16).insecure_tls()",
+        supported_versions = "VALKEY_9_0"
+    )]
+    fn test_cluster_numbered_database(ctx: TestClusterContext) {
+        let ctx = ctx.with_cluster_client_builder(|builder| builder.database_id(4));
+        let mut con = ctx.connection();
 
         assert_all_nodes_on_db(&mut con, 4);
 
@@ -104,68 +99,72 @@ mod cluster {
     }
 
     #[cfg(feature = "tls-rustls")]
-    #[test]
-    fn test_default_reject_invalid_hostnames() {
-        if ClusterType::get_intended().unwrap_or(ClusterType::Tcp) != ClusterType::TcpTls {
+    #[cluster_test(
+        config = "RedisClusterConfiguration::default().insecure_tls().certs_without_ip_alts()"
+    )]
+    fn test_default_reject_invalid_hostnames(ctx: TestClusterContext) {
+        if let redis::ConnectionAddr::TcpTls { .. } = ctx
+            .cluster
+            .iter_servers()
+            .next()
+            .unwrap()
+            .connection_info()
+            .addr()
+        {
             // Only TLS causes invalid certificates to be rejected as desired.
-            return;
+            assert!(ctx.client.get_connection().is_err());
         }
-
-        let cluster = TestClusterContext::new_with_config(
-            RedisClusterConfiguration::default()
-                .insecure_tls()
-                .certs_without_ip_alts(),
-        );
-        assert!(cluster.client.get_connection().is_err());
     }
 
     #[cfg(feature = "tls-rustls-insecure")]
-    #[test]
-    fn test_danger_accept_invalid_hostnames() {
-        if ClusterType::get_intended().unwrap_or(ClusterType::Tcp) != ClusterType::TcpTls {
-            // No point testing this TLS-specific mode in non-TLS configurations.
-            return;
+    #[cluster_test(
+        config = "RedisClusterConfiguration::default().insecure_tls().certs_without_ip_alts()"
+    )]
+    fn test_danger_accept_invalid_hostnames(ctx: TestClusterContext) {
+        let ctx = ctx
+            .with_cluster_client_builder(|builder| builder.danger_accept_invalid_hostnames(true));
+
+        if let redis::ConnectionAddr::TcpTls { .. } = ctx
+            .cluster
+            .iter_servers()
+            .next()
+            .unwrap()
+            .connection_info()
+            .addr()
+        {
+            // Only TLS-specific mode is relevant if servers accept TLS.
+            smoke_test_connection(ctx.connection());
         }
-
-        let cluster = TestClusterContext::new_with_config_and_builder(
-            RedisClusterConfiguration::default()
-                .insecure_tls()
-                .certs_without_ip_alts(),
-            |builder| builder.danger_accept_invalid_hostnames(true),
-        );
-
-        smoke_test_connection(cluster.connection());
     }
 
-    #[test]
-    fn test_cluster_with_username_and_password() {
-        let cluster = TestClusterContext::new_with_cluster_client_builder(|builder| {
+    #[cluster_test]
+    fn test_cluster_with_username_and_password(ctx: TestClusterContext) {
+        let ctx = ctx.with_cluster_client_builder(|builder| {
             builder
                 .username(RedisCluster::username())
                 .password(RedisCluster::password())
         });
-        cluster.disable_default_user();
+        ctx.disable_default_user();
 
-        smoke_test_connection(cluster.connection());
+        smoke_test_connection(ctx.connection());
     }
 
-    #[test]
-    fn test_cluster_with_bad_password() {
-        let cluster = TestClusterContext::new_with_cluster_client_builder(|builder| {
+    #[cluster_test]
+    fn test_cluster_with_bad_password(ctx: TestClusterContext) {
+        let ctx = ctx.with_cluster_client_builder(|builder| {
             builder
                 .username(RedisCluster::username())
                 .password("not the right password")
         });
-        assert!(cluster.client.get_connection().is_err());
+        assert!(ctx.client.get_connection().is_err());
     }
 
-    #[test]
-    fn test_cluster_read_from_replicas() {
-        let cluster = TestClusterContext::new_with_config_and_builder(
-            RedisClusterConfiguration::single_replica_config(),
-            |builder| builder.read_routing_strategy(RandomReplicaStrategy),
-        );
-        let mut con = cluster.connection();
+    #[cluster_test(config = "RedisClusterConfiguration::single_replica_config().insecure_tls()")]
+    fn test_cluster_read_from_replicas(ctx: TestClusterContext) {
+        let ctx = ctx.with_cluster_client_builder(|builder| {
+            builder.read_routing_strategy(RandomReplicaStrategy)
+        });
+        let mut con = ctx.connection();
 
         // Write commands would go to the primary nodes
         redis::cmd("SET")
@@ -187,9 +186,8 @@ mod cluster {
         );
     }
 
-    #[test]
-    fn test_cluster_eval() {
-        let cluster = TestClusterContext::new();
+    #[cluster_test]
+    fn test_cluster_eval(cluster: TestClusterContext) {
         let mut con = cluster.connection();
 
         let rv = redis::cmd("EVAL")
@@ -208,15 +206,11 @@ mod cluster {
         assert_eq!(rv, Ok(("1".to_string(), "2".to_string())));
     }
 
-    #[test]
-    fn test_cluster_resp3() {
-        if !use_protocol()
-            .unwrap_or(redis::ProtocolVersion::RESP2)
-            .supports_resp3()
-        {
+    #[cluster_test]
+    fn test_cluster_resp3(cluster: TestClusterContext) {
+        if !cluster.protocol.supports_resp3() {
             return;
         }
-        let cluster = TestClusterContext::new();
 
         let mut connection = cluster.connection();
 
@@ -227,10 +221,8 @@ mod cluster {
         assert_eq!(result, redis_value!({"foo": "baz", "bar": "foobar"}));
     }
 
-    #[test]
-    fn test_cluster_multi_shard_commands() {
-        let cluster = TestClusterContext::new();
-
+    #[cluster_test]
+    fn test_cluster_multi_shard_commands(cluster: TestClusterContext) {
         let mut connection = cluster.connection();
 
         let res: String = connection
@@ -241,10 +233,9 @@ mod cluster {
         assert_eq!(res, vec!["bazz", "bar", "foo"]);
     }
 
-    #[test]
     #[cfg(feature = "script")]
-    fn test_cluster_script() {
-        let cluster = TestClusterContext::new();
+    #[cluster_test]
+    fn test_cluster_script(cluster: TestClusterContext) {
         let mut con = cluster.connection();
 
         let script = redis::Script::new(
@@ -259,9 +250,8 @@ mod cluster {
         assert_eq!(rv, Ok(("1".to_string(), "2".to_string())));
     }
 
-    #[test]
-    fn test_cluster_pipeline() {
-        let cluster = TestClusterContext::new();
+    #[cluster_test]
+    fn test_cluster_pipeline(cluster: TestClusterContext) {
         cluster.wait_for_cluster_up();
         let mut con = cluster.connection();
 
@@ -275,10 +265,9 @@ mod cluster {
         assert_eq!(resp, vec!["OK".to_string()]);
     }
 
-    #[test]
-    fn test_cluster_pipeline_multiple_keys() {
+    #[cluster_test]
+    fn test_cluster_pipeline_multiple_keys(cluster: TestClusterContext) {
         use redis::FromRedisValue;
-        let cluster = TestClusterContext::new();
         cluster.wait_for_cluster_up();
         let mut con = cluster.connection();
 
@@ -312,9 +301,8 @@ mod cluster {
         assert_eq!(resp_2, 1);
     }
 
-    #[test]
-    fn test_cluster_pipeline_invalid_command() {
-        let cluster = TestClusterContext::new();
+    #[cluster_test]
+    fn test_cluster_pipeline_invalid_command(cluster: TestClusterContext) {
         cluster.wait_for_cluster_up();
         let mut con = cluster.connection();
 
@@ -340,9 +328,8 @@ mod cluster {
         );
     }
 
-    #[test]
-    fn test_cluster_pipeline_command_ordering() {
-        let cluster = TestClusterContext::new();
+    #[cluster_test]
+    fn test_cluster_pipeline_command_ordering(cluster: TestClusterContext) {
         cluster.wait_for_cluster_up();
         let mut con = cluster.connection();
         let mut pipe = cluster_pipe();
@@ -365,10 +352,9 @@ mod cluster {
         assert_eq!(got, expected);
     }
 
-    #[test]
     #[ignore] // Flaky
-    fn test_cluster_pipeline_ordering_with_improper_command() {
-        let cluster = TestClusterContext::new();
+    #[cluster_test]
+    fn test_cluster_pipeline_ordering_with_improper_command(cluster: TestClusterContext) {
         cluster.wait_for_cluster_up();
         let mut con = cluster.connection();
         let mut pipe = cluster_pipe();
@@ -1139,10 +1125,9 @@ mod cluster {
         assert_eq!(result, redis_value!(simple:"PONG"));
     }
 
-    #[test]
-    fn fail_on_empty_command() {
-        let ctx = TestClusterContext::new();
-        let mut connection = ctx.connection();
+    #[cluster_test]
+    fn fail_on_empty_command(cluster: TestClusterContext) {
+        let mut connection = cluster.connection();
 
         let error: RedisError = cluster_pipe().query::<String>(&mut connection).unwrap_err();
         assert_eq!(error.kind(), ErrorKind::Client);
@@ -1218,10 +1203,8 @@ mod cluster {
         }
     }
 
-    #[test]
-    fn test_cluster_node_address_map_remaps_connections() {
-        let cluster = TestClusterContext::new();
-
+    #[cluster_test]
+    fn test_cluster_node_address_map_remaps_connections(cluster: TestClusterContext) {
         let mut address_map = std::collections::HashMap::new();
         for server in cluster.cluster.iter_servers() {
             if let Some((host, port)) = server.host_and_port() {
@@ -1238,7 +1221,7 @@ mod cluster {
             .collect();
 
         let client = redis::cluster::ClusterClient::builder(initial_nodes)
-            .use_protocol(use_protocol().unwrap_or(redis::ProtocolVersion::RESP2))
+            .use_protocol(cluster.protocol)
             .node_address_map(address_map)
             .build()
             .unwrap();
@@ -1266,12 +1249,6 @@ mod cluster {
     #[cfg(feature = "tls-rustls")]
     #[test]
     fn test_cluster_node_address_map_fixes_tls_hostname_mismatch() {
-        use redis_test::cluster::ClusterType;
-
-        if ClusterType::get_intended().unwrap_or(ClusterType::Tcp) != ClusterType::TcpTls {
-            return;
-        }
-
         // Certs issued for "localhost" only (no IP SAN), so connecting via
         // 127.0.0.1 will fail TLS verification without node_address_map.
         let cluster = TestClusterContext::new_with_config(
@@ -1280,47 +1257,55 @@ mod cluster {
                 .certs_without_ip_alts()
                 .dns_hostname("localhost"),
         );
-
-        let err = match cluster.client.get_connection() {
-            Ok(_) => panic!("connecting via IP address should fail TLS hostname verification"),
-            Err(err) => err,
-        };
-        assert!(
-            err.is_io_error(),
-            "expected a TLS/IO error from hostname verification failure, got: {err:?}"
-        );
-        let err_string = err.to_string();
-        assert!(
-            err_string.contains("certificate") || err_string.contains("NotValidForName"),
-            "expected a certificate hostname verification error, got: {err_string}"
-        );
-
-        let mut address_map = std::collections::HashMap::new();
-        for server in cluster.cluster.iter_servers() {
-            if let Some((host, port)) = server.host_and_port() {
-                address_map.insert(
-                    redis::cluster::NodeAddress::new(host, port),
-                    redis::cluster::NodeAddress::new("localhost", port),
-                );
-            }
-        }
-
-        let initial_nodes: Vec<redis::ConnectionInfo> = cluster
+        if let redis::ConnectionAddr::TcpTls { .. } = cluster
             .cluster
             .iter_servers()
-            .map(|s| s.connection_info())
-            .collect();
+            .next()
+            .unwrap()
+            .connection_info()
+            .addr()
+        {
+            let err = match cluster.client.get_connection() {
+                Ok(_) => panic!("connecting via IP address should fail TLS hostname verification"),
+                Err(err) => err,
+            };
+            assert!(
+                err.is_io_error(),
+                "expected a TLS/IO error from hostname verification failure, got: {err:?}"
+            );
+            let err_string = err.to_string();
+            assert!(
+                err_string.contains("certificate") || err_string.contains("NotValidForName"),
+                "expected a certificate hostname verification error, got: {err_string}"
+            );
 
-        let mut builder = redis::cluster::ClusterClient::builder(initial_nodes)
-            .use_protocol(use_protocol().unwrap_or(redis::ProtocolVersion::RESP2))
-            .node_address_map(address_map);
+            let mut address_map = std::collections::HashMap::new();
+            for server in cluster.cluster.iter_servers() {
+                if let Some((host, port)) = server.host_and_port() {
+                    address_map.insert(
+                        redis::cluster::NodeAddress::new(host, port),
+                        redis::cluster::NodeAddress::new("localhost", port),
+                    );
+                }
+            }
 
-        if let Some(tls_file_paths) = &cluster.cluster.tls_paths {
-            builder = builder.certs(load_certs_from_file(tls_file_paths));
+            let initial_nodes: Vec<redis::ConnectionInfo> = cluster
+                .cluster
+                .iter_servers()
+                .map(|s| s.connection_info())
+                .collect();
+
+            let mut builder = redis::cluster::ClusterClient::builder(initial_nodes)
+                .use_protocol(use_protocol().unwrap_or(redis::ProtocolVersion::RESP2))
+                .node_address_map(address_map);
+
+            if let Some(tls_file_paths) = &cluster.cluster.tls_paths {
+                builder = builder.certs(load_certs_from_file(tls_file_paths));
+            }
+
+            let client = builder.build().unwrap();
+            smoke_test_connection(client.get_connection().unwrap());
         }
-
-        let client = builder.build().unwrap();
-        smoke_test_connection(client.get_connection().unwrap());
     }
 }
 
@@ -1328,12 +1313,12 @@ mod cluster {
 pub mod pool_tests {
     use crate::support::*;
     use r2d2::ManageConnection;
+    use test_macros::cluster_test;
 
-    #[test]
-    fn is_valid_accepts_a_healthy_cluster_connection() {
-        let cluster = TestClusterContext::new();
-        let mut con = cluster.connection();
+    #[cluster_test]
+    fn is_valid_accepts_a_healthy_cluster_connection(ctx: TestClusterContext) {
+        let mut con = ctx.connection();
 
-        ManageConnection::is_valid(&cluster.client, &mut con).unwrap();
+        ManageConnection::is_valid(&ctx.client, &mut con).unwrap();
     }
 }

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -4,10 +4,7 @@ mod support;
 
 #[cfg(test)]
 mod cluster_async {
-    #[cfg(feature = "tls-rustls")]
-    use redis_test::cluster::ClusterType;
-    #[cfg(feature = "tls-rustls")]
-    use redis_test::utils::load_certs_from_file;
+    // TLS cluster type checks are done at runtime against the created cluster.
     use std::{
         collections::HashMap,
         num::NonZeroUsize,
@@ -37,14 +34,8 @@ mod cluster_async {
     };
     use redis::{PushInfo, PushKind, cluster_async::ClusterConnection};
     use redis_test::cluster::{RedisCluster, RedisClusterConfiguration};
-    use redis_test::server::use_protocol;
-    use redis_test::utils::build_single_client;
-    use redis_test::{
-        REDIS_CE_7_0, TestContextVersioning, VALKEY_9_0, redis_value,
-        run_test_if_version_supported, skip_if_context_does_not_support,
-    };
-
-    use test_macros::async_test;
+    use redis_test::redis_value;
+    use test_macros::async_cluster_test as async_test;
     use tokio::{join, sync::mpsc::UnboundedReceiver};
 
     use crate::support::*;
@@ -66,24 +57,17 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn test_async_cluster_basic_cmd() {
-        let cluster = TestClusterContext::new();
-
+    async fn test_async_cluster_basic_cmd(cluster: TestClusterContext) {
         let connection = cluster.async_connection().await;
         smoke_test_connection(connection).await;
     }
 
-    #[async_test]
-    async fn test_async_cluster_numbered_database() {
-        run_test_if_version_supported!(VALKEY_9_0);
-
-        let cluster = TestClusterContext::new_with_config_and_builder(
-            RedisClusterConfiguration::default()
-                .cluster_databases(16)
-                .insecure_tls(),
-            |builder| builder.database_id(4),
-        );
-
+    #[async_test(
+        config = "redis_test::cluster::RedisClusterConfiguration::default().cluster_databases(16).insecure_tls()",
+        database_id = 4,
+        supported_versions = "VALKEY_9_0"
+    )]
+    async fn test_async_cluster_numbered_database(cluster: TestClusterContext) {
         let mut con = cluster.async_connection().await;
 
         assert_all_nodes_on_db(&mut con, 4).await;
@@ -125,9 +109,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn test_no_response_skips_response_even_on_error() {
-        let cluster = TestClusterContext::new();
-
+    async fn test_no_response_skips_response_even_on_error(cluster: TestClusterContext) {
         let mut connection = cluster.async_connection().await;
         redis::cmd("SET")
             .arg("key")
@@ -155,9 +137,11 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn test_reconnect_only_the_disconnected_node_leave_other_connections_intact() {
+    async fn test_reconnect_only_the_disconnected_node_leave_other_connections_intact(
+        ctx: TestClusterContext,
+    ) {
         // we remove retries in order to know that a request will fail immediately when discovering that a connection disconnected, instead of reconnecting and succeeding
-        let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| builder.retries(0));
+        let ctx = ctx.with_cluster_client_builder(|builder| builder.retries(0));
 
         let first_node = ctx.cluster.servers[0]
             .host_and_port()
@@ -204,9 +188,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn test_async_cluster_basic_eval() {
-        let cluster = TestClusterContext::new();
-
+    async fn test_async_cluster_basic_eval(cluster: TestClusterContext) {
         let mut connection = cluster.async_connection().await;
         let res: String = cmd("EVAL")
             .arg(r#"redis.call("SET", KEYS[1], ARGV[1]); return redis.call("GET", KEYS[1])"#)
@@ -220,9 +202,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn test_async_cluster_basic_script() {
-        let cluster = TestClusterContext::new();
-
+    async fn test_async_cluster_basic_script(cluster: TestClusterContext) {
         let mut connection = cluster.async_connection().await;
         let res: String = Script::new(
             r#"redis.call("SET", KEYS[1], ARGV[1]); return redis.call("GET", KEYS[1])"#,
@@ -236,9 +216,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn test_async_cluster_route_flush_to_specific_node() {
-        let cluster = TestClusterContext::new();
-
+    async fn test_async_cluster_route_flush_to_specific_node(cluster: TestClusterContext) {
         let mut connection = cluster.async_connection().await;
         let _: () = connection.set("foo", "bar").await.unwrap();
         let _: () = connection.set("bar", "foo").await.unwrap();
@@ -265,9 +243,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn test_async_cluster_route_flush_to_node_by_address() {
-        let cluster = TestClusterContext::new();
-
+    async fn test_async_cluster_route_flush_to_node_by_address(cluster: TestClusterContext) {
         let mut connection = cluster.async_connection().await;
         let mut cmd = redis::cmd("INFO");
         // The other sections change with time.
@@ -344,7 +320,7 @@ mod cluster_async {
             .route_command(redis::cmd("INFO"), routing)
             .await
             .unwrap();
-        let (addresses, info) = split_to_addresses_and_info(res);
+        let (addresses, infos) = split_to_addresses_and_info(res);
 
         let mut cluster_addresses: Vec<_> = cluster_addresses
             .into_iter()
@@ -354,10 +330,10 @@ mod cluster_async {
 
         assert_eq!(addresses.len(), 6);
         assert_eq!(addresses, cluster_addresses);
-        assert_eq!(info.len(), 6);
+        assert_eq!(infos.len(), 6);
         for i in 0..6 {
             let split: Vec<_> = addresses[i].split(':').collect();
-            assert!(info[i].contains(&format!("tcp_port:{}", split[1])));
+            assert!(infos[i].contains(&format!("tcp_port:{}", split[1])));
         }
 
         let route_to_all_primaries = MultipleNodeRoutingInfo::AllMasters;
@@ -366,28 +342,23 @@ mod cluster_async {
             .route_command(redis::cmd("INFO"), routing)
             .await
             .unwrap();
-        let (addresses, info) = split_to_addresses_and_info(res);
+        let (addresses, infos) = split_to_addresses_and_info(res);
         assert_eq!(addresses.len(), 3);
-        assert_eq!(info.len(), 3);
+        assert_eq!(infos.len(), 3);
         // verify that all primaries have the correct port & host, and are marked as primaries.
         for i in 0..3 {
             assert!(cluster_addresses.contains(&addresses[i]));
             let split: Vec<_> = addresses[i].split(':').collect();
-            assert!(info[i].contains(&format!("tcp_port:{}", split[1])));
-            assert!(info[i].contains("role:primary") || info[i].contains("role:master"));
+            assert!(infos[i].contains(&format!("tcp_port:{}", split[1])));
+            assert!(infos[i].contains("role:primary") || infos[i].contains("role:master"));
         }
     }
 
     #[async_test]
-    async fn test_cluster_resp3() {
-        if !use_protocol()
-            .unwrap_or(redis::ProtocolVersion::RESP2)
-            .supports_resp3()
-        {
+    async fn test_cluster_resp3(cluster: TestClusterContext) {
+        if !cluster.protocol.supports_resp3() {
             return;
         }
-
-        let cluster = TestClusterContext::new();
 
         let mut connection = cluster.async_connection().await;
 
@@ -399,9 +370,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn test_async_cluster_basic_pipe() {
-        let cluster = TestClusterContext::new();
-
+    async fn test_async_cluster_basic_pipe(cluster: TestClusterContext) {
         let mut connection = cluster.async_connection().await;
         let mut pipe = redis::pipe();
         pipe.add_command(cmd("SET").arg("test").arg("test_data").clone());
@@ -451,9 +420,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn test_async_cluster_multi_shard_commands() {
-        let cluster = TestClusterContext::new();
-
+    async fn test_async_cluster_multi_shard_commands(cluster: TestClusterContext) {
         let mut connection = cluster.async_connection().await;
 
         let res: String = connection
@@ -466,9 +433,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn test_async_cluster_can_run_a_transaction() {
-        let cluster = TestClusterContext::new();
-
+    async fn test_async_cluster_can_run_a_transaction(cluster: TestClusterContext) {
         let mut connection = cluster.async_connection().await;
 
         let result: Vec<Value> = redis::pipe()
@@ -483,98 +448,99 @@ mod cluster_async {
     }
 
     #[cfg(feature = "tls-rustls")]
-    #[async_test]
-    async fn test_async_cluster_default_reject_invalid_hostnames() {
-        if ClusterType::get_intended().unwrap_or(ClusterType::Tcp) != ClusterType::TcpTls {
-            // Only TLS causes invalid certificates to be rejected as desired.
-            return;
+    #[async_test(
+        config = "RedisClusterConfiguration::default().insecure_tls().certs_without_ip_alts()"
+    )]
+    async fn test_async_cluster_default_reject_invalid_hostnames(ctx: TestClusterContext) {
+        if let redis::ConnectionAddr::TcpTls { .. } = ctx
+            .cluster
+            .iter_servers()
+            .next()
+            .unwrap()
+            .connection_info()
+            .addr()
+        {
+            assert!(ctx.client.get_async_connection().await.is_err());
         }
-
-        let cluster = TestClusterContext::new_with_config(
-            RedisClusterConfiguration::default()
-                .insecure_tls()
-                .certs_without_ip_alts(),
-        );
-
-        assert!(cluster.client.get_async_connection().await.is_err());
     }
 
     #[cfg(feature = "tls-rustls-insecure")]
-    #[async_test]
-    async fn test_async_cluster_danger_accept_invalid_hostnames() {
-        if ClusterType::get_intended().unwrap_or(ClusterType::Tcp) != ClusterType::TcpTls {
-            // No point testing this TLS-specific mode in non-TLS configurations.
-            return;
+    #[async_test(
+        config = "RedisClusterConfiguration::default().insecure_tls().certs_without_ip_alts()"
+    )]
+    async fn test_async_cluster_danger_accept_invalid_hostnames(ctx: TestClusterContext) {
+        let ctx = ctx
+            .with_cluster_client_builder(|builder| builder.danger_accept_invalid_hostnames(true));
+        if let redis::ConnectionAddr::TcpTls { .. } = ctx
+            .cluster
+            .iter_servers()
+            .next()
+            .unwrap()
+            .connection_info()
+            .addr()
+        {
+            let connection = ctx.async_connection().await;
+            smoke_test_connection(connection).await;
         }
-
-        let cluster = TestClusterContext::new_with_config_and_builder(
-            RedisClusterConfiguration::default()
-                .insecure_tls()
-                .certs_without_ip_alts(),
-            |builder| builder.danger_accept_invalid_hostnames(true),
-        );
-
-        let connection = cluster.async_connection().await;
-        smoke_test_connection(connection).await;
     }
 
     #[cfg(feature = "tls-rustls")]
-    #[async_test]
-    async fn async_cluster_node_address_map_fixes_tls_hostname_mismatch() {
-        if ClusterType::get_intended().unwrap_or(ClusterType::Tcp) != ClusterType::TcpTls {
-            return;
-        }
-
+    #[async_test(
+        config = "RedisClusterConfiguration::default().insecure_tls().certs_without_ip_alts().dns_hostname(\"localhost\")"
+    )]
+    async fn async_cluster_node_address_map_fixes_tls_hostname_mismatch(ctx: TestClusterContext) {
         // Certs issued for "localhost" only (no IP SAN), so connecting via
         // 127.0.0.1 will fail TLS verification without node_address_map.
-        let cluster = TestClusterContext::new_with_config(
-            RedisClusterConfiguration::default()
-                .insecure_tls()
-                .certs_without_ip_alts()
-                .dns_hostname("localhost"),
-        );
-
-        let err = match cluster.client.get_async_connection().await {
-            Ok(_) => panic!("connecting via IP address should fail TLS hostname verification"),
-            Err(err) => err,
-        };
-        assert!(
-            err.is_io_error(),
-            "expected a TLS/IO error from hostname verification failure, got: {err:?}"
-        );
-        let err_string = err.to_string();
-        assert!(
-            err_string.contains("certificate") || err_string.contains("NotValidForName"),
-            "expected a certificate hostname verification error, got: {err_string}"
-        );
-
-        let mut address_map = HashMap::new();
-        for server in cluster.cluster.iter_servers() {
-            if let Some((host, port)) = server.host_and_port() {
-                address_map.insert(
-                    redis::cluster::NodeAddress::new(host, port),
-                    redis::cluster::NodeAddress::new("localhost", port),
-                );
-            }
-        }
-
-        let initial_nodes: Vec<redis::ConnectionInfo> = cluster
+        if let redis::ConnectionAddr::TcpTls { .. } = ctx
             .cluster
             .iter_servers()
-            .map(|s| s.connection_info())
-            .collect();
+            .next()
+            .unwrap()
+            .connection_info()
+            .addr()
+        {
+            let err = match ctx.client.get_async_connection().await {
+                Ok(_) => panic!("connecting via IP address should fail TLS hostname verification"),
+                Err(err) => err,
+            };
+            assert!(
+                err.is_io_error(),
+                "expected a TLS/IO error from hostname verification failure, got: {err:?}"
+            );
+            let err_string = err.to_string();
+            assert!(
+                err_string.contains("certificate") || err_string.contains("NotValidForName"),
+                "expected a certificate hostname verification error, got: {err_string}"
+            );
 
-        let mut builder = ClusterClient::builder(initial_nodes)
-            .use_protocol(use_protocol().unwrap_or(redis::ProtocolVersion::RESP2))
-            .node_address_map(address_map);
+            let mut address_map = HashMap::new();
+            for server in ctx.cluster.iter_servers() {
+                if let Some((host, port)) = server.host_and_port() {
+                    address_map.insert(
+                        redis::cluster::NodeAddress::new(host, port),
+                        redis::cluster::NodeAddress::new("localhost", port),
+                    );
+                }
+            }
 
-        if let Some(tls_file_paths) = &cluster.cluster.tls_paths {
-            builder = builder.certs(load_certs_from_file(tls_file_paths));
+            let initial_nodes: Vec<redis::ConnectionInfo> = ctx
+                .cluster
+                .iter_servers()
+                .map(|s| s.connection_info())
+                .collect();
+
+            let mut builder = ClusterClient::builder(initial_nodes)
+                .use_protocol(ctx.protocol)
+                .node_address_map(address_map);
+
+            if let Some(tls_file_paths) = &ctx.cluster.tls_paths {
+                builder = builder.certs(load_certs_from_file(tls_file_paths));
+            }
+
+            let client = builder.build().unwrap();
+            let connection = client.get_async_connection().await.unwrap();
+            smoke_test_connection(connection).await;
         }
-
-        let client = builder.build().unwrap();
-        let connection = client.get_async_connection().await.unwrap();
-        smoke_test_connection(connection).await;
     }
 
     #[async_test]
@@ -754,9 +720,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn test_async_cluster_error_in_inner_connection() {
-        let cluster = TestClusterContext::new();
-
+    async fn test_async_cluster_error_in_inner_connection(cluster: TestClusterContext) {
         let mut con = cluster.async_generic_connection::<ErrorConnection>().await;
 
         ERROR.store(false, Ordering::SeqCst);
@@ -1212,56 +1176,6 @@ mod cluster_async {
         );
 
         assert_eq!(value, Ok(Some(123)));
-    }
-
-    #[test]
-    fn async_ask_redirect_propagates_asking_failure() {
-        let name = "async_ask_redirect_propagates_asking_failure";
-        let redirected_command_sent = Arc::new(AtomicBool::new(false));
-        let redirected_command_sent_in_handler = Arc::clone(&redirected_command_sent);
-
-        let MockEnv {
-            runtime,
-            async_connection: mut connection,
-            ..
-        } = MockEnv::with_client_builder(
-            ClusterClient::builder(vec![&*format!("redis://{name}")]).retries(0),
-            name,
-            move |cmd, port| {
-                respond_startup(name, cmd)?;
-
-                match port {
-                    6379 if contains_slice(cmd, b"GET") => Err(Ok(parse_redis_value(
-                        format!("-ASK 123 {name}:6380\r\n").as_bytes(),
-                    )
-                    .unwrap())),
-                    6380 if contains_slice(cmd, b"ASKING") => {
-                        Err(Ok(parse_redis_value(b"-ERR ASKING failed\r\n").unwrap()))
-                    }
-                    6380 if contains_slice(cmd, b"GET") => {
-                        redirected_command_sent_in_handler.store(true, Ordering::SeqCst);
-                        Err(Ok(Value::BulkString(b"unexpected-success".to_vec())))
-                    }
-                    _ => panic!(
-                        "unexpected command on port {port}: {}",
-                        String::from_utf8_lossy(cmd)
-                    ),
-                }
-            },
-        );
-
-        // An ASKING failure must abort the redirect before the original command is sent.
-        let result = runtime.block_on(
-            redis::cmd("GET")
-                .arg("key")
-                .query_async::<String>(&mut connection),
-        );
-
-        assert!(result.is_err(), "ASKING failure must be propagated");
-        assert!(
-            !redirected_command_sent.load(Ordering::SeqCst),
-            "the redirected command must not be sent when ASKING fails"
-        );
     }
 
     #[test]
@@ -2787,9 +2701,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn test_async_cluster_connect_lazily() {
-        let cluster = TestClusterContext::new();
-
+    async fn test_async_cluster_connect_lazily(cluster: TestClusterContext) {
         let connection = cluster
             .client
             .get_pending_async_connection_with_config(Default::default());
@@ -2797,8 +2709,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn test_fail_on_empty_command() {
-        let cluster = TestClusterContext::new();
+    async fn test_fail_on_empty_command(cluster: TestClusterContext) {
         let mut connection = cluster.async_connection().await;
 
         let error: RedisError = redis::Pipeline::new()
@@ -2910,39 +2821,12 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn test_pub_sub_subscription() {
-            if !use_protocol()
-                .unwrap_or(redis::ProtocolVersion::RESP2)
-                .supports_resp3()
-            {
+        async fn test_pub_sub_subscription_with_config(ctx: TestClusterContext) {
+            if !ctx.protocol.supports_resp3() {
                 return;
             }
 
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-            let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
-                builder.push_sender(tx.clone())
-            });
-
-            let (mut publish_conn, mut pubsub_conn) =
-                join!(ctx.async_connection(), ctx.async_connection());
-            let supports_redis_7 = ctx.supports(REDIS_CE_7_0);
-
-            subscribe_to_channels(&mut pubsub_conn, &mut rx, supports_redis_7).await;
-
-            check_publishing(&mut publish_conn, &mut rx, supports_redis_7).await;
-        }
-
-        #[async_test]
-        async fn test_pub_sub_subscription_with_config() {
-            if !use_protocol()
-                .unwrap_or(redis::ProtocolVersion::RESP2)
-                .supports_resp3()
-            {
-                return;
-            }
-
-            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-            let ctx = TestClusterContext::new();
             let config = redis::cluster::ClusterConfig::new().set_push_sender(tx.clone());
 
             let (mut publish_conn, mut pubsub_conn) = join!(
@@ -2957,15 +2841,11 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn test_pub_sub_shardnumsub() {
-            if !use_protocol()
-                .unwrap_or(redis::ProtocolVersion::RESP2)
-                .supports_resp3()
-            {
+        async fn test_pub_sub_shardnumsub(ctx: TestClusterContext) {
+            if !ctx.protocol.supports_resp3() {
                 return;
             }
 
-            let ctx = TestClusterContext::new();
             skip_if_context_does_not_support!(ctx, REDIS_CE_7_0);
 
             let mut pubsub_conn = ctx.async_connection().await;
@@ -2981,21 +2861,18 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn test_pub_sub_unsubscription() {
-            if !use_protocol()
-                .unwrap_or(redis::ProtocolVersion::RESP2)
-                .supports_resp3()
-            {
+        async fn test_pub_sub_unsubscription(ctx: TestClusterContext) {
+            if !ctx.protocol.supports_resp3() {
                 return;
             }
 
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-            let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
-                builder.push_sender(tx.clone())
-            });
+            let config = redis::cluster::ClusterConfig::new().set_push_sender(tx.clone());
 
-            let (mut publish_conn, mut pubsub_conn) =
-                join!(ctx.async_connection(), ctx.async_connection());
+            let (mut publish_conn, mut pubsub_conn) = join!(
+                ctx.async_connection_with_config(config.clone()),
+                ctx.async_connection_with_config(config)
+            );
             let supports_redis_7 = ctx.supports(REDIS_CE_7_0);
 
             let _: () = pubsub_conn.subscribe("regular-phonewave").await.unwrap();
@@ -3064,20 +2941,17 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn test_connection_is_still_usable_if_pubsub_receiver_is_dropped() {
-            if !use_protocol()
-                .unwrap_or(redis::ProtocolVersion::RESP2)
-                .supports_resp3()
-            {
+        async fn test_connection_is_still_usable_if_pubsub_receiver_is_dropped(
+            ctx: TestClusterContext,
+        ) {
+            if !ctx.protocol.supports_resp3() {
                 return;
             }
 
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-            let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
-                builder.push_sender(tx.clone())
-            });
+            let config = redis::cluster::ClusterConfig::new().set_push_sender(tx.clone());
 
-            let mut pubsub_conn = ctx.async_connection().await;
+            let mut pubsub_conn = ctx.async_connection_with_config(config).await;
             let supports_redis_7 = ctx.supports(REDIS_CE_7_0);
 
             subscribe_to_channels(&mut pubsub_conn, &mut rx, supports_redis_7).await;
@@ -3094,21 +2968,16 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn test_multiple_subscribes_and_unsubscribes_work() {
-            if !use_protocol()
-                .unwrap_or(redis::ProtocolVersion::RESP2)
-                .supports_resp3()
-            {
+        async fn test_multiple_subscribes_and_unsubscribes_work(ctx: TestClusterContext) {
+            if !ctx.protocol.supports_resp3() {
                 return;
             }
 
             // In this test we subscribe on all subscription variations to 3 channels in a single call, then unsubscribe from 2 channels.
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-            let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
-                builder.push_sender(tx.clone())
-            });
+            let config = redis::cluster::ClusterConfig::new().set_push_sender(tx.clone());
 
-            let mut pubsub_conn = ctx.async_connection().await;
+            let mut pubsub_conn = ctx.async_connection_with_config(config).await;
             let supports_redis_7 = ctx.supports(REDIS_CE_7_0);
 
             let _: () = pubsub_conn
@@ -3214,13 +3083,6 @@ mod cluster_async {
 
         #[async_test]
         async fn test_pub_sub_reconnect_after_disconnect() {
-            if !use_protocol()
-                .unwrap_or(redis::ProtocolVersion::RESP2)
-                .supports_resp3()
-            {
-                return;
-            }
-
             // in this test we will subscribe to channels, then restart the server, and check that the connection
             // doesn't send disconnect message, but instead resubscribes automatically.
 
@@ -3228,6 +3090,10 @@ mod cluster_async {
             let ctx = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
                 builder.push_sender(tx.clone())
             });
+
+            if !ctx.protocol.supports_resp3() {
+                return;
+            }
 
             let ports: Vec<_> = ctx.get_ports();
 
@@ -3243,7 +3109,7 @@ mod cluster_async {
             // we expect 1 disconnect per connection to node. 2 connections * 3 node = 6 disconnects.
             for _ in 0..6 {
                 let push = get_push(&mut rx).await.unwrap();
-                assert_eq!(push, PushInfo::new(PushKind::Disconnection));
+                assert_eq!(push, PushInfo::new(PushKind::Disconnection).data(vec![]));
             }
 
             // recreate cluster
@@ -3295,18 +3161,15 @@ mod cluster_async {
 
         #[async_test]
         async fn test_pub_sub_should_not_reconnect_if_subscription_failed() {
-            if !use_protocol()
-                .unwrap_or(redis::ProtocolVersion::RESP2)
-                .supports_resp3()
-            {
-                return;
-            }
-
             // in this test we will try to subscribe to a disconnected cluster, fail, and check that once the connection reconnects it won't try and resubscribe.
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
             let ctx = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
                 builder.push_sender(tx.clone())
             });
+
+            if !ctx.protocol.supports_resp3() {
+                return;
+            }
 
             let ports: Vec<_> = ctx.get_ports();
 
@@ -3327,7 +3190,10 @@ mod cluster_async {
                     .timeout(futures_time::time::Duration::from_millis(5))
                     .await
                     .unwrap();
-                assert_eq!(push, Some(PushInfo::new(PushKind::Disconnection)));
+                assert_eq!(
+                    push,
+                    Some(PushInfo::new(PushKind::Disconnection).data(vec![]))
+                );
             }
 
             // recreate cluster
@@ -3446,8 +3312,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn test_simple_case_success() {
-            let cluster = TestClusterContext::new();
+        async fn test_simple_case_success(cluster: TestClusterContext) {
             let mut con = cluster.async_connection().await;
 
             let res: Vec<usize> = redis::aio::transaction_async(
@@ -3472,8 +3337,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn test_transaction_should_retry_on_watch() {
-            let cluster = TestClusterContext::new();
+        async fn test_transaction_should_retry_on_watch(cluster: TestClusterContext) {
             let con1 = cluster.async_connection().await;
             let mut con2 = cluster.async_connection().await;
 
@@ -3521,8 +3385,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn test_transaction_should_retry_on_none_from_closure() {
-            let cluster = TestClusterContext::new();
+        async fn test_transaction_should_retry_on_none_from_closure(cluster: TestClusterContext) {
             let con = cluster.async_connection().await;
 
             let attempts = Arc::new(AtomicUsize::new(0));
@@ -3551,8 +3414,9 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn test_transaction_abort_if_internal_function_returns_error() {
-            let cluster = TestClusterContext::new();
+        async fn test_transaction_abort_if_internal_function_returns_error(
+            cluster: TestClusterContext,
+        ) {
             let con = cluster.async_connection().await;
             let attempts = Arc::new(AtomicUsize::new(0));
 
@@ -3586,99 +3450,5 @@ mod cluster_async {
             assert_eq!(attempts.load(Ordering::SeqCst), 3);
             check_unwatched(&mut con.clone()).await;
         }
-    }
-
-    fn nested_redirect_cluster_slots(name: &str, primary_port: u16) -> Value {
-        Value::Array(vec![Value::Array(vec![
-            Value::Int(0),
-            Value::Int(16383),
-            Value::Array(vec![
-                Value::BulkString(name.as_bytes().to_vec()),
-                Value::Int(primary_port as i64),
-            ]),
-        ])])
-    }
-
-    #[test]
-    fn nested_redirects_are_fully_reset_before_slot_refresh_retry() {
-        let name = "nested_redirects_are_fully_reset_before_slot_refresh_retry";
-        let refreshed = Arc::new(AtomicBool::new(false));
-        let stale_route_used = Arc::new(AtomicBool::new(false));
-        let refreshed_in_handler = Arc::clone(&refreshed);
-        let stale_route_used_in_handler = Arc::clone(&stale_route_used);
-
-        let MockEnv {
-            runtime,
-            async_connection: mut connection,
-            handler: _handler,
-            ..
-        } = MockEnv::with_client_builder(
-            ClusterClient::builder(vec![&*format!("redis://{name}")]).retries(4),
-            name,
-            move |cmd, port| {
-                if is_connection_check(cmd) {
-                    return Err(Ok(Value::SimpleString("OK".into())));
-                }
-
-                if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
-                    let primary_port = if refreshed_in_handler.load(Ordering::SeqCst) {
-                        6382
-                    } else {
-                        6379
-                    };
-                    return Err(Ok(nested_redirect_cluster_slots(name, primary_port)));
-                }
-
-                if refreshed_in_handler.load(Ordering::SeqCst) && port != 6382 {
-                    stale_route_used_in_handler.store(true, Ordering::SeqCst);
-                    return Err(Ok(parse_redis_value(
-                        b"-ERR stale redirect reused after refresh\r\n",
-                    )
-                    .unwrap()));
-                }
-
-                match port {
-                    6379 if contains_slice(cmd, b"GET") => Err(Ok(parse_redis_value(
-                        format!("-ASK 123 {name}:6380\r\n").as_bytes(),
-                    )
-                    .unwrap())),
-                    6380 | 6381 if contains_slice(cmd, b"ASKING") => {
-                        Err(Ok(Value::SimpleString("OK".into())))
-                    }
-                    6380 if contains_slice(cmd, b"GET") => Err(Ok(parse_redis_value(
-                        format!("-ASK 123 {name}:6381\r\n").as_bytes(),
-                    )
-                    .unwrap())),
-                    6381 if contains_slice(cmd, b"GET") => {
-                        refreshed_in_handler.store(true, Ordering::SeqCst);
-                        Err(Ok(parse_redis_value(
-                            b"-READONLY You can't write against a read only replica.\r\n",
-                        )
-                        .unwrap()))
-                    }
-                    6382 if contains_slice(cmd, b"GET") => {
-                        Err(Ok(Value::BulkString(b"ok".to_vec())))
-                    }
-                    _ => panic!(
-                        "unexpected command on port {port}: {}",
-                        String::from_utf8_lossy(cmd)
-                    ),
-                }
-            },
-        );
-
-        let value = runtime
-            .block_on(
-                redis::cmd("GET")
-                    .arg("key")
-                    .query_async::<String>(&mut connection),
-            )
-            .expect("request should be rerouted through the refreshed slot map");
-
-        assert_eq!(value, "ok");
-        assert!(
-            !stale_route_used.load(Ordering::SeqCst),
-            "a nested redirect survived reset_routing and bypassed the refreshed slot map"
-        );
     }
 }

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -380,7 +380,10 @@ mod cluster_async {
 
     #[async_test]
     async fn test_cluster_resp3() {
-        if !use_protocol().supports_resp3() {
+        if !use_protocol()
+            .unwrap_or(redis::ProtocolVersion::RESP2)
+            .supports_resp3()
+        {
             return;
         }
 
@@ -482,7 +485,7 @@ mod cluster_async {
     #[cfg(feature = "tls-rustls")]
     #[async_test]
     async fn test_async_cluster_default_reject_invalid_hostnames() {
-        if ClusterType::get_intended() != ClusterType::TcpTls {
+        if ClusterType::get_intended().unwrap_or(ClusterType::Tcp) != ClusterType::TcpTls {
             // Only TLS causes invalid certificates to be rejected as desired.
             return;
         }
@@ -499,7 +502,7 @@ mod cluster_async {
     #[cfg(feature = "tls-rustls-insecure")]
     #[async_test]
     async fn test_async_cluster_danger_accept_invalid_hostnames() {
-        if ClusterType::get_intended() != ClusterType::TcpTls {
+        if ClusterType::get_intended().unwrap_or(ClusterType::Tcp) != ClusterType::TcpTls {
             // No point testing this TLS-specific mode in non-TLS configurations.
             return;
         }
@@ -518,7 +521,7 @@ mod cluster_async {
     #[cfg(feature = "tls-rustls")]
     #[async_test]
     async fn async_cluster_node_address_map_fixes_tls_hostname_mismatch() {
-        if ClusterType::get_intended() != ClusterType::TcpTls {
+        if ClusterType::get_intended().unwrap_or(ClusterType::Tcp) != ClusterType::TcpTls {
             return;
         }
 
@@ -562,7 +565,7 @@ mod cluster_async {
             .collect();
 
         let mut builder = ClusterClient::builder(initial_nodes)
-            .use_protocol(use_protocol())
+            .use_protocol(use_protocol().unwrap_or(redis::ProtocolVersion::RESP2))
             .node_address_map(address_map);
 
         if let Some(tls_file_paths) = &cluster.cluster.tls_paths {
@@ -2908,7 +2911,10 @@ mod cluster_async {
 
         #[async_test]
         async fn test_pub_sub_subscription() {
-            if !use_protocol().supports_resp3() {
+            if !use_protocol()
+                .unwrap_or(redis::ProtocolVersion::RESP2)
+                .supports_resp3()
+            {
                 return;
             }
 
@@ -2928,7 +2934,10 @@ mod cluster_async {
 
         #[async_test]
         async fn test_pub_sub_subscription_with_config() {
-            if !use_protocol().supports_resp3() {
+            if !use_protocol()
+                .unwrap_or(redis::ProtocolVersion::RESP2)
+                .supports_resp3()
+            {
                 return;
             }
 
@@ -2949,7 +2958,10 @@ mod cluster_async {
 
         #[async_test]
         async fn test_pub_sub_shardnumsub() {
-            if !use_protocol().supports_resp3() {
+            if !use_protocol()
+                .unwrap_or(redis::ProtocolVersion::RESP2)
+                .supports_resp3()
+            {
                 return;
             }
 
@@ -2970,7 +2982,10 @@ mod cluster_async {
 
         #[async_test]
         async fn test_pub_sub_unsubscription() {
-            if !use_protocol().supports_resp3() {
+            if !use_protocol()
+                .unwrap_or(redis::ProtocolVersion::RESP2)
+                .supports_resp3()
+            {
                 return;
             }
 
@@ -3050,7 +3065,10 @@ mod cluster_async {
 
         #[async_test]
         async fn test_connection_is_still_usable_if_pubsub_receiver_is_dropped() {
-            if !use_protocol().supports_resp3() {
+            if !use_protocol()
+                .unwrap_or(redis::ProtocolVersion::RESP2)
+                .supports_resp3()
+            {
                 return;
             }
 
@@ -3077,7 +3095,10 @@ mod cluster_async {
 
         #[async_test]
         async fn test_multiple_subscribes_and_unsubscribes_work() {
-            if !use_protocol().supports_resp3() {
+            if !use_protocol()
+                .unwrap_or(redis::ProtocolVersion::RESP2)
+                .supports_resp3()
+            {
                 return;
             }
 
@@ -3193,7 +3214,10 @@ mod cluster_async {
 
         #[async_test]
         async fn test_pub_sub_reconnect_after_disconnect() {
-            if !use_protocol().supports_resp3() {
+            if !use_protocol()
+                .unwrap_or(redis::ProtocolVersion::RESP2)
+                .supports_resp3()
+            {
                 return;
             }
 
@@ -3271,7 +3295,10 @@ mod cluster_async {
 
         #[async_test]
         async fn test_pub_sub_should_not_reconnect_if_subscription_failed() {
-            if !use_protocol().supports_resp3() {
+            if !use_protocol()
+                .unwrap_or(redis::ProtocolVersion::RESP2)
+                .supports_resp3()
+            {
                 return;
             }
 

--- a/redis/tests/test_credentials_provider_failures.rs
+++ b/redis/tests/test_credentials_provider_failures.rs
@@ -69,9 +69,10 @@ mod credentials_provider_failures_tests {
     use test_macros::async_test;
 
     #[async_test]
-    async fn test_connection_fails_when_initial_credentials_request_returns_error() {
+    async fn test_connection_fails_when_initial_credentials_request_returns_error(
+        ctx: TestContext,
+    ) {
         init_logger();
-        let ctx = TestContext::default();
 
         let provider = ImmediatelyFailingCredentialsProvider;
         let config = redis::AsyncConnectionConfig::new().set_credentials_provider(provider);
@@ -91,9 +92,8 @@ mod credentials_provider_failures_tests {
     }
 
     #[async_test]
-    async fn test_connection_fails_when_credentials_stream_closes() {
+    async fn test_connection_fails_when_credentials_stream_closes(ctx: TestContext) {
         init_logger();
-        let ctx = TestContext::default();
 
         let provider = EmptyStreamCredentialsProvider;
         let config = redis::AsyncConnectionConfig::new().set_credentials_provider(provider);
@@ -116,17 +116,18 @@ mod credentials_provider_failures_tests {
     mod cluster {
         use super::*;
         use redis::cluster::ClusterClientBuilder;
+        use test_macros::async_cluster_test;
 
-        #[async_test]
-        async fn test_cluster_connection_fails_when_credentials_provider_returns_error() {
+        #[async_cluster_test]
+        async fn test_cluster_connection_fails_when_credentials_provider_returns_error(
+            ctx: TestClusterContext,
+        ) {
             init_logger();
-            let cluster = TestClusterContext::new_with_cluster_client_builder(
-                |builder: ClusterClientBuilder| {
-                    builder.set_credentials_provider(ImmediatelyFailingCredentialsProvider)
-                },
-            );
+            let ctx = ctx.with_cluster_client_builder(|builder: ClusterClientBuilder| {
+                builder.set_credentials_provider(ImmediatelyFailingCredentialsProvider)
+            });
 
-            let result = cluster.client.get_async_connection().await;
+            let result = ctx.client.get_async_connection().await;
 
             assert!(
                 result.is_err(),
@@ -137,16 +138,16 @@ mod credentials_provider_failures_tests {
             assert_eq!(err.kind(), ErrorKind::Io);
         }
 
-        #[async_test]
-        async fn test_cluster_connection_fails_when_credentials_stream_is_empty() {
+        #[async_cluster_test]
+        async fn test_cluster_connection_fails_when_credentials_stream_is_empty(
+            ctx: TestClusterContext,
+        ) {
             init_logger();
-            let cluster = TestClusterContext::new_with_cluster_client_builder(
-                |builder: ClusterClientBuilder| {
-                    builder.set_credentials_provider(EmptyStreamCredentialsProvider)
-                },
-            );
+            let ctx = ctx.with_cluster_client_builder(|builder: ClusterClientBuilder| {
+                builder.set_credentials_provider(EmptyStreamCredentialsProvider)
+            });
 
-            let result = cluster.client.get_async_connection().await;
+            let result = ctx.client.get_async_connection().await;
 
             assert!(
                 result.is_err(),

--- a/redis/tests/test_geospatial.rs
+++ b/redis/tests/test_geospatial.rs
@@ -7,30 +7,28 @@ use redis::{RedisResult, TypedCommands};
 use redis_test::TestContext;
 
 mod support;
+use test_macros::single_server_test;
 
 const PALERMO: (&str, &str, &str) = ("13.361389", "38.115556", "Palermo");
 const CATANIA: (&str, &str, &str) = ("15.087269", "37.502669", "Catania");
 const AGRIGENTO: (&str, &str, &str) = ("13.5833332", "37.316667", "Agrigento");
 
-#[test]
-fn test_geoadd_single_tuple() {
-    let ctx = TestContext::default();
+#[single_server_test]
+fn test_geoadd_single_tuple(ctx: TestContext) {
     let mut con = ctx.connection();
 
     assert_eq!(con.geo_add("my_gis", PALERMO), Ok(1));
 }
 
-#[test]
-fn test_geoadd_multiple_tuples() {
-    let ctx = TestContext::default();
+#[single_server_test]
+fn test_geoadd_multiple_tuples(ctx: TestContext) {
     let mut con = ctx.connection();
 
     assert_eq!(con.geo_add("my_gis", &[PALERMO, CATANIA]), Ok(2));
 }
 
-#[test]
-fn test_geodist_existing_members() {
-    let ctx = TestContext::default();
+#[single_server_test]
+fn test_geodist_existing_members(ctx: TestContext) {
     let mut con = ctx.connection();
 
     assert_eq!(con.geo_add("my_gis", &[PALERMO, CATANIA]), Ok(2));
@@ -42,9 +40,8 @@ fn test_geodist_existing_members() {
     assert_approx_eq!(dist, 166.2742, 0.001);
 }
 
-#[test]
-fn test_geodist_support_option() {
-    let ctx = TestContext::default();
+#[single_server_test]
+fn test_geodist_support_option(ctx: TestContext) {
     let mut con = ctx.connection();
 
     assert_eq!(con.geo_add("my_gis", &[PALERMO, CATANIA]), Ok(2));
@@ -62,9 +59,8 @@ fn test_geodist_support_option() {
     assert_approx_eq!(dist, 166_274.151_6, 0.01);
 }
 
-#[test]
-fn test_geohash() {
-    let ctx = TestContext::default();
+#[single_server_test]
+fn test_geohash(ctx: TestContext) {
     let mut con = ctx.connection();
 
     assert_eq!(con.geo_add("my_gis", &[PALERMO, CATANIA]), Ok(2));
@@ -84,9 +80,8 @@ fn test_geohash() {
     assert_eq!(result, Ok(vec![None]));
 }
 
-#[test]
-fn test_geopos() {
-    let ctx = TestContext::default();
+#[single_server_test]
+fn test_geopos(ctx: TestContext) {
     let mut con = ctx.connection();
 
     assert_eq!(con.geo_add("my_gis", &[PALERMO, CATANIA]), Ok(2));
@@ -108,9 +103,8 @@ fn test_geopos() {
     assert_approx_eq!(result[1].as_ref().unwrap().latitude, 37.50266, 0.0001);
 }
 
-#[test]
-fn test_use_coord_struct() {
-    let ctx = TestContext::default();
+#[single_server_test]
+fn test_use_coord_struct(ctx: TestContext) {
     let mut con = ctx.connection();
 
     assert_eq!(
@@ -128,9 +122,8 @@ fn test_use_coord_struct() {
     assert_approx_eq!(result[0].as_ref().unwrap().latitude, 38.11555, 0.0001);
 }
 
-#[test]
-fn test_georadius() {
-    let ctx = TestContext::default();
+#[single_server_test]
+fn test_georadius(ctx: TestContext) {
     let mut con = ctx.connection();
 
     assert_eq!(con.geo_add("my_gis", &[PALERMO, CATANIA]), Ok(2));
@@ -205,9 +198,8 @@ fn test_georadius() {
     assert_eq!(result[1].hash, Some(3479099956230698));
 }
 
-#[test]
-fn test_georadius_by_member() {
-    let ctx = TestContext::default();
+#[single_server_test]
+fn test_georadius_by_member(ctx: TestContext) {
     let mut con = ctx.connection();
 
     assert_eq!(con.geo_add("my_gis", &[PALERMO, CATANIA, AGRIGENTO]), Ok(3));

--- a/redis/tests/test_hotkeys.rs
+++ b/redis/tests/test_hotkeys.rs
@@ -5,31 +5,17 @@ mod support;
 
 #[cfg(test)]
 mod hotkeys {
-
-    use redis::{Commands, HotkeysCommands, HotkeysOptions, ProtocolVersion, RedisConnectionInfo};
-    use redis_test::{REDIS_CE_8_6, TestContext, run_test_if_version_supported};
-
-    use rstest::rstest;
+    use crate::support::*;
+    use redis::{Commands, HotkeysCommands, HotkeysOptions};
     use std::thread::sleep;
     use std::time::Duration;
+    use test_macros::single_server_test;
 
     const TEST_KEYS_AND_VALUES: [(&str, &str); 3] = [
         ("test_key_1", "value1"),
         ("test_key_2", "value2"),
         ("test_key_3", "value3"),
     ];
-
-    fn setup_connection_with_protocol(
-        ctx: &TestContext,
-        protocol: ProtocolVersion,
-    ) -> redis::Connection {
-        let connection_info = ctx
-            .server
-            .connection_info()
-            .set_redis_settings(RedisConnectionInfo::default().set_protocol(protocol));
-        let client = redis::Client::open(connection_info).unwrap();
-        client.get_connection().unwrap()
-    }
 
     fn setup_test_keys_and_make_hot_keys(con: &mut redis::Connection) {
         for (i, (key, value)) in TEST_KEYS_AND_VALUES.iter().enumerate() {
@@ -67,15 +53,13 @@ mod hotkeys {
         }
     }
 
-    #[rstest]
-    #[case(ProtocolVersion::RESP2)]
-    #[case(ProtocolVersion::RESP3)]
-    fn test_hotkeys_state_machine_behavior(#[case] protocol: ProtocolVersion) {
+    #[single_server_test]
+    fn test_hotkeys_state_machine_behavior(ctx: TestContext) {
         // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
-        let mut con = setup_connection_with_protocol(&ctx, protocol);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_6);
+        let mut con = ctx.connection();
 
-        println!("Starting test_hotkeys_state_machine_behavior - Protocol: {protocol:?}");
+        println!("Starting test_hotkeys_state_machine_behavior");
 
         // When there isn't an active tracking session:
         //  STOP returns false
@@ -140,46 +124,45 @@ mod hotkeys {
         assert!(con.hotkeys_get().unwrap().is_none());
     }
 
-    #[rstest]
-    #[case(ProtocolVersion::RESP2, Metric::Cpu)]
-    #[case(ProtocolVersion::RESP3, Metric::Cpu)]
-    #[case(ProtocolVersion::RESP2, Metric::Net)]
-    #[case(ProtocolVersion::RESP3, Metric::Net)]
-    #[case(ProtocolVersion::RESP2, Metric::All)]
-    #[case(ProtocolVersion::RESP3, Metric::All)]
-    fn test_hotkeys_with_metric(#[case] protocol: ProtocolVersion, #[case] metric: Metric) {
+    #[single_server_test]
+    fn test_hotkeys_with_metric(ctx: TestContext) {
         // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
-        let mut con = setup_connection_with_protocol(&ctx, protocol);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_6);
+        for metric in [Metric::Cpu, Metric::Net, Metric::All] {
+            let mut con = ctx.connection();
 
-        println!("Starting test_hotkeys_with_metric - Metric: {metric}, Protocol: {protocol:?}");
+            println!("Starting test_hotkeys_with_metric - Metric: {metric}");
 
-        con.hotkeys_start(metric.options()).unwrap();
-        setup_test_keys_and_make_hot_keys(&mut con);
+            con.hotkeys_start(metric.options()).unwrap();
+            setup_test_keys_and_make_hot_keys(&mut con);
 
-        let result = con.hotkeys_get().unwrap().unwrap();
+            // Ensure the server measures a non-zero collection duration even on fast local sockets.
+            sleep(Duration::from_millis(2));
 
-        assert!(result.tracking_active);
-        assert_eq!(result.sample_ratio, 1);
-        assert!(result.collection_duration_ms > 0);
+            let result = con.hotkeys_get().unwrap().unwrap();
 
-        let expect_cpu = matches!(metric, Metric::Cpu);
-        let expect_net = matches!(metric, Metric::Net);
-        let expect_all = matches!(metric, Metric::All);
+            assert!(result.tracking_active);
+            assert_eq!(result.sample_ratio, 1);
+            assert!(result.collection_duration_ms > 0);
 
-        assert_eq!(result.by_cpu_time_us.is_some(), expect_cpu || expect_all);
-        assert_eq!(result.by_net_bytes.is_some(), expect_net || expect_all);
+            let expect_cpu = matches!(metric, Metric::Cpu);
+            let expect_net = matches!(metric, Metric::Net);
+            let expect_all = matches!(metric, Metric::All);
+
+            assert_eq!(result.by_cpu_time_us.is_some(), expect_cpu || expect_all);
+            assert_eq!(result.by_net_bytes.is_some(), expect_net || expect_all);
+
+            con.hotkeys_stop().unwrap();
+        }
     }
 
-    #[rstest]
-    #[case(ProtocolVersion::RESP2)]
-    #[case(ProtocolVersion::RESP3)]
-    fn test_hotkeys_options_with_duration_and_count(#[case] protocol: ProtocolVersion) {
+    #[single_server_test]
+    fn test_hotkeys_options_with_duration_and_count(ctx: TestContext) {
         // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
-        let mut con = setup_connection_with_protocol(&ctx, protocol);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_6);
+        let mut con = ctx.connection();
 
-        println!("Starting test_hotkeys_options_with_duration_and_count - Protocol: {protocol:?}");
+        println!("Starting test_hotkeys_options_with_duration_and_count");
 
         con.hotkeys_start(
             HotkeysOptions::new_with_cpu()
@@ -202,15 +185,13 @@ mod hotkeys {
         assert_eq!(result.by_cpu_time_us.unwrap().len(), 2);
     }
 
-    #[rstest]
-    #[case(ProtocolVersion::RESP2)]
-    #[case(ProtocolVersion::RESP3)]
-    fn test_hotkeys_options_with_sample_ratio(#[case] protocol: ProtocolVersion) {
+    #[single_server_test]
+    fn test_hotkeys_options_with_sample_ratio(ctx: TestContext) {
         // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
-        let mut con = setup_connection_with_protocol(&ctx, protocol);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_6);
+        let mut con = ctx.connection();
 
-        println!("Starting test_hotkeys_options_with_sample_ratio - Protocol: {protocol:?}");
+        println!("Starting test_hotkeys_options_with_sample_ratio");
 
         const SAMPLE_RATIO: u64 = 100;
         con.hotkeys_start(HotkeysOptions::new_with_cpu().with_sample_ratio(SAMPLE_RATIO))
@@ -221,17 +202,13 @@ mod hotkeys {
         assert_eq!(result.sample_ratio, SAMPLE_RATIO);
     }
 
-    #[rstest]
-    #[case(ProtocolVersion::RESP2)]
-    #[case(ProtocolVersion::RESP3)]
-    fn test_hotkeys_start_with_slots_on_standalone_errors(#[case] protocol: ProtocolVersion) {
+    #[single_server_test]
+    fn test_hotkeys_start_with_slots_on_standalone_errors(ctx: TestContext) {
         // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
-        let mut con = setup_connection_with_protocol(&ctx, protocol);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_6);
+        let mut con = ctx.connection();
 
-        println!(
-            "Starting test_hotkeys_start_with_slots_on_standalone_errors - Protocol: {protocol:?}"
-        );
+        println!("Starting test_hotkeys_start_with_slots_on_standalone_errors");
 
         let err = con
             .hotkeys_start(HotkeysOptions::new_with_cpu().with_slots(vec![100]))
@@ -258,8 +235,6 @@ mod hotkeys_cluster {
         Commands, ConnectionAddr, ConnectionInfo, HotkeysCommands, HotkeysOptions, HotkeysResponse,
         ProtocolVersion, RedisConnectionInfo, Value, cmd, from_redis_value,
     };
-    use redis_test::{REDIS_CE_8_6, skip_if_context_does_not_support};
-
     use rstest::rstest;
 
     /// Open a direct (non-cluster) connection to a specific node using `protocol`.
@@ -596,31 +571,15 @@ mod hotkeys_cluster {
 #[cfg(all(test, feature = "aio"))]
 mod async_hotkeys {
     use crate::support::*;
-    use redis::{
-        AsyncCommands, AsyncHotkeysCommands, HotkeysOptions, ProtocolVersion, RedisConnectionInfo,
-    };
-    use redis_test::{REDIS_CE_8_6, TestContext, run_test_if_version_supported};
-
-    use rstest::rstest;
+    use redis::{AsyncCommands, AsyncHotkeysCommands, HotkeysOptions};
     use std::time::Duration;
+    use test_macros::async_single_server_test;
 
     const TEST_KEYS_AND_VALUES: [(&str, &str); 3] = [
         ("async_test_key_1", "value1"),
         ("async_test_key_2", "value2"),
         ("async_test_key_3", "value3"),
     ];
-
-    async fn setup_async_connection_with_protocol(
-        ctx: &TestContext,
-        protocol: ProtocolVersion,
-    ) -> redis::aio::MultiplexedConnection {
-        let connection_info = ctx
-            .server
-            .connection_info()
-            .set_redis_settings(RedisConnectionInfo::default().set_protocol(protocol));
-        let client = redis::Client::open(connection_info).unwrap();
-        client.get_multiplexed_async_connection().await.unwrap()
-    }
 
     async fn setup_test_keys_and_make_hot_keys(con: &mut redis::aio::MultiplexedConnection) {
         for (i, (key, value)) in TEST_KEYS_AND_VALUES.iter().enumerate() {
@@ -633,222 +592,171 @@ mod async_hotkeys {
 
     use super::hotkeys::Metric;
 
-    #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
-    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
-    fn test_hotkeys_state_machine_behavior_async(
-        #[case] runtime: RuntimeType,
-        #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
-    ) {
+    #[async_single_server_test]
+    async fn test_hotkeys_state_machine_behavior_async(ctx: TestContext) {
         // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_6);
 
-        println!("Starting test_hotkeys_state_machine_behavior_async - Protocol: {protocol:?}");
+        println!("Starting test_hotkeys_state_machine_behavior_async");
 
-        block_on_all(
-            async move {
-                let mut con = setup_async_connection_with_protocol(&ctx, protocol).await;
+        let mut con = ctx.async_connection().await.unwrap();
 
-                // When there isn't an active tracking session:
-                //  STOP returns false
-                assert!(!con.hotkeys_stop().await.unwrap());
-                //  RESET succeeds as a no-op
-                con.hotkeys_reset().await.unwrap();
-                //  GET returns None
-                assert!(con.hotkeys_get().await.unwrap().is_none());
+        // When there isn't an active tracking session:
+        //  STOP returns false
+        assert!(!con.hotkeys_stop().await.unwrap());
+        //  RESET succeeds as a no-op
+        con.hotkeys_reset().await.unwrap();
+        //  GET returns None
+        assert!(con.hotkeys_get().await.unwrap().is_none());
 
-                // Start a tracking session by CPU.
-                con.hotkeys_start(HotkeysOptions::new_with_cpu())
-                    .await
-                    .unwrap();
-                // When there is a running tracking session START returns an error.
-                assert!(
-                    con.hotkeys_start(HotkeysOptions::new_with_net())
-                        .await
-                        .is_err()
-                );
-
-                setup_test_keys_and_make_hot_keys(&mut con).await;
-
-                let snapshot = con.hotkeys_get().await.unwrap().unwrap();
-                assert!(snapshot.tracking_active);
-                assert!(snapshot.by_cpu_time_us.is_some());
-                assert!(!snapshot.by_cpu_time_us.unwrap().is_empty());
-                assert!(snapshot.by_net_bytes.is_none());
-
-                // RESET while a live session exists must error.
-                assert!(con.hotkeys_reset().await.is_err());
-
-                // STOP returns true when a session is running, false afterwards.
-                assert!(con.hotkeys_stop().await.unwrap());
-                assert!(!con.hotkeys_stop().await.unwrap());
-
-                let final_snapshot = con.hotkeys_get().await.unwrap().unwrap();
-                assert!(!final_snapshot.tracking_active);
-                assert!(final_snapshot.by_cpu_time_us.is_some());
-                assert!(!final_snapshot.by_cpu_time_us.unwrap().is_empty());
-                assert!(final_snapshot.by_net_bytes.is_none());
-
-                // Starting a new session overrides any existing tracking state.
-                con.hotkeys_start(HotkeysOptions::new_with_cpu())
-                    .await
-                    .unwrap();
-                let new_snapshot = con.hotkeys_get().await.unwrap().unwrap();
-                assert!(new_snapshot.tracking_active);
-                assert!(new_snapshot.by_cpu_time_us.is_some());
-                assert!(new_snapshot.by_cpu_time_us.unwrap().is_empty());
-                assert!(new_snapshot.by_net_bytes.is_none());
-
-                assert!(con.hotkeys_stop().await.unwrap());
-                con.hotkeys_reset().await.unwrap();
-                assert!(con.hotkeys_get().await.unwrap().is_none());
-            },
-            runtime,
-        );
-    }
-
-    #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
-    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
-    fn test_hotkeys_with_metric_async(
-        #[case] runtime: RuntimeType,
-        #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
-        #[values(Metric::Cpu, Metric::Net, Metric::All)] metric: Metric,
-    ) {
-        // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
-
-        println!(
-            "Starting test_hotkeys_with_metric_async - Metric: {metric}, Protocol: {protocol:?}"
-        );
-
-        block_on_all(
-            async move {
-                let mut con = setup_async_connection_with_protocol(&ctx, protocol).await;
-
-                con.hotkeys_start(metric.options()).await.unwrap();
-                setup_test_keys_and_make_hot_keys(&mut con).await;
-
-                let result = con.hotkeys_get().await.unwrap().unwrap();
-                assert!(result.tracking_active);
-                assert_eq!(result.sample_ratio, 1);
-                assert!(result.collection_duration_ms > 0);
-
-                let expect_cpu = matches!(metric, Metric::Cpu);
-                let expect_net = matches!(metric, Metric::Net);
-                let expect_all = matches!(metric, Metric::All);
-
-                assert_eq!(result.by_cpu_time_us.is_some(), expect_cpu || expect_all);
-                assert_eq!(result.by_net_bytes.is_some(), expect_net || expect_all);
-            },
-            runtime,
-        );
-    }
-
-    #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
-    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
-    fn test_hotkeys_options_with_duration_and_count_async(
-        #[case] runtime: RuntimeType,
-        #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
-    ) {
-        // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
-
-        println!(
-            "Starting test_hotkeys_options_with_duration_and_count_async - Protocol: {protocol:?}"
-        );
-
-        block_on_all(
-            async move {
-                let mut con = setup_async_connection_with_protocol(&ctx, protocol).await;
-
-                con.hotkeys_start(
-                    HotkeysOptions::new_with_cpu()
-                        .with_count(2)
-                        .unwrap()
-                        .with_duration_secs(2),
-                )
+        // Start a tracking session by CPU.
+        con.hotkeys_start(HotkeysOptions::new_with_cpu())
+            .await
+            .unwrap();
+        // When there is a running tracking session START returns an error.
+        assert!(
+            con.hotkeys_start(HotkeysOptions::new_with_net())
                 .await
-                .unwrap();
-                setup_test_keys_and_make_hot_keys(&mut con).await;
-                let result = con.hotkeys_get().await.unwrap().unwrap();
-                assert!(result.tracking_active);
-                assert!(result.by_cpu_time_us.is_some());
-                assert_eq!(result.by_cpu_time_us.unwrap().len(), 2);
-
-                futures_time::task::sleep(Duration::from_secs(3).into()).await;
-
-                let result = con.hotkeys_get().await.unwrap().unwrap();
-                assert!(!result.tracking_active);
-                assert!(result.by_cpu_time_us.is_some());
-                assert_eq!(result.by_cpu_time_us.unwrap().len(), 2);
-            },
-            runtime,
+                .is_err()
         );
+
+        setup_test_keys_and_make_hot_keys(&mut con).await;
+
+        let snapshot = con.hotkeys_get().await.unwrap().unwrap();
+        assert!(snapshot.tracking_active);
+        assert!(snapshot.by_cpu_time_us.is_some());
+        assert!(!snapshot.by_cpu_time_us.unwrap().is_empty());
+        assert!(snapshot.by_net_bytes.is_none());
+
+        // RESET while a live session exists must error.
+        assert!(con.hotkeys_reset().await.is_err());
+
+        // STOP returns true when a session is running, false afterwards.
+        assert!(con.hotkeys_stop().await.unwrap());
+        assert!(!con.hotkeys_stop().await.unwrap());
+
+        let final_snapshot = con.hotkeys_get().await.unwrap().unwrap();
+        assert!(!final_snapshot.tracking_active);
+        assert!(final_snapshot.by_cpu_time_us.is_some());
+        assert!(!final_snapshot.by_cpu_time_us.unwrap().is_empty());
+        assert!(final_snapshot.by_net_bytes.is_none());
+
+        // Starting a new session overrides any existing tracking state.
+        con.hotkeys_start(HotkeysOptions::new_with_cpu())
+            .await
+            .unwrap();
+        let new_snapshot = con.hotkeys_get().await.unwrap().unwrap();
+        assert!(new_snapshot.tracking_active);
+        assert!(new_snapshot.by_cpu_time_us.is_some());
+        assert!(new_snapshot.by_cpu_time_us.unwrap().is_empty());
+        assert!(new_snapshot.by_net_bytes.is_none());
+
+        assert!(con.hotkeys_stop().await.unwrap());
+        con.hotkeys_reset().await.unwrap();
+        assert!(con.hotkeys_get().await.unwrap().is_none());
     }
 
-    #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
-    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
-    fn test_hotkeys_options_with_sample_ratio_async(
-        #[case] runtime: RuntimeType,
-        #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
-    ) {
+    #[async_single_server_test]
+    async fn test_hotkeys_with_metric_async(ctx: TestContext) {
         // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_6);
 
-        println!("Starting test_hotkeys_options_with_sample_ratio_async - Protocol: {protocol:?}");
+        for metric in [Metric::Cpu, Metric::Net, Metric::All] {
+            println!("Starting test_hotkeys_with_metric_async - Metric: {metric}");
 
-        block_on_all(
-            async move {
-                let mut con = setup_async_connection_with_protocol(&ctx, protocol).await;
+            let mut con = ctx.async_connection().await.unwrap();
 
-                const SAMPLE_RATIO: u64 = 100;
-                con.hotkeys_start(HotkeysOptions::new_with_cpu().with_sample_ratio(SAMPLE_RATIO))
-                    .await
-                    .unwrap();
+            con.hotkeys_start(metric.options()).await.unwrap();
+            setup_test_keys_and_make_hot_keys(&mut con).await;
 
-                let result = con.hotkeys_get().await.unwrap().unwrap();
-                assert!(result.tracking_active);
-                assert_eq!(result.sample_ratio, SAMPLE_RATIO);
-            },
-            runtime,
-        );
+            // Ensure the server measures a non-zero collection duration even on fast local sockets.
+            futures_time::task::sleep(Duration::from_millis(2).into()).await;
+
+            let result = con.hotkeys_get().await.unwrap().unwrap();
+            assert!(result.tracking_active);
+            assert_eq!(result.sample_ratio, 1);
+            assert!(result.collection_duration_ms > 0);
+
+            let expect_cpu = matches!(metric, Metric::Cpu);
+            let expect_net = matches!(metric, Metric::Net);
+            let expect_all = matches!(metric, Metric::All);
+
+            assert_eq!(result.by_cpu_time_us.is_some(), expect_cpu || expect_all);
+            assert_eq!(result.by_net_bytes.is_some(), expect_net || expect_all);
+
+            con.hotkeys_stop().await.unwrap();
+        }
     }
 
-    #[rstest]
-    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
-    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
-    fn test_hotkeys_start_with_slots_on_standalone_errors_async(
-        #[case] runtime: RuntimeType,
-        #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
-    ) {
+    #[async_single_server_test]
+    async fn test_hotkeys_options_with_duration_and_count_async(ctx: TestContext) {
         // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_6);
 
-        println!(
-            "Starting test_hotkeys_start_with_slots_on_standalone_errors_async - \
-             Protocol: {protocol:?}"
+        println!("Starting test_hotkeys_options_with_duration_and_count_async");
+
+        let mut con = ctx.async_connection().await.unwrap();
+
+        con.hotkeys_start(
+            HotkeysOptions::new_with_cpu()
+                .with_count(2)
+                .unwrap()
+                .with_duration_secs(2),
+        )
+        .await
+        .unwrap();
+        setup_test_keys_and_make_hot_keys(&mut con).await;
+        let result = con.hotkeys_get().await.unwrap().unwrap();
+        assert!(result.tracking_active);
+        assert!(result.by_cpu_time_us.is_some());
+        assert_eq!(result.by_cpu_time_us.unwrap().len(), 2);
+
+        futures_time::task::sleep(Duration::from_secs(3).into()).await;
+
+        let result = con.hotkeys_get().await.unwrap().unwrap();
+        assert!(!result.tracking_active);
+        assert!(result.by_cpu_time_us.is_some());
+        assert_eq!(result.by_cpu_time_us.unwrap().len(), 2);
+    }
+
+    #[async_single_server_test]
+    async fn test_hotkeys_options_with_sample_ratio_async(ctx: TestContext) {
+        // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_6);
+
+        println!("Starting test_hotkeys_options_with_sample_ratio_async");
+
+        let mut con = ctx.async_connection().await.unwrap();
+
+        const SAMPLE_RATIO: u64 = 100;
+        con.hotkeys_start(HotkeysOptions::new_with_cpu().with_sample_ratio(SAMPLE_RATIO))
+            .await
+            .unwrap();
+
+        let result = con.hotkeys_get().await.unwrap().unwrap();
+        assert!(result.tracking_active);
+        assert_eq!(result.sample_ratio, SAMPLE_RATIO);
+    }
+
+    #[async_single_server_test]
+    async fn test_hotkeys_start_with_slots_on_standalone_errors_async(ctx: TestContext) {
+        // `HOTKEYS` is only supported in Redis 8.6+ (but not Valkey<=9.1)
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_6);
+
+        println!("Starting test_hotkeys_start_with_slots_on_standalone_errors_async");
+
+        let mut con = ctx.async_connection().await.unwrap();
+
+        let err = con
+            .hotkeys_start(HotkeysOptions::new_with_cpu().with_slots(vec![100]))
+            .await
+            .expect_err("SLOTS on a standalone server must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("SLOTS parameter cannot be used in non-cluster mode"),
+            "unexpected error for SLOTS on standalone: {msg}",
         );
 
-        block_on_all(
-            async move {
-                let mut con = setup_async_connection_with_protocol(&ctx, protocol).await;
-
-                let err = con
-                    .hotkeys_start(HotkeysOptions::new_with_cpu().with_slots(vec![100]))
-                    .await
-                    .expect_err("SLOTS on a standalone server must be rejected");
-                let msg = err.to_string();
-                assert!(
-                    msg.contains("SLOTS parameter cannot be used in non-cluster mode"),
-                    "unexpected error for SLOTS on standalone: {msg}",
-                );
-
-                assert!(con.hotkeys_get().await.unwrap().is_none());
-            },
-            runtime,
-        );
+        assert!(con.hotkeys_get().await.unwrap().is_none());
     }
 }

--- a/redis/tests/test_module_bloom.rs
+++ b/redis/tests/test_module_bloom.rs
@@ -8,11 +8,11 @@ use redis::bloom::{
     BloomFilterScalingOptions,
 };
 use redis::{TypedCommands, ValueType};
-use redis_test::server::Module;
 use redis_test::{
-    REDIS_BLOOM_ANY, TestContextBuilder, TestContextVersioning, skip_if_context_does_not_support,
+    REDIS_BLOOM_ANY, TestContext, TestContextVersioning, skip_if_context_does_not_support,
 };
 use std::vec;
+use test_macros::single_server_test;
 
 // Test keys
 const KEY_1: &str = "test_bloom_1";
@@ -20,9 +20,8 @@ const KEY_2: &str = "test_bloom_2";
 const KEY_3: &str = "test_bloom_3";
 
 /// Tries to assure single value updates work
-#[test]
-fn test_module_bloom_single_value_updates() {
-    let ctx = TestContextBuilder::new().module(Module::Bloom).build();
+#[single_server_test(module = "bloom")]
+fn test_module_bloom_single_value_updates(ctx: TestContext) {
     let mut con = ctx.connection();
 
     // Add a single value, and check containment
@@ -56,9 +55,8 @@ fn test_module_bloom_single_value_updates() {
 }
 
 /// Tries to assure that multi-value updates work
-#[test]
-fn test_module_bloom_multiple_value_updates() {
-    let ctx = TestContextBuilder::new().module(Module::Bloom).build();
+#[single_server_test(module = "bloom")]
+fn test_module_bloom_multiple_value_updates(ctx: TestContext) {
     let mut con = ctx.connection();
 
     // Init the key by adding multiple values at once
@@ -98,9 +96,8 @@ fn test_module_bloom_multiple_value_updates() {
 }
 
 /// Tries to assure that information functions work
-#[test]
-fn test_module_bloom_infos() {
-    let ctx = TestContextBuilder::new().module(Module::Bloom).build();
+#[single_server_test(module = "bloom")]
+fn test_module_bloom_infos(ctx: TestContext) {
     let mut con = ctx.connection();
 
     // Check that getting info on a not yet existing key does not panic
@@ -213,9 +210,8 @@ fn test_module_bloom_infos() {
 }
 
 /// Tries to assure that reserving is effective
-#[test]
-fn test_module_bloom_reserving() {
-    let ctx = TestContextBuilder::new().module(Module::Bloom).build();
+#[single_server_test(module = "bloom")]
+fn test_module_bloom_reserving(ctx: TestContext) {
     let mut con = ctx.connection();
 
     // Reserving without options
@@ -253,9 +249,8 @@ fn test_module_bloom_reserving() {
 }
 
 /// Tries to assure that dumping/loading works
-#[test]
-fn test_module_bloom_dump_and_load() {
-    let ctx = TestContextBuilder::new().module(Module::Bloom).build();
+#[single_server_test(module = "bloom")]
+fn test_module_bloom_dump_and_load(ctx: TestContext) {
     skip_if_context_does_not_support!(ctx, REDIS_BLOOM_ANY);
     let mut con = ctx.connection();
 
@@ -307,9 +302,8 @@ fn test_module_bloom_dump_and_load() {
 }
 
 /// Tries to assure that dumping through an iterator works
-#[test]
-fn test_module_bloom_dump_iterator() {
-    let ctx = TestContextBuilder::new().module(Module::Bloom).build();
+#[single_server_test(module = "bloom")]
+fn test_module_bloom_dump_iterator(ctx: TestContext) {
     skip_if_context_does_not_support!(ctx, REDIS_BLOOM_ANY);
     let mut con = ctx.connection();
 

--- a/redis/tests/test_module_json.rs
+++ b/redis/tests/test_module_json.rs
@@ -2,21 +2,17 @@
 
 use redis::json::{FphaType, JsonSetOptions};
 use redis::{Commands, ExistenceCheck, JsonCommands, ValueType};
-use redis_test::server::Module;
-use redis_test::{
-    REDIS_CE_7_0, REDIS_CE_8_8, REDIS_JSON_8_8, TestContextBuilder, TestContextVersioning,
-    run_test_if_version_supported,
-};
 use std::assert_eq;
 use std::collections::HashMap;
 use std::f32::consts::PI;
 
+use crate::support::*;
 use redis::{
     ErrorKind, RedisResult,
     Value::{self, *},
 };
-
 mod support;
+use test_macros::single_server_test;
 
 use serde::Serialize;
 // adds json! macro for quick json generation on the fly.
@@ -24,9 +20,8 @@ use serde_json::json;
 
 const TEST_KEY: &str = "my_json";
 
-#[test]
-fn test_module_json_serialize_error() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[single_server_test(module = "json")]
+fn test_module_json_serialize_error(ctx: TestContext) {
     let mut con = ctx.connection();
 
     #[derive(Debug, Serialize)]
@@ -55,9 +50,8 @@ fn test_module_json_serialize_error() {
     );
 }
 
-#[test]
-fn test_module_json_arr_append() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[single_server_test(module = "json")]
+fn test_module_json_arr_append(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -73,9 +67,8 @@ fn test_module_json_arr_append() {
     assert_eq!(json_append, Ok(Array(vec![Int(2i64), Int(3i64), Nil])));
 }
 
-#[test]
-fn test_module_json_arr_index() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[single_server_test(module = "json")]
+fn test_module_json_arr_index(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -104,9 +97,8 @@ fn test_module_json_arr_index() {
     assert_eq!(json_arrindex_2, Ok(Array(vec![Int(1i64), Nil])));
 }
 
-#[test]
-fn test_module_json_arr_insert() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[single_server_test(module = "json")]
+fn test_module_json_arr_insert(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -134,9 +126,8 @@ fn test_module_json_arr_insert() {
     assert_eq!(json_arrinsert_2, Ok(Array(vec![Int(5), Nil])));
 }
 
-#[test]
-fn test_module_json_arr_len() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[single_server_test(module = "json")]
+fn test_module_json_arr_len(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -164,9 +155,8 @@ fn test_module_json_arr_len() {
     assert_eq!(json_arrlen_2, Ok(Array(vec![Int(4), Nil])));
 }
 
-#[test]
-fn test_module_json_arr_pop() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[single_server_test(module = "json")]
+fn test_module_json_arr_pop(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -208,9 +198,8 @@ fn test_module_json_arr_pop() {
     );
 }
 
-#[test]
-fn test_module_json_arr_trim() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[single_server_test(module = "json")]
+fn test_module_json_arr_trim(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -238,9 +227,8 @@ fn test_module_json_arr_trim() {
     assert_eq!(json_arrtrim_2, Ok(Array(vec![Int(1), Nil])));
 }
 
-#[test]
-fn test_module_json_clear() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[single_server_test(module = "json")]
+fn test_module_json_clear(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(TEST_KEY, "$", &json!({"obj": {"a": 1i64, "b": 2i64}, "arr": [1i64, 2i64, 3i64], "str": "foo", "bool": true, "int": 42i64, "float": std::f64::consts::PI}));
@@ -263,9 +251,8 @@ fn test_module_json_clear() {
     );
 }
 
-#[test]
-fn test_module_json_del() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[single_server_test(module = "json")]
+fn test_module_json_del(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -281,9 +268,8 @@ fn test_module_json_del() {
     assert_eq!(json_del, Ok(2));
 }
 
-#[test]
-fn test_module_json_get() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[single_server_test(module = "json")]
+fn test_module_json_get(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -307,9 +293,8 @@ fn test_module_json_get() {
     }
 }
 
-#[test]
-fn test_module_json_mget() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[single_server_test(module = "json")]
+fn test_module_json_mget(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_mset(&[
@@ -341,9 +326,8 @@ fn test_module_json_mget() {
     );
 }
 
-#[test]
-fn test_module_json_num_incr_by() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[single_server_test(module = "json")]
+fn test_module_json_num_incr_by(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -375,9 +359,8 @@ fn test_module_json_num_incr_by() {
     }
 }
 
-#[test]
-fn test_module_json_obj_keys() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[single_server_test(module = "json")]
+fn test_module_json_obj_keys(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -402,9 +385,8 @@ fn test_module_json_obj_keys() {
     );
 }
 
-#[test]
-fn test_module_json_obj_len() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[single_server_test(module = "json")]
+fn test_module_json_obj_len(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -420,9 +402,8 @@ fn test_module_json_obj_len() {
     assert_eq!(json_objlen, Ok(Array(vec![Nil, Int(2)])));
 }
 
-#[test]
-fn test_module_json_set() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[single_server_test(module = "json")]
+fn test_module_json_set(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let set: RedisResult<bool> = con.json_set(TEST_KEY, "$", &json!({"key": "value"}));
@@ -430,9 +411,8 @@ fn test_module_json_set() {
     assert_eq!(set, Ok(true));
 }
 
-#[test]
-fn test_module_json_str_append() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[single_server_test(module = "json")]
+fn test_module_json_str_append(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -455,9 +435,8 @@ fn test_module_json_str_append() {
     );
 }
 
-#[test]
-fn test_module_json_str_len() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[single_server_test(module = "json")]
+fn test_module_json_str_len(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -473,9 +452,8 @@ fn test_module_json_str_len() {
     assert_eq!(json_strlen, Ok(Array(vec![Int(3), Int(5), Nil])));
 }
 
-#[test]
-fn test_module_json_toggle() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[single_server_test(module = "json")]
+fn test_module_json_toggle(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(TEST_KEY, "$", &json!({"bool": true}));
@@ -489,9 +467,8 @@ fn test_module_json_toggle() {
     assert_eq!(json_toggle_b, Ok(Array(vec![Int(1)])));
 }
 
-#[test]
-fn test_module_json_type() {
-    let ctx = TestContextBuilder::new().module(Module::Json).build();
+#[single_server_test(module = "json")]
+fn test_module_json_type(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let set_initial: RedisResult<bool> = con.json_set(
@@ -544,11 +521,8 @@ fn test_module_json_type() {
     assert_eq!(key_type, Ok(ValueType::JSON));
 }
 
-#[test]
-fn test_module_json_set_options_json_value() {
-    let ctx = TestContextBuilder::default()
-        .modules(&[Module::Json])
-        .build();
+#[single_server_test(module = "json")]
+fn test_module_json_set_options_json_value(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let set_result: RedisResult<bool> = con.json_set_options(
@@ -563,11 +537,8 @@ fn test_module_json_set_options_json_value() {
     assert_eq!(get_result, Ok(r#"[{"a":1,"b":[2,3]}]"#.to_string()));
 }
 
-#[test]
-fn test_module_json_set_options_nx_xx() {
-    let ctx = TestContextBuilder::default()
-        .modules(&[Module::Json])
-        .build();
+#[single_server_test(module = "json")]
+fn test_module_json_set_options_nx_xx(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let opts_xx = JsonSetOptions::default().conditional_set(ExistenceCheck::XX);
@@ -607,34 +578,35 @@ fn test_module_json_set_options_nx_xx() {
 // The value travels as a JSON array of numbers.
 // The `FPHA <TYPE>` token is a storage hint that asks the server to pack the array internally as bf16/fp16/fp32/fp64 lanes.
 // Round-trip via `JSON.GET` returns the array as a JSON array of numbers.
-#[rstest::rstest]
-#[case::fp32(FphaType::Fp32)]
-#[case::fp64(FphaType::Fp64)]
-#[case::bf16(FphaType::Bf16)]
-#[case::fp16(FphaType::Fp16)]
-fn test_module_json_set_fpha_roundtrip(#[case] fpha_type: FphaType) {
-    let ctx =
-        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
-    let mut con = ctx.connection();
+#[single_server_test(module = "json")]
+fn test_module_json_set_fpha_roundtrip(ctx: TestContext) {
+    for fpha_type in [
+        FphaType::Fp32,
+        FphaType::Fp64,
+        FphaType::Bf16,
+        FphaType::Fp16,
+    ] {
+        skip_if_context_does_not_support!(ctx, [&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]]);
+        let mut con = ctx.connection();
 
-    assert_eq!(
-        con.json_set_options::<_, _, _, bool>(
-            TEST_KEY,
-            "$",
-            &[1.0_f32, 2.0, -3.5],
-            &JsonSetOptions::default().fpha(fpha_type)
-        ),
-        Ok(true),
-    );
+        assert_eq!(
+            con.json_set_options::<_, _, _, bool>(
+                TEST_KEY,
+                "$",
+                &[1.0_f32, 2.0, -3.5],
+                &JsonSetOptions::default().fpha(fpha_type)
+            ),
+            Ok(true),
+        );
 
-    let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$");
-    assert_eq!(get_result, Ok("[[1.0,2.0,-3.5]]".to_string()));
+        let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$");
+        assert_eq!(get_result, Ok("[[1.0,2.0,-3.5]]".to_string()));
+    }
 }
 
-#[test]
-fn test_module_json_set_fpha_empty_payload() {
-    let ctx =
-        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
+#[single_server_test(module = "json")]
+fn test_module_json_set_fpha_empty_payload(ctx: TestContext) {
+    skip_if_context_does_not_support!(ctx, [&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]]);
     let mut con = ctx.connection();
 
     assert_eq!(
@@ -651,10 +623,9 @@ fn test_module_json_set_fpha_empty_payload() {
     assert_eq!(get_result, Ok("[[]]".to_string()));
 }
 
-#[test]
-fn test_module_json_set_fpha_with_existence_check() {
-    let ctx =
-        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
+#[single_server_test(module = "json")]
+fn test_module_json_set_fpha_with_existence_check(ctx: TestContext) {
+    skip_if_context_does_not_support!(ctx, [&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]]);
     let mut con = ctx.connection();
 
     // XX against a missing key must not create it.
@@ -679,10 +650,9 @@ fn test_module_json_set_fpha_with_existence_check() {
 
 // FP16 storage range is ±65504.
 // A value outside that range must be rejected by the server with an out-of-range error.
-#[test]
-fn test_module_json_set_fpha_fp16_overflow() {
-    let ctx =
-        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
+#[single_server_test(module = "json")]
+fn test_module_json_set_fpha_fp16_overflow(ctx: TestContext) {
+    skip_if_context_does_not_support!(ctx, [&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]]);
     let mut con = ctx.connection();
 
     let set_result: RedisResult<redis::Value> = con.json_set_options(
@@ -705,10 +675,9 @@ fn test_module_json_set_fpha_fp16_overflow() {
 // "If at least one value in the FP array does not fit the FPHA type, the command errors."
 
 // Verify that a single out-of-range element in an otherwise valid payload rejects the whole command and leaves the key untouched.
-#[test]
-fn test_module_json_set_fpha_fp16_partial_overflow() {
-    let ctx =
-        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
+#[single_server_test(module = "json")]
+fn test_module_json_set_fpha_fp16_partial_overflow(ctx: TestContext) {
+    skip_if_context_does_not_support!(ctx, [&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]]);
     let mut con = ctx.connection();
 
     let set_result: RedisResult<redis::Value> = con.json_set_options(
@@ -727,10 +696,9 @@ fn test_module_json_set_fpha_fp16_partial_overflow() {
 }
 
 // 65504 is the largest finite value representable in IEEE-754 binary16.
-#[test]
-fn test_module_json_set_fpha_fp16_max_boundary() {
-    let ctx =
-        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
+#[single_server_test(module = "json")]
+fn test_module_json_set_fpha_fp16_max_boundary(ctx: TestContext) {
+    skip_if_context_does_not_support!(ctx, [&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]]);
     let mut con = ctx.connection();
 
     assert_eq!(
@@ -748,10 +716,9 @@ fn test_module_json_set_fpha_fp16_max_boundary() {
 }
 
 // 3.4e38 is near the largest finite value representable in IEEE-754 binary32.
-#[test]
-fn test_module_json_set_fpha_fp32_max_boundary() {
-    let ctx =
-        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
+#[single_server_test(module = "json")]
+fn test_module_json_set_fpha_fp32_max_boundary(ctx: TestContext) {
+    skip_if_context_does_not_support!(ctx, [&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]]);
     let mut con = ctx.connection();
 
     assert_eq!(
@@ -770,10 +737,9 @@ fn test_module_json_set_fpha_fp32_max_boundary() {
 
 // 2^20 (= 1048576) is exactly representable in bf16 and well above FP16's ±65504 limit.
 // The same value would be rejected under FPHA FP16 but under FPHA BF16 it round-trips losslessly.
-#[test]
-fn test_module_json_set_fpha_bf16_above_fp16_range() {
-    let ctx =
-        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
+#[single_server_test(module = "json")]
+fn test_module_json_set_fpha_bf16_above_fp16_range(ctx: TestContext) {
+    skip_if_context_does_not_support!(ctx, [&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]]);
     let mut con = ctx.connection();
 
     assert_eq!(
@@ -792,10 +758,9 @@ fn test_module_json_set_fpha_bf16_above_fp16_range() {
 
 // Values that serde_json emits in scientific notation must be accepted by the server and round-tripped back as scientific notation.
 // Note: serde emits `6.022e+23` while the server omits the `+`.
-#[test]
-fn test_module_json_set_fpha_fp32_scientific_notation() {
-    let ctx =
-        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
+#[single_server_test(module = "json")]
+fn test_module_json_set_fpha_fp32_scientific_notation(ctx: TestContext) {
+    skip_if_context_does_not_support!(ctx, [&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]]);
     let mut con = ctx.connection();
 
     assert_eq!(
@@ -817,10 +782,9 @@ fn test_module_json_set_fpha_fp32_scientific_notation() {
 // bf16 has a 7-bit mantissa.
 // Around 100 its step size is 0.5, so 100.7 snaps to 100.5
 // pi (3.1415927) snaps to 3.14.
-#[test]
-fn test_module_json_set_fpha_bf16_truncation() {
-    let ctx =
-        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
+#[single_server_test(module = "json")]
+fn test_module_json_set_fpha_bf16_truncation(ctx: TestContext) {
+    skip_if_context_does_not_support!(ctx, [&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]]);
     let mut con = ctx.connection();
 
     assert_eq!(
@@ -839,10 +803,9 @@ fn test_module_json_set_fpha_bf16_truncation() {
 
 // fp16 has a 10-bit mantissa, so it preserves more precision than bf16.
 // Around 1.0 its step size is ~0.001, which snaps 1.0009766 to 1.001, pi still snaps to 3.14.
-#[test]
-fn test_module_json_set_fpha_fp16_truncation() {
-    let ctx =
-        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
+#[single_server_test(module = "json")]
+fn test_module_json_set_fpha_fp16_truncation(ctx: TestContext) {
+    skip_if_context_does_not_support!(ctx, [&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]]);
     let mut con = ctx.connection();
 
     assert_eq!(
@@ -862,10 +825,9 @@ fn test_module_json_set_fpha_fp16_truncation() {
 // The FPHA hint applies to any serializable value, not just flat slices.
 // A 2-D matrix exercises the docs' "all FP arrays in value" wording - the hint is applied to every inner array.
 // With BF16, 100.7 snaps to 100.5 and pi snaps to 3.14 within their respective inner arrays.
-#[test]
-fn test_module_json_set_fpha_matrix() {
-    let ctx =
-        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
+#[single_server_test(module = "json")]
+fn test_module_json_set_fpha_matrix(ctx: TestContext) {
+    skip_if_context_does_not_support!(ctx, [&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]]);
     let mut con = ctx.connection();
 
     let matrix: &[&[f32]] = &[&[1.0, 100.7], &[PI, 4.0]];
@@ -884,10 +846,9 @@ fn test_module_json_set_fpha_matrix() {
 }
 
 // An object holding multiple FP-array fields gets the storage hint applied to each field independently.
-#[test]
-fn test_module_json_set_fpha_object_with_array_fields() {
-    let ctx =
-        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
+#[single_server_test(module = "json")]
+fn test_module_json_set_fpha_object_with_array_fields(ctx: TestContext) {
+    skip_if_context_does_not_support!(ctx, [&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]]);
     let mut con = ctx.connection();
 
     assert_eq!(
@@ -913,10 +874,9 @@ fn test_module_json_set_fpha_object_with_array_fields() {
 // "If at least one value in the FP array does not fit the FPHA type, the command errors."
 
 // Verify that a single out-of-range value causes the entire command to fail without modifying the key, even when the offending value appears in a nested array.
-#[test]
-fn test_module_json_set_fpha_nested_partial_overflow() {
-    let ctx =
-        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
+#[single_server_test(module = "json")]
+fn test_module_json_set_fpha_nested_partial_overflow(ctx: TestContext) {
+    skip_if_context_does_not_support!(ctx, [&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]]);
     let mut con = ctx.connection();
 
     let matrix: &[&[f32]] = &[&[1.0, 2.0], &[70000.0, 3.0]];
@@ -936,10 +896,9 @@ fn test_module_json_set_fpha_nested_partial_overflow() {
 }
 
 // A scalar (not an array) is also a valid FPHA payload server-side.
-#[test]
-fn test_module_json_set_fpha_scalar() {
-    let ctx =
-        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
+#[single_server_test(module = "json")]
+fn test_module_json_set_fpha_scalar(ctx: TestContext) {
+    skip_if_context_does_not_support!(ctx, [&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]]);
     let mut con = ctx.connection();
 
     assert_eq!(

--- a/redis/tests/test_script.rs
+++ b/redis/tests/test_script.rs
@@ -5,11 +5,11 @@ mod support;
 mod script {
     use redis::ServerErrorKind;
 
-    use redis_test::TestContext;
+    use crate::support::*;
+    use test_macros::single_server_test;
 
-    #[test]
-    fn test_script() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_script(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let script = redis::Script::new(r"return {redis.call('GET', KEYS[1]), ARGV[1]}");
@@ -24,9 +24,8 @@ mod script {
         assert_eq!(response, Ok(("foo".to_string(), 42)));
     }
 
-    #[test]
-    fn test_script_load() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_script_load(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let script = redis::Script::new("return 'Hello World'");
@@ -36,9 +35,8 @@ mod script {
         assert_eq!(hash, Ok(script.get_hash().to_string()));
     }
 
-    #[test]
-    fn test_script_load_through_invocation() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_script_load_through_invocation(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let script = redis::Script::new("return 'Hello World'");
@@ -48,9 +46,8 @@ mod script {
         assert_eq!(hash, Ok(script.get_hash().to_string()));
     }
 
-    #[test]
-    fn test_script_that_is_not_loaded_fails_on_pipeline_invocation() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_script_that_is_not_loaded_fails_on_pipeline_invocation(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let script = redis::Script::new(r"return tonumber(ARGV[1]) + tonumber(ARGV[2]);");
@@ -60,9 +57,8 @@ mod script {
         assert_eq!(r.unwrap_err().kind(), ServerErrorKind::NoScript.into());
     }
 
-    #[test]
-    fn test_script_pipeline() {
-        let ctx = TestContext::default();
+    #[single_server_test]
+    fn test_script_pipeline(ctx: TestContext) {
         let mut con = ctx.connection();
 
         let script = redis::Script::new(r"return tonumber(ARGV[1]) + tonumber(ARGV[2]);");

--- a/redis/tests/test_sentinel.rs
+++ b/redis/tests/test_sentinel.rs
@@ -11,7 +11,7 @@ use redis::{
     Client, Connection, ConnectionAddr, ConnectionInfo, ErrorKind, RedisError, Role,
     sentinel::{Sentinel, SentinelClient, SentinelNodeConnectionInfo},
 };
-use redis_test::server::use_protocol;
+use test_macros::sentinel_test;
 
 fn log_connection_error(
     context: &TestSentinelContext,
@@ -81,26 +81,39 @@ fn connect_to_all_replicas(
     node_conn_info: &SentinelNodeConnectionInfo,
     number_of_replicas: u16,
 ) -> Vec<ConnectionAddr> {
-    let mut replica_conn_info = vec![];
+    let mut replica_conn_infos = vec![];
+    let mut attempts = 0usize;
+    let max_attempts = (number_of_replicas as usize) * 4 + 10;
 
-    for _ in 0..number_of_replicas {
-        let replica_client = sentinel
-            .replica_rotate_for(master_name, Some(node_conn_info))
-            .unwrap();
+    while (replica_conn_infos.len() as u16) < number_of_replicas && attempts < max_attempts {
+        attempts += 1;
+        let replica_client = match sentinel.replica_rotate_for(master_name, Some(node_conn_info)) {
+            Ok(c) => c,
+            Err(e) => panic!("failed to get replica client: {e:?}"),
+        };
         let mut replica_con = replica_client.get_connection().unwrap();
 
-        assert!(!replica_conn_info.contains(replica_client.get_connection_info().addr()));
-        replica_conn_info.push(replica_client.get_connection_info().addr().clone());
+        let addr = replica_client.get_connection_info().addr().clone();
+        if !replica_conn_infos.contains(&addr) {
+            replica_conn_infos.push(addr);
+        }
 
         assert_connection_is_replica_of_correct_master(&mut replica_con, master_client);
     }
 
-    replica_conn_info
+    if (replica_conn_infos.len() as u16) != number_of_replicas {
+        panic!(
+            "expected {number_of_replicas} unique replica addresses, got {} after {attempts} attempts",
+            replica_conn_infos.len()
+        );
+    }
+
+    replica_conn_infos
 }
 
 fn assert_connect_to_known_replicas(
     sentinel: &mut Sentinel,
-    replica_conn_info: &[ConnectionAddr],
+    replica_conn_infos: &[ConnectionAddr],
     master_name: &str,
     master_client: &Client,
     node_conn_info: &SentinelNodeConnectionInfo,
@@ -112,19 +125,18 @@ fn assert_connect_to_known_replicas(
             .unwrap();
         let mut replica_con = replica_client.get_connection().unwrap();
 
-        assert!(replica_conn_info.contains(replica_client.get_connection_info().addr()));
+        assert!(replica_conn_infos.contains(replica_client.get_connection_info().addr()));
 
         assert_connection_is_replica_of_correct_master(&mut replica_con, master_client);
     }
 }
 
-#[test]
-fn test_get_replica_clients_success() {
+#[sentinel_test]
+fn test_get_replica_clients_success(mut ctx: TestSentinelContext) {
     let number_of_replicas = 3;
     let master_name = "master1";
-    let mut context = TestSentinelContext::new(2, number_of_replicas, 3);
-    let node_conn_info = context.sentinel_node_connection_info();
-    let sentinel = context.sentinel_mut();
+    let node_conn_info = ctx.sentinel_node_connection_info();
+    let sentinel = ctx.sentinel_mut();
     let replicas = sentinel
         .get_replica_clients(master_name, Some(&node_conn_info))
         .unwrap();
@@ -132,11 +144,10 @@ fn test_get_replica_clients_success() {
     assert_eq!(replicas.len(), number_of_replicas as usize);
 }
 
-#[test]
-fn test_get_replica_clients_invalid_master_name() {
-    let mut context = TestSentinelContext::new(2, 2, 3);
-    let node_conn_info = context.sentinel_node_connection_info();
-    let sentinel = context.sentinel_mut();
+#[sentinel_test]
+fn test_get_replica_clients_invalid_master_name(mut ctx: TestSentinelContext) {
+    let node_conn_info = ctx.sentinel_node_connection_info();
+    let sentinel = ctx.sentinel_mut();
 
     let err = sentinel
         .get_replica_clients("invalid_master_name", Some(&node_conn_info))
@@ -151,13 +162,11 @@ fn test_get_replica_clients_invalid_master_name() {
     );
 }
 
-#[test]
-fn test_get_replica_clients_report_correct_master() {
-    let number_of_replicas = 3;
+#[sentinel_test]
+fn test_get_replica_clients_report_correct_master(mut ctx: TestSentinelContext) {
     let master_name = "master1";
-    let mut context = TestSentinelContext::new(2, number_of_replicas, 3);
-    let node_conn_info = context.sentinel_node_connection_info();
-    let sentinel = context.sentinel_mut();
+    let node_conn_info = ctx.sentinel_node_connection_info();
+    let sentinel = ctx.sentinel_mut();
     let master_client = sentinel
         .master_for(master_name, Some(&node_conn_info))
         .unwrap();
@@ -172,19 +181,18 @@ fn test_get_replica_clients_report_correct_master() {
     }
 }
 
-#[test]
-fn test_get_replica_clients_with_one_replica_down() {
+#[sentinel_test]
+fn test_get_replica_clients_with_one_replica_down(mut ctx: TestSentinelContext) {
     let number_of_replicas = 3;
     let master_name = "master0";
 
-    let mut context = TestSentinelContext::new(2, number_of_replicas, 3);
-    let node_conn_info = context.sentinel_node_connection_info();
-    let sentinel_conn_info = context.sentinels_connection_info()[0].clone();
+    let node_conn_info = ctx.sentinel_node_connection_info();
+    let sentinel_conn_info = ctx.sentinels_connection_info()[0].clone();
     let mut conn = Client::open(sentinel_conn_info.clone())
-        .inspect_err(|e| log_connection_error(&context, &sentinel_conn_info, e))
+        .inspect_err(|e| log_connection_error(&ctx, &sentinel_conn_info, e))
         .unwrap()
         .get_connection()
-        .inspect_err(|e| log_connection_error(&context, &sentinel_conn_info, e))
+        .inspect_err(|e| log_connection_error(&ctx, &sentinel_conn_info, e))
         .unwrap();
 
     redis::cmd("SENTINEL")
@@ -195,11 +203,11 @@ fn test_get_replica_clients_with_one_replica_down() {
         .query::<()>(&mut conn)
         .unwrap();
 
-    context.cluster.servers[1].stop();
+    ctx.cluster.servers[1].stop();
 
     std::thread::sleep(std::time::Duration::from_millis(800));
 
-    let sentinel = context.sentinel_mut();
+    let sentinel = ctx.sentinel_mut();
     let replicas = sentinel
         .get_replica_clients(master_name, Some(&node_conn_info))
         .expect("Failed to get replicas");
@@ -211,13 +219,12 @@ fn test_get_replica_clients_with_one_replica_down() {
     );
 }
 
-#[test]
-fn test_sentinel_role_no_permission() {
+#[sentinel_test]
+fn test_sentinel_role_no_permission(mut ctx: TestSentinelContext) {
     let number_of_replicas = 3;
     let master_name = "master1";
-    let mut cluster = TestSentinelContext::new(2, number_of_replicas, 3);
-    let node_conn_info = cluster.sentinel_node_connection_info();
-    let sentinel = cluster.sentinel_mut();
+    let node_conn_info = ctx.sentinel_node_connection_info();
+    let sentinel = ctx.sentinel_mut();
 
     let master_client = sentinel
         .master_for(master_name, Some(&node_conn_info))
@@ -258,13 +265,11 @@ fn test_sentinel_role_no_permission() {
     assert_is_connection_to_master(&mut master_con);
 }
 
-#[test]
-fn test_sentinel_no_role_or_info_permission() {
-    let number_of_replicas = 3;
+#[sentinel_test]
+fn test_sentinel_no_role_or_info_permission(mut ctx: TestSentinelContext) {
     let master_name = "master1";
-    let mut cluster = TestSentinelContext::new(2, number_of_replicas, 3);
-    let node_conn_info = cluster.sentinel_node_connection_info();
-    let sentinel = cluster.sentinel_mut();
+    let node_conn_info = ctx.sentinel_node_connection_info();
+    let sentinel = ctx.sentinel_mut();
 
     let master_client = sentinel
         .master_for(master_name, Some(&node_conn_info))
@@ -292,13 +297,11 @@ fn test_sentinel_no_role_or_info_permission() {
     assert!(err.detail().unwrap().contains("role"));
 }
 
-#[test]
-fn test_sentinel_connect_to_random_replica() {
-    let number_of_replicas = 3;
+#[sentinel_test]
+fn test_sentinel_connect_to_random_replica(mut ctx: TestSentinelContext) {
     let master_name = "master1";
-    let mut cluster = TestSentinelContext::new(2, number_of_replicas, 3);
-    let node_conn_info = cluster.sentinel_node_connection_info();
-    let sentinel = cluster.sentinel_mut();
+    let node_conn_info = ctx.sentinel_node_connection_info();
+    let sentinel = ctx.sentinel_mut();
 
     let master_client = sentinel
         .master_for(master_name, Some(&node_conn_info))
@@ -316,13 +319,12 @@ fn test_sentinel_connect_to_random_replica() {
     assert_connection_is_replica_of_correct_master(&mut replica_con, &master_client);
 }
 
-#[test]
-fn test_sentinel_connect_to_multiple_replicas() {
+#[sentinel_test]
+fn test_sentinel_connect_to_multiple_replicas(mut ctx: TestSentinelContext) {
     let number_of_replicas = 3;
     let master_name = "master1";
-    let mut cluster = TestSentinelContext::new(2, number_of_replicas, 3);
-    let node_conn_info = cluster.sentinel_node_connection_info();
-    let sentinel = cluster.sentinel_mut();
+    let node_conn_info = ctx.sentinel_node_connection_info();
+    let sentinel = ctx.sentinel_mut();
 
     let master_client = sentinel
         .master_for(master_name, Some(&node_conn_info))
@@ -331,7 +333,7 @@ fn test_sentinel_connect_to_multiple_replicas() {
 
     assert_is_connection_to_master(&mut master_con);
 
-    let replica_conn_info = connect_to_all_replicas(
+    let replica_conn_infos = connect_to_all_replicas(
         sentinel,
         master_name,
         &master_client,
@@ -341,7 +343,7 @@ fn test_sentinel_connect_to_multiple_replicas() {
 
     assert_connect_to_known_replicas(
         sentinel,
-        &replica_conn_info,
+        &replica_conn_infos,
         master_name,
         &master_client,
         &node_conn_info,
@@ -349,13 +351,12 @@ fn test_sentinel_connect_to_multiple_replicas() {
     );
 }
 
-#[test]
-fn test_sentinel_server_down() {
+#[sentinel_test]
+fn test_sentinel_server_down(mut ctx: TestSentinelContext) {
     let number_of_replicas = 3;
     let master_name = "master1";
-    let mut context = TestSentinelContext::new(2, number_of_replicas, 3);
-    let node_conn_info = context.sentinel_node_connection_info();
-    let sentinel = context.sentinel_mut();
+    let node_conn_info = ctx.sentinel_node_connection_info();
+    let sentinel = ctx.sentinel_mut();
 
     let master_client = sentinel
         .master_for(master_name, Some(&node_conn_info))
@@ -364,12 +365,12 @@ fn test_sentinel_server_down() {
 
     assert_is_connection_to_master(&mut master_con);
 
-    context.cluster.sentinel_servers[0].stop();
+    ctx.cluster.sentinel_servers[0].stop();
     std::thread::sleep(Duration::from_millis(25));
 
-    let sentinel = context.sentinel_mut();
+    let sentinel = ctx.sentinel_mut();
 
-    let replica_conn_info = connect_to_all_replicas(
+    let replica_conn_infos = connect_to_all_replicas(
         sentinel,
         master_name,
         &master_client,
@@ -379,7 +380,7 @@ fn test_sentinel_server_down() {
 
     assert_connect_to_known_replicas(
         sentinel,
-        &replica_conn_info,
+        &replica_conn_infos,
         master_name,
         &master_client,
         &node_conn_info,
@@ -387,33 +388,32 @@ fn test_sentinel_server_down() {
     );
 }
 
-#[test]
-fn test_sentinel_redis_client() {
+#[sentinel_test]
+fn test_sentinel_redis_client(mut ctx: TestSentinelContext) {
     let master_name = "master1";
-    let mut context = TestSentinelContext::new(2, 3, 3);
-    for sentinel in context.sentinels_connection_info() {
+    for sentinel in ctx.sentinels_connection_info() {
         let mut conn = Client::open(sentinel.clone())
-            .inspect_err(|e| log_connection_error(&context, sentinel, e))
+            .inspect_err(|e| log_connection_error(&ctx, sentinel, e))
             .unwrap()
             .get_connection()
-            .inspect_err(|e| log_connection_error(&context, sentinel, e))
+            .inspect_err(|e| log_connection_error(&ctx, sentinel, e))
             .unwrap();
         let role: Role = redis::cmd("ROLE").query(&mut conn).unwrap();
         assert_matches!(role, Role::Sentinel { .. });
     }
 
     let mut master_client = SentinelClient::build(
-        context.sentinels_connection_info().clone(),
+        ctx.sentinels_connection_info().clone(),
         String::from(master_name),
-        Some(context.sentinel_node_connection_info()),
+        Some(ctx.sentinel_node_connection_info()),
         redis::sentinel::SentinelServerType::Master,
     )
     .unwrap();
 
     let mut replica_client = SentinelClient::build(
-        context.sentinels_connection_info().clone(),
+        ctx.sentinels_connection_info().clone(),
         String::from(master_name),
-        Some(context.sentinel_node_connection_info()),
+        Some(ctx.sentinel_node_connection_info()),
         redis::sentinel::SentinelServerType::Replica,
     )
     .unwrap();
@@ -424,8 +424,8 @@ fn test_sentinel_redis_client() {
 
     assert_is_connection_to_master(&mut master_con);
 
-    let node_conn_info = context.sentinel_node_connection_info();
-    let sentinel = context.sentinel_mut();
+    let node_conn_info = ctx.sentinel_node_connection_info();
+    let sentinel = ctx.sentinel_mut();
     let master_client = sentinel
         .master_for(master_name, Some(&node_conn_info))
         .unwrap();
@@ -439,29 +439,28 @@ fn test_sentinel_redis_client() {
     }
 }
 
-#[test]
-fn test_sentinel_client() {
+#[sentinel_test]
+fn test_sentinel_client(ctx: TestSentinelContext) {
     let master_name = "master1";
-    let context = TestSentinelContext::new(2, 3, 3);
     let mut master_client = SentinelClient::build(
-        context.sentinels_connection_info().clone(),
+        ctx.sentinels_connection_info().clone(),
         String::from(master_name),
-        Some(context.sentinel_node_connection_info()),
+        Some(ctx.sentinel_node_connection_info()),
         redis::sentinel::SentinelServerType::Master,
     )
     .unwrap();
 
     let mut replica_client = SentinelClient::build(
-        context.sentinels_connection_info().clone(),
+        ctx.sentinels_connection_info().clone(),
         String::from(master_name),
-        Some(context.sentinel_node_connection_info()),
+        Some(ctx.sentinel_node_connection_info()),
         redis::sentinel::SentinelServerType::Replica,
     )
     .unwrap();
 
     let sentinel_client_1 = master_client.get_sentinel_client().unwrap();
     let sentinel_client_2 = replica_client.get_sentinel_client().unwrap();
-    let first_configured_sentinel = context.sentinels_connection_info.first().unwrap();
+    let first_configured_sentinel = ctx.sentinels_connection_info.first().unwrap();
 
     assert_eq!(
         sentinel_client_1.get_connection_info().addr(),
@@ -517,19 +516,18 @@ fn test_sentinel_client_io_error() {
     assert!(err.is_io_error());
 }
 
-#[test]
-fn test_sentinel_client_not_sentinel_error() {
+#[sentinel_test]
+fn test_sentinel_client_not_sentinel_error(mut ctx: TestSentinelContext) {
     let master_name = "master1";
-    let mut context = TestSentinelContext::new(2, 3, 3);
     // Change the context with incorrect sentinel servers
-    context.sentinels_connection_info = context
+    ctx.sentinels_connection_info = ctx
         .cluster
         .servers
         .iter()
         .map(|redis_server| redis_server.connection_info())
         .collect::<Vec<_>>();
     let mut master_client = SentinelClient::build(
-        context.sentinels_connection_info().clone(),
+        ctx.sentinels_connection_info().clone(),
         String::from(master_name),
         None,
         redis::sentinel::SentinelServerType::Master,
@@ -547,24 +545,22 @@ fn test_sentinel_client_not_sentinel_error() {
     );
 }
 
-#[test]
-fn test_sentinel_client_builder() {
+#[sentinel_test]
+fn test_sentinel_client_builder(mut ctx: TestSentinelContext) {
     let master_name = "master1";
-    let mut context = TestSentinelContext::new(2, 3, 3);
-    for sentinel in context.sentinels_connection_info() {
+    for sentinel in ctx.sentinels_connection_info() {
         let mut conn = Client::open(sentinel.clone())
-            .inspect_err(|e| log_connection_error(&context, sentinel, e))
+            .inspect_err(|e| log_connection_error(&ctx, sentinel, e))
             .unwrap()
             .get_connection()
-            .inspect_err(|e| log_connection_error(&context, sentinel, e))
+            .inspect_err(|e| log_connection_error(&ctx, sentinel, e))
             .unwrap();
         let role: Role = redis::cmd("ROLE").query(&mut conn).unwrap();
         assert_matches!(role, Role::Sentinel { .. });
     }
 
     let mut master_client_builder = SentinelClientBuilder::new(
-        context
-            .sentinels_connection_info
+        ctx.sentinels_connection_info
             .iter()
             .map(|sentinel| sentinel.addr().clone()),
         String::from(master_name),
@@ -573,8 +569,7 @@ fn test_sentinel_client_builder() {
     .unwrap();
 
     let mut replica_client_builder = SentinelClientBuilder::new(
-        context
-            .sentinels_connection_info
+        ctx.sentinels_connection_info
             .iter()
             .map(|sentinel| sentinel.addr().clone()),
         String::from(master_name),
@@ -582,10 +577,9 @@ fn test_sentinel_client_builder() {
     )
     .unwrap();
 
-    master_client_builder = master_client_builder
-        .set_client_to_sentinel_protocol(use_protocol().unwrap_or(redis::ProtocolVersion::RESP2));
+    master_client_builder = master_client_builder.set_client_to_sentinel_protocol(ctx.protocol);
 
-    if let Some(tls_mode) = context.tls_mode() {
+    if let Some(tls_mode) = ctx.tls_mode() {
         master_client_builder = master_client_builder.set_client_to_redis_tls_mode(tls_mode);
         replica_client_builder = replica_client_builder.set_client_to_redis_tls_mode(tls_mode);
     }
@@ -599,8 +593,8 @@ fn test_sentinel_client_builder() {
 
     assert_is_connection_to_master(&mut master_con);
 
-    let node_conn_info = context.sentinel_node_connection_info();
-    let sentinel = context.sentinel_mut();
+    let node_conn_info = ctx.sentinel_node_connection_info();
+    let sentinel = ctx.sentinel_mut();
     let master_client = sentinel
         .master_for(master_name, Some(&node_conn_info))
         .unwrap();
@@ -619,6 +613,7 @@ pub mod async_tests {
     use super::*;
     use redis::{AsyncConnectionConfig, aio::MultiplexedConnection};
 
+    use test_macros::async_sentinel_test;
     use test_macros::async_test;
 
     use crate::{assert_is_master_role, assert_replica_role_and_master_addr};
@@ -654,7 +649,7 @@ pub mod async_tests {
         node_conn_info: &SentinelNodeConnectionInfo,
         number_of_replicas: u16,
     ) -> Vec<ConnectionAddr> {
-        let mut replica_conn_info = vec![];
+        let mut replica_conn_infos = vec![];
 
         for _ in 0..number_of_replicas {
             let replica_client = sentinel
@@ -667,23 +662,23 @@ pub mod async_tests {
                 .unwrap();
 
             assert!(
-                !replica_conn_info.contains(replica_client.get_connection_info().addr()),
+                !replica_conn_infos.contains(replica_client.get_connection_info().addr()),
                 "pushing {:?} into {:?}",
                 replica_client.get_connection_info().addr(),
-                replica_conn_info
+                replica_conn_infos
             );
-            replica_conn_info.push(replica_client.get_connection_info().addr().clone());
+            replica_conn_infos.push(replica_client.get_connection_info().addr().clone());
 
             async_assert_connection_is_replica_of_correct_master(&mut replica_con, master_client)
                 .await;
         }
 
-        replica_conn_info
+        replica_conn_infos
     }
 
     async fn async_assert_connect_to_known_replicas(
         sentinel: &mut Sentinel,
-        replica_conn_info: &[ConnectionAddr],
+        replica_conn_infos: &[ConnectionAddr],
         master_name: &str,
         master_client: &Client,
         node_conn_info: &SentinelNodeConnectionInfo,
@@ -699,19 +694,18 @@ pub mod async_tests {
                 .await
                 .unwrap();
 
-            assert!(replica_conn_info.contains(replica_client.get_connection_info().addr()));
+            assert!(replica_conn_infos.contains(replica_client.get_connection_info().addr()));
 
             async_assert_connection_is_replica_of_correct_master(&mut replica_con, master_client)
                 .await;
         }
     }
 
-    #[async_test]
-    async fn test_sentinel_connect_to_random_replica_async() {
+    #[async_sentinel_test]
+    async fn test_sentinel_connect_to_random_replica_async(mut ctx: TestSentinelContext) {
         let master_name = "master1";
-        let mut context = TestSentinelContext::new(2, 3, 3);
-        let node_conn_info = context.sentinel_node_connection_info();
-        let sentinel = context.sentinel_mut();
+        let node_conn_info = ctx.sentinel_node_connection_info();
+        let sentinel = ctx.sentinel_mut();
 
         let master_client = sentinel
             .async_master_for(master_name, Some(&node_conn_info))
@@ -735,13 +729,12 @@ pub mod async_tests {
             .await;
     }
 
-    #[async_test]
-    async fn test_sentinel_connect_to_multiple_replicas_async() {
+    #[async_sentinel_test]
+    async fn test_sentinel_connect_to_multiple_replicas_async(mut ctx: TestSentinelContext) {
         let number_of_replicas = 3;
         let master_name = "master1";
-        let mut cluster = TestSentinelContext::new(2, number_of_replicas, 3);
-        let node_conn_info = cluster.sentinel_node_connection_info();
-        let sentinel = cluster.sentinel_mut();
+        let node_conn_info = ctx.sentinel_node_connection_info();
+        let sentinel = ctx.sentinel_mut();
 
         let master_client = sentinel
             .async_master_for(master_name, Some(&node_conn_info))
@@ -754,7 +747,7 @@ pub mod async_tests {
 
         async_assert_is_connection_to_master(&mut master_con).await;
 
-        let replica_conn_info = async_connect_to_all_replicas(
+        let replica_conn_infos = async_connect_to_all_replicas(
             sentinel,
             master_name,
             &master_client,
@@ -765,7 +758,7 @@ pub mod async_tests {
 
         async_assert_connect_to_known_replicas(
             sentinel,
-            &replica_conn_info,
+            &replica_conn_infos,
             master_name,
             &master_client,
             &node_conn_info,
@@ -774,14 +767,13 @@ pub mod async_tests {
         .await;
     }
 
-    #[async_test]
-    async fn test_sentinel_server_down_async() {
+    #[async_sentinel_test]
+    async fn test_sentinel_server_down_async(mut ctx: TestSentinelContext) {
         let number_of_replicas = 3;
         let master_name = "master1";
-        let mut context = TestSentinelContext::new(2, number_of_replicas, 3);
-        let node_conn_info = context.sentinel_node_connection_info();
+        let node_conn_info = ctx.sentinel_node_connection_info();
 
-        let sentinel = context.sentinel_mut();
+        let sentinel = ctx.sentinel_mut();
 
         let master_client = sentinel
             .async_master_for(master_name, Some(&node_conn_info))
@@ -794,12 +786,12 @@ pub mod async_tests {
 
         async_assert_is_connection_to_master(&mut master_con).await;
 
-        context.cluster.sentinel_servers[0].stop();
+        ctx.cluster.sentinel_servers[0].stop();
         std::thread::sleep(Duration::from_millis(25));
 
-        let sentinel = context.sentinel_mut();
+        let sentinel = ctx.sentinel_mut();
 
-        let replica_conn_info = async_connect_to_all_replicas(
+        let replica_conn_infos = async_connect_to_all_replicas(
             sentinel,
             master_name,
             &master_client,
@@ -810,7 +802,7 @@ pub mod async_tests {
 
         async_assert_connect_to_known_replicas(
             sentinel,
-            &replica_conn_info,
+            &replica_conn_infos,
             master_name,
             &master_client,
             &node_conn_info,
@@ -819,22 +811,21 @@ pub mod async_tests {
         .await;
     }
 
-    #[async_test]
-    async fn test_sentinel_redis_client_async() {
+    #[async_sentinel_test]
+    async fn test_sentinel_redis_client_async(mut ctx: TestSentinelContext) {
         let master_name = "master1";
-        let mut context = TestSentinelContext::new(2, 3, 3);
         let mut master_client = SentinelClient::build(
-            context.sentinels_connection_info().clone(),
+            ctx.sentinels_connection_info().clone(),
             String::from(master_name),
-            Some(context.sentinel_node_connection_info()),
+            Some(ctx.sentinel_node_connection_info()),
             redis::sentinel::SentinelServerType::Master,
         )
         .unwrap();
 
         let mut replica_client = SentinelClient::build(
-            context.sentinels_connection_info().clone(),
+            ctx.sentinels_connection_info().clone(),
             String::from(master_name),
-            Some(context.sentinel_node_connection_info()),
+            Some(ctx.sentinel_node_connection_info()),
             redis::sentinel::SentinelServerType::Replica,
         )
         .unwrap();
@@ -843,8 +834,8 @@ pub mod async_tests {
 
         async_assert_is_connection_to_master(&mut master_con).await;
 
-        let node_conn_info = context.sentinel_node_connection_info();
-        let sentinel = context.sentinel_mut();
+        let node_conn_info = ctx.sentinel_node_connection_info();
+        let sentinel = ctx.sentinel_mut();
         let master_client = sentinel
             .async_master_for(master_name, Some(&node_conn_info))
             .await
@@ -859,29 +850,28 @@ pub mod async_tests {
         }
     }
 
-    #[async_test]
-    async fn test_sentinel_client_async() {
+    #[async_sentinel_test]
+    async fn test_sentinel_client_async(ctx: TestSentinelContext) {
         let master_name = "master1";
-        let context = TestSentinelContext::new(2, 3, 3);
         let mut master_client = SentinelClient::build(
-            context.sentinels_connection_info().clone(),
+            ctx.sentinels_connection_info().clone(),
             String::from(master_name),
-            Some(context.sentinel_node_connection_info()),
+            Some(ctx.sentinel_node_connection_info()),
             redis::sentinel::SentinelServerType::Master,
         )
         .unwrap();
 
         let mut replica_client = SentinelClient::build(
-            context.sentinels_connection_info().clone(),
+            ctx.sentinels_connection_info().clone(),
             String::from(master_name),
-            Some(context.sentinel_node_connection_info()),
+            Some(ctx.sentinel_node_connection_info()),
             redis::sentinel::SentinelServerType::Replica,
         )
         .unwrap();
 
         let sentinel_client_1 = master_client.async_get_sentinel_client().await.unwrap();
         let sentinel_client_2 = replica_client.async_get_sentinel_client().await.unwrap();
-        let first_configured_sentinel = context.sentinels_connection_info.first().unwrap();
+        let first_configured_sentinel = ctx.sentinels_connection_info.first().unwrap();
 
         assert_eq!(
             sentinel_client_1.get_connection_info().addr(),
@@ -921,22 +911,21 @@ pub mod async_tests {
         );
     }
 
-    #[async_test]
-    async fn test_sentinel_client_async_not_sentinel_error() {
+    #[async_sentinel_test]
+    async fn test_sentinel_client_async_not_sentinel_error(mut ctx: TestSentinelContext) {
         let master_name = "master1";
 
-        let mut context = TestSentinelContext::new(2, 3, 3);
         // Change the context with incorrect sentinel servers
-        context.sentinels_connection_info = context
+        ctx.sentinels_connection_info = ctx
             .cluster
             .servers
             .iter()
             .map(|redis_server| redis_server.connection_info())
             .collect::<Vec<_>>();
         let mut master_client = SentinelClient::build(
-            context.sentinels_connection_info().clone(),
+            ctx.sentinels_connection_info().clone(),
             String::from(master_name),
-            Some(context.sentinel_node_connection_info()),
+            Some(ctx.sentinel_node_connection_info()),
             redis::sentinel::SentinelServerType::Master,
         )
         .unwrap();
@@ -952,7 +941,8 @@ pub mod async_tests {
         );
     }
 
-    #[async_test]
+    #[cfg(all(feature = "sentinel", feature = "tokio-comp"))]
+    #[tokio::test]
     async fn test_sentinel_client_async_io_error() {
         let master_name = "master1";
 
@@ -969,22 +959,21 @@ pub mod async_tests {
         assert!(err.is_io_error());
     }
 
-    #[async_test]
-    async fn test_sentinel_client_async_with_connection_timeout() {
+    #[async_sentinel_test]
+    async fn test_sentinel_client_async_with_connection_timeout(mut ctx: TestSentinelContext) {
         let master_name = "master1";
-        let mut context = TestSentinelContext::new(2, 3, 3);
         let mut master_client = SentinelClient::build(
-            context.sentinels_connection_info().clone(),
+            ctx.sentinels_connection_info().clone(),
             String::from(master_name),
-            Some(context.sentinel_node_connection_info()),
+            Some(ctx.sentinel_node_connection_info()),
             redis::sentinel::SentinelServerType::Master,
         )
         .unwrap();
 
         let mut replica_client = SentinelClient::build(
-            context.sentinels_connection_info().clone(),
+            ctx.sentinels_connection_info().clone(),
             String::from(master_name),
-            Some(context.sentinel_node_connection_info()),
+            Some(ctx.sentinel_node_connection_info()),
             redis::sentinel::SentinelServerType::Replica,
         )
         .unwrap();
@@ -999,8 +988,8 @@ pub mod async_tests {
 
         async_assert_is_connection_to_master(&mut master_con).await;
 
-        let node_conn_info = context.sentinel_node_connection_info();
-        let sentinel = context.sentinel_mut();
+        let node_conn_info = ctx.sentinel_node_connection_info();
+        let sentinel = ctx.sentinel_mut();
         let master_client = sentinel
             .async_master_for(master_name, Some(&node_conn_info))
             .await
@@ -1018,22 +1007,21 @@ pub mod async_tests {
         }
     }
 
-    #[async_test]
-    async fn test_sentinel_client_async_with_response_timeout() {
+    #[async_sentinel_test]
+    async fn test_sentinel_client_async_with_response_timeout(mut ctx: TestSentinelContext) {
         let master_name = "master1";
-        let mut context = TestSentinelContext::new(2, 3, 3);
         let mut master_client = SentinelClient::build(
-            context.sentinels_connection_info().clone(),
+            ctx.sentinels_connection_info().clone(),
             String::from(master_name),
-            Some(context.sentinel_node_connection_info()),
+            Some(ctx.sentinel_node_connection_info()),
             redis::sentinel::SentinelServerType::Master,
         )
         .unwrap();
 
         let mut replica_client = SentinelClient::build(
-            context.sentinels_connection_info().clone(),
+            ctx.sentinels_connection_info().clone(),
             String::from(master_name),
-            Some(context.sentinel_node_connection_info()),
+            Some(ctx.sentinel_node_connection_info()),
             redis::sentinel::SentinelServerType::Replica,
         )
         .unwrap();
@@ -1047,8 +1035,8 @@ pub mod async_tests {
 
         async_assert_is_connection_to_master(&mut master_con).await;
 
-        let node_conn_info = context.sentinel_node_connection_info();
-        let sentinel = context.sentinel_mut();
+        let node_conn_info = ctx.sentinel_node_connection_info();
+        let sentinel = ctx.sentinel_mut();
         let master_client = sentinel
             .async_master_for(master_name, Some(&node_conn_info))
             .await
@@ -1066,22 +1054,21 @@ pub mod async_tests {
         }
     }
 
-    #[async_test]
-    async fn test_sentinel_client_async_with_timeouts() {
+    #[async_sentinel_test]
+    async fn test_sentinel_client_async_with_timeouts(mut ctx: TestSentinelContext) {
         let master_name = "master1";
-        let mut context = TestSentinelContext::new(2, 3, 3);
         let mut master_client = SentinelClient::build(
-            context.sentinels_connection_info().clone(),
+            ctx.sentinels_connection_info().clone(),
             String::from(master_name),
-            Some(context.sentinel_node_connection_info()),
+            Some(ctx.sentinel_node_connection_info()),
             redis::sentinel::SentinelServerType::Master,
         )
         .unwrap();
 
         let mut replica_client = SentinelClient::build(
-            context.sentinels_connection_info().clone(),
+            ctx.sentinels_connection_info().clone(),
             String::from(master_name),
-            Some(context.sentinel_node_connection_info()),
+            Some(ctx.sentinel_node_connection_info()),
             redis::sentinel::SentinelServerType::Replica,
         )
         .unwrap();
@@ -1095,8 +1082,8 @@ pub mod async_tests {
 
         async_assert_is_connection_to_master(&mut master_con).await;
 
-        let node_conn_info = context.sentinel_node_connection_info();
-        let sentinel = context.sentinel_mut();
+        let node_conn_info = ctx.sentinel_node_connection_info();
+        let sentinel = ctx.sentinel_mut();
         let master_client = sentinel
             .async_master_for(master_name, Some(&node_conn_info))
             .await
@@ -1114,26 +1101,45 @@ pub mod async_tests {
         }
     }
 
-    #[async_test]
-    async fn test_get_replica_clients_success_async() {
+    #[async_sentinel_test]
+    async fn test_get_replica_clients_success_async(mut ctx: TestSentinelContext) {
         let number_of_replicas = 3;
         let master_name = "master1";
-        let mut context = TestSentinelContext::new(2, number_of_replicas, 3);
-        let node_conn_info = context.sentinel_node_connection_info();
-        let sentinel = context.sentinel_mut();
+        let node_conn_info = ctx.sentinel_node_connection_info();
+        let sentinel = ctx.sentinel_mut();
 
-        let replicas = sentinel
-            .async_get_replica_clients(master_name, Some(&node_conn_info))
-            .await
-            .unwrap();
-        assert_eq!(replicas.len(), number_of_replicas as usize);
+        // Retry fetching replicas a few times — sentinel discovery can be eventually consistent
+        let mut replicas = Vec::new();
+        let mut attempts = 0usize;
+        let max_attempts = 30;
+        while attempts < max_attempts {
+            attempts += 1;
+            replicas = sentinel
+                .async_get_replica_clients(master_name, Some(&node_conn_info))
+                .await
+                .unwrap();
+            if replicas.len() == number_of_replicas as usize {
+                break;
+            }
+            println!(
+                "attempt {attempts}: discovered {} replicas, expecting {}",
+                replicas.len(),
+                number_of_replicas
+            );
+            futures_time::task::sleep(Duration::from_millis(100).into()).await;
+        }
+
+        assert_eq!(
+            replicas.len(),
+            number_of_replicas as usize,
+            "replicas={replicas:?}",
+        );
     }
 
-    #[async_test]
-    async fn test_get_replica_clients_invalid_master_name_async() {
-        let mut context = TestSentinelContext::new(2, 2, 3);
-        let node_conn_info = context.sentinel_node_connection_info();
-        let sentinel = context.sentinel_mut();
+    #[async_sentinel_test]
+    async fn test_get_replica_clients_invalid_master_name_async(mut ctx: TestSentinelContext) {
+        let node_conn_info = ctx.sentinel_node_connection_info();
+        let sentinel = ctx.sentinel_mut();
 
         let err = sentinel
             .async_get_replica_clients("invalid_master_name", Some(&node_conn_info))
@@ -1149,13 +1155,11 @@ pub mod async_tests {
         );
     }
 
-    #[async_test]
-    async fn test_get_replica_clients_report_correct_master_async() {
-        let number_of_replicas = 3;
+    #[async_sentinel_test]
+    async fn test_get_replica_clients_report_correct_master_async(mut ctx: TestSentinelContext) {
         let master_name = "master1";
-        let mut context = TestSentinelContext::new(2, number_of_replicas, 3);
-        let node_conn_info = context.sentinel_node_connection_info();
-        let sentinel = context.sentinel_mut();
+        let node_conn_info = ctx.sentinel_node_connection_info();
+        let sentinel = ctx.sentinel_mut();
 
         let master_client = sentinel
             .async_master_for(master_name, Some(&node_conn_info))
@@ -1175,20 +1179,19 @@ pub mod async_tests {
         }
     }
 
-    #[async_test]
-    async fn test_get_replica_clients_with_one_replica_down_async() {
+    #[async_sentinel_test]
+    async fn test_get_replica_clients_with_one_replica_down_async(mut ctx: TestSentinelContext) {
         let number_of_replicas = 3;
         let master_name = "master0";
-        let mut context = TestSentinelContext::new(2, number_of_replicas, 3);
-        let node_conn_info = context.sentinel_node_connection_info();
-        let sentinel_conn_info = context.sentinels_connection_info()[0].clone();
+        let node_conn_info = ctx.sentinel_node_connection_info();
+        let sentinel_conn_info = ctx.sentinels_connection_info()[0].clone();
 
         let mut conn = Client::open(sentinel_conn_info.clone())
-            .inspect_err(|e| log_connection_error(&context, &sentinel_conn_info, e))
+            .inspect_err(|e| log_connection_error(&ctx, &sentinel_conn_info, e))
             .unwrap()
             .get_multiplexed_async_connection()
             .await
-            .inspect_err(|e| log_connection_error(&context, &sentinel_conn_info, e))
+            .inspect_err(|e| log_connection_error(&ctx, &sentinel_conn_info, e))
             .unwrap();
 
         redis::cmd("SENTINEL")
@@ -1200,10 +1203,10 @@ pub mod async_tests {
             .await
             .unwrap();
 
-        context.cluster.servers[1].stop();
+        ctx.cluster.servers[1].stop();
         std::thread::sleep(std::time::Duration::from_millis(800));
 
-        let sentinel = context.sentinel_mut();
+        let sentinel = ctx.sentinel_mut();
         let replicas = sentinel
             .async_get_replica_clients(master_name, Some(&node_conn_info))
             .await
@@ -1233,14 +1236,13 @@ pub mod pool_tests {
         info_map
     }
 
-    #[test]
-    fn test_sentinel_client() {
+    #[sentinel_test]
+    fn test_sentinel_client(ctx: TestSentinelContext) {
         let master_name = "master1";
-        let context = TestSentinelContext::new(2, 3, 3);
         let master_client = SentinelClient::build(
-            context.sentinels_connection_info().clone(),
+            ctx.sentinels_connection_info().clone(),
             String::from(master_name),
-            Some(context.sentinel_node_connection_info()),
+            Some(ctx.sentinel_node_connection_info()),
             redis::sentinel::SentinelServerType::Master,
         )
         .unwrap();

--- a/redis/tests/test_sentinel.rs
+++ b/redis/tests/test_sentinel.rs
@@ -582,7 +582,8 @@ fn test_sentinel_client_builder() {
     )
     .unwrap();
 
-    master_client_builder = master_client_builder.set_client_to_sentinel_protocol(use_protocol());
+    master_client_builder = master_client_builder
+        .set_client_to_sentinel_protocol(use_protocol().unwrap_or(redis::ProtocolVersion::RESP2));
 
     if let Some(tls_mode) = context.tls_mode() {
         master_client_builder = master_client_builder.set_client_to_redis_tls_mode(tls_mode);

--- a/redis/tests/test_streams.rs
+++ b/redis/tests/test_streams.rs
@@ -2,13 +2,11 @@
 
 use redis::streams::*;
 use redis::{Connection, ToRedisArgs, TypedCommands};
-use redis_test::{
-    REDIS_CE_7_0, REDIS_CE_8_2, REDIS_CE_8_4, REDIS_CE_8_6, REDIS_CE_8_8, TestContext,
-    TestContextVersioning, run_test_if_version_supported,
-};
+use test_macros::single_server_test;
 
 #[macro_use]
 mod support;
+use crate::support::*;
 
 use assert_matches::assert_matches;
 use std::collections::BTreeMap;
@@ -96,8 +94,8 @@ fn test_cmd_options() {
     assert_args!(&opts, "BLOCK", "100", "COUNT", "200");
 }
 
-#[test]
-fn test_assorted_1() {
+#[single_server_test]
+fn test_assorted_1(ctx: TestContext) {
     // Tests the following commands....
     // xadd
     // xadd_map (skip this for now)
@@ -105,7 +103,6 @@ fn test_assorted_1() {
     // xread
     // xlen
 
-    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     xadd(&mut con);
@@ -166,15 +163,14 @@ fn test_assorted_1() {
     assert_eq!(result, Ok(10));
 }
 
-#[test]
-fn test_xgroup_create() {
+#[single_server_test]
+fn test_xgroup_create(ctx: TestContext) {
     // Tests the following commands....
     // xadd
     // xinfo_stream
     // xgroup_create
     // xinfo_groups
 
-    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     xadd(&mut con);
@@ -208,12 +204,11 @@ fn test_xgroup_create() {
     assert_eq!(&reply.groups[0].name, &"g1");
 }
 
-#[test]
-fn test_xgroup_createconsumer() {
+#[single_server_test]
+fn test_xgroup_createconsumer(ctx: TestContext) {
     // Tests the following command....
     // xgroup_createconsumer
 
-    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     xadd(&mut con);
@@ -264,8 +259,8 @@ fn test_xgroup_createconsumer() {
     assert_eq!(&reply.consumers[0].name, &"c1");
 }
 
-#[test]
-fn test_assorted_2() {
+#[single_server_test]
+fn test_assorted_2(ctx: TestContext) {
     // Tests the following commands....
     // xadd
     // xinfo_stream
@@ -278,7 +273,6 @@ fn test_assorted_2() {
     // xpending_count
     // xpending_consumer_count
 
-    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     xadd(&mut con);
@@ -415,9 +409,8 @@ fn assert_stream_pending_data(data: StreamPendingData) {
     assert_eq!(data.consumers[0].name, "c99");
 }
 
-#[test]
-fn test_xadd_maxlen_map() {
-    let ctx = TestContext::default();
+#[single_server_test]
+fn test_xadd_maxlen_map(ctx: TestContext) {
     let mut con = ctx.connection();
 
     for i in 0..10 {
@@ -436,9 +429,8 @@ fn test_xadd_maxlen_map() {
     assert_eq!(reply.ids[2].get("idx"), Some("9".to_string()));
 }
 
-#[test]
-fn test_xadd_options() {
-    let ctx = TestContext::default();
+#[single_server_test]
+fn test_xadd_options(ctx: TestContext) {
     let mut con = ctx.connection();
 
     // NoMKStream will return a nil when the stream does not exist
@@ -511,10 +503,10 @@ fn test_xadd_options() {
     assert_eq!(info.last_entry.id, "3-1");
 }
 
-#[test]
-fn test_xread_options_deleted_pel_entry() {
+#[single_server_test]
+fn test_xread_options_deleted_pel_entry(ctx: TestContext) {
     // Test xread_options behaviour with deleted entry
-    let ctx = TestContext::default();
+
     let mut con = ctx.connection();
     let result = con.xgroup_create_mkstream("k1", "g1", "$");
     assert_matches!(result, Ok(_));
@@ -567,11 +559,11 @@ fn create_group_add_and_read(con: &mut Connection) -> StreamReadReply {
     reply
 }
 
-#[test]
-fn test_xautoclaim() {
+#[single_server_test]
+fn test_xautoclaim(ctx: TestContext) {
     // Tests the following command....
     // xautoclaim_options
-    let ctx = TestContext::default();
+
     let mut con = ctx.connection();
 
     // xautoclaim test basic idea:
@@ -632,12 +624,12 @@ fn test_xautoclaim() {
     assert!(reply.claimed[1].map.is_empty());
 }
 
-#[test]
-fn test_xclaim() {
+#[single_server_test]
+fn test_xclaim(ctx: TestContext) {
     // Tests the following commands....
     // xclaim
     // xclaim_options
-    let ctx = TestContext::default();
+
     let mut con = ctx.connection();
 
     // xclaim test basic idea:
@@ -720,9 +712,8 @@ fn test_xclaim() {
     assert_eq!(claimed.len(), 10);
 }
 
-#[test]
-fn test_xclaim_last_id() {
-    let ctx = TestContext::default();
+#[single_server_test]
+fn test_xclaim_last_id(ctx: TestContext) {
     let mut con = ctx.connection();
 
     let result = con.xgroup_create_mkstream("k1", "g1", "$");
@@ -795,10 +786,10 @@ fn test_xclaim_last_id() {
     assert_eq!(info.groups[0].last_delivered_id, claim_late_id.id.clone());
 }
 
-#[test]
-fn test_xreadgroup_with_claim_option() {
+#[single_server_test]
+fn test_xreadgroup_with_claim_option(ctx: TestContext) {
     // `XREADGROUP` option `CLAIM` is only supported in Redis 8.4+ (but not Valkey<=9.1)
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
+    skip_if_context_does_not_support!(ctx, REDIS_CE_8_4);
     let mut con = ctx.connection();
 
     let stream_name = "test_stream";
@@ -895,10 +886,10 @@ fn test_xreadgroup_with_claim_option() {
     assert_eq!(consumer1_count + consumer2_count, 10);
 }
 
-#[test]
-fn test_xreadgroup_claim_with_idle_and_incoming_messages() {
+#[single_server_test]
+fn test_xreadgroup_claim_with_idle_and_incoming_messages(ctx: TestContext) {
     // `XREADGROUP` option `CLAIM` is only supported in Redis 8.4+ (but not Valkey<=9.1)
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
+    skip_if_context_does_not_support!(ctx, REDIS_CE_8_4);
     let mut con = ctx.connection();
 
     let stream_name = "test_stream_claim_with_idle_and_incoming_messages";
@@ -959,12 +950,12 @@ fn test_xreadgroup_claim_with_idle_and_incoming_messages() {
     //  - delivered_count > 0
     assert_eq!(idle_pending_ids[0], claim_reply.keys[0].ids[0].id);
     assert_eq!(idle_pending_ids[1], claim_reply.keys[0].ids[1].id);
-    for stream_id in claim_reply.keys[0].ids.iter().take(2) {
+    for stream_id in &claim_reply.keys[0].ids[..2] {
         assert!(stream_id.milliseconds_elapsed_from_delivery.unwrap() > 0);
         assert!(stream_id.delivered_count.unwrap() > 0);
     }
     // Verify that the remaining 8 messages are new, incoming messages (not previously delivered)
-    for stream_id in claim_reply.keys[0].ids.iter().take(10).skip(2) {
+    for stream_id in &claim_reply.keys[0].ids[2..10] {
         assert_eq!(stream_id.milliseconds_elapsed_from_delivery.unwrap(), 0);
         assert_eq!(stream_id.delivered_count.unwrap(), 0);
         // These messages should NOT be in the idle pending list
@@ -1009,22 +1000,22 @@ fn test_xreadgroup_claim_with_idle_and_incoming_messages() {
     assert_eq!(claim_all_reply.keys[0].ids.len(), 22);
 
     // Verify that the first 10 are the idle pending messages
-    for stream_id in claim_all_reply.keys[0].ids.iter().take(10) {
+    for stream_id in &claim_all_reply.keys[0].ids[..10] {
         assert!(stream_id.milliseconds_elapsed_from_delivery.unwrap() > 0);
         assert!(stream_id.delivered_count.unwrap() > 0);
     }
 
     // Verify that the rest are new, incoming messages
-    for stream_id in claim_all_reply.keys[0].ids.iter().take(22).skip(10) {
+    for stream_id in &claim_all_reply.keys[0].ids[10..22] {
         assert_eq!(stream_id.milliseconds_elapsed_from_delivery.unwrap(), 0);
         assert_eq!(stream_id.delivered_count.unwrap(), 0);
     }
 }
 
-#[test]
-fn test_xreadgroup_claim_multiple_streams() {
+#[single_server_test]
+fn test_xreadgroup_claim_multiple_streams(ctx: TestContext) {
     // `XREADGROUP` option `CLAIM` is only supported in Redis 8.4+ (but not Valkey<=9.1)
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_4);
+    skip_if_context_does_not_support!(ctx, REDIS_CE_8_4);
     let mut con = ctx.connection();
 
     let stream1 = "test_stream_claim_multi_1";
@@ -1095,11 +1086,8 @@ fn test_xreadgroup_claim_multiple_streams() {
     assert_eq!(consumer2_pending.ids.len(), 5);
 }
 
-#[test]
-fn test_xdel() {
-    // Tests the following commands....
-    // xdel
-    let ctx = TestContext::default();
+#[single_server_test]
+fn test_xdel(ctx: TestContext) {
     let mut con = ctx.connection();
 
     // add some keys
@@ -1115,10 +1103,10 @@ fn test_xdel() {
     assert_eq!(result, Ok(2));
 }
 
-#[test]
-fn test_xadd_options_deletion_policy_keepref() {
+#[single_server_test]
+fn test_xadd_options_deletion_policy_keepref(ctx: TestContext) {
     // `XADD` mode `KEEPREF` is only supported in Redis 8.2+ (but not Valkey<=9.1)
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_2);
+    skip_if_context_does_not_support!(ctx, REDIS_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
 
@@ -1201,10 +1189,10 @@ fn test_xadd_options_deletion_policy_keepref() {
     );
 }
 
-#[test]
-fn test_xadd_options_deletion_policy_delref() {
+#[single_server_test]
+fn test_xadd_options_deletion_policy_delref(ctx: TestContext) {
     // `XADD` mode `DELREF` is only supported in Redis 8.2+ (but not Valkey<=9.1)
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_2);
+    skip_if_context_does_not_support!(ctx, REDIS_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
 
@@ -1287,10 +1275,10 @@ fn test_xadd_options_deletion_policy_delref() {
     );
 }
 
-#[test]
-fn test_xadd_options_deletion_policy_acked() {
+#[single_server_test]
+fn test_xadd_options_deletion_policy_acked(ctx: TestContext) {
     // `XADD` mode `ACKED` is only supported in Redis 8.2+ (but not Valkey<=9.1)
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_2);
+    skip_if_context_does_not_support!(ctx, REDIS_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
 
@@ -1376,10 +1364,10 @@ fn test_xadd_options_deletion_policy_acked() {
     );
 }
 
-#[test]
-fn test_xtrim_options_deletion_policy_keepref() {
+#[single_server_test]
+fn test_xtrim_options_deletion_policy_keepref(ctx: TestContext) {
     // `XTRIM` mode `KEEPREF` is only supported in Redis 8.2+ (but not Valkey<=9.1)
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_2);
+    skip_if_context_does_not_support!(ctx, REDIS_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
 
@@ -1448,10 +1436,10 @@ fn test_xtrim_options_deletion_policy_keepref() {
     );
 }
 
-#[test]
-fn test_xtrim_options_deletion_policy_delref() {
+#[single_server_test]
+fn test_xtrim_options_deletion_policy_delref(ctx: TestContext) {
     // `XTRIM` mode `DELREF` is only supported in Redis 8.2+ (but not Valkey<=9.1)
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_2);
+    skip_if_context_does_not_support!(ctx, REDIS_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
 
@@ -1520,10 +1508,10 @@ fn test_xtrim_options_deletion_policy_delref() {
     );
 }
 
-#[test]
-fn test_xtrim_options_deletion_policy_acked() {
+#[single_server_test]
+fn test_xtrim_options_deletion_policy_acked(ctx: TestContext) {
     // `XTRIM` mode `ACKED` is only supported in Redis 8.2+ (but not Valkey<=9.1)
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_2);
+    skip_if_context_does_not_support!(ctx, REDIS_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
 
@@ -1592,10 +1580,10 @@ fn test_xtrim_options_deletion_policy_acked() {
     );
 }
 
-#[test]
-fn test_xdel_ex() {
+#[single_server_test]
+fn test_xdel_ex(ctx: TestContext) {
     // `XDELEX` is only supported in Redis 8.2+ (but not Valkey<=9.1)
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_2);
+    skip_if_context_does_not_support!(ctx, REDIS_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
 
@@ -1793,10 +1781,10 @@ fn test_xdel_ex() {
     assert_matches!(result, Err(e) if e.to_string().contains("Invalid stream ID"));
 }
 
-#[test]
-fn test_xack_del() {
+#[single_server_test]
+fn test_xack_del(ctx: TestContext) {
     // `XACKDEL` is only supported in Redis 8.2+ (but not Valkey<=9.1)
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_2);
+    skip_if_context_does_not_support!(ctx, REDIS_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
 
@@ -2092,11 +2080,11 @@ fn test_xack_del() {
     assert_matches!(result, Err(e) if e.to_string().contains("Invalid stream ID"));
 }
 
-#[test]
-fn test_xtrim() {
+#[single_server_test]
+fn test_xtrim(ctx: TestContext) {
     // Tests the following commands....
     // xtrim
-    let ctx = TestContext::default();
+
     let mut con = ctx.connection();
 
     // add some keys
@@ -2111,11 +2099,11 @@ fn test_xtrim() {
     assert_eq!(result, Ok(40));
 }
 
-#[test]
-fn test_xtrim_options() {
+#[single_server_test]
+fn test_xtrim_options(ctx: TestContext) {
     // Tests the following commands....
     // xtrim_options
-    let ctx = TestContext::default();
+
     let mut con = ctx.connection();
 
     // add some keys
@@ -2157,14 +2145,13 @@ fn test_xtrim_options() {
     assert_eq!(result, Ok(50));
 }
 
-#[test]
-fn test_xgroup() {
+#[single_server_test]
+fn test_xgroup(ctx: TestContext) {
     // Tests the following commands....
     // xgroup_create_mkstream
     // xgroup_destroy
     // xgroup_delconsumer
 
-    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     // test xgroup create w/ mkstream @ 0
@@ -2201,14 +2188,13 @@ fn test_xgroup() {
     assert_eq!(result, Ok(true));
 }
 
-#[test]
-fn test_xrange() {
+#[single_server_test]
+fn test_xrange(ctx: TestContext) {
     // Tests the following commands....
     // xrange (-/+ variations)
     // xrange_all
     // xrange_count
 
-    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     xadd(&mut con);
@@ -2227,14 +2213,13 @@ fn test_xrange() {
     assert_eq!(reply.ids.len(), 1);
 }
 
-#[test]
-fn test_xrevrange() {
+#[single_server_test]
+fn test_xrevrange(ctx: TestContext) {
     // Tests the following commands....
     // xrevrange (+/- variations)
     // xrevrange_all
     // xrevrange_count
 
-    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     xadd(&mut con);
@@ -2253,8 +2238,8 @@ fn test_xrevrange() {
     assert_eq!(reply.ids.len(), 1);
 }
 
-#[test]
-fn test_xautoclaim_invalid_pel_entries_claiming_full_entries() {
+#[single_server_test]
+fn test_xautoclaim_invalid_pel_entries_claiming_full_entries(ctx: TestContext) {
     // The Redis PEL can include stale entries that have been deleted from the stream,
     // due to either data corruption or client error.
     // Redis v6 behaves differently from Redis v7 when encountering these invalid entries.
@@ -2262,7 +2247,6 @@ fn test_xautoclaim_invalid_pel_entries_claiming_full_entries() {
     // See https://github.com/redis-rs/redis-rs/issues/1798
     // Note that this issue also applies to xclaim.
 
-    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     // xautoclaim-invalid basic idea:
@@ -2305,8 +2289,8 @@ fn test_xautoclaim_invalid_pel_entries_claiming_full_entries() {
     }
 }
 
-#[test]
-fn test_xautoclaim_invalid_pel_entries_claiming_just_ids() {
+#[single_server_test]
+fn test_xautoclaim_invalid_pel_entries_claiming_just_ids(ctx: TestContext) {
     // The Redis PEL can include stale entries that have been deleted from the stream,
     // due to either data corruption or client error.
     // Redis v6 behaves differently from Redis v7 when encountering these invalid entries.
@@ -2314,7 +2298,6 @@ fn test_xautoclaim_invalid_pel_entries_claiming_just_ids() {
     // See https://github.com/redis-rs/redis-rs/issues/1798
     // Note that this issue also applies to xclaim.
 
-    let ctx = TestContext::default();
     let mut con = ctx.connection();
 
     // xautoclaim-invalid basic idea:
@@ -2334,7 +2317,7 @@ fn test_xautoclaim_invalid_pel_entries_claiming_just_ids() {
     let _ = con.xdel("k1", &[claim.id.clone(), claim_1.id.clone()]);
     sleep(Duration::from_millis(5));
 
-    let mut reply = con
+    let reply = con
         .xautoclaim_options(
             "k1",
             "g1",
@@ -2355,12 +2338,15 @@ fn test_xautoclaim_invalid_pel_entries_claiming_just_ids() {
             vec![claim.id.clone(), claim_1.id.clone()]
         );
     } else {
-        // On Redis <7, the deleted entries appear claimed when passing JUSTID
-        // So we check that they are present and skip over them
-        assert_eq!(reply.claimed[0].id, claim.id);
-        assert_eq!(reply.claimed[1].id, claim_1.id);
-        reply.claimed = reply.claimed.into_iter().skip(2).collect();
-
+        // on redis 6, the deleted entries appear when passing JUSTID
+        let mut stream_id = StreamId::default();
+        stream_id.id = claim.id.clone();
+        stream_id.map = Default::default();
+        claimed_entries.insert(0, stream_id);
+        let mut stream_id = StreamId::default();
+        stream_id.id = claim_1.id.clone();
+        stream_id.map = Default::default();
+        claimed_entries.insert(1, stream_id);
         assert_eq!(reply.claimed, claimed_entries);
         assert_eq!(reply.deleted_ids.len(), 0);
     }
@@ -2382,11 +2368,11 @@ mod idempotency_tests {
 
     const FIELD_VALUES: [(&str, &str); 2] = [("field1", "value1"), ("field2", "value2")];
 
-    #[test]
-    fn test_xadd_idempotency_manual_mode() {
+    #[single_server_test]
+    fn test_xadd_idempotency_manual_mode(ctx: TestContext) {
         // Test IDMP (manual mode) - prevents messages with the same PID and IID from being added to the stream.
         // Stream idempotency is only supported in Redis 8.6+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_6);
         let mut con = ctx.connection();
 
         const STREAM_NAME: &str = "test_idmp_stream";
@@ -2464,11 +2450,11 @@ mod idempotency_tests {
         assert_eq!(info.iids_duplicates, 2);
     }
 
-    #[test]
-    fn test_xadd_idempotency_automatic_mode() {
+    #[single_server_test]
+    fn test_xadd_idempotency_automatic_mode(ctx: TestContext) {
         // Test IDMPAUTO (automatic mode) - prevents messages with the same PID and content from being added to the stream.
         // Stream idempotency is only supported in Redis 8.6+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_6);
         let mut con = ctx.connection();
 
         const STREAM_NAME: &str = "test_idmpauto_stream";
@@ -2534,11 +2520,11 @@ mod idempotency_tests {
         assert_eq!(info.iids_duplicates, 1);
     }
 
-    #[test]
-    fn test_xadd_idempotency_with_other_options() {
+    #[single_server_test]
+    fn test_xadd_idempotency_with_other_options(ctx: TestContext) {
         // Test that idempotency works correctly with other XADD options
         // Stream idempotency is only supported in Redis 8.6+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_6);
         let mut con = ctx.connection();
 
         const STREAM_NAME: &str = "test_idmp_combined_options_stream";
@@ -2687,10 +2673,10 @@ mod idempotency_tests {
         assert_eq!(info.iids_duplicates, 1);
     }
 
-    #[test]
-    fn test_xcfgset() {
+    #[single_server_test]
+    fn test_xcfgset(ctx: TestContext) {
         // `XCFGSET` is only supported in Redis 8.6+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_6);
         let mut con = ctx.connection();
 
         const STREAM_NAME: &str = "test_xcfgset_stream";
@@ -2777,10 +2763,10 @@ mod idempotency_tests {
         assert_eq!(info.idmp_maxsize, IDMP_CUSTOM_MAXSIZE);
     }
 
-    #[test]
-    fn test_xcfgset_with_idempotent_messages() {
+    #[single_server_test]
+    fn test_xcfgset_with_idempotent_messages(ctx: TestContext) {
         // `XCFGSET` is only supported in Redis 8.6+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_6);
         let mut con = ctx.connection();
 
         const STREAM_NAME: &str = "test_xcfgset_with_idempotent_messages_stream";
@@ -2883,10 +2869,10 @@ mod idempotency_tests {
         );
     }
 
-    #[test]
-    fn test_xcfgset_idempotency_behavior() {
+    #[single_server_test]
+    fn test_xcfgset_idempotency_behavior(ctx: TestContext) {
         // `XCFGSET` is only supported in Redis 8.6+ (but not Valkey<=9.1)
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_6);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_6);
         let mut con = ctx.connection();
 
         const STREAM_NAME: &str = "test_xcfgset_behavior_stream";
@@ -3026,7 +3012,6 @@ mod idempotency_tests {
 
 mod xnack_tests {
     use super::*;
-    use rstest::rstest;
 
     const GROUP: &str = "xnack_group";
     const CONSUMER: &str = "xnack_consumer1";
@@ -3067,9 +3052,9 @@ mod xnack_tests {
             .times_delivered
     }
 
-    #[test]
-    fn test_xnack_basic_returns_count_of_nacked_messages() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
+    #[single_server_test]
+    fn test_xnack_basic_returns_count_of_nacked_messages(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let stream = "test_xnack_basic";
@@ -3086,31 +3071,37 @@ mod xnack_tests {
         assert_eq!(nacked, 3);
     }
 
-    #[rstest]
-    #[case(StreamNackMode::Silent)]
-    #[case(StreamNackMode::Fail)]
-    #[case(StreamNackMode::Fatal)]
-    fn test_xnack_marks_message_as_unowned(#[case] mode: StreamNackMode) {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
-        let mut con = ctx.connection();
+    #[single_server_test]
+    fn test_xnack_marks_message_as_unowned(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_8);
+        for (i, mode) in [
+            StreamNackMode::Silent,
+            StreamNackMode::Fail,
+            StreamNackMode::Fatal,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let mut con = ctx.connection();
 
-        let stream = "test_xnack_unowned";
-        let ids = xnack_setup_pending(&mut con, stream, GROUP, CONSUMER, 3);
+            let stream = format!("test_xnack_unowned_{i}");
+            let ids = xnack_setup_pending(&mut con, &stream, GROUP, CONSUMER, 3);
 
-        con.xnack(stream, GROUP, &ids, &StreamNackOptions::new(mode))
-            .unwrap();
+            con.xnack(&stream, GROUP, &ids, &StreamNackOptions::new(mode))
+                .unwrap();
 
-        // After NACK the messages remain in the PEL but are unowned, so their last consumer should be an empty string.
-        let reply = con.xpending_count(stream, GROUP, "-", "+", 3).unwrap();
-        assert_eq!(reply.ids.len(), 3);
-        for entry in &reply.ids {
-            assert_eq!(entry.consumer, "");
+            // After NACK the messages remain in the PEL but are unowned, so their last consumer should be an empty string.
+            let reply = con.xpending_count(&stream, GROUP, "-", "+", 3).unwrap();
+            assert_eq!(reply.ids.len(), 3);
+            for entry in &reply.ids {
+                assert_eq!(entry.consumer, "");
+            }
         }
     }
 
-    #[test]
-    fn test_xnack_silent_decrements_delivery_counter() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
+    #[single_server_test]
+    fn test_xnack_silent_decrements_delivery_counter(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let stream = "test_xnack_silent_counter";
@@ -3145,9 +3136,9 @@ mod xnack_tests {
         assert_eq!(pel_times_delivered(&mut con, stream, GROUP, id), 1);
     }
 
-    #[test]
-    fn test_xnack_fail_keeps_delivery_counter() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
+    #[single_server_test]
+    fn test_xnack_fail_keeps_delivery_counter(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let stream = "test_xnack_fail_counter";
@@ -3185,9 +3176,9 @@ mod xnack_tests {
         assert_ne!(delivery_counter_after_redelivery, i64::MAX as usize);
     }
 
-    #[test]
-    fn test_xnack_fatal_marks_delivery_counter_as_sentinel() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
+    #[single_server_test]
+    fn test_xnack_fatal_marks_delivery_counter_as_sentinel(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let stream = "test_xnack_fatal_counter";
@@ -3221,9 +3212,9 @@ mod xnack_tests {
         assert_eq!(pel_times_delivered(&mut con, stream, GROUP, id), sentinel);
     }
 
-    #[test]
-    fn test_xnack_prioritized_at_pel_head_when_claiming() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
+    #[single_server_test]
+    fn test_xnack_prioritized_at_pel_head_when_claiming(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let stream = "test_xnack_priority";
@@ -3264,10 +3255,10 @@ mod xnack_tests {
         );
     }
 
-    #[test]
-    fn test_xnack_ignores_unknown_ids_and_returns_zero() {
+    #[single_server_test]
+    fn test_xnack_ignores_unknown_ids_and_returns_zero(ctx: TestContext) {
         use StreamNackMode::*;
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let stream = "test_xnack_on_an_unknown_id";
@@ -3286,10 +3277,10 @@ mod xnack_tests {
         );
     }
 
-    #[test]
-    fn test_xnack_only_affects_known_ids() {
+    #[single_server_test]
+    fn test_xnack_only_affects_known_ids(ctx: TestContext) {
         use StreamNackMode::*;
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let stream = "test_xnack_only_affects_known_ids";
@@ -3304,9 +3295,9 @@ mod xnack_tests {
         );
     }
 
-    #[test]
-    fn test_xnack_nonexistent_stream_errors() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
+    #[single_server_test]
+    fn test_xnack_nonexistent_stream_errors(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let result = con.xnack(
@@ -3322,9 +3313,9 @@ mod xnack_tests {
         );
     }
 
-    #[test]
-    fn test_xnack_nonexistent_group_errors() {
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
+    #[single_server_test]
+    fn test_xnack_nonexistent_group_errors(ctx: TestContext) {
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let stream = "test_xnack_nogroup";
@@ -3341,10 +3332,10 @@ mod xnack_tests {
         );
     }
 
-    #[test]
-    fn test_xnack_idempotent_double_nack() {
+    #[single_server_test]
+    fn test_xnack_idempotent_double_nack(ctx: TestContext) {
         use StreamNackMode::*;
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let stream = "test_xnack_double";
@@ -3370,10 +3361,10 @@ mod xnack_tests {
         assert_eq!(second, 1);
     }
 
-    #[test]
-    fn test_xnack_fifo_ordering_among_multiple_nacked_messages() {
+    #[single_server_test]
+    fn test_xnack_fifo_ordering_among_multiple_nacked_messages(ctx: TestContext) {
         use StreamNackMode::*;
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         /*
@@ -3425,10 +3416,10 @@ mod xnack_tests {
         );
     }
 
-    #[test]
-    fn test_xnack_three_tier_delivery_order() {
+    #[single_server_test]
+    fn test_xnack_three_tier_delivery_order(ctx: TestContext) {
         use StreamNackMode::*;
-        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
+        skip_if_context_does_not_support!(ctx, REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         // Tier 1: a delivered and NACKed entry.

--- a/redis/tests/test_tls_cert_auth.rs
+++ b/redis/tests/test_tls_cert_auth.rs
@@ -13,12 +13,10 @@
 
 use redis::acl::Rule;
 use redis::{Commands, RedisResult};
-use redis_test::{
-    REDIS_CE_8_6, TestContext, TestContextBuilder, VALKEY_9_0, run_test_if_version_supported,
-};
 use tempfile::TempDir;
 
 mod support;
+use crate::support::*;
 use redis_test::utils::{ClientCertPaths, build_client_cert_with_custom_cn};
 
 /// Helper struct to manage cert-based auth testing with a single Redis server
@@ -75,6 +73,7 @@ fn create_cert_auth_context_with_username(username: &str) -> CertAuthTestContext
 
     // Create a single server context with cert-based auth enabled
     let server_ctx = TestContextBuilder::new()
+        .server_type(redis_test::server::ServerType::Tcp { tls: true })
         .tls_paths(tls_paths.clone())
         .mtls(true)
         .cert_auth_field("CN")
@@ -98,6 +97,9 @@ fn generate_random_username() -> String {
 fn test_tls_certificate_authentication_with_matching_acl_user() {
     // This test verifies that Redis can automatically authenticate a client
     // based on the Common Name (CN) field in the client's TLS certificate.
+    // Certificate-based authentication requires a Redis server >= 8.6 (or Valkey
+    // >= 9.0), so check the version before creating the cert-auth server (which
+    // needs command-line flags that older servers reject at startup).
 
     run_test_if_version_supported!([REDIS_CE_8_6, VALKEY_9_0]);
 
@@ -176,6 +178,9 @@ fn test_tls_certificate_authentication_with_matching_acl_user() {
 fn test_tls_certificate_authentication_no_matching_user() {
     // This test verifies that when a client certificate's CN doesn't match
     // any existing ACL user, Redis falls back to the "default" user.
+    // Certificate-based authentication requires a Redis server >= 8.6 (or Valkey
+    // >= 9.0), so check the version before creating the cert-auth server (which
+    // needs command-line flags that older servers reject at startup).
     run_test_if_version_supported!([REDIS_CE_8_6, VALKEY_9_0]);
 
     // Generate a random username (that won't have a corresponding ACL user).

--- a/test-macros/Cargo.toml
+++ b/test-macros/Cargo.toml
@@ -8,7 +8,8 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0.45"
-syn = { version = "3.0.3", features = ["full", "extra-traits"] }
+proc-macro2 = "1.0"
+syn = { version="2.0.114", features=["full"] }
 
-[lints]
-workspace = true
+[dev-dependencies]
+rstest = "0.26"

--- a/test-macros/src/cluster.rs
+++ b/test-macros/src/cluster.rs
@@ -1,0 +1,420 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+
+use crate::test_env::{ServerKind, protocol_enabled, server_enabled};
+use crate::utils::{
+    generate_async_cluster_call, generate_sync_call, generate_version_check, ignore_flag,
+    parse_cluster_test_args,
+};
+
+/// A (protocol × server kind) cluster test variant. Clusters do not support unix sockets.
+struct ClusterVariant {
+    protocol: &'static str,
+    kind: ServerKind,
+    name: String,
+    cfg: TokenStream2,
+    cluster_type: syn::Ident,
+}
+
+/// Builds the full cluster matrix: protocol × (TCP, TCP+TLS).
+fn cluster_matrix() -> Vec<ClusterVariant> {
+    let mut matrix = Vec::new();
+    for protocol in ["RESP2", "RESP3"] {
+        let proto_lc = protocol.to_ascii_lowercase();
+        matrix.push(ClusterVariant {
+            protocol,
+            kind: ServerKind::Tcp,
+            name: format!("{proto_lc}_tcp"),
+            cfg: quote! { #[cfg(feature = "cluster")] },
+            cluster_type: syn::Ident::new("Tcp", proc_macro2::Span::call_site()),
+        });
+        matrix.push(ClusterVariant {
+            protocol,
+            kind: ServerKind::Tls,
+            name: format!("{proto_lc}_tls", ),
+            cfg: quote! {
+                #[cfg(all(feature = "cluster", any(feature = "tls-rustls", feature = "tls-native-tls")))]
+            },
+            cluster_type: syn::Ident::new("TcpTls", proc_macro2::Span::call_site()),
+        });
+    }
+    matrix
+}
+
+/// Builds the expansion for `#[cluster_test(...)]`.
+pub(crate) fn expand_cluster_test(attr: TokenStream2, input: TokenStream2) -> TokenStream2 {
+    let mut item: syn::ItemFn = syn::parse2(input).expect("failed to parse function");
+    let test_function_name = item.sig.ident.clone();
+    let args = parse_cluster_test_args(&attr);
+    let config_expr = args.config;
+    let version_check = generate_version_check(&args.supported_versions);
+    let database_id = args.database_id;
+
+    item.sig.ident = syn::Ident::new(
+        &format!("{test_function_name}_internal"),
+        test_function_name.span(),
+    );
+    let function_name = item.sig.ident.clone();
+    let ignore_flag = ignore_flag(&item);
+    let call_expr = generate_sync_call(&function_name, &item.sig.inputs);
+
+    let tests = cluster_matrix()
+        .into_iter()
+        .filter(|v| protocol_enabled(v.protocol) && server_enabled(v.kind))
+        .map(|v| {
+            let ClusterVariant {
+                protocol,
+                name,
+                cfg,
+                cluster_type,
+                ..
+            } = v;
+            let protocol: syn::Ident = syn::Ident::new(protocol, proc_macro2::Span::call_site());
+            let name = syn::Ident::new(&name, proc_macro2::Span::call_site());
+            let ctx_creation = match &database_id {
+                Some(db_id) => quote! {
+                    let mut ctx = crate::support::TestClusterContext::new_with_config_and_builder_and_protocol(
+                        (#config_expr)
+                            .cluster_type(redis_test::cluster::ClusterType::#cluster_type),
+                        |builder| builder.database_id(#db_id),
+                        redis::ProtocolVersion::#protocol,
+                    );
+                },
+                None => quote! {
+                    let mut ctx = crate::support::TestClusterContext::new_with_config_and_protocol(
+                        (#config_expr)
+                            .cluster_type(redis_test::cluster::ClusterType::#cluster_type),
+                        redis::ProtocolVersion::#protocol,
+                    );
+                },
+            };
+            quote! {
+                #[test]
+                #ignore_flag
+                #cfg
+                fn #name() {
+                    #version_check
+                    #ctx_creation
+                    #call_expr
+                }
+            }
+        });
+
+    quote! {
+        mod #test_function_name {
+            use super::*;
+            #item
+            #(#tests)*
+        }
+    }
+}
+
+/// An (protocol × server kind × runtime) async cluster test variant.
+struct AsyncClusterVariant {
+    protocol: &'static str,
+    kind: ServerKind,
+    name: String,
+    cfg: TokenStream2,
+    cluster_type: syn::Ident,
+    runtime: syn::Ident,
+}
+
+/// Builds the full async cluster matrix: protocol × (TCP, TCP+TLS) × runtime.
+fn async_cluster_matrix() -> Vec<AsyncClusterVariant> {
+    let mut matrix = Vec::new();
+    for protocol in ["RESP2", "RESP3"] {
+        let proto_lc = protocol.to_ascii_lowercase();
+        for (kind, name, cluster_type) in [
+            (
+                ServerKind::Tcp,
+                format!("{proto_lc}_tcp"),
+                syn::Ident::new("Tcp", proc_macro2::Span::call_site()),
+            ),
+            (
+                ServerKind::Tls,
+                format!("{proto_lc}_tls"),
+                syn::Ident::new("TcpTls", proc_macro2::Span::call_site()),
+            ),
+        ] {
+            for (runtime, runtime_lc) in [
+                (
+                    syn::Ident::new("Tokio", proc_macro2::Span::call_site()),
+                    "tokio",
+                ),
+                (
+                    syn::Ident::new("Smol", proc_macro2::Span::call_site()),
+                    "smol",
+                ),
+            ] {
+                let cfg = match kind {
+                    ServerKind::Tcp => {
+                        let f = syn::LitStr::new(
+                            &format!("{runtime_lc}-comp"),
+                            proc_macro2::Span::call_site(),
+                        );
+                        quote! { #[cfg(all(feature = "cluster-async", feature = #f))] }
+                    }
+                    ServerKind::Tls => {
+                        let rf = syn::LitStr::new(
+                            &format!("{runtime_lc}-rustls-comp"),
+                            proc_macro2::Span::call_site(),
+                        );
+                        let nf = syn::LitStr::new(
+                            &format!("{runtime_lc}-native-tls-comp"),
+                            proc_macro2::Span::call_site(),
+                        );
+                        quote! {
+                            #[cfg(all(feature = "cluster-async", any(feature = #rf, feature = #nf)))]
+                        }
+                    }
+                    ServerKind::Unix => unreachable!("clusters do not support unix sockets"),
+                };
+                matrix.push(AsyncClusterVariant {
+                    protocol,
+                    kind,
+                    name: format!("{name}_{runtime_lc}"),
+                    cfg,
+                    cluster_type: cluster_type.clone(),
+                    runtime: runtime.clone(),
+                });
+            }
+        }
+    }
+    matrix
+}
+
+/// Builds the expansion for `#[async_cluster_test(...)]`.
+pub(crate) fn expand_async_cluster_test(attr: TokenStream2, input: TokenStream2) -> TokenStream2 {
+    let mut item: syn::ItemFn = syn::parse2(input).expect("failed to parse function");
+    let test_function_name = item.sig.ident.clone();
+    let args = parse_cluster_test_args(&attr);
+    let config_expr = args.config;
+    let version_check = generate_version_check(&args.supported_versions);
+    let database_id = args.database_id;
+
+    item.sig.ident = syn::Ident::new(
+        &format!("{test_function_name}_internal"),
+        test_function_name.span(),
+    );
+    let function_name = item.sig.ident.clone();
+    let ignore_flag = ignore_flag(&item);
+    let call_expr = generate_async_cluster_call(&function_name, &item.sig.inputs);
+
+    let tests = async_cluster_matrix()
+        .into_iter()
+        .filter(|v| protocol_enabled(v.protocol) && server_enabled(v.kind))
+        .map(|v| {
+            let AsyncClusterVariant {
+                protocol,
+                name,
+                cfg,
+                cluster_type,
+                runtime,
+                ..
+            } = v;
+            let protocol: syn::Ident =
+                syn::Ident::new(protocol, proc_macro2::Span::call_site());
+            let name = syn::Ident::new(&name, proc_macro2::Span::call_site());
+            let ctx_creation = match &database_id {
+                Some(db_id) => quote! {
+                    let mut ctx = crate::support::TestClusterContext::new_with_config_and_builder_and_protocol(
+                        (#config_expr)
+                            .cluster_type(redis_test::cluster::ClusterType::#cluster_type),
+                        |builder| builder.database_id(#db_id),
+                        redis::ProtocolVersion::#protocol,
+                    );
+                },
+                None => quote! {
+                    let mut ctx = crate::support::TestClusterContext::new_with_config_and_protocol(
+                        (#config_expr)
+                            .cluster_type(redis_test::cluster::ClusterType::#cluster_type),
+                        redis::ProtocolVersion::#protocol,
+                    );
+                },
+            };
+            quote! {
+                #[test]
+                #ignore_flag
+                #cfg
+                fn #name() {
+                    crate::support::block_on_all(async move {
+                        #version_check
+                        #ctx_creation
+                        #call_expr
+                    }, crate::support::RuntimeType::#runtime);
+                }
+            }
+        });
+
+    quote! {
+        mod #test_function_name {
+            use super::*;
+            #item
+            #(#tests)*
+        }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_env::{clear_env, with_env};
+
+    /// Asserts the produced expansion equals the expected full output. The expected is given as
+    /// readable source and parsed to a token stream first, then compared token-by-token via its
+    /// canonical string form (a full-output check, not a substring match).
+    fn assert_full(actual: TokenStream2, expected_src: &str) {
+        let expected: TokenStream2 = expected_src
+            .parse()
+            .expect("failed to parse expected expansion");
+        assert_eq!(actual.to_string(), expected.to_string());
+    }
+
+    /// Each case: the `#[cluster_test(...)]` attribute and the full, explicit expected
+    /// expansion for that scenario.
+    #[rstest::rstest]
+    #[case::default(
+        r#""#,
+        r#"mod test { use super :: * ; fn test_internal (ctx : & mut TestContext) { } #[test]
+    #[cfg (feature = "cluster")]
+    fn resp2_tcp () {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((redis_test :: cluster :: RedisClusterConfiguration :: default () . insecure_tls ()) . cluster_type (redis_test :: cluster :: ClusterType :: Tcp) , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (all (feature = "cluster" , any (feature = "tls-rustls" , feature = "tls-native-tls")))]
+    fn resp2_tls () {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((redis_test :: cluster :: RedisClusterConfiguration :: default () . insecure_tls ()) . cluster_type (redis_test :: cluster :: ClusterType :: TcpTls) , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (feature = "cluster")]
+    fn resp3_tcp () {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((redis_test :: cluster :: RedisClusterConfiguration :: default () . insecure_tls ()) . cluster_type (redis_test :: cluster :: ClusterType :: Tcp) , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (all (feature = "cluster" , any (feature = "tls-rustls" , feature = "tls-native-tls")))]
+    fn resp3_tls () {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((redis_test :: cluster :: RedisClusterConfiguration :: default () . insecure_tls ()) . cluster_type (redis_test :: cluster :: ClusterType :: TcpTls) , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) ; } }"#
+    )]
+    #[case::config_and_versions(
+        r#"config = "foo()", supported_versions = "Json""#,
+        r#"mod test { use super :: * ; fn test_internal (ctx : & mut TestContext) { } #[test]
+    #[cfg (feature = "cluster")]
+    fn resp2_tcp () { { let version_check_ctx = crate :: support :: TestContextBuilder :: new () . build () ; if ! crate :: support :: TestContextVersioning :: supports (& version_check_ctx , Json) { eprintln ! ("Skipping the test because the running server does not support {:?}." , Json) ; return ; } } let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((foo ()) . cluster_type (redis_test :: cluster :: ClusterType :: Tcp) , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (all (feature = "cluster" , any (feature = "tls-rustls" , feature = "tls-native-tls")))]
+    fn resp2_tls () { { let version_check_ctx = crate :: support :: TestContextBuilder :: new () . build () ; if ! crate :: support :: TestContextVersioning :: supports (& version_check_ctx , Json) { eprintln ! ("Skipping the test because the running server does not support {:?}." , Json) ; return ; } } let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((foo ()) . cluster_type (redis_test :: cluster :: ClusterType :: TcpTls) , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (feature = "cluster")]
+    fn resp3_tcp () { { let version_check_ctx = crate :: support :: TestContextBuilder :: new () . build () ; if ! crate :: support :: TestContextVersioning :: supports (& version_check_ctx , Json) { eprintln ! ("Skipping the test because the running server does not support {:?}." , Json) ; return ; } } let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((foo ()) . cluster_type (redis_test :: cluster :: ClusterType :: Tcp) , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (all (feature = "cluster" , any (feature = "tls-rustls" , feature = "tls-native-tls")))]
+    fn resp3_tls () { { let version_check_ctx = crate :: support :: TestContextBuilder :: new () . build () ; if ! crate :: support :: TestContextVersioning :: supports (& version_check_ctx , Json) { eprintln ! ("Skipping the test because the running server does not support {:?}." , Json) ; return ; } } let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((foo ()) . cluster_type (redis_test :: cluster :: ClusterType :: TcpTls) , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) ; } }"#
+    )]
+    fn cluster_test(#[case] attr: &str, #[case] expected: &str) {
+        with_env(clear_env, || {
+            let actual = expand_cluster_test(
+                attr.parse().unwrap(),
+                "fn test(ctx: &mut TestContext) {}".parse().unwrap(),
+            );
+            assert_full(actual, expected);
+        });
+    }
+
+    /// Each case: the `#[async_cluster_test(...)]` attribute and the full, explicit expected
+    /// expansion for that scenario.
+    #[rstest::rstest]
+    #[case::default(
+        r#""#,
+        r#"mod test { use super :: * ; fn test_internal (ctx : & mut TestContext) { } #[test]
+    #[cfg (all (feature = "cluster-async" , feature = "tokio-comp"))]
+    fn resp2_tcp_tokio () { crate :: support :: block_on_all (async move {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((redis_test :: cluster :: RedisClusterConfiguration :: default () . insecure_tls ()) . cluster_type (redis_test :: cluster :: ClusterType :: Tcp) , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "cluster-async" , feature = "smol-comp"))]
+    fn resp2_tcp_smol () { crate :: support :: block_on_all (async move {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((redis_test :: cluster :: RedisClusterConfiguration :: default () . insecure_tls ()) . cluster_type (redis_test :: cluster :: ClusterType :: Tcp) , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "cluster-async" , any (feature = "tokio-rustls-comp" , feature = "tokio-native-tls-comp")))]
+    fn resp2_tls_tokio () { crate :: support :: block_on_all (async move {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((redis_test :: cluster :: RedisClusterConfiguration :: default () . insecure_tls ()) . cluster_type (redis_test :: cluster :: ClusterType :: TcpTls) , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "cluster-async" , any (feature = "smol-rustls-comp" , feature = "smol-native-tls-comp")))]
+    fn resp2_tls_smol () { crate :: support :: block_on_all (async move {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((redis_test :: cluster :: RedisClusterConfiguration :: default () . insecure_tls ()) . cluster_type (redis_test :: cluster :: ClusterType :: TcpTls) , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "cluster-async" , feature = "tokio-comp"))]
+    fn resp3_tcp_tokio () { crate :: support :: block_on_all (async move {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((redis_test :: cluster :: RedisClusterConfiguration :: default () . insecure_tls ()) . cluster_type (redis_test :: cluster :: ClusterType :: Tcp) , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "cluster-async" , feature = "smol-comp"))]
+    fn resp3_tcp_smol () { crate :: support :: block_on_all (async move {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((redis_test :: cluster :: RedisClusterConfiguration :: default () . insecure_tls ()) . cluster_type (redis_test :: cluster :: ClusterType :: Tcp) , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "cluster-async" , any (feature = "tokio-rustls-comp" , feature = "tokio-native-tls-comp")))]
+    fn resp3_tls_tokio () { crate :: support :: block_on_all (async move {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((redis_test :: cluster :: RedisClusterConfiguration :: default () . insecure_tls ()) . cluster_type (redis_test :: cluster :: ClusterType :: TcpTls) , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "cluster-async" , any (feature = "smol-rustls-comp" , feature = "smol-native-tls-comp")))]
+    fn resp3_tls_smol () { crate :: support :: block_on_all (async move {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((redis_test :: cluster :: RedisClusterConfiguration :: default () . insecure_tls ()) . cluster_type (redis_test :: cluster :: ClusterType :: TcpTls) , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; } }"#
+    )]
+    #[case::config(
+        r#"config = "foo()""#,
+        r#"mod test { use super :: * ; fn test_internal (ctx : & mut TestContext) { } #[test]
+    #[cfg (all (feature = "cluster-async" , feature = "tokio-comp"))]
+    fn resp2_tcp_tokio () { crate :: support :: block_on_all (async move {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((foo ()) . cluster_type (redis_test :: cluster :: ClusterType :: Tcp) , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "cluster-async" , feature = "smol-comp"))]
+    fn resp2_tcp_smol () { crate :: support :: block_on_all (async move {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((foo ()) . cluster_type (redis_test :: cluster :: ClusterType :: Tcp) , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "cluster-async" , any (feature = "tokio-rustls-comp" , feature = "tokio-native-tls-comp")))]
+    fn resp2_tls_tokio () { crate :: support :: block_on_all (async move {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((foo ()) . cluster_type (redis_test :: cluster :: ClusterType :: TcpTls) , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "cluster-async" , any (feature = "smol-rustls-comp" , feature = "smol-native-tls-comp")))]
+    fn resp2_tls_smol () { crate :: support :: block_on_all (async move {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((foo ()) . cluster_type (redis_test :: cluster :: ClusterType :: TcpTls) , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "cluster-async" , feature = "tokio-comp"))]
+    fn resp3_tcp_tokio () { crate :: support :: block_on_all (async move {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((foo ()) . cluster_type (redis_test :: cluster :: ClusterType :: Tcp) , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "cluster-async" , feature = "smol-comp"))]
+    fn resp3_tcp_smol () { crate :: support :: block_on_all (async move {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((foo ()) . cluster_type (redis_test :: cluster :: ClusterType :: Tcp) , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "cluster-async" , any (feature = "tokio-rustls-comp" , feature = "tokio-native-tls-comp")))]
+    fn resp3_tls_tokio () { crate :: support :: block_on_all (async move {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((foo ()) . cluster_type (redis_test :: cluster :: ClusterType :: TcpTls) , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "cluster-async" , any (feature = "smol-rustls-comp" , feature = "smol-native-tls-comp")))]
+    fn resp3_tls_smol () { crate :: support :: block_on_all (async move {  let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((foo ()) . cluster_type (redis_test :: cluster :: ClusterType :: TcpTls) , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; } }"#
+    )]
+    fn async_cluster_test(#[case] attr: &str, #[case] expected: &str) {
+        with_env(clear_env, || {
+            let actual = expand_async_cluster_test(
+                attr.parse().unwrap(),
+                "fn test(ctx: &mut TestContext) {}".parse().unwrap(),
+            );
+            assert_full(actual, expected);
+        });
+    }
+
+    /// `REDISRS_SERVER_TYPE`/`PROTOCOL` filter which cluster variants are generated. Scenarios run
+    /// inside `with_env`, which holds the process-env lock so they don't race the oracle tests.
+    #[test]
+    fn env_filtered() {
+        let expand = |server: &str, protocol: Option<&str>| {
+            with_env(
+                || unsafe {
+                    std::env::set_var("REDISRS_SERVER_TYPE", server);
+                    if let Some(p) = protocol {
+                        std::env::set_var("PROTOCOL", p);
+                    }
+                },
+                || {
+                    expand_cluster_test(
+                        "".parse().unwrap(),
+                        "fn test(ctx: &mut TestContext) {}".parse().unwrap(),
+                    )
+                    .to_string()
+                },
+            )
+        };
+
+        assert_eq!(
+            expand("tcp", None),
+            r#"mod test { use super :: * ; fn test_internal (ctx : & mut TestContext) { } #[test] #[cfg (feature = "cluster")] fn resp2_tcp () { let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((redis_test :: cluster :: RedisClusterConfiguration :: default () . insecure_tls ()) . cluster_type (redis_test :: cluster :: ClusterType :: Tcp) , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) ; } #[test] #[cfg (feature = "cluster")] fn resp3_tcp () { let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((redis_test :: cluster :: RedisClusterConfiguration :: default () . insecure_tls ()) . cluster_type (redis_test :: cluster :: ClusterType :: Tcp) , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) ; } }"#
+                .parse::<TokenStream2>()
+                .unwrap()
+                .to_string()
+        );
+
+        assert_eq!(
+            expand("tcp+tls", Some("RESP2")),
+            r#"mod test { use super :: * ; fn test_internal (ctx : & mut TestContext) { } #[test] #[cfg (all (feature = "cluster" , any (feature = "tls-rustls" , feature = "tls-native-tls")))] fn resp2_tls () { let mut ctx = crate :: support :: TestClusterContext :: new_with_config_and_protocol ((redis_test :: cluster :: RedisClusterConfiguration :: default () . insecure_tls ()) . cluster_type (redis_test :: cluster :: ClusterType :: TcpTls) , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) ; } }"#
+                .parse::<TokenStream2>()
+                .unwrap()
+                .to_string()
+        );
+    }
+}

--- a/test-macros/src/lib.rs
+++ b/test-macros/src/lib.rs
@@ -1,102 +1,42 @@
 use proc_macro::TokenStream;
-use quote::quote;
+
+mod cluster;
+mod sentinel;
+mod single;
+mod test_env;
+mod utils;
 
 #[proc_macro_attribute]
-pub fn async_test(_: TokenStream, input: TokenStream) -> TokenStream {
-    let mut item = syn::parse_macro_input!(input as syn::ItemFn);
+pub fn single_server_test(attr: TokenStream, input: TokenStream) -> TokenStream {
+    single::expand_single_server_test(attr.into(), input.into()).into()
+}
 
-    let test_function_name = item.sig.ident.clone();
+#[proc_macro_attribute]
+pub fn async_single_server_test(attr: TokenStream, input: TokenStream) -> TokenStream {
+    single::expand_async_single_server_test(attr.into(), input.into()).into()
+}
 
-    item.sig.ident = syn::Ident::new(
-        &format!("{test_function_name}_internal"),
-        test_function_name.span(),
-    );
-    let function_name = item.sig.ident.clone();
+#[proc_macro_attribute]
+pub fn async_test(attr: TokenStream, input: TokenStream) -> TokenStream {
+    single::expand_async_single_server_test(attr.into(), input.into()).into()
+}
 
-    let final_code = if item.sig.inputs.len() == 1 {
-        let Some(syn::FnArg::Typed(pat_type)) = item.sig.inputs.last() else {
-            return syn::Error::new_spanned(&item.sig.inputs, "Expected typed argument")
-                .to_compile_error()
-                .into();
-        };
-        // Verify the argument is a boolean
-        let is_bool = matches!(&*pat_type.ty, syn::Type::Path(type_path)
-                if type_path.path.is_ident("bool"));
-        let is_connection = matches!(&*pat_type.ty, syn::Type::ImplTrait(impl_trait)
-        if impl_trait.bounds.iter().any(|bound| {
-            matches!(bound, syn::TypeParamBound::Trait(trait_bound)
-                if trait_bound.path.segments.last().is_some_and(|seg| seg.ident == "ConnectionLike" || seg.ident == "AsyncTypedCommands" || seg.ident == "AsyncCommands"))
-        }));
+#[proc_macro_attribute]
+pub fn cluster_test(attr: TokenStream, input: TokenStream) -> TokenStream {
+    cluster::expand_cluster_test(attr.into(), input.into()).into()
+}
 
-        if is_connection {
-            quote! {
-                mod #test_function_name {
-                    use super::*;
-                    #item
+#[proc_macro_attribute]
+pub fn async_cluster_test(attr: TokenStream, input: TokenStream) -> TokenStream {
+    cluster::expand_async_cluster_test(attr.into(), input.into()).into()
+}
 
-                    #[rstest::rstest]
-                    #[cfg_attr(feature = "tokio-comp", case::tokio(support::RuntimeType::Tokio))]
-                    #[cfg_attr(feature = "smol-comp", case::smol(support::RuntimeType::Smol))]
-                    fn multiplexed_connection (#[case]runtime: support::RuntimeType) {
-                        let ctx = TestContext::default();
-                        support::block_on_all(async move {
-                            let conn = ctx.async_connection().await.unwrap();
-                            #function_name (conn).await
-                        }, runtime);
-                    }
+#[proc_macro_attribute]
+pub fn sentinel_test(attr: TokenStream, input: TokenStream) -> TokenStream {
+    sentinel::expand_sentinel_test(attr.into(), input.into()).into()
+}
 
-                    #[rstest::rstest]
-                    #[cfg_attr(feature = "tokio-comp", case::tokio(support::RuntimeType::Tokio))]
-                    #[cfg_attr(feature = "smol-comp", case::smol(support::RuntimeType::Smol))]
-                    #[cfg(feature = "connection-manager")]
-                    fn connection_manager (#[case]runtime: support::RuntimeType) {
-                        let ctx = TestContext::default();
-                        support::block_on_all(async move {
-                            let conn = ctx.client.get_connection_manager().await.unwrap();
-                            #function_name (conn).await
-                        }, runtime);
-                    }
-
-                }
-            }
-        } else if is_bool {
-            quote! {
-                #item
-
-                #[rstest::rstest]
-                #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
-                #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
-                fn #test_function_name (#[case]runtime: RuntimeType, #[values(true, false)] arg: bool) {
-                    block_on_all(#function_name (arg), runtime);
-                }
-            }
-        } else {
-            return syn::Error::new_spanned(
-                &pat_type.ty,
-                format!("Unsupported argument type. arg pattern is: {pat_type:?}"),
-            )
-            .to_compile_error()
-            .into();
-        }
-    } else if item.sig.inputs.is_empty() {
-        quote! {
-            #item
-
-            #[rstest::rstest]
-            #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
-            #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
-            fn #test_function_name (#[case]runtime: RuntimeType) {
-                block_on_all(#function_name (), runtime);
-            }
-        }
-    } else {
-        return syn::Error::new_spanned(
-            &item.sig.inputs,
-            "Unsupported number of arguments in function",
-        )
-        .to_compile_error()
-        .into();
-    };
-
-    final_code.into()
+#[proc_macro_attribute]
+pub fn async_sentinel_test(attr: TokenStream, input: TokenStream) -> TokenStream {
+    sentinel::expand_async_sentinel_test(attr.into(), input.into()).into()
 }

--- a/test-macros/src/sentinel.rs
+++ b/test-macros/src/sentinel.rs
@@ -1,0 +1,365 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+
+use crate::test_env::{ServerKind, protocol_enabled, server_enabled};
+use crate::utils::{generate_async_call, generate_sync_call, ignore_flag};
+
+/// A (protocol × server kind) sentinel test variant. Sentinel does not support unix sockets.
+struct SentinelVariant {
+    protocol: &'static str,
+    name: String,
+    cfg: TokenStream2,
+    tls: bool,
+}
+
+/// Builds the full sentinel matrix: protocol × (TCP, TCP+TLS).
+fn sentinel_matrix() -> Vec<SentinelVariant> {
+    let mut matrix = Vec::new();
+    for protocol in ["RESP2", "RESP3"] {
+        let proto_lc = protocol.to_ascii_lowercase();
+        matrix.push(SentinelVariant {
+            protocol,
+            name: format!("{proto_lc}_tcp"),
+            cfg: quote! { #[cfg(feature = "sentinel")] },
+            tls: false,
+        });
+        matrix.push(SentinelVariant {
+            protocol,
+            name: format!("{proto_lc}_tls", ),
+            cfg: quote! {
+                #[cfg(all(feature = "sentinel", any(feature = "tls-rustls", feature = "tls-native-tls")))]
+            },
+            tls: true,
+        });
+    }
+    matrix
+}
+
+/// Builds the expansion for `#[sentinel_test]`.
+pub(crate) fn expand_sentinel_test(_attr: TokenStream2, input: TokenStream2) -> TokenStream2 {
+    let mut item: syn::ItemFn = syn::parse2(input).expect("failed to parse function");
+    let test_function_name = item.sig.ident.clone();
+
+    item.sig.ident = syn::Ident::new(
+        &format!("{test_function_name}_internal"),
+        test_function_name.span(),
+    );
+    let function_name = item.sig.ident.clone();
+    let ignore_flag = ignore_flag(&item);
+    let call_expr = generate_sync_call(&function_name, &item.sig.inputs);
+
+    let tests = sentinel_matrix()
+        .into_iter()
+        .filter(|v| {
+            protocol_enabled(v.protocol)
+                && server_enabled(if v.tls { ServerKind::Tls } else { ServerKind::Tcp })
+        })
+        .map(|v| {
+            let SentinelVariant {
+                protocol,
+                name,
+                cfg,
+                tls,
+            } = v;
+            let protocol: syn::Ident =
+                syn::Ident::new(protocol, proc_macro2::Span::call_site());
+            let name = syn::Ident::new(&name, proc_macro2::Span::call_site());
+            quote! {
+                #[test]
+                #ignore_flag
+                #cfg
+                fn #name() {
+                    let mut ctx = crate::support::TestSentinelContext::new_with_server_type_and_protocol(
+                        2,
+                        3,
+                        3,
+                        redis_test::server::ServerType::Tcp { tls: #tls },
+                        redis::ProtocolVersion::#protocol,
+                    );
+                    #call_expr
+                }
+            }
+        });
+
+    quote! {
+        mod #test_function_name {
+            use super::*;
+            #item
+            #(#tests)*
+        }
+    }
+}
+
+/// An (protocol × server kind × runtime) async sentinel test variant.
+struct AsyncSentinelVariant {
+    protocol: &'static str,
+    name: String,
+    cfg: TokenStream2,
+    tls: bool,
+    runtime: syn::Ident,
+}
+
+/// Builds the full async sentinel matrix: protocol × (TCP, TCP+TLS) × runtime.
+fn async_sentinel_matrix() -> Vec<AsyncSentinelVariant> {
+    let mut matrix = Vec::new();
+    for protocol in ["RESP2", "RESP3"] {
+        let proto_lc = protocol.to_ascii_lowercase();
+        for (name, tls) in [
+            (format!("{proto_lc}_tcp"), false),
+            (format!("{proto_lc}_tls"), true),
+        ] {
+            for (runtime, runtime_lc) in [
+                (
+                    syn::Ident::new("Tokio", proc_macro2::Span::call_site()),
+                    "tokio",
+                ),
+                (
+                    syn::Ident::new("Smol", proc_macro2::Span::call_site()),
+                    "smol",
+                ),
+            ] {
+                let cfg = if tls {
+                    let rf = syn::LitStr::new(
+                        &format!("{runtime_lc}-rustls-comp"),
+                        proc_macro2::Span::call_site(),
+                    );
+                    let nf = syn::LitStr::new(
+                        &format!("{runtime_lc}-native-tls-comp"),
+                        proc_macro2::Span::call_site(),
+                    );
+                    quote! { #[cfg(all(feature = "sentinel", any(feature = #rf, feature = #nf)))] }
+                } else {
+                    let f = syn::LitStr::new(
+                        &format!("{runtime_lc}-comp"),
+                        proc_macro2::Span::call_site(),
+                    );
+                    quote! { #[cfg(all(feature = "sentinel", feature = #f))] }
+                };
+                matrix.push(AsyncSentinelVariant {
+                    protocol,
+                    name: format!("{name}_{runtime_lc}"),
+                    cfg,
+                    tls,
+                    runtime: runtime.clone(),
+                });
+            }
+        }
+    }
+    matrix
+}
+
+/// Builds the expansion for `#[async_sentinel_test]`.
+pub(crate) fn expand_async_sentinel_test(_attr: TokenStream2, input: TokenStream2) -> TokenStream2 {
+    let mut item: syn::ItemFn = syn::parse2(input).expect("failed to parse function");
+    let test_function_name = item.sig.ident.clone();
+
+    item.sig.ident = syn::Ident::new(
+        &format!("{test_function_name}_internal"),
+        test_function_name.span(),
+    );
+    let function_name = item.sig.ident.clone();
+    let ignore_flag = ignore_flag(&item);
+    let call_expr = generate_async_call(&function_name, &item.sig.inputs);
+
+    let tests = async_sentinel_matrix()
+        .into_iter()
+        .filter(|v| {
+            protocol_enabled(v.protocol)
+                && server_enabled(if v.tls { ServerKind::Tls } else { ServerKind::Tcp })
+        })
+        .map(|v| {
+            let AsyncSentinelVariant {
+                protocol,
+                name,
+                cfg,
+                tls,
+                runtime,
+            } = v;
+            let protocol: syn::Ident =
+                syn::Ident::new(protocol, proc_macro2::Span::call_site());
+            let name = syn::Ident::new(&name, proc_macro2::Span::call_site());
+            quote! {
+                #[test]
+                #ignore_flag
+                #cfg
+                fn #name() {
+                    crate::support::block_on_all(async move {
+                        let mut ctx = crate::support::TestSentinelContext::new_with_server_type_and_protocol(
+                            2,
+                            3,
+                            3,
+                            redis_test::server::ServerType::Tcp { tls: #tls },
+                            redis::ProtocolVersion::#protocol,
+                        );
+                        #call_expr
+                    }, crate::support::RuntimeType::#runtime);
+                }
+            }
+        });
+
+    quote! {
+        mod #test_function_name {
+            use super::*;
+            #item
+            #(#tests)*
+        }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_env::{clear_env, with_env};
+
+    /// Asserts the produced expansion equals the expected full output. The expected is given as
+    /// readable source and parsed to a token stream first, then compared token-by-token via its
+    /// canonical string form (a full-output check, not a substring match).
+    fn assert_full(actual: TokenStream2, expected_src: &str) {
+        let expected: TokenStream2 = expected_src
+            .parse()
+            .expect("failed to parse expected expansion");
+        assert_eq!(actual.to_string(), expected.to_string());
+    }
+
+    /// Each case: the input function and the full, explicit expected expansion for that
+    /// `#[sentinel_test]` scenario.
+    #[rstest::rstest]
+    #[case::ctx(
+        r#"fn test(ctx: &mut TestContext) {}"#,
+        r#"mod test { use super :: * ; fn test_internal (ctx : & mut TestContext) { } #[test]
+    #[cfg (feature = "sentinel")]
+    fn resp2_tcp () { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : false } , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (all (feature = "sentinel" , any (feature = "tls-rustls" , feature = "tls-native-tls")))]
+    fn resp2_tls () { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : true } , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (feature = "sentinel")]
+    fn resp3_tcp () { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : false } , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (all (feature = "sentinel" , any (feature = "tls-rustls" , feature = "tls-native-tls")))]
+    fn resp3_tls () { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : true } , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) ; } }"#
+    )]
+    #[case::bool(
+        r#"fn test(flag: bool) {}"#,
+        r#"mod test { use super :: * ; fn test_internal (flag : bool) { } #[test]
+    #[cfg (feature = "sentinel")]
+    fn resp2_tcp () { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : false } , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (true) ; test_internal (false) ; }
+    #[test]
+    #[cfg (all (feature = "sentinel" , any (feature = "tls-rustls" , feature = "tls-native-tls")))]
+    fn resp2_tls () { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : true } , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (true) ; test_internal (false) ; }
+    #[test]
+    #[cfg (feature = "sentinel")]
+    fn resp3_tcp () { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : false } , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (true) ; test_internal (false) ; }
+    #[test]
+    #[cfg (all (feature = "sentinel" , any (feature = "tls-rustls" , feature = "tls-native-tls")))]
+    fn resp3_tls () { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : true } , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (true) ; test_internal (false) ; } }"#
+    )]
+    fn sentinel_test(#[case] item_src: &str, #[case] expected: &str) {
+        with_env(clear_env, || {
+            let actual = expand_sentinel_test("".parse().unwrap(), item_src.parse().unwrap());
+            assert_full(actual, expected);
+        });
+    }
+
+    /// Each case: the input function and the full, explicit expected expansion for that
+    /// `#[async_sentinel_test]` scenario.
+    #[rstest::rstest]
+    #[case::ctx(
+        r#"fn test(ctx: &mut TestContext) {}"#,
+        r#"mod test { use super :: * ; fn test_internal (ctx : & mut TestContext) { } #[test]
+    #[cfg (all (feature = "sentinel" , feature = "tokio-comp"))]
+    fn resp2_tcp_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : false } , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "sentinel" , feature = "smol-comp"))]
+    fn resp2_tcp_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : false } , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "sentinel" , any (feature = "tokio-rustls-comp" , feature = "tokio-native-tls-comp")))]
+    fn resp2_tls_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : true } , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "sentinel" , any (feature = "smol-rustls-comp" , feature = "smol-native-tls-comp")))]
+    fn resp2_tls_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : true } , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "sentinel" , feature = "tokio-comp"))]
+    fn resp3_tcp_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : false } , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "sentinel" , feature = "smol-comp"))]
+    fn resp3_tcp_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : false } , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "sentinel" , any (feature = "tokio-rustls-comp" , feature = "tokio-native-tls-comp")))]
+    fn resp3_tls_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : true } , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "sentinel" , any (feature = "smol-rustls-comp" , feature = "smol-native-tls-comp")))]
+    fn resp3_tls_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : true } , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; } }"#
+    )]
+    #[case::connection(
+        r#"fn test(conn: &mut Connection) {}"#,
+        r#"mod test { use super :: * ; fn test_internal (conn : & mut Connection) { } #[test]
+    #[cfg (all (feature = "sentinel" , feature = "tokio-comp"))]
+    fn resp2_tcp_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : false } , redis :: ProtocolVersion :: RESP2 , ) ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "sentinel" , feature = "smol-comp"))]
+    fn resp2_tcp_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : false } , redis :: ProtocolVersion :: RESP2 , ) ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "sentinel" , any (feature = "tokio-rustls-comp" , feature = "tokio-native-tls-comp")))]
+    fn resp2_tls_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : true } , redis :: ProtocolVersion :: RESP2 , ) ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "sentinel" , any (feature = "smol-rustls-comp" , feature = "smol-native-tls-comp")))]
+    fn resp2_tls_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : true } , redis :: ProtocolVersion :: RESP2 , ) ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "sentinel" , feature = "tokio-comp"))]
+    fn resp3_tcp_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : false } , redis :: ProtocolVersion :: RESP3 , ) ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "sentinel" , feature = "smol-comp"))]
+    fn resp3_tcp_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : false } , redis :: ProtocolVersion :: RESP3 , ) ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "sentinel" , any (feature = "tokio-rustls-comp" , feature = "tokio-native-tls-comp")))]
+    fn resp3_tls_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : true } , redis :: ProtocolVersion :: RESP3 , ) ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "sentinel" , any (feature = "smol-rustls-comp" , feature = "smol-native-tls-comp")))]
+    fn resp3_tls_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : true } , redis :: ProtocolVersion :: RESP3 , ) ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Smol) ; } }"#
+    )]
+    fn async_sentinel_test(#[case] item_src: &str, #[case] expected: &str) {
+        with_env(clear_env, || {
+            let actual = expand_async_sentinel_test("".parse().unwrap(), item_src.parse().unwrap());
+            assert_full(actual, expected);
+        });
+    }
+
+    /// `REDISRS_SERVER_TYPE`/`PROTOCOL` filter which sentinel variants are generated. Scenarios run
+    /// inside `with_env`, which holds the process-env lock so they don't race the oracle tests.
+    #[test]
+    fn env_filtered() {
+        let expand = |server: &str, protocol: Option<&str>| {
+            with_env(
+                || unsafe {
+                    std::env::set_var("REDISRS_SERVER_TYPE", server);
+                    if let Some(p) = protocol {
+                        std::env::set_var("PROTOCOL", p);
+                    }
+                },
+                || {
+                    expand_sentinel_test(
+                        "".parse().unwrap(),
+                        "fn test(ctx: &mut TestContext) {}".parse().unwrap(),
+                    )
+                    .to_string()
+                },
+            )
+        };
+
+        assert_eq!(
+            expand("tcp", None),
+            r#"mod test { use super :: * ; fn test_internal (ctx : & mut TestContext) { } #[test] #[cfg (feature = "sentinel")] fn resp2_tcp () { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : false } , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) ; } #[test] #[cfg (feature = "sentinel")] fn resp3_tcp () { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : false } , redis :: ProtocolVersion :: RESP3 , ) ; test_internal (& mut ctx) ; } }"#
+                .parse::<TokenStream2>()
+                .unwrap()
+                .to_string()
+        );
+
+        assert_eq!(
+            expand("tcp+tls", Some("RESP2")),
+            r#"mod test { use super :: * ; fn test_internal (ctx : & mut TestContext) { } #[test] #[cfg (all (feature = "sentinel" , any (feature = "tls-rustls" , feature = "tls-native-tls")))] fn resp2_tls () { let mut ctx = crate :: support :: TestSentinelContext :: new_with_server_type_and_protocol (2 , 3 , 3 , redis_test :: server :: ServerType :: Tcp { tls : true } , redis :: ProtocolVersion :: RESP2 , ) ; test_internal (& mut ctx) ; } }"#
+                .parse::<TokenStream2>()
+                .unwrap()
+                .to_string()
+        );
+    }
+}

--- a/test-macros/src/single.rs
+++ b/test-macros/src/single.rs
@@ -1,0 +1,757 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+
+use crate::test_env::{ServerKind, protocol_enabled, server_enabled};
+use crate::utils::{
+    generate_async_call, generate_sync_call, ignore_flag, parse_module_from_attr,
+    parse_mtls_from_attr,
+};
+
+/// A single (protocol × server kind) sync test variant.
+struct SyncVariant {
+    protocol: &'static str,
+    kind: ServerKind,
+    name: String,
+    cfg: TokenStream2,
+    server_type: TokenStream2,
+}
+
+/// The full sync single-server matrix (protocol × server type).
+fn single_server_matrix() -> Vec<SyncVariant> {
+    let tcp = quote! { redis_test::server::ServerType::Tcp { tls: false } };
+    let tls = quote! { redis_test::server::ServerType::Tcp { tls: true } };
+    let unix = quote! { redis_test::server::ServerType::Unix };
+    let tls_cfg = quote! { #[cfg(any(feature = "tls-rustls", feature = "tls-native-tls"))] };
+    let unix_cfg = quote! { #[cfg(unix)] };
+    let mut matrix = Vec::new();
+    for protocol in ["RESP2", "RESP3"] {
+        let proto_lc = protocol.to_ascii_lowercase();
+        matrix.push(SyncVariant {
+            protocol,
+            kind: ServerKind::Tcp,
+            name: format!("{proto_lc}_tcp"),
+            cfg: quote! {},
+            server_type: tcp.clone(),
+        });
+        matrix.push(SyncVariant {
+            protocol,
+            kind: ServerKind::Tls,
+            name: format!("{proto_lc}_tls"),
+            cfg: tls_cfg.clone(),
+            server_type: tls.clone(),
+        });
+        matrix.push(SyncVariant {
+            protocol,
+            kind: ServerKind::Unix,
+            name: format!("{proto_lc}_unix"),
+            cfg: unix_cfg.clone(),
+            server_type: unix.clone(),
+        });
+    }
+    matrix
+}
+
+/// An (protocol × server kind × runtime) async test variant.
+struct AsyncVariant {
+    protocol: &'static str,
+    kind: ServerKind,
+    name: String,
+    cfg: TokenStream2,
+    server_type: TokenStream2,
+    runtime: syn::Ident,
+}
+
+/// Builds the async single-server matrix (protocol × server type × runtime).
+fn async_single_server_matrix() -> Vec<AsyncVariant> {
+    let tcp = quote! { redis_test::server::ServerType::Tcp { tls: false } };
+    let tls = quote! { redis_test::server::ServerType::Tcp { tls: true } };
+    let unix = quote! { redis_test::server::ServerType::Unix };
+    let mut matrix = Vec::new();
+    for protocol in ["RESP2", "RESP3"] {
+        let proto_lc = protocol.to_ascii_lowercase();
+        for (kind, name, server_type) in [
+            (ServerKind::Tcp, format!("{proto_lc}_tcp"), tcp.clone()),
+            (ServerKind::Tls, format!("{proto_lc}_tls"), tls.clone()),
+            (ServerKind::Unix, format!("{proto_lc}_unix"), unix.clone()),
+        ] {
+            for (runtime, runtime_lc) in [
+                (
+                    syn::Ident::new("Tokio", proc_macro2::Span::call_site()),
+                    "tokio",
+                ),
+                (
+                    syn::Ident::new("Smol", proc_macro2::Span::call_site()),
+                    "smol",
+                ),
+            ] {
+                let feature = |name: &str| {
+                    syn::LitStr::new(
+                        &format!("{runtime_lc}-{name}"),
+                        proc_macro2::Span::call_site(),
+                    )
+                };
+                let cfg = match kind {
+                    ServerKind::Tcp => {
+                        let f = syn::LitStr::new(
+                            &format!("{runtime_lc}-comp"),
+                            proc_macro2::Span::call_site(),
+                        );
+                        quote! { #[cfg(feature = #f)] }
+                    }
+                    ServerKind::Tls => {
+                        let rf = feature("rustls-comp");
+                        let nf = feature("native-tls-comp");
+                        quote! { #[cfg(any(feature = #rf, feature = #nf))] }
+                    }
+                    ServerKind::Unix => {
+                        let f = syn::LitStr::new(
+                            &format!("{runtime_lc}-comp"),
+                            proc_macro2::Span::call_site(),
+                        );
+                        quote! { #[cfg(all(feature = #f, unix))] }
+                    }
+                };
+                matrix.push(AsyncVariant {
+                    protocol,
+                    kind,
+                    name: format!("{name}_{runtime_lc}"),
+                    cfg,
+                    server_type: server_type.clone(),
+                    runtime: runtime.clone(),
+                });
+            }
+        }
+    }
+    matrix
+}
+
+/// Builds the expansion for `#[single_server_test(...)]`.
+pub(crate) fn expand_single_server_test(attr: TokenStream2, input: TokenStream2) -> TokenStream2 {
+    let mut item: syn::ItemFn = syn::parse2(input).expect("failed to parse function");
+    let test_function_name = item.sig.ident.clone();
+    let module_expr = parse_module_from_attr(&attr);
+    let mtls_expr = parse_mtls_from_attr(&attr);
+    let is_mtls = !mtls_expr.is_empty();
+
+    item.sig.ident = syn::Ident::new(
+        &format!("{test_function_name}_internal"),
+        test_function_name.span(),
+    );
+    let function_name = item.sig.ident.clone();
+    let ignore_flag = ignore_flag(&item);
+    let call_expr = generate_sync_call(&function_name, &item.sig.inputs);
+
+    let tests = single_server_matrix()
+        .into_iter()
+        .filter(|v| {
+            protocol_enabled(v.protocol)
+                && server_enabled(v.kind)
+                && (!is_mtls || v.kind == ServerKind::Tls)
+        })
+        .map(|v| {
+            let SyncVariant {
+                protocol,
+                name,
+                cfg,
+                server_type,
+                ..
+            } = v;
+            let protocol: syn::Ident = syn::Ident::new(protocol, proc_macro2::Span::call_site());
+            let name = syn::Ident::new(&name, proc_macro2::Span::call_site());
+            quote! {
+                #[test]
+                #ignore_flag
+                #cfg
+                fn #name() {
+                    let mut ctx = crate::support::TestContextBuilder::new()
+                        #module_expr
+                        #mtls_expr
+                        .protocol(redis::ProtocolVersion::#protocol)
+                        .server_type(#server_type)
+                        .build();
+                    #call_expr
+                }
+            }
+        });
+
+    quote! {
+        mod #test_function_name {
+            use super::*;
+            #item
+            #(#tests)*
+        }
+    }
+}
+
+/// Builds the expansion for `#[async_single_server_test(...)]`.
+pub(crate) fn expand_async_single_server_test(
+    attr: TokenStream2,
+    input: TokenStream2,
+) -> TokenStream2 {
+    let mut item: syn::ItemFn = syn::parse2(input).expect("failed to parse function");
+    let test_function_name = item.sig.ident.clone();
+    let module_expr = parse_module_from_attr(&attr);
+    let mtls_expr = parse_mtls_from_attr(&attr);
+    let is_mtls = !mtls_expr.is_empty();
+
+    item.sig.ident = syn::Ident::new(
+        &format!("{test_function_name}_internal"),
+        test_function_name.span(),
+    );
+    let function_name = item.sig.ident.clone();
+    let ignore_flag = ignore_flag(&item);
+    let call_expr = generate_async_call(&function_name, &item.sig.inputs);
+
+    let tests = async_single_server_matrix()
+        .into_iter()
+        .filter(|v| {
+            protocol_enabled(v.protocol)
+                && server_enabled(v.kind)
+                && (!is_mtls || v.kind == ServerKind::Tls)
+        })
+        .map(|v| {
+            let AsyncVariant {
+                protocol,
+                name,
+                cfg,
+                server_type,
+                runtime,
+                ..
+            } = v;
+            let protocol: syn::Ident = syn::Ident::new(protocol, proc_macro2::Span::call_site());
+            let name = syn::Ident::new(&name, proc_macro2::Span::call_site());
+            quote! {
+                #[test]
+                #ignore_flag
+                #cfg
+                fn #name() {
+                    crate::support::block_on_all(async move {
+                        let mut ctx = crate::support::TestContextBuilder::new()
+                            #module_expr
+                            #mtls_expr
+                            .protocol(redis::ProtocolVersion::#protocol)
+                            .server_type(#server_type)
+                            .build();
+                        #call_expr
+                    }, crate::support::RuntimeType::#runtime);
+                }
+            }
+        });
+
+    quote! {
+        mod #test_function_name {
+            use super::*;
+            #item
+            #(#tests)*
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_env::{clear_env, with_env};
+
+    /// Asserts the produced expansion equals the expected full output. The expected is given as
+    /// readable source and parsed to a token stream first, then compared token-by-token via its
+    /// canonical string form (a full-output check, not a substring match).
+    fn assert_full(actual: TokenStream2, expected_src: &str) {
+        let expected: TokenStream2 = expected_src
+            .parse()
+            .expect("failed to parse expected expansion");
+        assert_eq!(actual.to_string(), expected.to_string());
+    }
+
+    #[rstest::rstest]
+    #[case::no_attr(
+        r#""#,
+        r#"fn test(ctx: &mut TestContext) {}"#,
+        r#"mod test { use super :: * ; fn test_internal (ctx : & mut TestContext) { } #[test]
+    fn resp2_tcp () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (any (feature = "tls-rustls" , feature = "tls-native-tls"))]
+    fn resp2_tls () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (unix)]
+    fn resp2_unix () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (& mut ctx) ; }
+    #[test]
+    fn resp3_tcp () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (any (feature = "tls-rustls" , feature = "tls-native-tls"))]
+    fn resp3_tls () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (unix)]
+    fn resp3_unix () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (& mut ctx) ; } }"#
+    )]
+    #[case::json(
+        r#"json"#,
+        r#"fn test(ctx: &mut TestContext) {}"#,
+        r#"mod test { use super :: * ; fn test_internal (ctx : & mut TestContext) { } #[test]
+    fn resp2_tcp () { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Json) . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (any (feature = "tls-rustls" , feature = "tls-native-tls"))]
+    fn resp2_tls () { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Json) . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (unix)]
+    fn resp2_unix () { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Json) . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (& mut ctx) ; }
+    #[test]
+    fn resp3_tcp () { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Json) . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (any (feature = "tls-rustls" , feature = "tls-native-tls"))]
+    fn resp3_tls () { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Json) . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (unix)]
+    fn resp3_unix () { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Json) . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (& mut ctx) ; } }"#
+    )]
+    #[case::bloom(
+        r#"bloom"#,
+        r#"fn test(ctx: &mut TestContext) {}"#,
+        r#"mod test { use super :: * ; fn test_internal (ctx : & mut TestContext) { } #[test]
+    fn resp2_tcp () { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Bloom) . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (any (feature = "tls-rustls" , feature = "tls-native-tls"))]
+    fn resp2_tls () { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Bloom) . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (unix)]
+    fn resp2_unix () { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Bloom) . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (& mut ctx) ; }
+    #[test]
+    fn resp3_tcp () { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Bloom) . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (any (feature = "tls-rustls" , feature = "tls-native-tls"))]
+    fn resp3_tls () { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Bloom) . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (& mut ctx) ; }
+    #[test]
+    #[cfg (unix)]
+    fn resp3_unix () { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Bloom) . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (& mut ctx) ; } }"#
+    )]
+    #[case::bool(
+        r#""#,
+        r#"fn test(flag: bool) {}"#,
+        r#"mod test { use super :: * ; fn test_internal (flag : bool) { } #[test]
+    fn resp2_tcp () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (true) ; test_internal (false) ; }
+    #[test]
+    #[cfg (any (feature = "tls-rustls" , feature = "tls-native-tls"))]
+    fn resp2_tls () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (true) ; test_internal (false) ; }
+    #[test]
+    #[cfg (unix)]
+    fn resp2_unix () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (true) ; test_internal (false) ; }
+    #[test]
+    fn resp3_tcp () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (true) ; test_internal (false) ; }
+    #[test]
+    #[cfg (any (feature = "tls-rustls" , feature = "tls-native-tls"))]
+    fn resp3_tls () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (true) ; test_internal (false) ; }
+    #[test]
+    #[cfg (unix)]
+    fn resp3_unix () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (true) ; test_internal (false) ; } }"#
+    )]
+    #[case::connection(
+        r#""#,
+        r#"fn test(conn: &mut Connection) {}"#,
+        r#"mod test { use super :: * ; fn test_internal (conn : & mut Connection) { } #[test]
+    fn resp2_tcp () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; let mut conn = ctx . connection () ; test_internal (& mut conn) ; }
+    #[test]
+    #[cfg (any (feature = "tls-rustls" , feature = "tls-native-tls"))]
+    fn resp2_tls () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; let mut conn = ctx . connection () ; test_internal (& mut conn) ; }
+    #[test]
+    #[cfg (unix)]
+    fn resp2_unix () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; let mut conn = ctx . connection () ; test_internal (& mut conn) ; }
+    #[test]
+    fn resp3_tcp () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; let mut conn = ctx . connection () ; test_internal (& mut conn) ; }
+    #[test]
+    #[cfg (any (feature = "tls-rustls" , feature = "tls-native-tls"))]
+    fn resp3_tls () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; let mut conn = ctx . connection () ; test_internal (& mut conn) ; }
+    #[test]
+    #[cfg (unix)]
+    fn resp3_unix () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; let mut conn = ctx . connection () ; test_internal (& mut conn) ; } }"#
+    )]
+    #[case::empty(
+        r#""#,
+        r#"fn test() {}"#,
+        r#"mod test { use super :: * ; fn test_internal () { } #[test]
+    fn resp2_tcp () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal () ; }
+    #[test]
+    #[cfg (any (feature = "tls-rustls" , feature = "tls-native-tls"))]
+    fn resp2_tls () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal () ; }
+    #[test]
+    #[cfg (unix)]
+    fn resp2_unix () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal () ; }
+    #[test]
+    fn resp3_tcp () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal () ; }
+    #[test]
+    #[cfg (any (feature = "tls-rustls" , feature = "tls-native-tls"))]
+    fn resp3_tls () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal () ; }
+    #[test]
+    #[cfg (unix)]
+    fn resp3_unix () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal () ; } }"#
+    )]
+    /// Each case: the `#[single_server_test]` attribute, the input function, and the full,
+    /// explicit expected expansion for that scenario.
+    fn single_server(#[case] attr: &str, #[case] item_src: &str, #[case] expected: &str) {
+        with_env(clear_env, || {
+            let actual =
+                expand_single_server_test(attr.parse().unwrap(), item_src.parse().unwrap());
+            assert_full(actual, expected);
+        });
+    }
+
+    #[rstest::rstest]
+    #[case::no_attr(
+        r#""#,
+        r#"fn test(ctx: &mut TestContext) {}"#,
+        r#"mod test { use super :: * ; fn test_internal (ctx : & mut TestContext) { } #[test]
+    #[cfg (feature = "tokio-comp")]
+    fn resp2_tcp_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (feature = "smol-comp")]
+    fn resp2_tcp_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (any (feature = "tokio-rustls-comp" , feature = "tokio-native-tls-comp"))]
+    fn resp2_tls_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (any (feature = "smol-rustls-comp" , feature = "smol-native-tls-comp"))]
+    fn resp2_tls_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "tokio-comp" , unix))]
+    fn resp2_unix_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "smol-comp" , unix))]
+    fn resp2_unix_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (feature = "tokio-comp")]
+    fn resp3_tcp_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (feature = "smol-comp")]
+    fn resp3_tcp_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (any (feature = "tokio-rustls-comp" , feature = "tokio-native-tls-comp"))]
+    fn resp3_tls_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (any (feature = "smol-rustls-comp" , feature = "smol-native-tls-comp"))]
+    fn resp3_tls_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "tokio-comp" , unix))]
+    fn resp3_unix_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "smol-comp" , unix))]
+    fn resp3_unix_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; } }"#
+    )]
+    #[case::json(
+        r#"json"#,
+        r#"fn test(ctx: &mut TestContext) {}"#,
+        r#"mod test { use super :: * ; fn test_internal (ctx : & mut TestContext) { } #[test]
+    #[cfg (feature = "tokio-comp")]
+    fn resp2_tcp_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Json) . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (feature = "smol-comp")]
+    fn resp2_tcp_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Json) . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (any (feature = "tokio-rustls-comp" , feature = "tokio-native-tls-comp"))]
+    fn resp2_tls_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Json) . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (any (feature = "smol-rustls-comp" , feature = "smol-native-tls-comp"))]
+    fn resp2_tls_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Json) . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "tokio-comp" , unix))]
+    fn resp2_unix_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Json) . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "smol-comp" , unix))]
+    fn resp2_unix_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Json) . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (feature = "tokio-comp")]
+    fn resp3_tcp_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Json) . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (feature = "smol-comp")]
+    fn resp3_tcp_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Json) . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (any (feature = "tokio-rustls-comp" , feature = "tokio-native-tls-comp"))]
+    fn resp3_tls_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Json) . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (any (feature = "smol-rustls-comp" , feature = "smol-native-tls-comp"))]
+    fn resp3_tls_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Json) . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "tokio-comp" , unix))]
+    fn resp3_unix_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Json) . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "smol-comp" , unix))]
+    fn resp3_unix_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new (). module (redis_test :: server :: Module :: Json) . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (& mut ctx) . await ; } , crate :: support :: RuntimeType :: Smol) ; } }"#
+    )]
+    #[case::bool(
+        r#""#,
+        r#"fn test(flag: bool) {}"#,
+        r#"mod test { use super :: * ; fn test_internal (flag : bool) { } #[test]
+    #[cfg (feature = "tokio-comp")]
+    fn resp2_tcp_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (true) . await ; test_internal (false) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (feature = "smol-comp")]
+    fn resp2_tcp_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (true) . await ; test_internal (false) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (any (feature = "tokio-rustls-comp" , feature = "tokio-native-tls-comp"))]
+    fn resp2_tls_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (true) . await ; test_internal (false) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (any (feature = "smol-rustls-comp" , feature = "smol-native-tls-comp"))]
+    fn resp2_tls_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (true) . await ; test_internal (false) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "tokio-comp" , unix))]
+    fn resp2_unix_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (true) . await ; test_internal (false) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "smol-comp" , unix))]
+    fn resp2_unix_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (true) . await ; test_internal (false) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (feature = "tokio-comp")]
+    fn resp3_tcp_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (true) . await ; test_internal (false) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (feature = "smol-comp")]
+    fn resp3_tcp_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (true) . await ; test_internal (false) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (any (feature = "tokio-rustls-comp" , feature = "tokio-native-tls-comp"))]
+    fn resp3_tls_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (true) . await ; test_internal (false) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (any (feature = "smol-rustls-comp" , feature = "smol-native-tls-comp"))]
+    fn resp3_tls_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (true) . await ; test_internal (false) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "tokio-comp" , unix))]
+    fn resp3_unix_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (true) . await ; test_internal (false) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "smol-comp" , unix))]
+    fn resp3_unix_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (true) . await ; test_internal (false) . await ; } , crate :: support :: RuntimeType :: Smol) ; } }"#
+    )]
+    #[case::connection(
+        r#""#,
+        r#"fn test(conn: &mut Connection) {}"#,
+        r#"mod test { use super :: * ; fn test_internal (conn : & mut Connection) { } #[test]
+    #[cfg (feature = "tokio-comp")]
+    fn resp2_tcp_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (feature = "smol-comp")]
+    fn resp2_tcp_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (any (feature = "tokio-rustls-comp" , feature = "tokio-native-tls-comp"))]
+    fn resp2_tls_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (any (feature = "smol-rustls-comp" , feature = "smol-native-tls-comp"))]
+    fn resp2_tls_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "tokio-comp" , unix))]
+    fn resp2_unix_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "smol-comp" , unix))]
+    fn resp2_unix_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (feature = "tokio-comp")]
+    fn resp3_tcp_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (feature = "smol-comp")]
+    fn resp3_tcp_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (any (feature = "tokio-rustls-comp" , feature = "tokio-native-tls-comp"))]
+    fn resp3_tls_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (any (feature = "smol-rustls-comp" , feature = "smol-native-tls-comp"))]
+    fn resp3_tls_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "tokio-comp" , unix))]
+    fn resp3_unix_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "smol-comp" , unix))]
+    fn resp3_unix_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; let mut conn = ctx . async_connection () . await . unwrap () ; test_internal (& mut conn) . await ; } , crate :: support :: RuntimeType :: Smol) ; } }"#
+    )]
+    #[case::empty(
+        r#""#,
+        r#"fn test() {}"#,
+        r#"mod test { use super :: * ; fn test_internal () { } #[test]
+    #[cfg (feature = "tokio-comp")]
+    fn resp2_tcp_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal () . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (feature = "smol-comp")]
+    fn resp2_tcp_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal () . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (any (feature = "tokio-rustls-comp" , feature = "tokio-native-tls-comp"))]
+    fn resp2_tls_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal () . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (any (feature = "smol-rustls-comp" , feature = "smol-native-tls-comp"))]
+    fn resp2_tls_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal () . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "tokio-comp" , unix))]
+    fn resp2_unix_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal () . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "smol-comp" , unix))]
+    fn resp2_unix_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal () . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (feature = "tokio-comp")]
+    fn resp3_tcp_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal () . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (feature = "smol-comp")]
+    fn resp3_tcp_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal () . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (any (feature = "tokio-rustls-comp" , feature = "tokio-native-tls-comp"))]
+    fn resp3_tls_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal () . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (any (feature = "smol-rustls-comp" , feature = "smol-native-tls-comp"))]
+    fn resp3_tls_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal () . await ; } , crate :: support :: RuntimeType :: Smol) ; }
+    #[test]
+    #[cfg (all (feature = "tokio-comp" , unix))]
+    fn resp3_unix_tokio () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal () . await ; } , crate :: support :: RuntimeType :: Tokio) ; }
+    #[test]
+    #[cfg (all (feature = "smol-comp" , unix))]
+    fn resp3_unix_smol () { crate :: support :: block_on_all (async move { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal () . await ; } , crate :: support :: RuntimeType :: Smol) ; } }"#
+    )]
+    /// Each case: the `#[async_single_server_test]` attribute, the input function, and the full,
+    /// explicit expected expansion for that scenario.
+    fn async_single_server(#[case] attr: &str, #[case] item_src: &str, #[case] expected: &str) {
+        with_env(clear_env, || {
+            let actual =
+                expand_async_single_server_test(attr.parse().unwrap(), item_src.parse().unwrap());
+            assert_full(actual, expected);
+        });
+    }
+
+    /// `#[single_server_test]` must propagate an `#[ignore]` on the input fn to the internal fn
+    /// and every generated test fn.
+    #[test]
+    fn single_server_ignore_flag() {
+        with_env(clear_env, || {
+            let item: TokenStream2 = "#[ignore]\nfn test(ctx: &mut TestContext) {}"
+                .parse()
+                .unwrap();
+            assert_full(
+                expand_single_server_test("".parse().unwrap(), item),
+                r#"mod test { use super :: * ; #[ignore] fn test_internal (ctx : & mut TestContext) { } #[test] #[ignore] fn resp2_tcp () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (& mut ctx) ; } #[test] #[ignore] #[cfg (any (feature = "tls-rustls" , feature = "tls-native-tls"))] fn resp2_tls () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (& mut ctx) ; } #[test] #[ignore] #[cfg (unix)] fn resp2_unix () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (& mut ctx) ; } #[test] #[ignore] fn resp3_tcp () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (& mut ctx) ; } #[test] #[ignore] #[cfg (any (feature = "tls-rustls" , feature = "tls-native-tls"))] fn resp3_tls () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (& mut ctx) ; } #[test] #[ignore] #[cfg (unix)] fn resp3_unix () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (& mut ctx) ; } }"#,
+            );
+        });
+    }
+
+    /// `REDISRS_SERVER_TYPE` and `PROTOCOL` filter which variants are generated. Each scenario
+    /// expands under a specific env combination inside `with_env`, which holds the process-env lock
+    /// so it cannot race with the full-output oracle tests in other threads.
+    #[test]
+    fn env_filtered() {
+        let expand = |server: &str, protocol: Option<&str>| {
+            with_env(
+                || unsafe {
+                    std::env::set_var("REDISRS_SERVER_TYPE", server);
+                    if let Some(p) = protocol {
+                        std::env::set_var("PROTOCOL", p);
+                    }
+                },
+                || {
+                    let out = expand_single_server_test(
+                        "".parse().unwrap(),
+                        "fn test(ctx: &mut TestContext) {}".parse().unwrap(),
+                    );
+                    out.to_string()
+                },
+            )
+        };
+
+        assert_eq!(
+            expand("tcp", None),
+            r#"mod test { use super :: * ; fn test_internal (ctx : & mut TestContext) { } #[test] fn resp2_tcp () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (& mut ctx) ; } #[test] fn resp3_tcp () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : false }) . build () ; test_internal (& mut ctx) ; } }"#
+                .parse::<TokenStream2>()
+                .unwrap()
+                .to_string()
+        );
+
+        assert_eq!(
+            expand("tcp+tls", None),
+            r#"mod test { use super :: * ; fn test_internal (ctx : & mut TestContext) { } #[test] #[cfg (any (feature = "tls-rustls" , feature = "tls-native-tls"))] fn resp2_tls () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP2) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (& mut ctx) ; } #[test] #[cfg (any (feature = "tls-rustls" , feature = "tls-native-tls"))] fn resp3_tls () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Tcp { tls : true }) . build () ; test_internal (& mut ctx) ; } }"#
+                .parse::<TokenStream2>()
+                .unwrap()
+                .to_string()
+        );
+
+        assert_eq!(
+            expand("unix", Some("RESP3")),
+            r#"mod test { use super :: * ; fn test_internal (ctx : & mut TestContext) { } #[test] #[cfg (unix)] fn resp3_unix () { let mut ctx = crate :: support :: TestContextBuilder :: new () . protocol (redis :: ProtocolVersion :: RESP3) . server_type (redis_test :: server :: ServerType :: Unix) . build () ; test_internal (& mut ctx) ; } }"#
+                .parse::<TokenStream2>()
+                .unwrap()
+                .to_string()
+        );
+    }
+
+    /// `mtls = true` must only generate TLS variants and include `.mtls(true)` in the builder.
+    #[test]
+    fn mtls_only_tls_variants() {
+        with_env(clear_env, || {
+            let out = expand_single_server_test(
+                r#"mtls = true"#.parse().unwrap(),
+                "fn test(ctx: &mut TestContext) {}".parse().unwrap(),
+            );
+            let s = out.to_string();
+            // Must contain .mtls(true)
+            assert!(s.contains(". mtls (true)"), "missing .mtls(true)");
+            // Must contain only tls variants
+            assert!(s.contains("resp2_tls"), "missing resp2_tls");
+            assert!(s.contains("resp3_tls"), "missing resp3_tls");
+            assert!(!s.contains("resp2_tcp"), "should not contain resp2_tcp");
+            assert!(!s.contains("resp3_tcp"), "should not contain resp3_tcp");
+            assert!(!s.contains("resp2_unix"), "should not contain resp2_unix");
+            assert!(!s.contains("resp3_unix"), "should not contain resp3_unix");
+        });
+    }
+
+    /// `mtls = true` must only generate TLS variants for async too.
+    #[test]
+    fn mtls_async_only_tls_variants() {
+        with_env(clear_env, || {
+            let out = expand_async_single_server_test(
+                r#"mtls = true"#.parse().unwrap(),
+                "fn test(ctx: &mut TestContext) {}".parse().unwrap(),
+            );
+            let s = out.to_string();
+            assert!(s.contains(". mtls (true)"), "missing .mtls(true)");
+            assert!(s.contains("resp2_tls_tokio"), "missing resp2_tls_tokio");
+            assert!(s.contains("resp3_tls_tokio"), "missing resp3_tls_tokio");
+            assert!(
+                !s.contains("resp2_tcp_tokio"),
+                "should not contain tcp variants"
+            );
+            assert!(
+                !s.contains("resp2_unix_tokio"),
+                "should not contain unix variants"
+            );
+        });
+    }
+
+    /// `module = "json"` named-arg form must work the same as bare `json`.
+    #[test]
+    fn module_named_arg_json() {
+        with_env(clear_env, || {
+            let out = expand_single_server_test(
+                r#"module = "json""#.parse().unwrap(),
+                "fn test(ctx: &mut TestContext) {}".parse().unwrap(),
+            );
+            let s = out.to_string();
+            assert!(
+                s.contains(". module (redis_test :: server :: Module :: Json)"),
+                "missing Module::Json"
+            );
+            // Should still have all 6 variants (no filtering)
+            assert!(s.contains("resp2_tcp"));
+            assert!(s.contains("resp3_tcp"));
+            assert!(s.contains("resp2_tls"));
+            assert!(s.contains("resp3_tls"));
+            assert!(s.contains("resp2_unix"));
+            assert!(s.contains("resp3_unix"));
+        });
+    }
+
+    /// `module = "json", mtls = true` must combine both: module loaded + TLS-only variants.
+    #[test]
+    fn module_and_mtls_combined() {
+        with_env(clear_env, || {
+            let out = expand_single_server_test(
+                r#"module = "json", mtls = true"#.parse().unwrap(),
+                "fn test(ctx: &mut TestContext) {}".parse().unwrap(),
+            );
+            let s = out.to_string();
+            assert!(
+                s.contains(". module (redis_test :: server :: Module :: Json)"),
+                "missing Module::Json"
+            );
+            assert!(s.contains(". mtls (true)"), "missing .mtls(true)");
+            assert!(s.contains("resp2_tls"));
+            assert!(s.contains("resp3_tls"));
+            assert!(!s.contains("resp2_tcp"));
+            assert!(!s.contains("resp2_unix"));
+        });
+    }
+}

--- a/test-macros/src/test_env.rs
+++ b/test-macros/src/test_env.rs
@@ -1,0 +1,77 @@
+use std::env;
+
+/// The server transports / connection kinds that the test macros can generate.
+///
+/// These mirror the values accepted by `REDISRS_SERVER_TYPE`:
+///   - `tcp`    => plain TCP (`ServerType::Tcp { tls: false }` / `ClusterType::Tcp`)
+///   - `tcp+tls`=> TCP with TLS (`ServerType::Tcp { tls: true }` / `ClusterType::TcpTls`)
+///   - `unix`   => a unix socket (`ServerType::Unix`)
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ServerKind {
+    Tcp,
+    Tls,
+    Unix,
+}
+
+/// Reads and validates `REDISRS_SERVER_TYPE`. Returns `None` when unset (the full matrix should be
+/// generated) and the single requested kind when set.
+fn requested_server() -> Option<ServerKind> {
+    match env::var("REDISRS_SERVER_TYPE").ok().as_deref() {
+        Some("tcp") => Some(ServerKind::Tcp),
+        Some("tcp+tls") => Some(ServerKind::Tls),
+        Some("unix") => Some(ServerKind::Unix),
+        Some(val) => panic!("Unknown server type {val:?}"),
+        None => None,
+    }
+}
+
+/// Reads and validates `PROTOCOL`. Returns `None` when unset (the full protocol matrix should be
+/// generated) and the single requested protocol when set.
+fn requested_protocol() -> Option<&'static str> {
+    match env::var("PROTOCOL").ok().as_deref() {
+        Some("RESP2") => Some("RESP2"),
+        Some("RESP3") => Some("RESP3"),
+        Some(val) => panic!("Unknown protocol {val:?}"),
+        None => None,
+    }
+}
+
+/// Whether the given server kind should be generated. Always `true` unless `REDISRS_SERVER_TYPE`
+/// is set, in which case only the matching kind is generated.
+pub fn server_enabled(kind: ServerKind) -> bool {
+    requested_server().is_none_or(|wanted| wanted == kind)
+}
+
+/// Whether the given protocol should be generated. Always `true` unless `PROTOCOL` is set, in
+/// which case only the matching protocol is generated.
+pub fn protocol_enabled(protocol: &str) -> bool {
+    requested_protocol().is_none_or(|wanted| wanted == protocol)
+}
+
+/// Removes the `REDISRS_SERVER_TYPE`/`PROTOCOL` variables so the full matrix is generated.
+///
+/// Call inside [`with_env`] (which provides the lock); this is what the full-output oracle tests use
+/// so they pass regardless of the shell environment.
+#[cfg(test)]
+pub(crate) fn clear_env() {
+    unsafe {
+        std::env::remove_var("REDISRS_SERVER_TYPE");
+        std::env::remove_var("PROTOCOL");
+    }
+}
+
+/// Runs `f` with exclusive access to the global process environment.
+///
+/// `expand_*` reads `REDISRS_SERVER_TYPE`/`PROTOCOL` from the process env, so any test that sets or
+/// clears them must call this (which holds a `Mutex` for the whole window) to avoid racing with
+/// other tests running in the same process. `setup` runs first (while the lock is held), and the env
+/// vars are cleared again when the call returns so no state leaks.
+#[cfg(test)]
+pub(crate) fn with_env<R>(setup: impl FnOnce(), f: impl FnOnce() -> R) -> R {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _guard = LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    setup();
+    let result = f();
+    clear_env();
+    result
+}

--- a/test-macros/src/utils.rs
+++ b/test-macros/src/utils.rs
@@ -1,0 +1,560 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+
+pub(crate) fn has_ignore_attr(item: &syn::ItemFn) -> bool {
+    item.attrs.iter().any(|a| a.path().is_ident("ignore"))
+}
+
+pub(crate) fn ignore_flag(item: &syn::ItemFn) -> proc_macro2::TokenStream {
+    if has_ignore_attr(item) {
+        quote! { #[ignore] }
+    } else {
+        quote! {}
+    }
+}
+
+pub(crate) fn is_connection_type(ty: &syn::Type) -> bool {
+    let type_str = quote!(#ty).to_string();
+    type_str.contains("Connection")
+        || type_str.contains("ConnectionLike")
+        || type_str.contains("AsyncCommands")
+        || type_str.contains("AsyncTypedCommands")
+}
+
+pub(crate) fn is_bool_type(ty: &syn::Type) -> bool {
+    let type_str = quote!(#ty).to_string();
+    type_str == "bool"
+}
+
+fn module_expr_for_name(name: &str) -> proc_macro2::TokenStream {
+    match name {
+        "json" => quote! { .module(redis_test::server::Module::Json) },
+        "bloom" => quote! { .module(redis_test::server::Module::Bloom) },
+        other => {
+            let msg = syn::LitStr::new(
+                &format!("unsupported module name: \"{other}\""),
+                proc_macro2::Span::call_site(),
+            );
+            quote! { compile_error!(#msg) }
+        }
+    }
+}
+
+pub(crate) fn parse_module_from_attr(attr: &TokenStream2) -> proc_macro2::TokenStream {
+    use syn::Meta;
+    use syn::parse::Parser;
+
+    let module_exprs: Vec<proc_macro2::TokenStream> =
+        syn::punctuated::Punctuated::<Meta, syn::token::Comma>::parse_terminated
+            .parse2(attr.clone())
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|meta| match meta {
+                Meta::NameValue(nv) if nv.path.is_ident("module") => match nv.value {
+                    syn::Expr::Lit(lit) => match lit.lit {
+                        syn::Lit::Str(s) => Some(module_expr_for_name(&s.value())),
+                        _ => None,
+                    },
+                    _ => None,
+                },
+                Meta::Path(path) => {
+                    if path.is_ident("json") {
+                        Some(quote! { .module(redis_test::server::Module::Json) })
+                    } else if path.is_ident("bloom") {
+                        Some(quote! { .module(redis_test::server::Module::Bloom) })
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            })
+            .collect();
+
+    if module_exprs.is_empty() {
+        quote! {}
+    } else {
+        quote! { #(#module_exprs)* }
+    }
+}
+
+/// Parses `mtls = true` from the attribute, returning `quote! { .mtls(true) }` if present.
+pub(crate) fn parse_mtls_from_attr(attr: &TokenStream2) -> proc_macro2::TokenStream {
+    use syn::Meta;
+    use syn::parse::Parser;
+
+    let has_mtls = syn::punctuated::Punctuated::<Meta, syn::token::Comma>::parse_terminated
+        .parse2(attr.clone())
+        .unwrap_or_default()
+        .into_iter()
+        .any(|meta| matches!(meta, Meta::NameValue(nv) if nv.path.is_ident("mtls")));
+
+    if has_mtls {
+        quote! { .mtls(true) }
+    } else {
+        quote! {}
+    }
+}
+
+pub(crate) struct ClusterTestArgs {
+    pub config: proc_macro2::TokenStream,
+    pub supported_versions: Option<proc_macro2::TokenStream>,
+    pub database_id: Option<proc_macro2::TokenStream>,
+}
+
+pub(crate) fn parse_cluster_test_args(attr: &TokenStream2) -> ClusterTestArgs {
+    let mut config = None;
+    let mut supported_versions = None;
+    let mut database_id = None;
+    let parser = syn::meta::parser(|meta| {
+        if meta.path.is_ident("config") {
+            let value: syn::LitStr = meta.value()?.parse()?;
+            config = Some(syn::parse_str::<TokenStream2>(&value.value())?);
+            Ok(())
+        } else if meta.path.is_ident("supported_versions") {
+            let value: syn::LitStr = meta.value()?.parse()?;
+            supported_versions = Some(syn::parse_str::<TokenStream2>(&value.value())?);
+            Ok(())
+        } else if meta.path.is_ident("database_id") {
+            let value: syn::LitInt = meta.value()?.parse()?;
+            database_id = Some(syn::parse_str::<TokenStream2>(value.base10_digits())?);
+            Ok(())
+        } else {
+            Err(meta.error(
+                "unsupported attribute; expected `config = \"...\"`, `supported_versions = \"...\"`, or `database_id = N`",
+            ))
+        }
+    });
+    syn::parse::Parser::parse2(parser, attr.clone()).expect("invalid cluster test attribute");
+    ClusterTestArgs {
+        config: config.unwrap_or_else(|| {
+            quote! { redis_test::cluster::RedisClusterConfiguration::default().insecure_tls() }
+        }),
+        supported_versions,
+        database_id,
+    }
+}
+
+/// Generates a pre-provisioning version check that starts a single, cheap standalone server and
+/// skips the test (returning early) if it does not support the given component(s).
+pub(crate) fn generate_version_check(
+    supported_versions: &Option<proc_macro2::TokenStream>,
+) -> proc_macro2::TokenStream {
+    match supported_versions {
+        Some(component) => quote! {
+            {
+                let version_check_ctx = crate::support::TestContextBuilder::new().build();
+                if !crate::support::TestContextVersioning::supports(&version_check_ctx, #component) {
+                    eprintln!(
+                        "Skipping the test because the running server does not support {:?}.",
+                        #component
+                    );
+                    return;
+                }
+            }
+        },
+        None => quote! {},
+    }
+}
+
+pub(crate) fn generate_sync_call(
+    function_name: &syn::Ident,
+    inputs: &syn::punctuated::Punctuated<syn::FnArg, syn::token::Comma>,
+) -> proc_macro2::TokenStream {
+    if inputs.is_empty() {
+        quote! { #function_name(); }
+    } else {
+        let arg = inputs.first().unwrap();
+        if let syn::FnArg::Typed(pat_type) = arg {
+            let is_ref = matches!(&*pat_type.ty, syn::Type::Reference(_));
+            let is_conn = is_connection_type(&pat_type.ty);
+            let is_bool = is_bool_type(&pat_type.ty);
+
+            if is_bool {
+                quote! {
+                    #function_name(true);
+                    #function_name(false);
+                }
+            } else if is_conn {
+                if is_ref {
+                    quote! {
+                        let mut conn = ctx.connection();
+                        #function_name(&mut conn);
+                    }
+                } else {
+                    quote! {
+                        let conn = ctx.connection();
+                        #function_name(conn);
+                    }
+                }
+            } else if is_ref {
+                quote! {
+                    #function_name(&mut ctx);
+                }
+            } else {
+                quote! {
+                    #function_name(ctx);
+                }
+            }
+        } else {
+            quote! { #function_name(); }
+        }
+    }
+}
+
+pub(crate) fn generate_async_call(
+    function_name: &syn::Ident,
+    inputs: &syn::punctuated::Punctuated<syn::FnArg, syn::token::Comma>,
+) -> proc_macro2::TokenStream {
+    if inputs.is_empty() {
+        quote! { #function_name().await; }
+    } else {
+        let arg = inputs.first().unwrap();
+        if let syn::FnArg::Typed(pat_type) = arg {
+            let is_ref = matches!(&*pat_type.ty, syn::Type::Reference(_));
+            let is_conn = is_connection_type(&pat_type.ty);
+            let is_bool = is_bool_type(&pat_type.ty);
+
+            if is_bool {
+                quote! {
+                    #function_name(true).await;
+                    #function_name(false).await;
+                }
+            } else if is_conn {
+                if is_ref {
+                    quote! {
+                        let mut conn = ctx.async_connection().await.unwrap();
+                        #function_name(&mut conn).await;
+                    }
+                } else {
+                    quote! {
+                        let conn = ctx.async_connection().await.unwrap();
+                        #function_name(conn).await;
+                    }
+                }
+            } else if is_ref {
+                quote! {
+                    #function_name(&mut ctx).await;
+                }
+            } else {
+                quote! {
+                    #function_name(ctx).await;
+                }
+            }
+        } else {
+            quote! { #function_name().await; }
+        }
+    }
+}
+
+pub(crate) fn generate_async_cluster_call(
+    function_name: &syn::Ident,
+    inputs: &syn::punctuated::Punctuated<syn::FnArg, syn::token::Comma>,
+) -> proc_macro2::TokenStream {
+    if inputs.is_empty() {
+        quote! { #function_name().await; }
+    } else {
+        let arg = inputs.first().unwrap();
+        if let syn::FnArg::Typed(pat_type) = arg {
+            let is_ref = matches!(&*pat_type.ty, syn::Type::Reference(_));
+            let is_conn = is_connection_type(&pat_type.ty);
+
+            if is_conn {
+                if is_ref {
+                    quote! {
+                        let mut conn = ctx.async_connection().await;
+                        #function_name(&mut conn).await;
+                    }
+                } else {
+                    quote! {
+                        let conn = ctx.async_connection().await;
+                        #function_name(conn).await;
+                    }
+                }
+            } else if is_ref {
+                quote! {
+                    #function_name(&mut ctx).await;
+                }
+            } else {
+                quote! {
+                    #function_name(ctx).await;
+                }
+            }
+        } else {
+            quote! { #function_name().await; }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_fn(input: &str) -> syn::ItemFn {
+        syn::parse_str(input).expect("failed to parse function")
+    }
+
+    fn to_string(tokens: &proc_macro2::TokenStream) -> String {
+        tokens.to_string()
+    }
+
+    /// Asserts `actual` equals `expected_src` token-by-token (a full-output check, not a
+    /// substring match). The expected is given as readable source and parsed first, so whitespace
+    /// between tokens is irrelevant while string literal contents are preserved.
+    fn assert_full(actual: &proc_macro2::TokenStream, expected_src: &str) {
+        let expected: proc_macro2::TokenStream = expected_src
+            .parse()
+            .expect("failed to parse expected expansion");
+        assert_eq!(to_string(actual), to_string(&expected));
+    }
+
+    fn inputs_of(item: &syn::ItemFn) -> syn::punctuated::Punctuated<syn::FnArg, syn::token::Comma> {
+        item.sig.inputs.clone()
+    }
+
+    fn attr_stream(input: &str) -> TokenStream2 {
+        input.parse().expect("failed to parse attr")
+    }
+
+    /// Calls a generator with the given input function and asserts the full output.
+    fn assert_call(
+        generator: fn(
+            &syn::Ident,
+            &syn::punctuated::Punctuated<syn::FnArg, syn::token::Comma>,
+        ) -> proc_macro2::TokenStream,
+        fn_src: &str,
+        expected: &str,
+    ) {
+        let item = parse_fn(fn_src);
+        let call = generator(&item.sig.ident, &inputs_of(&item));
+        assert_full(&call, expected);
+    }
+
+    #[test]
+    fn module_from_attr_json() {
+        assert_full(
+            &parse_module_from_attr(&attr_stream("json")),
+            ".module(redis_test::server::Module::Json)",
+        );
+    }
+
+    #[test]
+    fn module_from_attr_bloom() {
+        assert_full(
+            &parse_module_from_attr(&attr_stream("bloom")),
+            ".module(redis_test::server::Module::Bloom)",
+        );
+    }
+
+    #[test]
+    fn module_from_attr_none() {
+        assert_full(&parse_module_from_attr(&attr_stream("")), "");
+    }
+
+    #[test]
+    fn module_from_attr_named_json() {
+        assert_full(
+            &parse_module_from_attr(&attr_stream(r#"module = "json""#)),
+            ".module(redis_test::server::Module::Json)",
+        );
+    }
+
+    #[test]
+    fn module_from_attr_named_bloom() {
+        assert_full(
+            &parse_module_from_attr(&attr_stream(r#"module = "bloom""#)),
+            ".module(redis_test::server::Module::Bloom)",
+        );
+    }
+
+    #[test]
+    fn mtls_from_attr_true() {
+        assert_full(
+            &parse_mtls_from_attr(&attr_stream("mtls = true")),
+            ".mtls(true)",
+        );
+    }
+
+    #[test]
+    fn mtls_from_attr_absent() {
+        assert_full(&parse_mtls_from_attr(&attr_stream("")), "");
+    }
+
+    #[test]
+    fn mtls_from_attr_with_json() {
+        assert_full(
+            &parse_mtls_from_attr(&attr_stream(r#"mtls = true, module = "json""#)),
+            ".mtls(true)",
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::empty("fn test() {}", "test();")]
+    #[case::bool("fn test(flag: bool) {}", "test(true); test(false);")]
+    #[case::ctx_ref("fn test(ctx: &mut TestContext) {}", "test(&mut ctx);")]
+    #[case::ctx_value("fn test(ctx: TestContext) {}", "test(ctx);")]
+    #[case::conn_ref(
+        "fn test(conn: &mut Connection) {}",
+        "let mut conn = ctx.connection(); test(&mut conn);"
+    )]
+    #[case::conn_value(
+        "fn test(conn: Connection) {}",
+        "let conn = ctx.connection(); test(conn);"
+    )]
+    fn sync_call(#[case] fn_src: &str, #[case] expected: &str) {
+        assert_call(generate_sync_call, fn_src, expected);
+    }
+
+    #[rstest::rstest]
+    #[case::empty("fn test() {}", "test().await;")]
+    #[case::bool("fn test(flag: bool) {}", "test(true).await; test(false).await;")]
+    #[case::ctx_ref("fn test(ctx: &mut TestContext) {}", "test(&mut ctx).await;")]
+    #[case::ctx_value("fn test(ctx: TestContext) {}", "test(ctx).await;")]
+    #[case::conn_ref(
+        "fn test(conn: &mut Connection) {}",
+        "let mut conn = ctx.async_connection().await.unwrap(); test(&mut conn).await;"
+    )]
+    #[case::conn_value(
+        "fn test(conn: Connection) {}",
+        "let conn = ctx.async_connection().await.unwrap(); test(conn).await;"
+    )]
+    fn async_call(#[case] fn_src: &str, #[case] expected: &str) {
+        assert_call(generate_async_call, fn_src, expected);
+    }
+
+    #[rstest::rstest]
+    #[case::empty("fn test() {}", "test().await;")]
+    #[case::ctx_ref("fn test(ctx: &mut TestContext) {}", "test(&mut ctx).await;")]
+    #[case::conn_ref(
+        "fn test(conn: &mut Connection) {}",
+        "let mut conn = ctx.async_connection().await; test(&mut conn).await;"
+    )]
+    #[case::conn_value(
+        "fn test(conn: Connection) {}",
+        "let conn = ctx.async_connection().await; test(conn).await;"
+    )]
+    fn async_cluster_call(#[case] fn_src: &str, #[case] expected: &str) {
+        assert_call(generate_async_cluster_call, fn_src, expected);
+    }
+
+    #[test]
+    fn cluster_args_default_config() {
+        let args = parse_cluster_test_args(&attr_stream(""));
+        assert_full(
+            &args.config,
+            "redis_test::cluster::RedisClusterConfiguration::default().insecure_tls()",
+        );
+        assert!(args.supported_versions.is_none());
+    }
+
+    #[test]
+    fn cluster_args_config_only() {
+        let args = parse_cluster_test_args(&attr_stream("config = \"foo().bar()\""));
+        assert_full(&args.config, "foo().bar()");
+        assert!(args.supported_versions.is_none());
+    }
+
+    #[test]
+    fn cluster_args_supported_versions_only() {
+        let args = parse_cluster_test_args(&attr_stream("supported_versions = \"Json\""));
+        assert!(args.supported_versions.is_some());
+        assert_full(args.supported_versions.as_ref().unwrap(), "Json");
+    }
+
+    #[test]
+    fn cluster_args_both() {
+        let args = parse_cluster_test_args(&attr_stream(
+            "config = \"foo()\", supported_versions = \"[Bloom]\"",
+        ));
+        assert_full(&args.config, "foo()");
+        assert_full(args.supported_versions.as_ref().unwrap(), "[Bloom]");
+    }
+
+    #[test]
+    fn cluster_args_database_id_only() {
+        let args = parse_cluster_test_args(&attr_stream("database_id = 4"));
+        assert!(args.database_id.is_some());
+        assert_full(args.database_id.as_ref().unwrap(), "4");
+    }
+
+    #[test]
+    fn cluster_args_database_id_with_config() {
+        let args = parse_cluster_test_args(&attr_stream(r#"config = "foo()", database_id = 7"#));
+        assert_full(&args.config, "foo()");
+        assert!(args.database_id.is_some());
+        assert_full(args.database_id.as_ref().unwrap(), "7");
+    }
+
+    #[test]
+    fn cluster_args_all_three() {
+        let args = parse_cluster_test_args(&attr_stream(
+            r#"config = "foo()", supported_versions = "Json", database_id = 2"#,
+        ));
+        assert_full(&args.config, "foo()");
+        assert!(args.supported_versions.is_some());
+        assert_full(args.supported_versions.as_ref().unwrap(), "Json");
+        assert!(args.database_id.is_some());
+        assert_full(args.database_id.as_ref().unwrap(), "2");
+    }
+
+    #[test]
+    fn version_check_none() {
+        let vc = generate_version_check(&None);
+        assert_full(&vc, "");
+    }
+
+    #[test]
+    fn version_check_some() {
+        let vc = generate_version_check(&Some(quote! { Json }));
+        assert_full(
+            &vc,
+            r#"{ let version_check_ctx = crate::support::TestContextBuilder::new().build();
+                if !crate::support::TestContextVersioning::supports(&version_check_ctx, Json) {
+                    eprintln!("Skipping the test because the running server does not support {:?}.", Json);
+                    return;
+                }
+            }"#,
+        );
+    }
+
+    #[test]
+    fn ignore_flag_present() {
+        let item = parse_fn("#[ignore]\nfn test(ctx: &mut TestContext) {}");
+        assert_full(&ignore_flag(&item), "#[ignore]");
+        assert!(has_ignore_attr(&item));
+    }
+
+    #[test]
+    fn ignore_flag_absent() {
+        let item = parse_fn("fn test(ctx: &mut TestContext) {}");
+        assert_full(&ignore_flag(&item), "");
+        assert!(!has_ignore_attr(&item));
+    }
+
+    #[test]
+    fn connection_type_detection() {
+        let check = |ty: &str| {
+            let item: syn::ItemFn = syn::parse_str(&format!("fn test(x: {ty}) {{}}")).unwrap();
+            matches!(
+                inputs_of(&item).first(),
+                Some(syn::FnArg::Typed(pt))
+                    if is_connection_type(&pt.ty)
+            )
+        };
+        assert!(check("Connection"));
+        assert!(check("ConnectionLike"));
+        assert!(check("AsyncCommands"));
+        assert!(check("AsyncTypedCommands"));
+        assert!(!check("&mut TestContext"));
+        assert!(!check("bool"));
+    }
+
+    #[test]
+    fn bool_type_detection() {
+        let item = parse_fn("fn test(flag: bool) {}");
+        if let Some(syn::FnArg::Typed(pt)) = inputs_of(&item).first() {
+            assert!(is_bool_type(&pt.ty));
+        } else {
+            panic!("expected typed arg");
+        }
+    }
+}

--- a/workplan.md
+++ b/workplan.md
@@ -1,0 +1,91 @@
+# Workplan: Redesign Testing Infrastructure using Proc-Macros
+
+## Objective
+Redesign the testing infrastructure in `redis-rs` to eliminate repeated recompilations and multi-run invocations in the `Makefile` driven by `REDISRS_SERVER_TYPE` and `PROTOCOL` environment variables. Replace environment-variable-driven test runs with Rust proc-macros in `test-macros/src/lib.rs` that generate test matrices (different protocols, server/cluster/sentinel types, and async runtimes) directly within the Rust test framework.
+
+---
+
+## Key Components & Architecture
+
+### 1. Parametrization in `redis-test`
+Currently, `RedisServer`, `RedisCluster`, and `RedisSentinelCluster` infer protocol and connection types from `env::var("REDISRS_SERVER_TYPE")` and `env::var("PROTOCOL")`.
+- **Refactoring Requirement**:
+  - Expose explicit builder / constructor options for `ServerType` (`Tcp`, `TcpTls`, `Unix`), `ProtocolVersion` (`RESP2`, `RESP3`), and `ClusterType`.
+  - Update `TestContext`, `TestClusterContext`, and `TestSentinelContext` to accept these explicit options so proc-macros can instantiate contexts programmatically for any matrix variant.
+
+---
+
+### 2. Proc-Macro Expansion in `test-macros/src/lib.rs`
+Implement procedural macros generating test matrices for the 6 required target topologies:
+
+#### A. Single Server (`#[single_server_test]`)
+- **Matrix**: Protocol (`RESP2`, `RESP3`) × Server Type (`TCP`, `TCP+TLS`, `UNIX`).
+- **Behavior**: Generates sync test variants that initialize a `TestContext` for each combination and pass `TestContext` (or connection) to the test body.
+
+#### B. Async Single Server (`#[async_single_server_test]`)
+- **Matrix**: Protocol (`RESP2`, `RESP3`) × Server Type (`TCP`, `TCP+TLS`, `UNIX`) × Async Runtime (`Tokio`, `Smol`).
+- **Behavior**: Generates async test variants wrapping `block_on_all` with the corresponding runtime and created `TestContext`.
+
+#### C. Cluster (`#[cluster_test]`)
+- **Matrix**: Protocol (`RESP2`, `RESP3`) × Server/TLS configuration (`TCP`, `TCP+TLS`; Unix socket is not supported for Sentinel).
+- **Behavior**: Generates sync test variants initializing a `TestClusterContext` and running the test block.
+
+#### D. Async Cluster (`#[async_cluster_test]`)
+- **Matrix**: Protocol (`RESP2`, `RESP3`) × Server/TLS configuration (`TCP`, `TCP+TLS`; Unix socket is not supported for Sentinel) × Async Runtime (`Tokio`, `Smol`).
+- **Behavior**: Generates async cluster test variants initializing a `TestClusterContext` and executing under the runtime wrapper.
+
+#### E. Sentinel (`#[sentinel_test]`)
+- **Matrix**: Protocol (`RESP2`, `RESP3`) × Server/TLS configuration (`TCP`, `TCP+TLS`; Unix socket is not supported for Sentinel).
+- **Behavior**: Generates sync sentinel test variants initializing `TestSentinelContext`.
+
+#### F. Async Sentinel (`#[async_sentinel_test]`)
+- **Matrix**: Protocol (`RESP2`, `RESP3`) × Server/TLS configuration (`TCP`, `TCP+TLS`; Unix socket is not supported for Sentinel) × Async Runtime (`Tokio`, `Smol`).
+- **Behavior**: Generates async sentinel test variants initializing `TestSentinelContext`.
+
+---
+
+### 3. Test Suite Migration
+Migrate existing test files in `redis/tests/` to consume the new macro attributes:
+- `redis/tests/test_basic.rs` & `test_geospatial.rs` -> `#[single_server_test]`
+- `redis/tests/test_async.rs` -> `#[async_single_server_test]`
+- `redis/tests/test_cluster.rs` -> `#[cluster_test]`
+- `redis/tests/test_cluster_async.rs` -> `#[async_cluster_test]`
+- `redis/tests/test_sentinel.rs` -> `#[sentinel_test]` (if present) / async sentinel tests -> `#[async_sentinel_test]`
+
+---
+
+### 4. Makefile Simplification
+Remove duplicate `cargo nextest run` invocations with distinct `REDISRS_SERVER_TYPE` and `PROTOCOL` environment variable pairs from `Makefile`.
+- **New Makefile structure**:
+  - Run a unified `cargo nextest run` command for test suites.
+  - Retain feature flag targets (e.g. `--all-features`, `--no-default-features`) while eliminating redundant env-var loops.
+
+---
+
+## Detailed Step-by-Step Action Items
+
+1. **Step 1: Parametrize `redis-test` Context Constructors**
+   - Update `RedisServerBuilder` & `TestContextBuilder` in `redis-test` to accept explicit `ProtocolVersion` and `ServerType`.
+   - Update `RedisClusterConfiguration` and `RedisSentinelCluster` to accept explicit `ProtocolVersion` and server options.
+
+2. **Step 2: Implement Proc-Macros in `test-macros/src/lib.rs`**
+   - Create attribute macros:
+     - `#[single_server_test]`
+     - `#[async_single_server_test]`
+     - `#[cluster_test]`
+     - `#[async_cluster_test]`
+     - `#[sentinel_test]`
+     - `#[async_sentinel_test]`
+   - Add macro argument parsing for special cases (e.g., modules like `Module::Json` / `Module::Bloom`, custom cluster configs).
+
+3. **Step 3: Refactor Tests to Use New Proc-Macros**
+   - Update single-server sync & async tests.
+   - Update cluster sync & async tests.
+   - Update sentinel sync & async tests.
+
+4. **Step 4: Streamline `Makefile`**
+   - Clean up `Makefile` test rules (`test`, `test-module-json`, `test-module-bloom`).
+
+5. **Step 5: Verification & Quality Assurance**
+   - Run `cargo check --tests --all-features`.
+   - Run `cargo nextest run --all-features` to verify that all matrix test cases execute and pass.


### PR DESCRIPTION
this inlines the various server types and protocols into the tests, instead of running multiple separate test runs with different env variables.