### PR TITLE
Optimize requests to preallocate the command

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -310,3 +310,6 @@ required-features = ["cluster-async", "tokio-comp"]
 
 [lints]
 workspace = true
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-Clink-arg=-Wl,--no-rosegment"]

--- a/redis/benches/bench_basic.rs
+++ b/redis/benches/bench_basic.rs
@@ -49,14 +49,10 @@ fn bench_simple_getsetdel_pipeline(b: &mut Bencher) {
     b.iter(|| {
         let key = "test_key";
         let _: (usize,) = redis::pipe()
-            .cmd("SET")
-            .arg(key)
-            .arg(42)
+            .set(key, 42)
             .ignore()
-            .cmd("GET")
-            .arg(key)
-            .cmd("DEL")
-            .arg(key)
+            .get(key)
+            .del(key)
             .ignore()
             .query(&mut con)
             .unwrap();
@@ -68,15 +64,7 @@ fn bench_simple_getsetdel_pipeline_precreated(b: &mut Bencher) {
     let mut con = ctx.connection();
     let key = "test_key";
     let mut pipe = redis::pipe();
-    pipe.cmd("SET")
-        .arg(key)
-        .arg(42)
-        .ignore()
-        .cmd("GET")
-        .arg(key)
-        .cmd("DEL")
-        .arg(key)
-        .ignore();
+    pipe.set(key, 42).ignore().get(key).del(key).ignore();
 
     b.iter(|| {
         let _: (usize,) = pipe.query(&mut con).unwrap();
@@ -231,11 +219,7 @@ fn bench_encode_set_ex(b: &mut Bencher, value: &[u8]) {
         let mut pipe = redis::pipe();
 
         for _ in 0..1_000 {
-            pipe.cmd("SET")
-                .arg("session:abc123")
-                .arg(value)
-                .arg(redis::SetExpiry::EX(3600))
-                .ignore();
+            pipe.set_ex("session:abc123", value, 3600).ignore();
         }
         pipe.get_packed_pipeline()
     });

--- a/redis/benches/bench_pipeline_build.rs
+++ b/redis/benches/bench_pipeline_build.rs
@@ -33,7 +33,7 @@ fn payload(len: usize) -> Vec<u8> {
 }
 
 fn add_set(pipe: &mut redis::Pipeline, value: &[u8]) {
-    pipe.cmd("SET").arg("some_key").arg(value).ignore();
+    pipe.set("some_key", value).ignore();
 }
 
 // Create and populate a pipeline with N simple commands carrying a payload of the given size.
@@ -60,14 +60,13 @@ fn bench_build_pipeline_nested(c: &mut Criterion) {
             b.iter(|| {
                 let mut pipe = redis::pipe();
                 for _ in 0..N / 5 {
-                    pipe.cmd("MSET")
-                        .arg(&[
-                            ("foo1", &value[..]),
-                            ("foo2", &value[..]),
-                            ("foo3", &value[..]),
-                            ("foo4", &value[..]),
-                        ])
-                        .ignore();
+                    pipe.mset(&[
+                        ("foo1", &value[..]),
+                        ("foo2", &value[..]),
+                        ("foo3", &value[..]),
+                        ("foo4", &value[..]),
+                    ])
+                    .ignore();
                 }
                 black_box(&pipe);
             });

--- a/redis/src/bloom.rs
+++ b/redis/src/bloom.rs
@@ -1,5 +1,6 @@
 //! Defines types to use with Bloom filter commands.
 
+use crate::cmd::count_digits;
 use crate::errors::invalid_type_error;
 use crate::{
     Commands, Connection, FromRedisValue, ParsingError, RedisResult, RedisWrite, ToRedisArgs,
@@ -35,37 +36,31 @@ pub enum BloomFilterInfoType {
     MaximumScaledCapacity,
 }
 
+impl BloomFilterInfoType {
+    fn bytes_rep(&self) -> &'static [u8] {
+        match *self {
+            Self::Capacity => b"CAPACITY",
+            Self::Expansion => b"EXPANSION",
+            Self::Filters => b"FILTERS",
+            Self::Items => b"ITEMS",
+            Self::Size => b"SIZE",
+            Self::Error => b"ERROR",
+            Self::Tightening => b"TIGHTENING",
+            Self::MaximumScaledCapacity => b"MAXSCALEDCAPACITY",
+        }
+    }
+}
+
 impl ToRedisArgs for BloomFilterInfoType {
     fn write_redis_args<W>(&self, out: &mut W)
     where
         W: ?Sized + RedisWrite,
     {
-        match *self {
-            Self::Capacity => {
-                out.write_arg(b"CAPACITY");
-            }
-            Self::Expansion => {
-                out.write_arg(b"EXPANSION");
-            }
-            Self::Filters => {
-                out.write_arg(b"FILTERS");
-            }
-            Self::Items => {
-                out.write_arg(b"ITEMS");
-            }
-            Self::Size => {
-                out.write_arg(b"SIZE");
-            }
-            Self::Error => {
-                out.write_arg(b"ERROR");
-            }
-            Self::Tightening => {
-                out.write_arg(b"TIGHTENING");
-            }
-            Self::MaximumScaledCapacity => {
-                out.write_arg(b"MAXSCALEDCAPACITY");
-            }
-        }
+        out.write_arg(self.bytes_rep());
+    }
+
+    fn args_size(&self) -> usize {
+        self.bytes_rep().len()
     }
 }
 
@@ -166,6 +161,20 @@ impl ToRedisArgs for BloomFilterScalingOptions {
             }
         }
     }
+
+    fn num_of_args(&self) -> usize {
+        match *self {
+            Self::ExpansionRate(_) => 2,
+            Self::NonScaling => 1,
+        }
+    }
+
+    fn args_size(&self) -> usize {
+        match *self {
+            Self::ExpansionRate(size) => b"EXPANSION".len() + count_digits(size),
+            Self::NonScaling => b"NONSCALING".len(),
+        }
+    }
 }
 
 /// Options for inserting items to a Bloom filter
@@ -224,6 +233,27 @@ impl ToRedisArgs for BloomFilterInsertOptions {
         if let Some(ref scaling) = self.expansion {
             scaling.write_redis_args(out);
         }
+    }
+
+    fn args_size(&self) -> usize {
+        let mut size = 0;
+        if Some(false) == self.create {
+            size += b"NOCREATE".len();
+        }
+
+        if let Some(ref error) = self.error_rate {
+            size += b"ERROR".len() + error.arg_size();
+        }
+
+        if let Some(ref capacity) = self.capacity {
+            size += b"CAPACITY".len() + capacity.arg_size();
+        }
+
+        if let Some(ref scaling) = self.expansion {
+            size += scaling.args_size();
+        }
+
+        size
     }
 }
 

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -421,7 +421,7 @@ impl<'a, T: FromRedisValue + Unpin + Send + 'a> Stream for AsyncIter<'a, T> {
     }
 }
 
-fn countdigits(mut v: usize) -> usize {
+pub(crate) fn count_digits(mut v: usize) -> usize {
     let mut result = 1;
     loop {
         if v < 10 {
@@ -444,17 +444,17 @@ fn countdigits(mut v: usize) -> usize {
 
 #[inline]
 fn bulklen(len: usize) -> usize {
-    1 + countdigits(len) + 2 + len + 2
+    1 + count_digits(len) + 2 + len + 2
 }
 
 pub(crate) fn args_len<'a, I>(args: I, cursor: u64) -> usize
 where
     I: IntoIterator<Item = Arg<&'a [u8]>> + ExactSizeIterator,
 {
-    let mut totlen = 1 + countdigits(args.len()) + 2;
+    let mut totlen = 1 + count_digits(args.len()) + 2;
     for item in args {
         totlen += bulklen(match item {
-            Arg::Cursor => countdigits(cursor as usize),
+            Arg::Cursor => count_digits(cursor as usize),
             Arg::Simple(val) => val.len(),
         });
     }

--- a/redis/src/commands/macros.rs
+++ b/redis/src/commands/macros.rs
@@ -6,13 +6,13 @@ macro_rules! implement_command_async {
         $lifetime: lifetime
         $(#[$attr:meta])+
         fn $name:ident<$($tyargs:ident : $ty:ident),*>(
-            $($argname:ident: $argty:ty),*) $body:block Generic
+            $($argname:ident: $argty:ty),*) { $($body:tt)* } Generic
     ) => {
         implement_command_async!(
             $lifetime
             $(#[$attr])+
             fn $name<$($tyargs : $ty,)* RV: FromRedisValue>(
-                $($argname: $argty),*) $body RV
+                $($argname: $argty),*) { $($body)* } RV
         );
     };
 
@@ -21,7 +21,7 @@ macro_rules! implement_command_async {
         $lifetime: lifetime
         $(#[$attr:meta])+
         fn $name:ident<$($tyargs:ident : $ty:ident),*>(
-            $($argname:ident: $argty:ty),*) $body:block $rettype:ty
+            $($argname:ident: $argty:ty),*) { $($body:tt)* } $rettype:ty
     ) => {
         $(#[$attr])*
         #[inline]
@@ -32,7 +32,7 @@ macro_rules! implement_command_async {
         ) -> crate::types::RedisFuture<$lifetime, $rettype>
 
         {
-            Box::pin(async move { $body.query_async(self).await })
+            Box::pin(async move { $($body)*.query_async(self).await })
         }
     };
 }
@@ -43,13 +43,13 @@ macro_rules! implement_command_sync {
         $lifetime: lifetime
         $(#[$attr:meta])+
         fn $name:ident<$($tyargs:ident : $ty:ident),*>(
-            $($argname:ident: $argty:ty),*) $body:block Generic
+            $($argname:ident: $argty:ty),*) { $($body:tt)* } Generic
     ) => {
         implement_command_sync!(
             $lifetime
             $(#[$attr])+
             fn $name<$($tyargs : $ty,)* RV: FromRedisValue>(
-                $($argname: $argty),*) $body RV
+                $($argname: $argty),*) { $($body)* } RV
         );
     };
 
@@ -58,7 +58,7 @@ macro_rules! implement_command_sync {
         $lifetime: lifetime
         $(#[$attr:meta])+
         fn $name:ident<$($tyargs:ident : $ty:ident),*>(
-            $($argname:ident: $argty:ty),*) $body:block $rettype:ty
+            $($argname:ident: $argty:ty),*) { $($body:tt)* } $rettype:ty
     ) => {
         $(#[$attr])*
         #[inline]
@@ -72,6 +72,46 @@ macro_rules! implement_command_sync {
             Cmd::$name($($argname),*).query(self)
         }
     };
+}
+
+macro_rules! ready_cmd {
+    ($name:expr $(, $arg:expr)*) => {{
+        let name = $name;
+        let args_count = 1usize;
+        let args_size = name.len();
+        $(
+            let (next_args_count, next_args_size) = $arg.num_of_args_and_size();
+            let args_count = args_count + next_args_count;
+            let args_size = args_size + next_args_size;
+        )*
+        let mut cmd = Cmd::with_capacity(args_count, args_size);
+        cmd.arg(name);
+        $(cmd.arg($arg);)*
+        cmd
+    }};
+}
+
+macro_rules! write_pipeline_command {
+    ($self:expr, { ready_cmd!($name:expr $(, $arg:expr)*).take() }) => {{
+        let name = $name;
+        let args_count = 1usize;
+        let args_size = name.len();
+        $(
+            let (next_args_count, next_args_size) = $arg.num_of_args_and_size();
+            let args_count = args_count + next_args_count;
+            let args_size = args_size + next_args_size;
+        )*
+        $self.reserve_for_args(args_count)
+          .reserve_for_data(args_size);
+        $self.start_command();
+        $crate::types::RedisWrite::write_arg($self, name.as_bytes());
+        $($self.arg($arg);)*
+        $self
+    }};
+
+    ($self:expr, $cmd:expr) => {{
+        $self.add_command($cmd)
+    }};
 }
 
 macro_rules! implement_iterators {
@@ -169,7 +209,7 @@ macro_rules! implement_commands {
         $(
             $(#[$attr:meta])+
             fn $name:ident<$($tyargs:ident : $ty:ident),*>(
-                $($argname:ident: $argty:ty),*) -> $rettype:tt $body:block
+                $($argname:ident: $argty:ty),*) -> $rettype:tt { $($body:tt)* }
         )*
     ) =>
     (
@@ -223,7 +263,7 @@ macro_rules! implement_commands {
                 $(#[$attr])*
                 #[allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
                 pub fn $name<$lifetime, $($tyargs: $ty),*>($($argname: $argty),*) -> Self {
-                    $body
+                    $($body)*
                 }
             )*
         }
@@ -270,7 +310,7 @@ macro_rules! implement_commands {
                 where
                     RV: FromRedisValue,
                 {
-                    Box::pin(async move { ($body).query_async(self).await })
+                    Box::pin(async move { {$($body)*}.query_async(self).await })
                 }
             )*
 
@@ -292,7 +332,7 @@ macro_rules! implement_commands {
                     )
 
                     {
-                        $body
+                        $($body)*
                     } $rettype
                 }
             )*
@@ -326,7 +366,7 @@ macro_rules! implement_commands {
                     )
 
                     {
-                        $body
+                        $($body)*
                     } $rettype
                 }
             )*
@@ -358,7 +398,7 @@ macro_rules! implement_commands {
                 pub fn $name<$lifetime, $($tyargs: $ty),*>(
                     &mut self $(, $argname: $argty)*
                 ) -> &mut Self {
-                    self.add_command($body)
+                    write_pipeline_command!(self,{ $($body)* })
                 }
             )*
         }
@@ -375,7 +415,7 @@ macro_rules! implement_commands {
                 pub fn $name<$lifetime, $($tyargs: $ty),*>(
                     &mut self $(, $argname: $argty)*
                 ) -> &mut Self {
-                    self.add_command($body)
+                    write_pipeline_command!(self,{ $($body)* })
                 }
             )*
         }

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -272,94 +272,94 @@ implement_commands! {
     /// Get the value of a key.  If key is a vec this becomes an `MGET` (if using `TypedCommands`, you should specifically use `mget` to get the correct return type.
     /// [Redis Docs](https://redis.io/commands/get/)
     fn get<K: ToSingleRedisArg >(key: K) -> (Option<String>) {
-        cmd("GET").arg(key).take()
+        ready_cmd!("GET", key).take()
     }
 
     /// Get values of keys
     /// [Redis Docs](https://redis.io/commands/MGET)
     fn mget<K: ToRedisArgs>(key: K) -> (Vec<Option<String>>) {
-        cmd("MGET").arg(key).take()
+        ready_cmd!("MGET", key).take()
     }
 
     /// Gets all keys matching pattern
     /// [Redis Docs](https://redis.io/commands/KEYS)
     fn keys<K: ToSingleRedisArg>(key: K) -> (Vec<String>) {
-        cmd("KEYS").arg(key).take()
+        ready_cmd!("KEYS", key).take()
     }
 
     /// Set the string value of a key.
     /// [Redis Docs](https://redis.io/commands/SET)
     fn set<K: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, value: V) -> (()) {
-        cmd("SET").arg(key).arg(value).take()
+        ready_cmd!("SET", key, value).take()
     }
 
     /// Set the string value of a key with options.
     /// [Redis Docs](https://redis.io/commands/SET)
     fn set_options<K: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, value: V, options: SetOptions) -> (Option<String>) {
-        cmd("SET").arg(key).arg(value).arg(options).take()
+        ready_cmd!("SET", key, value, options).take()
     }
 
     /// Sets multiple keys to their values.
     /// [Redis Docs](https://redis.io/commands/MSET)
     fn mset<K: ToRedisArgs, V: ToRedisArgs>(items: &'a [(K, V)]) -> (()) {
-        cmd("MSET").arg(items).take()
+        ready_cmd!("MSET", items).take()
     }
 
     /// Set the value and expiration of a key.
     /// [Redis Docs](https://redis.io/commands/SETEX)
     fn set_ex<K: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, value: V, seconds: u64) -> (()) {
-        cmd("SETEX").arg(key).arg(seconds).arg(value).take()
+        ready_cmd!("SETEX", key, seconds, value).take()
     }
 
     /// Set the value and expiration in milliseconds of a key.
     /// [Redis Docs](https://redis.io/commands/PSETEX)
     fn pset_ex<K: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, value: V, milliseconds: u64) -> (()) {
-        cmd("PSETEX").arg(key).arg(milliseconds).arg(value).take()
+        ready_cmd!("PSETEX", key, milliseconds, value).take()
     }
 
     /// Set the value of a key, only if the key does not exist
     /// [Redis Docs](https://redis.io/commands/SETNX)
     fn set_nx<K: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, value: V) -> (bool) {
-        cmd("SETNX").arg(key).arg(value).take()
+        ready_cmd!("SETNX", key, value).take()
     }
 
     /// Sets multiple keys to their values failing if at least one already exists.
     /// [Redis Docs](https://redis.io/commands/MSETNX)
     fn mset_nx<K: ToRedisArgs, V: ToRedisArgs>(items: &'a [(K, V)]) -> (bool) {
-        cmd("MSETNX").arg(items).take()
+        ready_cmd!("MSETNX", items).take()
     }
 
     /// Sets the given keys to their respective values.
     /// This command is an extension of the MSETNX that adds expiration and XX options.
     /// [Redis Docs](https://redis.io/commands/MSETEX)
     fn mset_ex<K: ToRedisArgs, V: ToRedisArgs>(items: &'a [(K, V)], options: MSetOptions) -> (bool) {
-        cmd("MSETEX").arg(items.len()).arg(items).arg(options).take()
+        ready_cmd!("MSETEX", items.len(), items, options).take()
     }
 
     /// Set the string value of a key and return its old value.
     /// [Redis Docs](https://redis.io/commands/GETSET)
     fn getset<K: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, value: V) -> (Option<String>) {
-        cmd("GETSET").arg(key).arg(value).take()
+        ready_cmd!("GETSET", key, value).take()
     }
 
     /// Get a range of bytes/substring from the value of a key. Negative values provide an offset from the end of the value.
     /// Redis returns an empty string if the key doesn't exist, not Nil
     /// [Redis Docs](https://redis.io/commands/GETRANGE)
     fn getrange<K: ToSingleRedisArg>(key: K, from: isize, to: isize) -> (String) {
-        cmd("GETRANGE").arg(key).arg(from).arg(to).take()
+        ready_cmd!("GETRANGE", key, from, to).take()
     }
 
     /// Overwrite the part of the value stored in key at the specified offset.
     /// [Redis Docs](https://redis.io/commands/SETRANGE)
     fn setrange<K: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, offset: isize, value: V) -> (usize) {
-        cmd("SETRANGE").arg(key).arg(offset).arg(value).take()
+        ready_cmd!("SETRANGE", key, offset, value).take()
     }
 
     /// Delete one or more keys.
     /// Returns the number of keys deleted.
     /// [Redis Docs](https://redis.io/commands/DEL)
     fn del<K: ToRedisArgs>(key: K) -> (usize) {
-        cmd("DEL").arg(key).take()
+        ready_cmd!("DEL", key).take()
     }
 
     /// Conditionally removes the specified key. A key is ignored if it does not exist.
@@ -369,101 +369,101 @@ implement_commands! {
     /// IFDNE `match-digest` - Delete the key only if the digest of its value is not equal to `match-digest`
     /// [Redis Docs](https://redis.io/commands/DELEX)
     fn del_ex<K: ToSingleRedisArg>(key: K, value_comparison: ValueComparison) -> (usize) {
-        cmd("DELEX").arg(key).arg(value_comparison).take()
+        ready_cmd!("DELEX", key, value_comparison).take()
     }
 
     /// Get the hex signature of the value stored in the specified key.
     /// For the digest, Redis will use [XXH3](https://xxhash.com)
     /// [Redis Docs](https://redis.io/commands/DIGEST)
     fn digest<K: ToSingleRedisArg>(key: K) -> (Option<String>) {
-        cmd("DIGEST").arg(key).take()
+        ready_cmd!("DIGEST", key).take()
     }
 
     /// Determine if a key exists.
     /// [Redis Docs](https://redis.io/commands/EXISTS)
     fn exists<K: ToRedisArgs>(key: K) -> (bool) {
-        cmd("EXISTS").arg(key).take()
+        ready_cmd!("EXISTS", key).take()
     }
 
     /// Determine the type of key.
     /// [Redis Docs](https://redis.io/commands/TYPE)
     fn key_type<K: ToSingleRedisArg>(key: K) -> (crate::types::ValueType) {
-        cmd("TYPE").arg(key).take()
+        ready_cmd!("TYPE", key).take()
     }
 
     /// Set a key's time to live in seconds.
     /// Returns whether expiration was set.
     /// [Redis Docs](https://redis.io/commands/EXPIRE)
     fn expire<K: ToSingleRedisArg>(key: K, seconds: i64) -> (bool) {
-        cmd("EXPIRE").arg(key).arg(seconds).take()
+        ready_cmd!("EXPIRE", key, seconds).take()
     }
 
     /// Set the expiration for a key as a UNIX timestamp.
     /// Returns whether expiration was set.
     /// [Redis Docs](https://redis.io/commands/EXPIREAT)
     fn expire_at<K: ToSingleRedisArg>(key: K, ts: i64) -> (bool) {
-        cmd("EXPIREAT").arg(key).arg(ts).take()
+        ready_cmd!("EXPIREAT", key, ts).take()
     }
 
     /// Set a key's time to live in milliseconds.
     /// Returns whether expiration was set.
     /// [Redis Docs](https://redis.io/commands/PEXPIRE)
     fn pexpire<K: ToSingleRedisArg>(key: K, ms: i64) -> (bool) {
-        cmd("PEXPIRE").arg(key).arg(ms).take()
+        ready_cmd!("PEXPIRE", key, ms).take()
     }
 
     /// Set the expiration for a key as a UNIX timestamp in milliseconds.
     /// Returns whether expiration was set.
     /// [Redis Docs](https://redis.io/commands/PEXPIREAT)
     fn pexpire_at<K: ToSingleRedisArg>(key: K, ts: i64) -> (bool) {
-        cmd("PEXPIREAT").arg(key).arg(ts).take()
+        ready_cmd!("PEXPIREAT", key, ts).take()
     }
 
     /// Get the absolute Unix expiration timestamp in seconds.
     /// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
     /// [Redis Docs](https://redis.io/commands/EXPIRETIME)
     fn expire_time<K: ToSingleRedisArg>(key: K) -> (IntegerReplyOrNoOp) {
-        cmd("EXPIRETIME").arg(key).take()
+        ready_cmd!("EXPIRETIME", key).take()
     }
 
     /// Get the absolute Unix expiration timestamp in milliseconds.
     /// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
     /// [Redis Docs](https://redis.io/commands/PEXPIRETIME)
     fn pexpire_time<K: ToSingleRedisArg>(key: K) -> (IntegerReplyOrNoOp) {
-        cmd("PEXPIRETIME").arg(key).take()
+        ready_cmd!("PEXPIRETIME", key).take()
     }
 
     /// Remove the expiration from a key.
     /// Returns whether a timeout was removed.
     /// [Redis Docs](https://redis.io/commands/PERSIST)
     fn persist<K: ToSingleRedisArg>(key: K) -> (bool) {
-        cmd("PERSIST").arg(key).take()
+        ready_cmd!("PERSIST", key).take()
     }
 
     /// Get the time to live for a key in seconds.
     /// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
     /// [Redis Docs](https://redis.io/commands/TTL)
     fn ttl<K: ToSingleRedisArg>(key: K) -> (IntegerReplyOrNoOp) {
-        cmd("TTL").arg(key).take()
+        ready_cmd!("TTL", key).take()
     }
 
     /// Get the time to live for a key in milliseconds.
     /// Returns `ExistsButNotRelevant` if key exists but has no expiration time.
     /// [Redis Docs](https://redis.io/commands/PTTL)
     fn pttl<K: ToSingleRedisArg>(key: K) -> (IntegerReplyOrNoOp) {
-        cmd("PTTL").arg(key).take()
+        ready_cmd!("PTTL", key).take()
     }
 
     /// Get the value of a key and set expiration
     /// [Redis Docs](https://redis.io/commands/GETEX)
     fn get_ex<K: ToSingleRedisArg>(key: K, expire_at: Expiry) -> (Option<String>) {
-        cmd("GETEX").arg(key).arg(expire_at).take()
+        ready_cmd!("GETEX", key, expire_at).take()
     }
 
     /// Get the value of a key and delete it
     /// [Redis Docs](https://redis.io/commands/GETDEL)
     fn get_del<K: ToSingleRedisArg>(key: K) -> (Option<String>) {
-        cmd("GETDEL").arg(key).take()
+        ready_cmd!("GETDEL", key).take()
     }
 
     /// Copy the value from one key to another, returning whether the copy was successful.
@@ -473,14 +473,14 @@ implement_commands! {
         destination: KDst,
         options: CopyOptions<Db>
     ) -> (bool) {
-        cmd("COPY").arg(source).arg(destination).arg(options).take()
+        ready_cmd!("COPY", source, destination, options).take()
     }
 
     /// Rename a key.
     /// Errors if key does not exist.
     /// [Redis Docs](https://redis.io/commands/RENAME)
     fn rename<K: ToSingleRedisArg, N: ToSingleRedisArg>(key: K, new_key: N) -> (()) {
-        cmd("RENAME").arg(key).arg(new_key).take()
+        ready_cmd!("RENAME", key, new_key).take()
     }
 
     /// Rename a key, only if the new key does not exist.
@@ -488,14 +488,14 @@ implement_commands! {
     /// Returns whether the key was renamed, or false if the new key already exists.
     /// [Redis Docs](https://redis.io/commands/RENAMENX)
     fn rename_nx<K: ToSingleRedisArg, N: ToSingleRedisArg>(key: K, new_key: N) -> (bool) {
-        cmd("RENAMENX").arg(key).arg(new_key).take()
+        ready_cmd!("RENAMENX", key, new_key).take()
     }
 
     /// Unlink one or more keys. This is a non-blocking version of `DEL`.
     /// Returns number of keys unlinked.
     /// [Redis Docs](https://redis.io/commands/UNLINK)
     fn unlink<K: ToRedisArgs>(key: K) -> (usize) {
-        cmd("UNLINK").arg(key).take()
+        ready_cmd!("UNLINK", key).take()
     }
 
     // common string operations
@@ -504,25 +504,25 @@ implement_commands! {
     /// Returns length of string after operation.
     /// [Redis Docs](https://redis.io/commands/APPEND)
     fn append<K: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, value: V) -> (usize) {
-        cmd("APPEND").arg(key).arg(value).take()
+        ready_cmd!("APPEND", key, value).take()
     }
 
     /// Increment the numeric value of a key by the given amount.  This
     /// issues a `INCRBY` or `INCRBYFLOAT` depending on the type.
     /// If the key does not exist, it is set to 0 before performing the operation.
     fn incr<K: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, delta: V) -> (isize) {
-        cmd(if delta.describe_numeric_behavior() == NumericBehavior::NumberIsFloat {
+        ready_cmd!(if delta.describe_numeric_behavior() == NumericBehavior::NumberIsFloat {
             "INCRBYFLOAT"
         } else {
             "INCRBY"
-        }).arg(key).arg(delta).take()
+        }, key, delta).take()
     }
 
     /// Decrement the numeric value of a key by the given amount.
     /// If the key does not exist, it is set to 0 before performing the operation.
     /// [Redis Docs](https://redis.io/commands/DECRBY)
     fn decr<K: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, delta: V) -> (isize) {
-        cmd("DECRBY").arg(key).arg(delta).take()
+        ready_cmd!("DECRBY", key, delta).take()
     }
 
     /// Increment the numeric value of a key by the given amount and set its expiration.
@@ -562,27 +562,27 @@ implement_commands! {
     /// Returns the original bit value stored at offset.
     /// [Redis Docs](https://redis.io/commands/SETBIT)
     fn setbit<K: ToSingleRedisArg>(key: K, offset: usize, value: bool) -> (bool) {
-        cmd("SETBIT").arg(key).arg(offset).arg(i32::from(value)).take()
+        ready_cmd!("SETBIT", key, offset, i32::from(value)).take()
     }
 
     /// Returns the bit value at offset in the string value stored at key.
     /// [Redis Docs](https://redis.io/commands/GETBIT)
     fn getbit<K: ToSingleRedisArg>(key: K, offset: usize) -> (bool) {
-        cmd("GETBIT").arg(key).arg(offset).take()
+        ready_cmd!("GETBIT", key, offset).take()
     }
 
     /// Count set bits in a string.
     /// Returns 0 if key does not exist.
     /// [Redis Docs](https://redis.io/commands/BITCOUNT)
     fn bitcount<K: ToSingleRedisArg>(key: K) -> (usize) {
-        cmd("BITCOUNT").arg(key).take()
+        ready_cmd!("BITCOUNT", key).take()
     }
 
     /// Count set bits in a string in a range.
     /// Returns 0 if key does not exist.
     /// [Redis Docs](https://redis.io/commands/BITCOUNT)
     fn bitcount_range<K: ToSingleRedisArg>(key: K, start: usize, end: usize) -> (usize) {
-        cmd("BITCOUNT").arg(key).arg(start).arg(end).take()
+        ready_cmd!("BITCOUNT", key, start, end).take()
     }
 
     /// Perform a bitwise AND between multiple keys (containing string values)
@@ -590,7 +590,7 @@ implement_commands! {
     /// Returns size of destination string after operation.
     /// [Redis Docs](https://redis.io/commands/BITOP)
     fn bit_and<D: ToSingleRedisArg, S: ToRedisArgs>(dstkey: D, srckeys: S) -> (usize) {
-        cmd("BITOP").arg("AND").arg(dstkey).arg(srckeys).take()
+        ready_cmd!("BITOP", "AND", dstkey, srckeys).take()
     }
 
     /// Perform a bitwise OR between multiple keys (containing string values)
@@ -598,7 +598,7 @@ implement_commands! {
     /// Returns size of destination string after operation.
     /// [Redis Docs](https://redis.io/commands/BITOP)
     fn bit_or<D: ToSingleRedisArg, S: ToRedisArgs>(dstkey: D, srckeys: S) -> (usize) {
-        cmd("BITOP").arg("OR").arg(dstkey).arg(srckeys).take()
+        ready_cmd!("BITOP", "OR", dstkey, srckeys).take()
     }
 
     /// Perform a bitwise XOR between multiple keys (containing string values)
@@ -606,7 +606,7 @@ implement_commands! {
     /// Returns size of destination string after operation.
     /// [Redis Docs](https://redis.io/commands/BITOP)
     fn bit_xor<D: ToSingleRedisArg, S: ToRedisArgs>(dstkey: D, srckeys: S) -> (usize) {
-        cmd("BITOP").arg("XOR").arg(dstkey).arg(srckeys).take()
+        ready_cmd!("BITOP", "XOR", dstkey, srckeys).take()
     }
 
     /// Perform a bitwise NOT of the key (containing string values)
@@ -614,7 +614,7 @@ implement_commands! {
     /// Returns size of destination string after operation.
     /// [Redis Docs](https://redis.io/commands/BITOP)
     fn bit_not<D: ToSingleRedisArg, S: ToSingleRedisArg>(dstkey: D, srckey: S) -> (usize) {
-        cmd("BITOP").arg("NOT").arg(dstkey).arg(srckey).take()
+        ready_cmd!("BITOP", "NOT", dstkey, srckey).take()
     }
 
     /// DIFF(X, Y1, Y2, …) \
@@ -622,7 +622,7 @@ implement_commands! {
     /// Logical representation: X  ∧ ¬(Y1 ∨ Y2 ∨ …) \
     /// [Redis Docs](https://redis.io/commands/BITOP)
     fn bit_diff<D: ToSingleRedisArg, S: ToRedisArgs>(dstkey: D, srckeys: S) -> (usize) {
-        cmd("BITOP").arg("DIFF").arg(dstkey).arg(srckeys).take()
+        ready_cmd!("BITOP", "DIFF", dstkey, srckeys).take()
     }
 
     /// DIFF1(X, Y1, Y2, …) (Relative complement difference) \
@@ -630,7 +630,7 @@ implement_commands! {
     /// Logical representation: ¬X  ∧ (Y1 ∨ Y2 ∨ …) \
     /// [Redis Docs](https://redis.io/commands/BITOP)
     fn bit_diff1<D: ToSingleRedisArg, S: ToRedisArgs>(dstkey: D, srckeys: S) -> (usize) {
-        cmd("BITOP").arg("DIFF1").arg(dstkey).arg(srckeys).take()
+        ready_cmd!("BITOP", "DIFF1", dstkey, srckeys).take()
     }
 
     /// ANDOR(X, Y1, Y2, …) \
@@ -638,7 +638,7 @@ implement_commands! {
     /// Logical representation: X ∧ (Y1 ∨ Y2 ∨ …) \
     /// [Redis Docs](https://redis.io/commands/BITOP)
     fn bit_and_or<D: ToSingleRedisArg, S: ToRedisArgs>(dstkey: D, srckeys: S) -> (usize) {
-        cmd("BITOP").arg("ANDOR").arg(dstkey).arg(srckeys).take()
+        ready_cmd!("BITOP", "ANDOR", dstkey, srckeys).take()
     }
 
     /// ONE(X, Y1, Y2, …) \
@@ -646,100 +646,100 @@ implement_commands! {
     /// Logical representation: (X ∨ Y1 ∨ Y2 ∨ …) ∧ ¬((X ∧ Y1) ∨ (X ∧ Y2) ∨ (Y1 ∧ Y2) ∨ (Y1 ∧ Y3) ∨ …) \
     /// [Redis Docs](https://redis.io/commands/BITOP)
     fn bit_one<D: ToSingleRedisArg, S: ToRedisArgs>(dstkey: D, srckeys: S) -> (usize) {
-        cmd("BITOP").arg("ONE").arg(dstkey).arg(srckeys).take()
+        ready_cmd!("BITOP", "ONE", dstkey, srckeys).take()
     }
 
     /// Get the length of the value stored in a key.
     /// 0 if key does not exist.
     /// [Redis Docs](https://redis.io/commands/STRLEN)
     fn strlen<K: ToSingleRedisArg>(key: K) -> (usize) {
-        cmd("STRLEN").arg(key).take()
+        ready_cmd!("STRLEN", key).take()
     }
 
     // hash operations
 
     /// Gets a single (or multiple) fields from a hash.
     fn hget<K: ToSingleRedisArg, F: ToSingleRedisArg>(key: K, field: F) -> (Option<String>) {
-        cmd("HGET").arg(key).arg(field).take()
+        ready_cmd!("HGET", key, field).take()
     }
 
     /// Gets multiple fields from a hash.
     /// [Redis Docs](https://redis.io/commands/HMGET)
     fn hmget<K: ToSingleRedisArg, F: ToRedisArgs>(key: K, fields: F) -> (Vec<Option<String>>) {
-        cmd("HMGET").arg(key).arg(fields).take()
+        ready_cmd!("HMGET", key, fields).take()
     }
 
     /// Get the value of one or more fields of a given hash key, and optionally set their expiration
     /// [Redis Docs](https://redis.io/commands/HGETEX)
     fn hget_ex<K: ToSingleRedisArg, F: ToRedisArgs>(key: K, fields: F, expire_at: Expiry) -> (Vec<Option<String>>) {
-        cmd("HGETEX").arg(key).arg(expire_at).arg("FIELDS").arg(fields.num_of_args()).arg(fields).take()
+        ready_cmd!("HGETEX", key, expire_at, "FIELDS", fields.num_of_args(), fields).take()
     }
 
     /// Deletes a single (or multiple) fields from a hash.
     /// Returns number of fields deleted.
     /// [Redis Docs](https://redis.io/commands/HDEL)
     fn hdel<K: ToSingleRedisArg, F: ToRedisArgs>(key: K, field: F) -> (usize) {
-        cmd("HDEL").arg(key).arg(field).take()
+        ready_cmd!("HDEL", key, field).take()
     }
 
     /// Get and delete the value of one or more fields of a given hash key
     /// [Redis Docs](https://redis.io/commands/HGETDEL)
     fn hget_del<K: ToSingleRedisArg, F: ToRedisArgs>(key: K, fields: F) -> (Vec<Option<String>>) {
-        cmd("HGETDEL").arg(key).arg("FIELDS").arg(fields.num_of_args()).arg(fields).take()
+        ready_cmd!("HGETDEL", key, "FIELDS", fields.num_of_args(), fields).take()
     }
 
     /// Sets a single field in a hash.
     /// Returns number of fields added.
     /// [Redis Docs](https://redis.io/commands/HSET)
     fn hset<K: ToSingleRedisArg, F: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, field: F, value: V) -> (usize) {
-        cmd("HSET").arg(key).arg(field).arg(value).take()
+        ready_cmd!("HSET", key, field, value).take()
     }
 
     /// Set the value of one or more fields of a given hash key, and optionally set their expiration
     /// [Redis Docs](https://redis.io/commands/HSETEX)
     fn hset_ex<K: ToSingleRedisArg, F: ToRedisArgs, V: ToRedisArgs>(key: K, hash_field_expiration_options: &'a HashFieldExpirationOptions, fields_values: &'a [(F, V)]) -> (bool) {
-        cmd("HSETEX").arg(key).arg(hash_field_expiration_options).arg("FIELDS").arg(fields_values.len()).arg(fields_values).take()
+        ready_cmd!("HSETEX", key, hash_field_expiration_options, "FIELDS", fields_values.len(), fields_values).take()
     }
 
     /// Sets a single field in a hash if it does not exist.
     /// Returns whether the field was added.
     /// [Redis Docs](https://redis.io/commands/HSETNX)
     fn hset_nx<K: ToSingleRedisArg, F: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, field: F, value: V) -> (bool) {
-        cmd("HSETNX").arg(key).arg(field).arg(value).take()
+        ready_cmd!("HSETNX", key, field, value).take()
     }
 
     /// Sets multiple fields in a hash.
     /// [Redis Docs](https://redis.io/commands/HMSET)
     fn hset_multiple<K: ToSingleRedisArg, F: ToRedisArgs, V: ToRedisArgs>(key: K, items: &'a [(F, V)]) -> (()) {
-        cmd("HMSET").arg(key).arg(items).take()
+        ready_cmd!("HMSET", key, items).take()
     }
 
     /// Increments a value.
     /// Returns the new value of the field after incrementation.
     fn hincr<K: ToSingleRedisArg, F: ToSingleRedisArg, D: ToSingleRedisArg>(key: K, field: F, delta: D) -> (f64) {
-        cmd(if delta.describe_numeric_behavior() == NumericBehavior::NumberIsFloat {
+        ready_cmd!(if delta.describe_numeric_behavior() == NumericBehavior::NumberIsFloat {
             "HINCRBYFLOAT"
         } else {
             "HINCRBY"
-        }).arg(key).arg(field).arg(delta).take()
+        }, key, field, delta).take()
     }
 
     /// Checks if a field in a hash exists.
     /// [Redis Docs](https://redis.io/commands/HEXISTS)
     fn hexists<K: ToSingleRedisArg, F: ToSingleRedisArg>(key: K, field: F) -> (bool) {
-        cmd("HEXISTS").arg(key).arg(field).take()
+        ready_cmd!("HEXISTS", key, field).take()
     }
 
     /// Get one or more fields' TTL in seconds.
     /// [Redis Docs](https://redis.io/commands/HTTL)
     fn httl<K: ToSingleRedisArg, F: ToRedisArgs>(key: K, fields: F) -> (Vec<IntegerReplyOrNoOp>) {
-        cmd("HTTL").arg(key).arg("FIELDS").arg(fields.num_of_args()).arg(fields).take()
+        ready_cmd!("HTTL", key, "FIELDS", fields.num_of_args(), fields).take()
     }
 
     /// Get one or more fields' TTL in milliseconds.
     /// [Redis Docs](https://redis.io/commands/HPTTL)
     fn hpttl<K: ToSingleRedisArg, F: ToRedisArgs>(key: K, fields: F) -> (Vec<IntegerReplyOrNoOp>) {
-        cmd("HPTTL").arg(key).arg("FIELDS").arg(fields.num_of_args()).arg(fields).take()
+        ready_cmd!("HPTTL", key, "FIELDS", fields.num_of_args(), fields).take()
     }
 
     /// Set one or more fields' time to live in seconds.
@@ -751,7 +751,7 @@ implement_commands! {
     /// Errors if provided key exists but is not a hash.
     /// [Redis Docs](https://redis.io/commands/HEXPIRE)
     fn hexpire<K: ToSingleRedisArg, F: ToRedisArgs>(key: K, seconds: i64, opt: ExpireOption, fields: F) -> (Vec<IntegerReplyOrNoOp>) {
-       cmd("HEXPIRE").arg(key).arg(seconds).arg(opt).arg("FIELDS").arg(fields.num_of_args()).arg(fields).take()
+       ready_cmd!("HEXPIRE", key, seconds, opt, "FIELDS", fields.num_of_args(), fields).take()
     }
 
 
@@ -764,20 +764,20 @@ implement_commands! {
     /// Errors if provided key exists but is not a hash.
     /// [Redis Docs](https://redis.io/commands/HEXPIREAT)
     fn hexpire_at<K: ToSingleRedisArg, F: ToRedisArgs>(key: K, ts: i64, opt: ExpireOption, fields: F) -> (Vec<IntegerReplyOrNoOp>) {
-        cmd("HEXPIREAT").arg(key).arg(ts).arg(opt).arg("FIELDS").arg(fields.num_of_args()).arg(fields).take()
+        ready_cmd!("HEXPIREAT", key, ts, opt, "FIELDS", fields.num_of_args(), fields).take()
     }
 
     /// Returns the absolute Unix expiration timestamp in seconds.
     /// [Redis Docs](https://redis.io/commands/HEXPIRETIME)
     fn hexpire_time<K: ToSingleRedisArg, F: ToRedisArgs>(key: K, fields: F) -> (Vec<IntegerReplyOrNoOp>) {
-        cmd("HEXPIRETIME").arg(key).arg("FIELDS").arg(fields.num_of_args()).arg(fields).take()
+        ready_cmd!("HEXPIRETIME", key, "FIELDS", fields.num_of_args(), fields).take()
     }
 
     /// Remove the expiration from a key.
     /// Returns 1 if the expiration was removed.
     /// [Redis Docs](https://redis.io/commands/HPERSIST)
     fn hpersist<K: ToSingleRedisArg, F :ToRedisArgs>(key: K, fields: F) -> (Vec<IntegerReplyOrNoOp>) {
-        cmd("HPERSIST").arg(key).arg("FIELDS").arg(fields.num_of_args()).arg(fields).take()
+        ready_cmd!("HPERSIST", key, "FIELDS", fields.num_of_args(), fields).take()
     }
 
     /// Set one or more fields' time to live in milliseconds.
@@ -789,7 +789,7 @@ implement_commands! {
     /// Errors if provided key exists but is not a hash.
     /// [Redis Docs](https://redis.io/commands/HPEXPIRE)
     fn hpexpire<K: ToSingleRedisArg, F: ToRedisArgs>(key: K, milliseconds: i64, opt: ExpireOption, fields: F) -> (Vec<IntegerReplyOrNoOp>) {
-        cmd("HPEXPIRE").arg(key).arg(milliseconds).arg(opt).arg("FIELDS").arg(fields.num_of_args()).arg(fields).take()
+        ready_cmd!("HPEXPIRE", key, milliseconds, opt, "FIELDS", fields.num_of_args(), fields).take()
     }
 
     /// Set the expiration for one or more fields as a UNIX timestamp in milliseconds.
@@ -801,38 +801,38 @@ implement_commands! {
     /// Errors if provided key exists but is not a hash.
     /// [Redis Docs](https://redis.io/commands/HPEXPIREAT)
     fn hpexpire_at<K: ToSingleRedisArg, F: ToRedisArgs>(key: K, ts: i64,  opt: ExpireOption, fields: F) -> (Vec<IntegerReplyOrNoOp>) {
-        cmd("HPEXPIREAT").arg(key).arg(ts).arg(opt).arg("FIELDS").arg(fields.num_of_args()).arg(fields).take()
+        ready_cmd!("HPEXPIREAT", key, ts, opt, "FIELDS", fields.num_of_args(), fields).take()
     }
 
     /// Returns the absolute Unix expiration timestamp in seconds.
     /// [Redis Docs](https://redis.io/commands/HPEXPIRETIME)
     fn hpexpire_time<K: ToSingleRedisArg, F: ToRedisArgs>(key: K, fields: F) -> (Vec<IntegerReplyOrNoOp>) {
-        cmd("HPEXPIRETIME").arg(key).arg("FIELDS").arg(fields.num_of_args()).arg(fields).take()
+        ready_cmd!("HPEXPIRETIME", key, "FIELDS", fields.num_of_args(), fields).take()
     }
 
     /// Gets all the keys in a hash.
     /// [Redis Docs](https://redis.io/commands/HKEYS)
     fn hkeys<K: ToSingleRedisArg>(key: K) -> (Vec<String>) {
-        cmd("HKEYS").arg(key).take()
+        ready_cmd!("HKEYS", key).take()
     }
 
     /// Gets all the values in a hash.
     /// [Redis Docs](https://redis.io/commands/HVALS)
     fn hvals<K: ToSingleRedisArg>(key: K) -> (Vec<String>) {
-        cmd("HVALS").arg(key).take()
+        ready_cmd!("HVALS", key).take()
     }
 
     /// Gets all the fields and values in a hash.
     /// [Redis Docs](https://redis.io/commands/HGETALL)
     fn hgetall<K: ToSingleRedisArg>(key: K) -> (std::collections::HashMap<String, String>) {
-        cmd("HGETALL").arg(key).take()
+        ready_cmd!("HGETALL", key).take()
     }
 
     /// Gets the length of a hash.
     /// Returns 0 if key does not exist.
     /// [Redis Docs](https://redis.io/commands/HLEN)
     fn hlen<K: ToSingleRedisArg>(key: K) -> (usize) {
-        cmd("HLEN").arg(key).take()
+        ready_cmd!("HLEN", key).take()
     }
 
     // list operations
@@ -841,72 +841,72 @@ implement_commands! {
     /// and return it; or block until one is available
     /// [Redis Docs](https://redis.io/commands/BLMOVE)
     fn blmove<S: ToSingleRedisArg, D: ToSingleRedisArg>(srckey: S, dstkey: D, src_dir: Direction, dst_dir: Direction, timeout: f64) -> (Option<String>) {
-        cmd("BLMOVE").arg(srckey).arg(dstkey).arg(src_dir).arg(dst_dir).arg(timeout).take()
+        ready_cmd!("BLMOVE", srckey, dstkey, src_dir, dst_dir, timeout).take()
     }
 
     /// Pops `count` elements from the first non-empty list key from the list of
     /// provided key names; or blocks until one is available.
     /// [Redis Docs](https://redis.io/commands/BLMPOP)
     fn blmpop<K: ToRedisArgs>(timeout: f64, numkeys: usize, key: K, dir: Direction, count: usize) -> (Option<[String; 2]>) {
-        cmd("BLMPOP").arg(timeout).arg(numkeys).arg(key).arg(dir).arg("COUNT").arg(count).take()
+        ready_cmd!("BLMPOP", timeout, numkeys, key, dir, "COUNT", count).take()
     }
 
     /// Remove and get the first element in a list, or block until one is available.
     /// [Redis Docs](https://redis.io/commands/BLPOP)
     fn blpop<K: ToRedisArgs>(key: K, timeout: f64) -> (Option<[String; 2]>) {
-        cmd("BLPOP").arg(key).arg(timeout).take()
+        ready_cmd!("BLPOP", key, timeout).take()
     }
 
     /// Remove and get the last element in a list, or block until one is available.
     /// [Redis Docs](https://redis.io/commands/BRPOP)
     fn brpop<K: ToRedisArgs>(key: K, timeout: f64) -> (Option<[String; 2]>) {
-        cmd("BRPOP").arg(key).arg(timeout).take()
+        ready_cmd!("BRPOP", key, timeout).take()
     }
 
     /// Pop a value from a list, push it to another list and return it;
     /// or block until one is available.
     /// [Redis Docs](https://redis.io/commands/BRPOPLPUSH)
     fn brpoplpush<S: ToSingleRedisArg, D: ToSingleRedisArg>(srckey: S, dstkey: D, timeout: f64) -> (Option<String>) {
-        cmd("BRPOPLPUSH").arg(srckey).arg(dstkey).arg(timeout).take()
+        ready_cmd!("BRPOPLPUSH", srckey, dstkey, timeout).take()
     }
 
     /// Get an element from a list by its index.
     /// [Redis Docs](https://redis.io/commands/LINDEX)
     fn lindex<K: ToSingleRedisArg>(key: K, index: isize) -> (Option<String>) {
-        cmd("LINDEX").arg(key).arg(index).take()
+        ready_cmd!("LINDEX", key, index).take()
     }
 
     /// Insert an element before another element in a list.
     /// [Redis Docs](https://redis.io/commands/LINSERT)
     fn linsert_before<K: ToSingleRedisArg, P: ToSingleRedisArg, V: ToSingleRedisArg>(
             key: K, pivot: P, value: V) -> (isize) {
-        cmd("LINSERT").arg(key).arg("BEFORE").arg(pivot).arg(value).take()
+        ready_cmd!("LINSERT", key, "BEFORE", pivot, value).take()
     }
 
     /// Insert an element after another element in a list.
     /// [Redis Docs](https://redis.io/commands/LINSERT)
     fn linsert_after<K: ToSingleRedisArg, P: ToSingleRedisArg, V: ToSingleRedisArg>(
             key: K, pivot: P, value: V) -> (isize) {
-        cmd("LINSERT").arg(key).arg("AFTER").arg(pivot).arg(value).take()
+        ready_cmd!("LINSERT", key, "AFTER", pivot, value).take()
     }
 
     /// Returns the length of the list stored at key.
     /// [Redis Docs](https://redis.io/commands/LLEN)
     fn llen<K: ToSingleRedisArg>(key: K) -> (usize) {
-        cmd("LLEN").arg(key).take()
+        ready_cmd!("LLEN", key).take()
     }
 
     /// Pop an element a list, push it to another list and return it
     /// [Redis Docs](https://redis.io/commands/LMOVE)
     fn lmove<S: ToSingleRedisArg, D: ToSingleRedisArg>(srckey: S, dstkey: D, src_dir: Direction, dst_dir: Direction) -> (String) {
-        cmd("LMOVE").arg(srckey).arg(dstkey).arg(src_dir).arg(dst_dir).take()
+        ready_cmd!("LMOVE", srckey, dstkey, src_dir, dst_dir).take()
     }
 
     /// Pops `count` elements from the first non-empty list key from the list of
     /// provided key names.
     /// [Redis Docs](https://redis.io/commands/LMPOP)
     fn lmpop<K: ToRedisArgs>( numkeys: usize, key: K, dir: Direction, count: usize) -> (Option<(String, Vec<String>)>) {
-        cmd("LMPOP").arg(numkeys).arg(key).arg(dir).arg("COUNT").arg(count).take()
+        ready_cmd!("LMPOP", numkeys, key, dir, "COUNT", count).take()
     }
 
     /// Removes and returns the up to `count` first elements of the list stored at key.
@@ -914,64 +914,64 @@ implement_commands! {
     /// If `count` is not specified, then defaults to first element.
     /// [Redis Docs](https://redis.io/commands/LPOP)
     fn lpop<K: ToSingleRedisArg>(key: K, count: Option<core::num::NonZeroUsize>) -> Generic {
-        cmd("LPOP").arg(key).arg(count).take()
+        ready_cmd!("LPOP", key, count).take()
     }
 
     /// Returns the index of the first matching value of the list stored at key.
     /// [Redis Docs](https://redis.io/commands/LPOS)
     fn lpos<K: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, value: V, options: LposOptions) -> Generic {
-        cmd("LPOS").arg(key).arg(value).arg(options).take()
+        ready_cmd!("LPOS", key, value, options).take()
     }
 
     /// Insert all the specified values at the head of the list stored at key.
     /// [Redis Docs](https://redis.io/commands/LPUSH)
     fn lpush<K: ToSingleRedisArg, V: ToRedisArgs>(key: K, value: V) -> (usize) {
-        cmd("LPUSH").arg(key).arg(value).take()
+        ready_cmd!("LPUSH", key, value).take()
     }
 
     /// Inserts a value at the head of the list stored at key, only if key
     /// already exists and holds a list.
     /// [Redis Docs](https://redis.io/commands/LPUSHX)
     fn lpush_exists<K: ToSingleRedisArg, V: ToRedisArgs>(key: K, value: V) -> (usize) {
-        cmd("LPUSHX").arg(key).arg(value).take()
+        ready_cmd!("LPUSHX", key, value).take()
     }
 
     /// Returns the specified elements of the list stored at key.
     /// [Redis Docs](https://redis.io/commands/LRANGE)
     fn lrange<K: ToSingleRedisArg>(key: K, start: isize, stop: isize) -> (Vec<String>) {
-        cmd("LRANGE").arg(key).arg(start).arg(stop).take()
+        ready_cmd!("LRANGE", key, start, stop).take()
     }
 
     /// Removes the first count occurrences of elements equal to value
     /// from the list stored at key.
     /// [Redis Docs](https://redis.io/commands/LREM)
     fn lrem<K: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, count: isize, value: V) -> (usize) {
-        cmd("LREM").arg(key).arg(count).arg(value).take()
+        ready_cmd!("LREM", key, count, value).take()
     }
 
     /// Trim an existing list so that it will contain only the specified
     /// range of elements specified.
     /// [Redis Docs](https://redis.io/commands/LTRIM)
     fn ltrim<K: ToSingleRedisArg>(key: K, start: isize, stop: isize) -> (()) {
-        cmd("LTRIM").arg(key).arg(start).arg(stop).take()
+        ready_cmd!("LTRIM", key, start, stop).take()
     }
 
     /// Sets the list element at index to value
     /// [Redis Docs](https://redis.io/commands/LSET)
     fn lset<K: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, index: isize, value: V) -> (()) {
-        cmd("LSET").arg(key).arg(index).arg(value).take()
+        ready_cmd!("LSET", key, index, value).take()
     }
 
     /// Sends a ping to the server
     /// [Redis Docs](https://redis.io/commands/PING)
     fn ping<>() -> (String) {
-         cmd("PING").take()
+         ready_cmd!("PING").take()
     }
 
     /// Sends a ping with a message to the server
     /// [Redis Docs](https://redis.io/commands/PING)
     fn ping_message<K: ToSingleRedisArg>(message: K) -> (String) {
-         cmd("PING").arg(message).take()
+         ready_cmd!("PING", message).take()
     }
 
     /// Removes and returns the up to `count` last elements of the list stored at key
@@ -979,26 +979,26 @@ implement_commands! {
     /// If `count` is not specified, then defaults to last element.
     /// [Redis Docs](https://redis.io/commands/RPOP)
     fn rpop<K: ToSingleRedisArg>(key: K, count: Option<core::num::NonZeroUsize>) -> Generic {
-        cmd("RPOP").arg(key).arg(count).take()
+        ready_cmd!("RPOP", key, count).take()
     }
 
     /// Pop a value from a list, push it to another list and return it.
     /// [Redis Docs](https://redis.io/commands/RPOPLPUSH)
     fn rpoplpush<K: ToSingleRedisArg, D: ToSingleRedisArg>(key: K, dstkey: D) -> (Option<String>) {
-        cmd("RPOPLPUSH").arg(key).arg(dstkey).take()
+        ready_cmd!("RPOPLPUSH", key, dstkey).take()
     }
 
     /// Insert all the specified values at the tail of the list stored at key.
     /// [Redis Docs](https://redis.io/commands/RPUSH)
     fn rpush<K: ToSingleRedisArg, V: ToRedisArgs>(key: K, value: V) -> (usize) {
-        cmd("RPUSH").arg(key).arg(value).take()
+        ready_cmd!("RPUSH", key, value).take()
     }
 
     /// Inserts value at the tail of the list stored at key, only if key
     /// already exists and holds a list.
     /// [Redis Docs](https://redis.io/commands/RPUSHX)
     fn rpush_exists<K: ToSingleRedisArg, V: ToRedisArgs>(key: K, value: V) -> (usize) {
-        cmd("RPUSHX").arg(key).arg(value).take()
+        ready_cmd!("RPUSHX", key, value).take()
     }
 
     // set commands
@@ -1006,97 +1006,97 @@ implement_commands! {
     /// Add one or more members to a set.
     /// [Redis Docs](https://redis.io/commands/SADD)
     fn sadd<K: ToSingleRedisArg, M: ToRedisArgs>(key: K, member: M) -> (usize) {
-        cmd("SADD").arg(key).arg(member).take()
+        ready_cmd!("SADD", key, member).take()
     }
 
     /// Get the number of members in a set.
     /// [Redis Docs](https://redis.io/commands/SCARD)
     fn scard<K: ToSingleRedisArg>(key: K) -> (usize) {
-        cmd("SCARD").arg(key).take()
+        ready_cmd!("SCARD", key).take()
     }
 
     /// Subtract multiple sets.
     /// [Redis Docs](https://redis.io/commands/SDIFF)
     fn sdiff<K: ToRedisArgs>(keys: K) -> (HashSet<String>) {
-        cmd("SDIFF").arg(keys).take()
+        ready_cmd!("SDIFF", keys).take()
     }
 
     /// Subtract multiple sets and store the resulting set in a key.
     /// [Redis Docs](https://redis.io/commands/SDIFFSTORE)
     fn sdiffstore<D: ToSingleRedisArg, K: ToRedisArgs>(dstkey: D, keys: K) -> (usize) {
-        cmd("SDIFFSTORE").arg(dstkey).arg(keys).take()
+        ready_cmd!("SDIFFSTORE", dstkey, keys).take()
     }
 
     /// Intersect multiple sets.
     /// [Redis Docs](https://redis.io/commands/SINTER)
     fn sinter<K: ToRedisArgs>(keys: K) -> (HashSet<String>) {
-        cmd("SINTER").arg(keys).take()
+        ready_cmd!("SINTER", keys).take()
     }
 
     /// Intersect multiple sets and store the resulting set in a key.
     /// [Redis Docs](https://redis.io/commands/SINTERSTORE)
     fn sinterstore<D: ToSingleRedisArg, K: ToRedisArgs>(dstkey: D, keys: K) -> (usize) {
-        cmd("SINTERSTORE").arg(dstkey).arg(keys).take()
+        ready_cmd!("SINTERSTORE", dstkey, keys).take()
     }
 
     /// Determine if a given value is a member of a set.
     /// [Redis Docs](https://redis.io/commands/SISMEMBER)
     fn sismember<K: ToSingleRedisArg, M: ToSingleRedisArg>(key: K, member: M) -> (bool) {
-        cmd("SISMEMBER").arg(key).arg(member).take()
+        ready_cmd!("SISMEMBER", key, member).take()
     }
 
     /// Determine if given values are members of a set.
     /// [Redis Docs](https://redis.io/commands/SMISMEMBER)
     fn smismember<K: ToSingleRedisArg, M: ToRedisArgs>(key: K, members: M) -> (Vec<bool>) {
-        cmd("SMISMEMBER").arg(key).arg(members).take()
+        ready_cmd!("SMISMEMBER", key, members).take()
     }
 
     /// Get all the members in a set.
     /// [Redis Docs](https://redis.io/commands/SMEMBERS)
     fn smembers<K: ToSingleRedisArg>(key: K) -> (HashSet<String>) {
-        cmd("SMEMBERS").arg(key).take()
+        ready_cmd!("SMEMBERS", key).take()
     }
 
     /// Move a member from one set to another.
     /// [Redis Docs](https://redis.io/commands/SMOVE)
     fn smove<S: ToSingleRedisArg, D: ToSingleRedisArg, M: ToSingleRedisArg>(srckey: S, dstkey: D, member: M) -> (bool) {
-        cmd("SMOVE").arg(srckey).arg(dstkey).arg(member).take()
+        ready_cmd!("SMOVE", srckey, dstkey, member).take()
     }
 
     /// Remove and return a random member from a set.
     /// [Redis Docs](https://redis.io/commands/SPOP)
     fn spop<K: ToSingleRedisArg>(key: K) -> Generic {
-        cmd("SPOP").arg(key).take()
+        ready_cmd!("SPOP", key).take()
     }
 
     /// Get one random member from a set.
     /// [Redis Docs](https://redis.io/commands/SRANDMEMBER)
     fn srandmember<K: ToSingleRedisArg>(key: K) -> (Option<String>) {
-        cmd("SRANDMEMBER").arg(key).take()
+        ready_cmd!("SRANDMEMBER", key).take()
     }
 
     /// Get multiple random members from a set.
     /// [Redis Docs](https://redis.io/commands/SRANDMEMBER)
     fn srandmember_multiple<K: ToSingleRedisArg>(key: K, count: isize) -> (Vec<String>) {
-        cmd("SRANDMEMBER").arg(key).arg(count).take()
+        ready_cmd!("SRANDMEMBER", key, count).take()
     }
 
     /// Remove one or more members from a set.
     /// [Redis Docs](https://redis.io/commands/SREM)
     fn srem<K: ToSingleRedisArg, M: ToRedisArgs>(key: K, member: M) -> (usize) {
-        cmd("SREM").arg(key).arg(member).take()
+        ready_cmd!("SREM", key, member).take()
     }
 
     /// Add multiple sets.
     /// [Redis Docs](https://redis.io/commands/SUNION)
     fn sunion<K: ToRedisArgs>(keys: K) -> (HashSet<String>) {
-        cmd("SUNION").arg(keys).take()
+        ready_cmd!("SUNION", keys).take()
     }
 
     /// Add multiple sets and store the resulting set in a key.
     /// [Redis Docs](https://redis.io/commands/SUNIONSTORE)
     fn sunionstore<D: ToSingleRedisArg, K: ToRedisArgs>(dstkey: D, keys: K) -> (usize) {
-        cmd("SUNIONSTORE").arg(dstkey).arg(keys).take()
+        ready_cmd!("SUNIONSTORE", dstkey, keys).take()
     }
 
     // sorted set commands
@@ -1104,44 +1104,44 @@ implement_commands! {
     /// Add one member to a sorted set, or update its score if it already exists.
     /// [Redis Docs](https://redis.io/commands/ZADD)
     fn zadd<K: ToSingleRedisArg, S: ToSingleRedisArg, M: ToSingleRedisArg>(key: K, member: M, score: S) -> usize{
-        cmd("ZADD").arg(key).arg(score).arg(member).take()
+        ready_cmd!("ZADD", key, score, member).take()
     }
 
     /// Add multiple members to a sorted set, or update its score if it already exists.
     /// [Redis Docs](https://redis.io/commands/ZADD)
     fn zadd_multiple<K: ToSingleRedisArg, S: ToRedisArgs, M: ToRedisArgs>(key: K, items: &'a [(S, M)]) -> (usize) {
-        cmd("ZADD").arg(key).arg(items).take()
+        ready_cmd!("ZADD", key, items).take()
     }
 
      /// Add one member to a sorted set, or update its score if it already exists.
      /// [Redis Docs](https://redis.io/commands/ZADD)
     fn zadd_options<K: ToSingleRedisArg, S: ToSingleRedisArg, M: ToSingleRedisArg>(key: K, member: M, score: S, options:&'a SortedSetAddOptions) -> usize{
-        cmd("ZADD").arg(key).arg(options).arg(score).arg(member).take()
+        ready_cmd!("ZADD", key, options, score, member).take()
     }
 
     /// Add multiple members to a sorted set, or update its score if it already exists.
     /// [Redis Docs](https://redis.io/commands/ZADD)
     fn zadd_multiple_options<K: ToSingleRedisArg, S: ToRedisArgs, M: ToRedisArgs>(key: K, items: &'a [(S, M)], options:&'a SortedSetAddOptions) -> (usize) {
-        cmd("ZADD").arg(key).arg(options).arg(items).take()
+        ready_cmd!("ZADD", key, options, items).take()
     }
 
     /// Get the number of members in a sorted set.
     /// [Redis Docs](https://redis.io/commands/ZCARD)
     fn zcard<K: ToSingleRedisArg>(key: K) -> (usize) {
-        cmd("ZCARD").arg(key).take()
+        ready_cmd!("ZCARD", key).take()
     }
 
     /// Count the members in a sorted set with scores within the given values.
     /// [Redis Docs](https://redis.io/commands/ZCOUNT)
     fn zcount<K: ToSingleRedisArg, M: ToSingleRedisArg, MM: ToSingleRedisArg>(key: K, min: M, max: MM) -> (usize) {
-        cmd("ZCOUNT").arg(key).arg(min).arg(max).take()
+        ready_cmd!("ZCOUNT", key, min, max).take()
     }
 
     /// Increments the member in a sorted set at key by delta.
     /// If the member does not exist, it is added with delta as its score.
     /// [Redis Docs](https://redis.io/commands/ZINCRBY)
     fn zincr<K: ToSingleRedisArg, M: ToSingleRedisArg, D: ToSingleRedisArg>(key: K, member: M, delta: D) -> (f64) {
-        cmd("ZINCRBY").arg(key).arg(delta).arg(member).take()
+        ready_cmd!("ZINCRBY", key, delta, member).take()
     }
 
     /// Intersect multiple sorted sets and store the resulting sorted set in
@@ -1149,7 +1149,7 @@ implement_commands! {
     /// If no `AGGREGATE` modifier is provided, `SUM` is used.
     /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
     fn zinterstore<D: ToSingleRedisArg, K: ToRedisArgs>(dstkey: D, keys: K, options: SortedSetOperationOptions) -> (usize) {
-        cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg(options).take()
+        ready_cmd!("ZINTERSTORE", dstkey, keys.num_of_args(), keys, options).take()
     }
 
     /// Intersect multiple sorted sets and store the resulting sorted set in
@@ -1157,14 +1157,14 @@ implement_commands! {
     /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
     fn zinterstore_with_weights<D: ToSingleRedisArg, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (usize) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
-        cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).take()
+        ready_cmd!("ZINTERSTORE", dstkey, keys.num_of_args(), keys, "WEIGHTS", weights, options).take()
     }
 
     /// Intersect multiple sorted sets and return the resulting members,
     /// applying an optional `AGGREGATE` modifier (SUM by default).
     /// [Redis Docs](https://redis.io/commands/ZINTER)
     fn zinter<K: ToRedisArgs>(keys: K, options: SortedSetOperationOptions) -> (Vec<String>) {
-        cmd("ZINTER").arg(keys.num_of_args()).arg(keys).arg(options).take()
+        ready_cmd!("ZINTER", keys.num_of_args(), keys, options).take()
     }
 
     /// [`Commands::zinter`], but with the ability to specify a weight for each
@@ -1172,52 +1172,52 @@ implement_commands! {
     /// [Redis Docs](https://redis.io/commands/ZINTER)
     fn zinter_with_weights<K: ToRedisArgs, W: ToRedisArgs>(keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (Vec<String>) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
-        cmd("ZINTER").arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).take()
+        ready_cmd!("ZINTER", keys.num_of_args(), keys, "WEIGHTS", weights, options).take()
     }
 
     /// [`Commands::zinter`], but additionally returns the score of each member.
     /// [Redis Docs](https://redis.io/commands/ZINTER)
     fn zinter_withscores<K: ToRedisArgs>(keys: K, options: SortedSetOperationOptions) -> (Vec<(String, f64)>) {
-        cmd("ZINTER").arg(keys.num_of_args()).arg(keys).arg(options).arg("WITHSCORES").take()
+        ready_cmd!("ZINTER", keys.num_of_args(), keys, options, "WITHSCORES").take()
     }
 
     /// [`Commands::zinter_with_weights`], but additionally returns the score of each member.
     /// [Redis Docs](https://redis.io/commands/ZINTER)
     fn zinter_with_weights_withscores<K: ToRedisArgs, W: ToRedisArgs>(keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (Vec<(String, f64)>) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
-        cmd("ZINTER").arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).arg("WITHSCORES").take()
+        ready_cmd!("ZINTER", keys.num_of_args(), keys, "WEIGHTS", weights, options, "WITHSCORES").take()
     }
 
     /// Count the number of members in a sorted set between a given lexicographical range.
     /// [Redis Docs](https://redis.io/commands/ZLEXCOUNT)
     fn zlexcount<K: ToSingleRedisArg, M: ToSingleRedisArg, MM: ToSingleRedisArg>(key: K, min: M, max: MM) -> (usize) {
-        cmd("ZLEXCOUNT").arg(key).arg(min).arg(max).take()
+        ready_cmd!("ZLEXCOUNT", key, min, max).take()
     }
 
     /// Removes and returns the member with the highest score in a sorted set.
     /// Blocks until a member is available otherwise.
     /// [Redis Docs](https://redis.io/commands/BZPOPMAX)
     fn bzpopmax<K: ToRedisArgs>(key: K, timeout: f64) -> (Option<(String, String, f64)>) {
-        cmd("BZPOPMAX").arg(key).arg(timeout).take()
+        ready_cmd!("BZPOPMAX", key, timeout).take()
     }
 
     /// Removes and returns up to count members with the highest scores in a sorted set
     /// [Redis Docs](https://redis.io/commands/ZPOPMAX)
     fn zpopmax<K: ToSingleRedisArg>(key: K, count: isize) -> (Vec<String>) {
-        cmd("ZPOPMAX").arg(key).arg(count).take()
+        ready_cmd!("ZPOPMAX", key, count).take()
     }
 
     /// Removes and returns the member with the lowest score in a sorted set.
     /// Blocks until a member is available otherwise.
     /// [Redis Docs](https://redis.io/commands/BZPOPMIN)
     fn bzpopmin<K: ToRedisArgs>(key: K, timeout: f64) -> (Option<(String, String, f64)>) {
-        cmd("BZPOPMIN").arg(key).arg(timeout).take()
+        ready_cmd!("BZPOPMIN", key, timeout).take()
     }
 
     /// Removes and returns up to count members with the lowest scores in a sorted set
     /// [Redis Docs](https://redis.io/commands/ZPOPMIN)
     fn zpopmin<K: ToSingleRedisArg>(key: K, count: isize) -> (Vec<String>) {
-        cmd("ZPOPMIN").arg(key).arg(count).take()
+        ready_cmd!("ZPOPMIN", key, count).take()
     }
 
     /// Removes and returns up to count members with the highest scores,
@@ -1225,14 +1225,14 @@ implement_commands! {
     /// Blocks until a member is available otherwise.
     /// [Redis Docs](https://redis.io/commands/BZMPOP)
     fn bzmpop_max<K: ToRedisArgs>(timeout: f64, keys: K, count: isize) -> (Option<(String, Vec<(String, f64)>)>) {
-        cmd("BZMPOP").arg(timeout).arg(keys.num_of_args()).arg(keys).arg("MAX").arg("COUNT").arg(count).take()
+        ready_cmd!("BZMPOP", timeout, keys.num_of_args(), keys, "MAX", "COUNT", count).take()
     }
 
     /// Removes and returns up to count members with the highest scores,
     /// from the first non-empty sorted set in the provided list of key names.
     /// [Redis Docs](https://redis.io/commands/ZMPOP)
     fn zmpop_max<K: ToRedisArgs>(keys: K, count: isize) -> (Option<(String, Vec<(String, f64)>)>) {
-        cmd("ZMPOP").arg(keys.num_of_args()).arg(keys).arg("MAX").arg("COUNT").arg(count).take()
+        ready_cmd!("ZMPOP", keys.num_of_args(), keys, "MAX", "COUNT", count).take()
     }
 
     /// Removes and returns up to count members with the lowest scores,
@@ -1240,44 +1240,44 @@ implement_commands! {
     /// Blocks until a member is available otherwise.
     /// [Redis Docs](https://redis.io/commands/BZMPOP)
     fn bzmpop_min<K: ToRedisArgs>(timeout: f64, keys: K, count: isize) -> (Option<(String, Vec<(String, f64)>)>) {
-        cmd("BZMPOP").arg(timeout).arg(keys.num_of_args()).arg(keys).arg("MIN").arg("COUNT").arg(count).take()
+        ready_cmd!("BZMPOP", timeout, keys.num_of_args(), keys, "MIN", "COUNT", count).take()
     }
 
     /// Removes and returns up to count members with the lowest scores,
     /// from the first non-empty sorted set in the provided list of key names.
     /// [Redis Docs](https://redis.io/commands/ZMPOP)
     fn zmpop_min<K: ToRedisArgs>(keys: K, count: isize) -> (Option<(String, Vec<(String, f64)>)>) {
-        cmd("ZMPOP").arg(keys.num_of_args()).arg(keys).arg("MIN").arg("COUNT").arg(count).take()
+        ready_cmd!("ZMPOP", keys.num_of_args(), keys, "MIN", "COUNT", count).take()
     }
 
     /// Return up to count random members in a sorted set (or 1 if `count == None`)
     /// [Redis Docs](https://redis.io/commands/ZRANDMEMBER)
     fn zrandmember<K: ToSingleRedisArg>(key: K, count: Option<isize>) -> Generic {
-        cmd("ZRANDMEMBER").arg(key).arg(count).take()
+        ready_cmd!("ZRANDMEMBER", key, count).take()
     }
 
     /// Return up to count random members in a sorted set with scores
     /// [Redis Docs](https://redis.io/commands/ZRANDMEMBER)
     fn zrandmember_withscores<K: ToSingleRedisArg>(key: K, count: isize) -> Generic {
-        cmd("ZRANDMEMBER").arg(key).arg(count).arg("WITHSCORES").take()
+        ready_cmd!("ZRANDMEMBER", key, count, "WITHSCORES").take()
     }
 
     /// Return a range of members in a sorted set, by index
     /// [Redis Docs](https://redis.io/commands/ZRANGE)
     fn zrange<K: ToSingleRedisArg>(key: K, start: isize, stop: isize) -> (Vec<String>) {
-        cmd("ZRANGE").arg(key).arg(start).arg(stop).take()
+        ready_cmd!("ZRANGE", key, start, stop).take()
     }
 
     /// Return a range of members in a sorted set, by index with scores.
     /// [Redis Docs](https://redis.io/commands/ZRANGE)
     fn zrange_withscores<K: ToSingleRedisArg>(key: K, start: isize, stop: isize) -> (Vec<(String, f64)>) {
-        cmd("ZRANGE").arg(key).arg(start).arg(stop).arg("WITHSCORES").take()
+        ready_cmd!("ZRANGE", key, start, stop, "WITHSCORES").take()
     }
 
     /// Return a range of members in a sorted set, by lexicographical range.
     /// [Redis Docs](https://redis.io/commands/ZRANGEBYLEX)
     fn zrangebylex<K: ToSingleRedisArg, M: ToSingleRedisArg, MM: ToSingleRedisArg>(key: K, min: M, max: MM) -> (Vec<String>) {
-        cmd("ZRANGEBYLEX").arg(key).arg(min).arg(max).take()
+        ready_cmd!("ZRANGEBYLEX", key, min, max).take()
     }
 
     /// Return a range of members in a sorted set, by lexicographical
@@ -1285,13 +1285,13 @@ implement_commands! {
     /// [Redis Docs](https://redis.io/commands/ZRANGEBYLEX)
     fn zrangebylex_limit<K: ToSingleRedisArg, M: ToSingleRedisArg, MM: ToSingleRedisArg>(
             key: K, min: M, max: MM, offset: isize, count: isize) -> (Vec<String>) {
-        cmd("ZRANGEBYLEX").arg(key).arg(min).arg(max).arg("LIMIT").arg(offset).arg(count).take()
+        ready_cmd!("ZRANGEBYLEX", key, min, max, "LIMIT", offset, count).take()
     }
 
     /// Return a range of members in a sorted set, by lexicographical range.
     /// [Redis Docs](https://redis.io/commands/ZREVRANGEBYLEX)
     fn zrevrangebylex<K: ToSingleRedisArg, MM: ToSingleRedisArg, M: ToSingleRedisArg>(key: K, max: MM, min: M) -> (Vec<String>) {
-        cmd("ZREVRANGEBYLEX").arg(key).arg(max).arg(min).take()
+        ready_cmd!("ZREVRANGEBYLEX", key, max, min).take()
     }
 
     /// Return a range of members in a sorted set, by lexicographical
@@ -1299,123 +1299,121 @@ implement_commands! {
     /// [Redis Docs](https://redis.io/commands/ZREVRANGEBYLEX)
     fn zrevrangebylex_limit<K: ToSingleRedisArg, MM: ToSingleRedisArg, M: ToSingleRedisArg>(
             key: K, max: MM, min: M, offset: isize, count: isize) -> (Vec<String>) {
-        cmd("ZREVRANGEBYLEX").arg(key).arg(max).arg(min).arg("LIMIT").arg(offset).arg(count).take()
+        ready_cmd!("ZREVRANGEBYLEX", key, max, min, "LIMIT", offset, count).take()
     }
 
     /// Return a range of members in a sorted set, by score.
     /// [Redis Docs](https://redis.io/commands/ZRANGEBYSCORE)
     fn zrangebyscore<K: ToSingleRedisArg, M: ToSingleRedisArg, MM: ToSingleRedisArg>(key: K, min: M, max: MM) -> (Vec<String>) {
-        cmd("ZRANGEBYSCORE").arg(key).arg(min).arg(max).take()
+        ready_cmd!("ZRANGEBYSCORE", key, min, max).take()
     }
 
     /// Return a range of members in a sorted set, by score with scores.
     /// [Redis Docs](https://redis.io/commands/ZRANGEBYSCORE)
     fn zrangebyscore_withscores<K: ToSingleRedisArg, M: ToSingleRedisArg, MM: ToSingleRedisArg>(key: K, min: M, max: MM) -> (Vec<(String, usize)>) {
-        cmd("ZRANGEBYSCORE").arg(key).arg(min).arg(max).arg("WITHSCORES").take()
+        ready_cmd!("ZRANGEBYSCORE", key, min, max, "WITHSCORES").take()
     }
 
     /// Return a range of members in a sorted set, by score with limit.
     /// [Redis Docs](https://redis.io/commands/ZRANGEBYSCORE)
     fn zrangebyscore_limit<K: ToSingleRedisArg, M: ToSingleRedisArg, MM: ToSingleRedisArg>
             (key: K, min: M, max: MM, offset: isize, count: isize) -> (Vec<String>) {
-        cmd("ZRANGEBYSCORE").arg(key).arg(min).arg(max).arg("LIMIT").arg(offset).arg(count).take()
+        ready_cmd!("ZRANGEBYSCORE", key, min, max, "LIMIT", offset, count).take()
     }
 
     /// Return a range of members in a sorted set, by score with limit with scores.
     /// [Redis Docs](https://redis.io/commands/ZRANGEBYSCORE)
     fn zrangebyscore_limit_withscores<K: ToSingleRedisArg, M: ToSingleRedisArg, MM: ToSingleRedisArg>
             (key: K, min: M, max: MM, offset: isize, count: isize) -> (Vec<(String, usize)>) {
-        cmd("ZRANGEBYSCORE").arg(key).arg(min).arg(max).arg("WITHSCORES")
-            .arg("LIMIT").arg(offset).arg(count).take()
+        ready_cmd!("ZRANGEBYSCORE", key, min, max, "WITHSCORES", "LIMIT", offset, count).take()
     }
 
     /// Determine the index of a member in a sorted set.
     /// [Redis Docs](https://redis.io/commands/ZRANK)
     fn zrank<K: ToSingleRedisArg, M: ToSingleRedisArg>(key: K, member: M) -> (Option<usize>) {
-        cmd("ZRANK").arg(key).arg(member).take()
+        ready_cmd!("ZRANK", key, member).take()
     }
 
     /// Remove one or more members from a sorted set.
     /// [Redis Docs](https://redis.io/commands/ZREM)
     fn zrem<K: ToSingleRedisArg, M: ToRedisArgs>(key: K, members: M) -> (usize) {
-        cmd("ZREM").arg(key).arg(members).take()
+        ready_cmd!("ZREM", key, members).take()
     }
 
     /// Remove all members in a sorted set between the given lexicographical range.
     /// [Redis Docs](https://redis.io/commands/ZREMRANGEBYLEX)
     fn zrembylex<K: ToSingleRedisArg, M: ToSingleRedisArg, MM: ToSingleRedisArg>(key: K, min: M, max: MM) -> (usize) {
-        cmd("ZREMRANGEBYLEX").arg(key).arg(min).arg(max).take()
+        ready_cmd!("ZREMRANGEBYLEX", key, min, max).take()
     }
 
     /// Remove all members in a sorted set within the given indexes.
     /// [Redis Docs](https://redis.io/commands/ZREMRANGEBYRANK)
     fn zremrangebyrank<K: ToSingleRedisArg>(key: K, start: isize, stop: isize) -> (usize) {
-        cmd("ZREMRANGEBYRANK").arg(key).arg(start).arg(stop).take()
+        ready_cmd!("ZREMRANGEBYRANK", key, start, stop).take()
     }
 
     /// Remove all members in a sorted set within the given scores.
     /// [Redis Docs](https://redis.io/commands/ZREMRANGEBYSCORE)
     fn zrembyscore<K: ToSingleRedisArg, M: ToSingleRedisArg, MM: ToSingleRedisArg>(key: K, min: M, max: MM) -> (usize) {
-        cmd("ZREMRANGEBYSCORE").arg(key).arg(min).arg(max).take()
+        ready_cmd!("ZREMRANGEBYSCORE", key, min, max).take()
     }
 
     /// Return a range of members in a sorted set, by index,
     /// ordered from high to low.
     /// [Redis Docs](https://redis.io/commands/ZREVRANGE)
     fn zrevrange<K: ToSingleRedisArg>(key: K, start: isize, stop: isize) -> (Vec<String>) {
-        cmd("ZREVRANGE").arg(key).arg(start).arg(stop).take()
+        ready_cmd!("ZREVRANGE", key, start, stop).take()
     }
 
     /// Return a range of members in a sorted set, by index, with scores
     /// ordered from high to low.
     /// [Redis Docs](https://redis.io/commands/ZREVRANGE)
     fn zrevrange_withscores<K: ToSingleRedisArg>(key: K, start: isize, stop: isize) -> (Vec<String>) {
-        cmd("ZREVRANGE").arg(key).arg(start).arg(stop).arg("WITHSCORES").take()
+        ready_cmd!("ZREVRANGE", key, start, stop, "WITHSCORES").take()
     }
 
     /// Return a range of members in a sorted set, by score.
     /// [Redis Docs](https://redis.io/commands/ZREVRANGEBYSCORE)
     fn zrevrangebyscore<K: ToSingleRedisArg, MM: ToSingleRedisArg, M: ToSingleRedisArg>(key: K, max: MM, min: M) -> (Vec<String>) {
-        cmd("ZREVRANGEBYSCORE").arg(key).arg(max).arg(min).take()
+        ready_cmd!("ZREVRANGEBYSCORE", key, max, min).take()
     }
 
     /// Return a range of members in a sorted set, by score with scores.
     /// [Redis Docs](https://redis.io/commands/ZREVRANGEBYSCORE)
     fn zrevrangebyscore_withscores<K: ToSingleRedisArg, MM: ToSingleRedisArg, M: ToSingleRedisArg>(key: K, max: MM, min: M) -> (Vec<String>) {
-        cmd("ZREVRANGEBYSCORE").arg(key).arg(max).arg(min).arg("WITHSCORES").take()
+        ready_cmd!("ZREVRANGEBYSCORE", key, max, min, "WITHSCORES").take()
     }
 
     /// Return a range of members in a sorted set, by score with limit.
     /// [Redis Docs](https://redis.io/commands/ZREVRANGEBYSCORE)
     fn zrevrangebyscore_limit<K: ToSingleRedisArg, MM: ToSingleRedisArg, M: ToSingleRedisArg>
             (key: K, max: MM, min: M, offset: isize, count: isize) -> (Vec<String>) {
-        cmd("ZREVRANGEBYSCORE").arg(key).arg(max).arg(min).arg("LIMIT").arg(offset).arg(count).take()
+        ready_cmd!("ZREVRANGEBYSCORE", key, max, min, "LIMIT", offset, count).take()
     }
 
     /// Return a range of members in a sorted set, by score with limit with scores.
     /// [Redis Docs](https://redis.io/commands/ZREVRANGEBYSCORE)
     fn zrevrangebyscore_limit_withscores<K: ToSingleRedisArg, MM: ToSingleRedisArg, M: ToSingleRedisArg>
             (key: K, max: MM, min: M, offset: isize, count: isize) -> (Vec<String>) {
-        cmd("ZREVRANGEBYSCORE").arg(key).arg(max).arg(min).arg("WITHSCORES")
-            .arg("LIMIT").arg(offset).arg(count).take()
+        ready_cmd!("ZREVRANGEBYSCORE", key, max, min, "WITHSCORES", "LIMIT", offset, count).take()
     }
 
     /// Determine the index of a member in a sorted set, with scores ordered from high to low.
     /// [Redis Docs](https://redis.io/commands/ZREVRANK)
     fn zrevrank<K: ToSingleRedisArg, M: ToSingleRedisArg>(key: K, member: M) -> (Option<usize>) {
-        cmd("ZREVRANK").arg(key).arg(member).take()
+        ready_cmd!("ZREVRANK", key, member).take()
     }
 
     /// Get the score associated with the given member in a sorted set.
     /// [Redis Docs](https://redis.io/commands/ZSCORE)
     fn zscore<K: ToSingleRedisArg, M: ToSingleRedisArg>(key: K, member: M) -> (Option<f64>) {
-        cmd("ZSCORE").arg(key).arg(member).take()
+        ready_cmd!("ZSCORE", key, member).take()
     }
 
     /// Get the scores associated with multiple members in a sorted set.
     /// [Redis Docs](https://redis.io/commands/ZMSCORE)
     fn zscore_multiple<K: ToSingleRedisArg, M: ToRedisArgs>(key: K, members: &'a [M]) -> (Vec<Option<f64>>) {
-        cmd("ZMSCORE").arg(key).arg(members).take()
+        ready_cmd!("ZMSCORE", key, members).take()
     }
 
     /// Union multiple sorted sets and store the resulting sorted set in
@@ -1423,7 +1421,7 @@ implement_commands! {
     /// If no `AGGREGATE` modifier is provided, `SUM` is used.
     /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
     fn zunionstore<D: ToSingleRedisArg, K: ToRedisArgs>(dstkey: D, keys: K, options: SortedSetOperationOptions) -> (usize) {
-        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg(options).take()
+        ready_cmd!("ZUNIONSTORE", dstkey, keys.num_of_args(), keys, options).take()
     }
 
     /// Union multiple sorted sets and store the resulting sorted set in
@@ -1431,14 +1429,14 @@ implement_commands! {
     /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
     fn zunionstore_with_weights<D: ToSingleRedisArg, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (usize) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
-        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).take()
+        ready_cmd!("ZUNIONSTORE", dstkey, keys.num_of_args(), keys, "WEIGHTS", weights, options).take()
     }
 
     /// Union multiple sorted sets and return the resulting members,
     /// applying an optional `AGGREGATE` modifier (SUM by default).
     /// [Redis Docs](https://redis.io/commands/ZUNION)
     fn zunion<K: ToRedisArgs>(keys: K, options: SortedSetOperationOptions) -> (Vec<String>) {
-        cmd("ZUNION").arg(keys.num_of_args()).arg(keys).arg(options).take()
+        ready_cmd!("ZUNION", keys.num_of_args(), keys, options).take()
     }
 
     /// [`Commands::zunion`], but with the ability to specify a weight for each
@@ -1446,20 +1444,20 @@ implement_commands! {
     /// [Redis Docs](https://redis.io/commands/ZUNION)
     fn zunion_with_weights<K: ToRedisArgs, W: ToRedisArgs>(keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (Vec<String>) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
-        cmd("ZUNION").arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).take()
+        ready_cmd!("ZUNION", keys.num_of_args(), keys, "WEIGHTS", weights, options).take()
     }
 
     /// [`Commands::zunion`], but additionally returns the score of each member.
     /// [Redis Docs](https://redis.io/commands/ZUNION)
     fn zunion_withscores<K: ToRedisArgs>(keys: K, options: SortedSetOperationOptions) -> (Vec<(String, f64)>) {
-        cmd("ZUNION").arg(keys.num_of_args()).arg(keys).arg(options).arg("WITHSCORES").take()
+        ready_cmd!("ZUNION", keys.num_of_args(), keys, options, "WITHSCORES").take()
     }
 
     /// [`Commands::zunion_with_weights`], but additionally returns the score of each member.
     /// [Redis Docs](https://redis.io/commands/ZUNION)
     fn zunion_with_weights_withscores<K: ToRedisArgs, W: ToRedisArgs>(keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (Vec<(String, f64)>) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
-        cmd("ZUNION").arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).arg("WITHSCORES").take()
+        ready_cmd!("ZUNION", keys.num_of_args(), keys, "WEIGHTS", weights, options, "WITHSCORES").take()
     }
 
     // vector set commands
@@ -1469,7 +1467,7 @@ implement_commands! {
     #[cfg(feature = "vector-sets")]
     #[cfg_attr(docsrs, doc(cfg(feature = "vector-sets")))]
     fn vadd<K: ToRedisArgs, E: ToRedisArgs>(key: K, input: vector_sets::VectorAddInput<'a>, element: E) -> (bool) {
-        cmd("VADD").arg(key).arg(input).arg(element).take()
+        ready_cmd!("VADD", key, input, element).take()
     }
 
     /// Add a new element into the vector set specified by key with optional parameters for fine-tuning the insertion process.
@@ -1477,7 +1475,7 @@ implement_commands! {
     #[cfg(feature = "vector-sets")]
     #[cfg_attr(docsrs, doc(cfg(feature = "vector-sets")))]
     fn vadd_options<K: ToRedisArgs, E: ToRedisArgs>(key: K, input: vector_sets::VectorAddInput<'a>, element: E, options: &'a vector_sets::VAddOptions) -> (bool) {
-        cmd("VADD").arg(key).arg(options.reduction_dimension.map(|_| "REDUCE")).arg(options.reduction_dimension).arg(input).arg(element).arg(options).take()
+        ready_cmd!("VADD", key, options.reduction_dimension.map(|_| "REDUCE"), options.reduction_dimension, input, element, options).take()
     }
 
     /// Get the number of members in a vector set.
@@ -1485,7 +1483,7 @@ implement_commands! {
     #[cfg(feature = "vector-sets")]
     #[cfg_attr(docsrs, doc(cfg(feature = "vector-sets")))]
     fn vcard<K: ToRedisArgs>(key: K) -> (usize) {
-        cmd("VCARD").arg(key).take()
+        ready_cmd!("VCARD", key).take()
     }
 
     /// Return the number of dimensions of the vectors in the specified vector set.
@@ -1493,7 +1491,7 @@ implement_commands! {
     #[cfg(feature = "vector-sets")]
     #[cfg_attr(docsrs, doc(cfg(feature = "vector-sets")))]
     fn vdim<K: ToRedisArgs>(key: K) -> (usize) {
-        cmd("VDIM").arg(key).take()
+        ready_cmd!("VDIM", key).take()
     }
 
     /// Return the approximate vector associated with a given element in the vector set.
@@ -1501,7 +1499,7 @@ implement_commands! {
     #[cfg(feature = "vector-sets")]
     #[cfg_attr(docsrs, doc(cfg(feature = "vector-sets")))]
     fn vemb<K: ToRedisArgs, E: ToRedisArgs>(key: K, element: E) -> Generic {
-        cmd("VEMB").arg(key).arg(element).take()
+        ready_cmd!("VEMB", key, element).take()
     }
 
     /// Return the raw internal representation of the approximate vector associated with a given element in the vector set.
@@ -1511,7 +1509,7 @@ implement_commands! {
     #[cfg(feature = "vector-sets")]
     #[cfg_attr(docsrs, doc(cfg(feature = "vector-sets")))]
     fn vemb_options<K: ToRedisArgs, E: ToRedisArgs>(key: K, element: E, options: &'a vector_sets::VEmbOptions) -> Generic {
-        cmd("VEMB").arg(key).arg(element).arg(options).take()
+        ready_cmd!("VEMB", key, element, options).take()
     }
 
     /// Remove an element from a vector set.
@@ -1519,7 +1517,7 @@ implement_commands! {
     #[cfg(feature = "vector-sets")]
     #[cfg_attr(docsrs, doc(cfg(feature = "vector-sets")))]
     fn vrem<K: ToRedisArgs, E: ToRedisArgs>(key: K, element: E) -> (bool) {
-        cmd("VREM").arg(key).arg(element).take()
+        ready_cmd!("VREM", key, element).take()
     }
 
     /// Associate a JSON object with an element in a vector set.
@@ -1533,7 +1531,7 @@ implement_commands! {
             _ => serde_json::to_string(json_object).unwrap(),
         };
 
-        cmd("VSETATTR").arg(key).arg(element).arg(attributes_json).take()
+        ready_cmd!("VSETATTR", key, element, attributes_json).take()
     }
 
     /// Delete the JSON attributes associated with an element in a vector set.
@@ -1542,7 +1540,7 @@ implement_commands! {
     #[cfg(feature = "vector-sets")]
     #[cfg_attr(docsrs, doc(cfg(feature = "vector-sets")))]
     fn vdelattr<K: ToRedisArgs, E: ToRedisArgs>(key: K, element: E) -> (bool) {
-        cmd("VSETATTR").arg(key).arg(element).arg("").take()
+        ready_cmd!("VSETATTR", key, element, "").take()
     }
 
     /// Return the JSON attributes associated with an element in a vector set.
@@ -1550,7 +1548,7 @@ implement_commands! {
     #[cfg(feature = "vector-sets")]
     #[cfg_attr(docsrs, doc(cfg(feature = "vector-sets")))]
     fn vgetattr<K: ToRedisArgs, E: ToRedisArgs>(key: K, element: E) -> (Option<String>) {
-        cmd("VGETATTR").arg(key).arg(element).take()
+        ready_cmd!("VGETATTR", key, element).take()
     }
 
     /// Return metadata and internal details about a vector set, including
@@ -1559,7 +1557,7 @@ implement_commands! {
     #[cfg(feature = "vector-sets")]
     #[cfg_attr(docsrs, doc(cfg(feature = "vector-sets")))]
     fn vinfo<K: ToRedisArgs>(key: K) -> (Option<std::collections::HashMap<String, Value>>) {
-        cmd("VINFO").arg(key).take()
+        ready_cmd!("VINFO", key).take()
     }
 
     /// Return the neighbors of a specified element in a vector set.
@@ -1568,7 +1566,7 @@ implement_commands! {
     #[cfg(feature = "vector-sets")]
     #[cfg_attr(docsrs, doc(cfg(feature = "vector-sets")))]
     fn vlinks<K: ToRedisArgs, E: ToRedisArgs>(key: K, element: E) -> Generic {
-        cmd("VLINKS").arg(key).arg(element).take()
+        ready_cmd!("VLINKS", key, element).take()
     }
 
     /// Return the neighbors of a specified element in a vector set.
@@ -1578,7 +1576,7 @@ implement_commands! {
     #[cfg(feature = "vector-sets")]
     #[cfg_attr(docsrs, doc(cfg(feature = "vector-sets")))]
     fn vlinks_with_scores<K: ToRedisArgs, E: ToRedisArgs>(key: K, element: E) -> Generic {
-        cmd("VLINKS").arg(key).arg(element).arg("WITHSCORES").take()
+        ready_cmd!("VLINKS", key, element, "WITHSCORES").take()
     }
 
     /// Return one random elements from a vector set.
@@ -1586,7 +1584,7 @@ implement_commands! {
     #[cfg(feature = "vector-sets")]
     #[cfg_attr(docsrs, doc(cfg(feature = "vector-sets")))]
     fn vrandmember<K: ToRedisArgs>(key: K) -> (Option<String>) {
-        cmd("VRANDMEMBER").arg(key).take()
+        ready_cmd!("VRANDMEMBER", key).take()
     }
 
     /// Return multiple random elements from a vector set.
@@ -1594,7 +1592,7 @@ implement_commands! {
     #[cfg(feature = "vector-sets")]
     #[cfg_attr(docsrs, doc(cfg(feature = "vector-sets")))]
     fn vrandmember_multiple<K: ToRedisArgs>(key: K, count: usize) -> (Vec<String>) {
-        cmd("VRANDMEMBER").arg(key).arg(count).take()
+        ready_cmd!("VRANDMEMBER", key, count).take()
     }
 
     /// Perform vector similarity search.
@@ -1602,7 +1600,7 @@ implement_commands! {
     #[cfg(feature = "vector-sets")]
     #[cfg_attr(docsrs, doc(cfg(feature = "vector-sets")))]
     fn vsim<K: ToRedisArgs>(key: K, input: vector_sets::VectorSimilaritySearchInput<'a>) -> Generic {
-        cmd("VSIM").arg(key).arg(input).take()
+        ready_cmd!("VSIM", key, input).take()
     }
 
     /// Performs a vector similarity search with optional parameters for customization.
@@ -1610,7 +1608,7 @@ implement_commands! {
     #[cfg(feature = "vector-sets")]
     #[cfg_attr(docsrs, doc(cfg(feature = "vector-sets")))]
     fn vsim_options<K: ToRedisArgs>(key: K, input: vector_sets::VectorSimilaritySearchInput<'a>, options: &'a vector_sets::VSimOptions) -> Generic {
-        cmd("VSIM").arg(key).arg(input).arg(options).take()
+        ready_cmd!("VSIM", key, input, options).take()
     }
 
     // hyperloglog commands
@@ -1618,32 +1616,32 @@ implement_commands! {
     /// Adds the specified elements to the specified HyperLogLog.
     /// [Redis Docs](https://redis.io/commands/PFADD)
     fn pfadd<K: ToSingleRedisArg, E: ToRedisArgs>(key: K, element: E) -> (bool) {
-        cmd("PFADD").arg(key).arg(element).take()
+        ready_cmd!("PFADD", key, element).take()
     }
 
     /// Return the approximated cardinality of the set(s) observed by the
     /// HyperLogLog at key(s).
     /// [Redis Docs](https://redis.io/commands/PFCOUNT)
     fn pfcount<K: ToRedisArgs>(key: K) -> (usize) {
-        cmd("PFCOUNT").arg(key).take()
+        ready_cmd!("PFCOUNT", key).take()
     }
 
     /// Merge N different HyperLogLogs into a single one.
     /// [Redis Docs](https://redis.io/commands/PFMERGE)
     fn pfmerge<D: ToSingleRedisArg, S: ToRedisArgs>(dstkey: D, srckeys: S) -> (()) {
-        cmd("PFMERGE").arg(dstkey).arg(srckeys).take()
+        ready_cmd!("PFMERGE", dstkey, srckeys).take()
     }
 
     /// Posts a message to the given channel.
     /// [Redis Docs](https://redis.io/commands/PUBLISH)
     fn publish<K: ToSingleRedisArg, E: ToSingleRedisArg>(channel: K, message: E) -> (usize) {
-        cmd("PUBLISH").arg(channel).arg(message).take()
+        ready_cmd!("PUBLISH", channel, message).take()
     }
 
     /// Posts a message to the given sharded channel.
     /// [Redis Docs](https://redis.io/commands/SPUBLISH)
     fn spublish<K: ToSingleRedisArg, E: ToSingleRedisArg>(channel: K, message: E) -> (usize) {
-        cmd("SPUBLISH").arg(channel).arg(message).take()
+        ready_cmd!("SPUBLISH", channel, message).take()
     }
 
     // Object commands
@@ -1651,43 +1649,43 @@ implement_commands! {
     /// Returns the encoding of a key.
     /// [Redis Docs](https://redis.io/commands/OBJECT)
     fn object_encoding<K: ToSingleRedisArg>(key: K) -> (Option<String>) {
-        cmd("OBJECT").arg("ENCODING").arg(key).take()
+        ready_cmd!("OBJECT", "ENCODING", key).take()
     }
 
     /// Returns the time in seconds since the last access of a key.
     /// [Redis Docs](https://redis.io/commands/OBJECT)
     fn object_idletime<K: ToSingleRedisArg>(key: K) -> (Option<usize>) {
-        cmd("OBJECT").arg("IDLETIME").arg(key).take()
+        ready_cmd!("OBJECT", "IDLETIME", key).take()
     }
 
     /// Returns the logarithmic access frequency counter of a key.
     /// [Redis Docs](https://redis.io/commands/OBJECT)
     fn object_freq<K: ToSingleRedisArg>(key: K) -> (Option<usize>) {
-        cmd("OBJECT").arg("FREQ").arg(key).take()
+        ready_cmd!("OBJECT", "FREQ", key).take()
     }
 
     /// Returns the reference count of a key.
     /// [Redis Docs](https://redis.io/commands/OBJECT)
     fn object_refcount<K: ToSingleRedisArg>(key: K) -> (Option<usize>) {
-        cmd("OBJECT").arg("REFCOUNT").arg(key).take()
+        ready_cmd!("OBJECT", "REFCOUNT", key).take()
     }
 
     /// Returns the name of the current connection as set by CLIENT SETNAME.
     /// [Redis Docs](https://redis.io/commands/CLIENT)
     fn client_getname<>() -> (Option<String>) {
-        cmd("CLIENT").arg("GETNAME").take()
+        ready_cmd!("CLIENT", "GETNAME").take()
     }
 
     /// Returns the ID of the current connection.
     /// [Redis Docs](https://redis.io/commands/CLIENT)
     fn client_id<>() -> (isize) {
-        cmd("CLIENT").arg("ID").take()
+        ready_cmd!("CLIENT", "ID").take()
     }
 
     /// Command assigns a name to the current connection.
     /// [Redis Docs](https://redis.io/commands/CLIENT)
     fn client_setname<K: ToSingleRedisArg>(connection_name: K) -> (()) {
-        cmd("CLIENT").arg("SETNAME").arg(connection_name).take()
+        ready_cmd!("CLIENT", "SETNAME", connection_name).take()
     }
 
     // ACL commands
@@ -1699,7 +1697,7 @@ implement_commands! {
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     /// [Redis Docs](https://redis.io/commands/ACL)
     fn acl_load<>() -> () {
-        cmd("ACL").arg("LOAD").take()
+        ready_cmd!("ACL", "LOAD").take()
     }
 
     /// When Redis is configured to use an ACL file (with the aclfile
@@ -1709,7 +1707,7 @@ implement_commands! {
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     /// [Redis Docs](https://redis.io/commands/ACL)
     fn acl_save<>() -> () {
-        cmd("ACL").arg("SAVE").take()
+        ready_cmd!("ACL", "SAVE").take()
     }
 
     /// Shows the currently active ACL rules in the Redis server.
@@ -1717,7 +1715,7 @@ implement_commands! {
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     /// [Redis Docs](https://redis.io/commands/ACL)
     fn acl_list<>() -> (Vec<String>) {
-        cmd("ACL").arg("LIST").take()
+        ready_cmd!("ACL", "LIST").take()
     }
 
     /// Shows a list of all the usernames of the currently configured users in
@@ -1726,7 +1724,7 @@ implement_commands! {
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     /// [Redis Docs](https://redis.io/commands/ACL)
     fn acl_users<>() -> (Vec<String>) {
-        cmd("ACL").arg("USERS").take()
+        ready_cmd!("ACL", "USERS").take()
     }
 
     /// Returns all the rules defined for an existing ACL user.
@@ -1734,7 +1732,7 @@ implement_commands! {
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     /// [Redis Docs](https://redis.io/commands/ACL)
     fn acl_getuser<K: ToSingleRedisArg>(username: K) -> (Option<acl::AclInfo>) {
-        cmd("ACL").arg("GETUSER").arg(username).take()
+        ready_cmd!("ACL", "GETUSER", username).take()
     }
 
     /// Creates an ACL user without any privilege.
@@ -1742,7 +1740,7 @@ implement_commands! {
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     /// [Redis Docs](https://redis.io/commands/ACL)
     fn acl_setuser<K: ToSingleRedisArg>(username: K) -> () {
-        cmd("ACL").arg("SETUSER").arg(username).take()
+        ready_cmd!("ACL", "SETUSER", username).take()
     }
 
     /// Creates an ACL user with the specified rules or modify the rules of
@@ -1751,7 +1749,7 @@ implement_commands! {
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     /// [Redis Docs](https://redis.io/commands/ACL)
     fn acl_setuser_rules<K: ToSingleRedisArg>(username: K, rules: &'a [acl::Rule]) -> () {
-        cmd("ACL").arg("SETUSER").arg(username).arg(rules).take()
+        ready_cmd!("ACL", "SETUSER", username, rules).take()
     }
 
     /// Delete all the specified ACL users and terminate all the connections
@@ -1760,7 +1758,7 @@ implement_commands! {
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     /// [Redis Docs](https://redis.io/commands/ACL)
     fn acl_deluser<K: ToRedisArgs>(usernames: &'a [K]) -> (usize) {
-        cmd("ACL").arg("DELUSER").arg(usernames).take()
+        ready_cmd!("ACL", "DELUSER", usernames).take()
     }
 
     /// Simulate the execution of a given command by a given user.
@@ -1768,7 +1766,7 @@ implement_commands! {
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     /// [Redis Docs](https://redis.io/commands/ACL)
     fn acl_dryrun<K: ToSingleRedisArg, C: ToSingleRedisArg, A: ToRedisArgs>(username: K, command: C, args: A) -> (String) {
-        cmd("ACL").arg("DRYRUN").arg(username).arg(command).arg(args).take()
+        ready_cmd!("ACL", "DRYRUN", username, command, args).take()
     }
 
     /// Shows the available ACL categories.
@@ -1776,7 +1774,7 @@ implement_commands! {
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_cat<>() -> (HashSet<String>) {
-        cmd("ACL").arg("CAT").take()
+        ready_cmd!("ACL", "CAT").take()
     }
 
     /// Shows all the Redis commands in the specified category.
@@ -1784,7 +1782,7 @@ implement_commands! {
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_cat_categoryname<K: ToSingleRedisArg>(categoryname: K) -> (HashSet<String>) {
-        cmd("ACL").arg("CAT").arg(categoryname).take()
+        ready_cmd!("ACL", "CAT", categoryname).take()
     }
 
     /// Generates a 256-bits password starting from /dev/urandom if available.
@@ -1792,7 +1790,7 @@ implement_commands! {
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_genpass<>() -> (String) {
-        cmd("ACL").arg("GENPASS").take()
+        ready_cmd!("ACL", "GENPASS").take()
     }
 
     /// Generates a 1-to-1024-bits password starting from /dev/urandom if available.
@@ -1800,7 +1798,7 @@ implement_commands! {
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_genpass_bits<>(bits: isize) -> (String) {
-        cmd("ACL").arg("GENPASS").arg(bits).take()
+        ready_cmd!("ACL", "GENPASS", bits).take()
     }
 
     /// Returns the username the current connection is authenticated with.
@@ -1808,7 +1806,7 @@ implement_commands! {
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_whoami<>() -> (String) {
-        cmd("ACL").arg("WHOAMI").take()
+        ready_cmd!("ACL", "WHOAMI").take()
     }
 
     /// Shows a list of recent ACL security events
@@ -1816,7 +1814,7 @@ implement_commands! {
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_log<>(count: isize) -> (Vec<String>) {
-        cmd("ACL").arg("LOG").arg(count).take()
+        ready_cmd!("ACL", "LOG", count).take()
 
     }
 
@@ -1825,7 +1823,7 @@ implement_commands! {
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_log_reset<>() -> () {
-        cmd("ACL").arg("LOG").arg("RESET").take()
+        ready_cmd!("ACL", "LOG", "RESET").take()
     }
 
     /// Returns a helpful text describing the different subcommands.
@@ -1833,7 +1831,7 @@ implement_commands! {
     #[cfg(feature = "acl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_help<>() -> (Vec<String>) {
-        cmd("ACL").arg("HELP").take()
+        ready_cmd!("ACL", "HELP").take()
     }
 
     //
@@ -1877,7 +1875,7 @@ implement_commands! {
     #[cfg(feature = "geospatial")]
     #[cfg_attr(docsrs, doc(cfg(feature = "geospatial")))]
     fn geo_add<K: ToSingleRedisArg, M: ToRedisArgs>(key: K, members: M) -> (usize) {
-        cmd("GEOADD").arg(key).arg(members).take()
+        ready_cmd!("GEOADD", key, members).take()
     }
 
     /// Return the distance between two members in the geospatial index
@@ -1920,12 +1918,7 @@ implement_commands! {
         member2: M2,
         unit: geo::Unit
     ) -> (Option<f64>) {
-        cmd("GEODIST")
-            .arg(key)
-            .arg(member1)
-            .arg(member2)
-            .arg(unit)
-            .take()
+        ready_cmd!("GEODIST", key, member1, member2, unit).take()
     }
 
     /// Return valid [Geohash][1] strings representing the position of one or
@@ -1951,7 +1944,7 @@ implement_commands! {
     #[cfg(feature = "geospatial")]
     #[cfg_attr(docsrs, doc(cfg(feature = "geospatial")))]
     fn geo_hash<K: ToSingleRedisArg, M: ToRedisArgs>(key: K, members: M) -> (Vec<Option<String>>) {
-        cmd("GEOHASH").arg(key).arg(members).take()
+        ready_cmd!("GEOHASH", key, members).take()
     }
 
     /// Return the positions of all the specified members of the geospatial
@@ -1981,7 +1974,7 @@ implement_commands! {
     #[cfg(feature = "geospatial")]
     #[cfg_attr(docsrs, doc(cfg(feature = "geospatial")))]
     fn geo_pos<K: ToSingleRedisArg, M: ToRedisArgs>(key: K, members: M) -> (Vec<Option<geo::Coord<f64>>>) {
-        cmd("GEOPOS").arg(key).arg(members).take()
+        ready_cmd!("GEOPOS", key, members).take()
     }
 
     /// Return the members of a sorted set populated with geospatial information
@@ -2014,14 +2007,7 @@ implement_commands! {
         unit: geo::Unit,
         options: geo::RadiusOptions
     ) -> (Vec<geo::RadiusSearchResult>) {
-        cmd("GEORADIUS")
-            .arg(key)
-            .arg(longitude)
-            .arg(latitude)
-            .arg(radius)
-            .arg(unit)
-            .arg(options)
-            .take()
+        ready_cmd!("GEORADIUS", key, longitude, latitude, radius, unit, options).take()
     }
 
     /// Retrieve members selected by distance with the center of `member`. The
@@ -2036,13 +2022,7 @@ implement_commands! {
         unit: geo::Unit,
         options: geo::RadiusOptions
     ) -> (Vec<geo::RadiusSearchResult>) {
-        cmd("GEORADIUSBYMEMBER")
-            .arg(key)
-            .arg(member)
-            .arg(radius)
-            .arg(unit)
-            .arg(options)
-            .take()
+        ready_cmd!("GEORADIUSBYMEMBER", key, member, radius, unit, options).take()
     }
 
     //
@@ -2061,10 +2041,7 @@ implement_commands! {
         key: K,
         group: G,
         ids: &'a [I]) -> (usize) {
-        cmd("XACK")            .arg(key)
-                        .arg(group)
-                        .arg(ids)
-            .take()
+        ready_cmd!("XACK", key, group, ids).take()
     }
 
     /// Negatively acknowledge (NACK) one or more pending stream messages.
@@ -2100,14 +2077,7 @@ implement_commands! {
         ids: &'a [ID],
         options: &'a streams::StreamNackOptions
     ) -> (usize) {
-        cmd("XNACK")
-            .arg(key)
-            .arg(group)
-            .arg(options)
-            .arg("IDS")
-            .arg(ids.len())
-            .arg(ids)
-            .take()
+        ready_cmd!("XNACK", key, group, options, "IDS", ids.len(), ids).take()
     }
 
 
@@ -2124,7 +2094,7 @@ implement_commands! {
         id: ID,
         items: &'a [(F, V)]
     ) -> (Option<String>) {
-        cmd("XADD").arg(key).arg(id).arg(items).take()
+        ready_cmd!("XADD", key, id, items).take()
     }
 
 
@@ -2142,7 +2112,7 @@ implement_commands! {
         id: ID,
         map: BTM
     ) -> (Option<String>) {
-        cmd("XADD").arg(key).arg(id).arg(map).take()
+        ready_cmd!("XADD", key, id, map).take()
     }
 
 
@@ -2179,11 +2149,7 @@ implement_commands! {
         items: I,
         options: &'a streams::StreamAddOptions
     ) -> (Option<String>) {
-        cmd("XADD")            .arg(key)
-                        .arg(options)
-                        .arg(id)
-                        .arg(items)
-            .take()
+        ready_cmd!("XADD", key, options, id, items).take()
     }
 
 
@@ -2206,11 +2172,7 @@ implement_commands! {
         id: ID,
         items: &'a [(F, V)]
     ) -> (Option<String>) {
-        cmd("XADD")            .arg(key)
-                        .arg(maxlen)
-                        .arg(id)
-                        .arg(items)
-            .take()
+        ready_cmd!("XADD", key, maxlen, id, items).take()
     }
 
 
@@ -2228,11 +2190,7 @@ implement_commands! {
         id: ID,
         map: BTM
     ) -> (Option<String>) {
-        cmd("XADD")            .arg(key)
-                        .arg(maxlen)
-                        .arg(id)
-                        .arg(map)
-            .take()
+        ready_cmd!("XADD", key, maxlen, id, map).take()
     }
 
     /// Perform a combined xpending and xclaim flow.
@@ -2267,13 +2225,7 @@ implement_commands! {
         start: S,
         options: streams::StreamAutoClaimOptions
     ) -> (streams::StreamAutoClaimReply) {
-        cmd("XAUTOCLAIM")            .arg(key)
-                        .arg(group)
-                        .arg(consumer)
-                        .arg(min_idle_time)
-                        .arg(start)
-                        .arg(options)
-            .take()
+        ready_cmd!("XAUTOCLAIM", key, group, consumer, min_idle_time, start, options).take()
     }
 
     /// Claim pending, unacked messages, after some period of time,
@@ -2295,12 +2247,7 @@ implement_commands! {
         min_idle_time: MIT,
         ids: &'a [ID]
     ) -> (streams::StreamClaimReply) {
-        cmd("XCLAIM")            .arg(key)
-                        .arg(group)
-                        .arg(consumer)
-                        .arg(min_idle_time)
-                        .arg(ids)
-            .take()
+        ready_cmd!("XCLAIM", key, group, consumer, min_idle_time, ids).take()
     }
 
     /// This is the optional arguments version for claiming unacked, pending messages
@@ -2353,13 +2300,7 @@ implement_commands! {
         ids: &'a [ID],
         options: streams::StreamClaimOptions
     ) -> Generic {
-        cmd("XCLAIM")            .arg(key)
-                        .arg(group)
-                        .arg(consumer)
-                        .arg(min_idle_time)
-                        .arg(ids)
-                        .arg(options)
-            .take()
+        ready_cmd!("XCLAIM", key, group, consumer, min_idle_time, ids, options).take()
     }
 
 
@@ -2375,21 +2316,21 @@ implement_commands! {
         key: K,
         ids: &'a [ID]
     ) -> (usize) {
-        cmd("XDEL").arg(key).arg(ids).take()
+        ready_cmd!("XDEL", key, ids).take()
     }
 
     /// An extension of the Streams `XDEL` command that provides finer control over how message entries are deleted with respect to consumer groups.
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xdel_ex<K: ToRedisArgs, ID: ToRedisArgs>(key: K, ids: &'a [ID], options: streams::StreamDeletionPolicy) -> (Vec<streams::XDelExStatusCode>) {
-        cmd("XDELEX").arg(key).arg(options).arg("IDS").arg(ids.len()).arg(ids).take()
+        ready_cmd!("XDELEX", key, options, "IDS", ids.len(), ids).take()
     }
 
     /// A combination of `XACK` and `XDEL` that acknowledges and attempts to delete a list of `ids` for a given stream `key` and consumer `group`.
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xack_del<K: ToRedisArgs, G: ToRedisArgs, ID: ToRedisArgs>(key: K, group: G, ids: &'a [ID], options: streams::StreamDeletionPolicy) -> (Vec<streams::XAckDelStatusCode>) {
-        cmd("XACKDEL").arg(key).arg(group).arg(options).arg("IDS").arg(ids.len()).arg(ids).take()
+        ready_cmd!("XACKDEL", key, group, options, "IDS", ids.len(), ids).take()
     }
 
     /// This command is used for creating a consumer `group`. It expects the stream key
@@ -2408,11 +2349,7 @@ implement_commands! {
         group: G,
         id: ID
     ) -> () {
-        cmd("XGROUP")            .arg("CREATE")
-                        .arg(key)
-                        .arg(group)
-                        .arg(id)
-            .take()
+        ready_cmd!("XGROUP", "CREATE", key, group, id).take()
     }
 
     /// This creates a `consumer` explicitly (vs implicit via XREADGROUP)
@@ -2432,11 +2369,7 @@ implement_commands! {
         group: G,
         consumer: C
     ) -> bool {
-        cmd("XGROUP")            .arg("CREATECONSUMER")
-                        .arg(key)
-                        .arg(group)
-                        .arg(consumer)
-            .take()
+        ready_cmd!("XGROUP", "CREATECONSUMER", key, group, consumer).take()
     }
 
     /// This is the alternate version for creating a consumer `group`
@@ -2457,12 +2390,7 @@ implement_commands! {
         group: G,
         id: ID
     ) -> () {
-        cmd("XGROUP")            .arg("CREATE")
-                        .arg(key)
-                        .arg(group)
-                        .arg(id)
-                        .arg("MKSTREAM")
-            .take()
+        ready_cmd!("XGROUP", "CREATE", key, group, id, "MKSTREAM").take()
     }
 
 
@@ -2480,12 +2408,7 @@ implement_commands! {
         group: G,
         id: ID
     ) -> () {
-        cmd("XGROUP")
-            .arg("SETID")
-            .arg(key)
-            .arg(group)
-            .arg(id)
-            .take()
+        ready_cmd!("XGROUP", "SETID", key, group, id).take()
     }
 
 
@@ -2501,7 +2424,7 @@ implement_commands! {
         key: K,
         group: G
     ) -> bool {
-        cmd("XGROUP").arg("DESTROY").arg(key).arg(group).take()
+        ready_cmd!("XGROUP", "DESTROY", key, group).take()
     }
 
     /// This deletes a `consumer` from an existing consumer `group`
@@ -2518,12 +2441,7 @@ implement_commands! {
         group: G,
         consumer: C
     ) -> usize {
-        cmd("XGROUP")
-            .arg("DELCONSUMER")
-            .arg(key)
-            .arg(group)
-            .arg(consumer)
-            .take()
+        ready_cmd!("XGROUP", "DELCONSUMER", key, group, consumer).take()
     }
 
 
@@ -2544,11 +2462,7 @@ implement_commands! {
         key: K,
         group: G
     ) -> (streams::StreamInfoConsumersReply) {
-        cmd("XINFO")
-            .arg("CONSUMERS")
-            .arg(key)
-            .arg(group)
-            .take()
+        ready_cmd!("XINFO", "CONSUMERS", key, group).take()
     }
 
 
@@ -2565,7 +2479,7 @@ implement_commands! {
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xinfo_groups<K: ToRedisArgs>(key: K) -> (streams::StreamInfoGroupsReply) {
-        cmd("XINFO").arg("GROUPS").arg(key).take()
+        ready_cmd!("XINFO", "GROUPS", key).take()
     }
 
 
@@ -2584,7 +2498,7 @@ implement_commands! {
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xinfo_stream<K: ToRedisArgs>(key: K) -> (streams::StreamInfoStreamReply) {
-        cmd("XINFO").arg("STREAM").arg(key).take()
+        ready_cmd!("XINFO", "STREAM", key).take()
     }
 
     // TODO: Remove this function when creating the next major release.
@@ -2601,7 +2515,7 @@ implement_commands! {
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xinfo_stream_with_idempotency<K: ToRedisArgs>(key: K) -> (streams::StreamInfoStreamReplyWithIdempotency) {
-        cmd("XINFO").arg("STREAM").arg(key).take()
+        ready_cmd!("XINFO", "STREAM", key).take()
     }
 
     /// Returns the number of messages for a given stream `key`.
@@ -2613,7 +2527,7 @@ implement_commands! {
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     /// [Redis Docs](https://redis.io/commands/XLEN)
     fn xlen<K: ToRedisArgs>(key: K) -> usize {
-        cmd("XLEN").arg(key).take()
+        ready_cmd!("XLEN", key).take()
     }
 
 
@@ -2638,7 +2552,7 @@ implement_commands! {
         key: K,
         group: G
     ) -> (streams::StreamPendingReply) {
-        cmd("XPENDING").arg(key).arg(group).take()
+        ready_cmd!("XPENDING", key, group).take()
     }
 
 
@@ -2669,13 +2583,7 @@ implement_commands! {
         end: E,
         count: C
     ) -> (streams::StreamPendingCountReply) {
-        cmd("XPENDING")
-            .arg(key)
-            .arg(group)
-            .arg(start)
-            .arg(end)
-            .arg(count)
-            .take()
+        ready_cmd!("XPENDING", key, group, start, end, count).take()
     }
 
 
@@ -2707,14 +2615,7 @@ implement_commands! {
         count: C,
         consumer: CN
     ) -> (streams::StreamPendingCountReply) {
-        cmd("XPENDING")
-            .arg(key)
-            .arg(group)
-            .arg(start)
-            .arg(end)
-            .arg(count)
-            .arg(consumer)
-            .take()
+        ready_cmd!("XPENDING", key, group, start, end, count, consumer).take()
     }
 
     /// Returns a range of messages in a given stream `key`.
@@ -2736,7 +2637,7 @@ implement_commands! {
         start: S,
         end: E
     ) -> (streams::StreamRangeReply) {
-        cmd("XRANGE").arg(key).arg(start).arg(end).take()
+        ready_cmd!("XRANGE", key, start, end).take()
     }
 
 
@@ -2750,7 +2651,7 @@ implement_commands! {
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xrange_all<K: ToRedisArgs>(key: K) -> (streams::StreamRangeReply) {
-        cmd("XRANGE").arg(key).arg("-").arg("+").take()
+        ready_cmd!("XRANGE", key, "-", "+").take()
     }
 
 
@@ -2768,13 +2669,7 @@ implement_commands! {
         end: E,
         count: C
     ) -> (streams::StreamRangeReply) {
-        cmd("XRANGE")
-            .arg(key)
-            .arg(start)
-            .arg(end)
-            .arg("COUNT")
-            .arg(count)
-            .take()
+        ready_cmd!("XRANGE", key, start, end, "COUNT", count).take()
     }
 
 
@@ -2793,7 +2688,7 @@ implement_commands! {
         keys: &'a [K],
         ids: &'a [ID]
     ) -> (Option<streams::StreamReadReply>) {
-        cmd("XREAD").arg("STREAMS").arg(keys).arg(ids).take()
+        ready_cmd!("XREAD", "STREAMS", keys, ids).take()
     }
 
     /// This method handles setting optional arguments for
@@ -2840,16 +2735,11 @@ implement_commands! {
         ids: &'a [ID],
         options: &'a streams::StreamReadOptions
     ) -> (Option<streams::StreamReadReply>) {
-        cmd(if options.read_only() {
+        ready_cmd!(if options.read_only() {
             "XREAD"
         } else {
             "XREADGROUP"
-        })
-        .arg(options)
-        .arg("STREAMS")
-        .arg(keys)
-        .arg(ids)
-        .take()
+        }, options, "STREAMS", keys, ids).take()
     }
 
     /// This is the reverse version of `xrange`.
@@ -2866,7 +2756,7 @@ implement_commands! {
         end: E,
         start: S
     ) -> (streams::StreamRangeReply) {
-        cmd("XREVRANGE").arg(key).arg(end).arg(start).take()
+        ready_cmd!("XREVRANGE", key, end, start).take()
     }
 
     /// This is the reverse version of `xrange_all`.
@@ -2879,7 +2769,7 @@ implement_commands! {
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xrevrange_all<K: ToRedisArgs>(key: K) -> (streams::StreamRangeReply) {
-        cmd("XREVRANGE").arg(key).arg("+").arg("-").take()
+        ready_cmd!("XREVRANGE", key, "+", "-").take()
     }
 
     /// This is the reverse version of `xrange_count`.
@@ -2897,13 +2787,7 @@ implement_commands! {
         start: S,
         count: C
     ) -> (streams::StreamRangeReply) {
-        cmd("XREVRANGE")
-            .arg(key)
-            .arg(end)
-            .arg(start)
-            .arg("COUNT")
-            .arg(count)
-            .take()
+        ready_cmd!("XREVRANGE", key, end, start, "COUNT", count).take()
     }
 
     /// Trim a stream `key` to a MAXLEN count.
@@ -2918,7 +2802,7 @@ implement_commands! {
         key: K,
         maxlen: streams::StreamMaxlen
     ) -> usize {
-        cmd("XTRIM").arg(key).arg(maxlen).take()
+        ready_cmd!("XTRIM", key, maxlen).take()
     }
 
      /// Trim a stream `key` with full options
@@ -2933,7 +2817,7 @@ implement_commands! {
         key: K,
         options: &'a streams::StreamTrimOptions
     ) -> usize {
-        cmd("XTRIM").arg(key).arg(options).take()
+        ready_cmd!("XTRIM", key, options).take()
     }
 
     /// Configure idempotency parameters for a stream
@@ -2970,7 +2854,7 @@ implement_commands! {
         key: K,
         options: &'a streams::StreamConfigOptions
     ) -> String {
-        cmd("XCFGSET").arg(key).arg(options).take()
+        ready_cmd!("XCFGSET", key, options).take()
     }
 
     // Search commands
@@ -3102,7 +2986,7 @@ assert_eq!(invok_2_res, 5);
     /// ```
     /// [Redis Docs](https://redis.io/commands/FLUSHALL)
     fn flushall<>() -> () {
-        cmd("FLUSHALL").take()
+        ready_cmd!("FLUSHALL").take()
     }
 
     /// Deletes all the keys of all databases with options
@@ -3112,7 +2996,7 @@ assert_eq!(invok_2_res, 5);
     /// ```
     /// [Redis Docs](https://redis.io/commands/FLUSHALL)
     fn flushall_options<>(options: &'a FlushAllOptions) -> () {
-        cmd("FLUSHALL").arg(options).take()
+        ready_cmd!("FLUSHALL", options).take()
     }
 
     /// Deletes all the keys of the current database
@@ -3127,7 +3011,7 @@ assert_eq!(invok_2_res, 5);
     /// ```
     /// [Redis Docs](https://redis.io/commands/FLUSHDB)
     fn flushdb<>() -> () {
-        cmd("FLUSHDB").take()
+        ready_cmd!("FLUSHDB").take()
     }
 
     /// Deletes all the keys of the current database with options
@@ -3137,7 +3021,7 @@ assert_eq!(invok_2_res, 5);
     /// ```
     /// [Redis Docs](https://redis.io/commands/FLUSHDB)
     fn flushdb_options<>(options: &'a FlushDbOptions) -> () {
-        cmd("FLUSHDB").arg(options).take()
+        ready_cmd!("FLUSHDB", options).take()
     }
 
     // Bloom filter commands
@@ -3152,7 +3036,7 @@ assert_eq!(invok_2_res, 5);
     #[cfg(feature = "bloom")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bloom")))]
     fn bf_add<K: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, value: V) -> (bool) {
-        cmd("BF.ADD").arg(key).arg(value).take()
+        ready_cmd!("BF.ADD", key, value).take()
     }
 
     /// Returns the number of items in a Bloom filter.
@@ -3165,7 +3049,7 @@ assert_eq!(invok_2_res, 5);
     #[cfg(feature = "bloom")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bloom")))]
     fn bf_card<K: ToSingleRedisArg>(key: K) -> (usize) {
-        cmd("BF.CARD").arg(key).take()
+        ready_cmd!("BF.CARD", key).take()
     }
 
     /// Checks if an item exists in a Bloom filter.
@@ -3184,7 +3068,7 @@ assert_eq!(invok_2_res, 5);
     #[cfg(feature = "bloom")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bloom")))]
     fn bf_exists<K: ToSingleRedisArg, V: ToSingleRedisArg>(key: K, value: V) -> (bool) {
-        cmd("BF.EXISTS").arg(key).arg(value).take()
+        ready_cmd!("BF.EXISTS", key, value).take()
     }
 
     /// Returns all available information about a Bloom filter.
@@ -3197,7 +3081,7 @@ assert_eq!(invok_2_res, 5);
     #[cfg(feature = "bloom")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bloom")))]
     fn bf_info<K: ToSingleRedisArg>(key: K) -> (std::collections::HashMap<String, crate::bloom::BloomFilterInfoTypeResponse>) {
-        cmd("BF.INFO").arg(key).take()
+        ready_cmd!("BF.INFO", key).take()
     }
 
     /// Returns specific information about a Bloom filter.
@@ -3215,7 +3099,7 @@ assert_eq!(invok_2_res, 5);
     #[cfg(feature = "bloom")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bloom")))]
     fn bf_info_type<K: ToSingleRedisArg>(key: K, info_type: crate::bloom::BloomFilterInfoType) -> (crate::bloom::BloomFilterInfoTypeResponse) {
-        cmd("BF.INFO").arg(key).arg(info_type).take()
+        ready_cmd!("BF.INFO", key, info_type).take()
     }
 
     /// Adds items to a Bloom filter, creating it with default options if it does not yet exist.
@@ -3230,11 +3114,7 @@ assert_eq!(invok_2_res, 5);
     fn bf_insert<K: ToSingleRedisArg,  V: ToRedisArgs>(
         key: K,
         items: V) -> (Vec<bool>){
-        cmd("BF.INSERT")
-            .arg(key)
-            .arg("ITEMS")
-            .arg(items)
-            .take()
+        ready_cmd!("BF.INSERT", key, "ITEMS", items).take()
     }
 
     /// Adds items to a Bloom filter, creating it with custom options if it does not exist yet.
@@ -3250,12 +3130,7 @@ assert_eq!(invok_2_res, 5);
         key: K,
         items: V,
         options: crate::bloom::BloomFilterInsertOptions) -> (Vec<bool>) {
-        cmd("BF.INSERT")
-            .arg(key)
-            .arg(options)
-            .arg("ITEMS")
-            .arg(items)
-            .take()
+        ready_cmd!("BF.INSERT", key, options, "ITEMS", items).take()
     }
 
 
@@ -3269,7 +3144,7 @@ assert_eq!(invok_2_res, 5);
     #[cfg(feature = "bloom")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bloom")))]
     fn bf_loadchunk<K: ToSingleRedisArg>(key: K, chunk: crate::bloom::BloomFilterDumpChunk) -> (()) {
-        cmd("BF.LOADCHUNK").arg(key).arg(chunk.iterator).arg(chunk.data).take()
+        ready_cmd!("BF.LOADCHUNK", key, chunk.iterator, chunk.data).take()
     }
 
     /// Adds multiple items to a Bloom filter.
@@ -3282,7 +3157,7 @@ assert_eq!(invok_2_res, 5);
     #[cfg(feature = "bloom")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bloom")))]
     fn bf_madd<K: ToSingleRedisArg, V: ToRedisArgs>(key: K, items: V) -> (Vec<bool>) {
-        cmd("BF.MADD").arg(key).arg(items).take()
+        ready_cmd!("BF.MADD", key, items).take()
     }
 
     /// Checks if an item exists in a Bloom filter.
@@ -3301,7 +3176,7 @@ assert_eq!(invok_2_res, 5);
     #[cfg(feature = "bloom")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bloom")))]
     fn bf_mexists<K: ToSingleRedisArg, V: ToRedisArgs>(key: K, items: &'a [V]) -> (Vec<bool>) {
-        cmd("BF.MEXISTS").arg(key).arg(items).take()
+        ready_cmd!("BF.MEXISTS", key, items).take()
     }
 
     /// Creates an empty Bloom filter with default settings.
@@ -3314,7 +3189,7 @@ assert_eq!(invok_2_res, 5);
     #[cfg(feature = "bloom")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bloom")))]
     fn bf_reserve<K: ToSingleRedisArg>(key: K, err_rate: f64, capacity: usize) -> (()) {
-        cmd("BF.RESERVE").arg(key).arg(err_rate).arg(capacity).take()
+        ready_cmd!("BF.RESERVE", key, err_rate, capacity).take()
     }
 
     /// Creates an empty Bloom filter with options.
@@ -3327,7 +3202,7 @@ assert_eq!(invok_2_res, 5);
     #[cfg(feature = "bloom")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bloom")))]
     fn bf_reserve_options<K: ToSingleRedisArg, E: ToSingleRedisArg, C: ToSingleRedisArg>(key: K, err_rate: E, capacity: C, options: crate::bloom::BloomFilterScalingOptions) -> (()) {
-      cmd("BF.RESERVE").arg(key).arg(err_rate).arg(capacity).arg(options).take()
+      ready_cmd!("BF.RESERVE", key, err_rate, capacity, options).take()
     }
 
     /// Begins an incremental save of the Bloom filter
@@ -3343,7 +3218,7 @@ assert_eq!(invok_2_res, 5);
     #[cfg(feature = "bloom")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bloom")))]
     fn bf_scandump<K: ToSingleRedisArg>(key: K, iterator: i64) -> (crate::bloom::BloomFilterDumpChunk) {
-        cmd("BF.SCANDUMP").arg(key).arg(iterator).take()
+        ready_cmd!("BF.SCANDUMP", key, iterator).take()
     }
 }
 

--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -346,7 +346,7 @@ macro_rules! implement_pipeline_commands {
             /// Pushes a new, empty command record. Subsequent arguments written through
             /// [`RedisWrite`](crate::RedisWrite) belong to it until the next command starts.
             #[inline]
-            fn start_command(&mut self) {
+            pub(crate) fn start_command(&mut self) {
                 self.commands.push($crate::pipeline::CommandRecord {
                     args_start: self.args.len(),
                     data_start: self.data.len(),

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -76,6 +76,26 @@ impl ToRedisArgs for SetExpiry {
             }
         }
     }
+
+    #[inline]
+    fn num_of_args(&self) -> usize {
+        match self {
+            Self::EX(_) | Self::PX(_) | Self::EXAT(_) | Self::PXAT(_) => 2,
+            Self::KEEPTTL => 1,
+        }
+    }
+
+    #[inline]
+    fn args_size(&self) -> usize {
+        let mut buf = ::itoa::Buffer::new();
+        match self {
+            Self::EX(secs) => b"EX".len() + buf.format(*secs).len(),
+            Self::PX(millis) => b"PX".len() + buf.format(*millis).len(),
+            Self::EXAT(unix_time) => b"EXAT".len() + buf.format(*unix_time).len(),
+            Self::PXAT(unix_time) => b"PXAT".len() + buf.format(*unix_time).len(),
+            Self::KEEPTTL => b"KEEPTTL".len(),
+        }
+    }
 }
 
 /// Helper enum that is used to define existence checks
@@ -102,6 +122,16 @@ impl ToRedisArgs for ExistenceCheck {
             }
         }
     }
+
+    #[inline]
+    fn num_of_args(&self) -> usize {
+        1
+    }
+
+    #[inline]
+    fn args_size(&self) -> usize {
+        2
+    }
 }
 
 /// Helper enum that is used to define field existence checks
@@ -123,6 +153,16 @@ impl ToRedisArgs for FieldExistenceCheck {
             Self::FNX => out.write_arg(b"FNX"),
             Self::FXX => out.write_arg(b"FXX"),
         }
+    }
+
+    #[inline]
+    fn num_of_args(&self) -> usize {
+        1
+    }
+
+    #[inline]
+    fn args_size(&self) -> usize {
+        3
     }
 }
 
@@ -302,6 +342,21 @@ impl ToRedisArgs for ValueComparison {
                 out.write_arg(b"IFDNE");
                 out.write_arg(digest);
             }
+        }
+    }
+
+    #[inline]
+    fn num_of_args(&self) -> usize {
+        2
+    }
+
+    #[inline]
+    fn args_size(&self) -> usize {
+        match self {
+            Self::IFEQ(value) => b"IFEQ".len() + value.len(),
+            Self::IFNE(value) => b"IFNE".len() + value.len(),
+            Self::IFDEQ(value) => b"IFDEQ".len() + value.len(),
+            Self::IFDNE(value) => b"IFDNE".len() + value.len(),
         }
     }
 }
@@ -1085,7 +1140,13 @@ impl RedisWrite for Vec<Vec<u8>> {
 ///
 /// This should be implemented only for types that are serialized into exactly one value,
 /// otherwise the compiler can't ensure the correctness of some commands.
-pub trait ToSingleRedisArg: ToRedisArgs {}
+pub trait ToSingleRedisArg: ToRedisArgs {
+    /// Returns an estimate of the number of bytes this single argument
+    /// will serialize to.
+    fn arg_size(&self) -> usize {
+        self.args_size()
+    }
+}
 
 /// Used to convert a value into one or multiple redis argument
 /// strings.  Most values will produce exactly one item but in
@@ -1114,6 +1175,7 @@ pub trait ToRedisArgs: Sized {
     /// to it's numeric behavior in a redis context.  This is used in
     /// some high level concepts to switch between different implementations
     /// of redis functions (for instance `INCR` vs `INCRBYFLOAT`).
+    #[inline]
     fn describe_numeric_behavior(&self) -> NumericBehavior {
         NumericBehavior::NonNumeric
     }
@@ -1124,8 +1186,23 @@ pub trait ToRedisArgs: Sized {
     /// between `GET` and `MGET` variants. Also, for some commands like HEXPIREDAT
     /// which require a specific number of arguments, this method can be used to
     /// know the number of arguments.
+    #[inline]
     fn num_of_args(&self) -> usize {
         1
+    }
+
+    /// Returns an estimate of the number of bytes that will be written to the
+    /// command for this value.
+    #[inline]
+    fn args_size(&self) -> usize {
+        0
+    }
+
+    /// Returns both the number of Redis arguments and the estimated number of bytes this value
+    /// will serialize to.
+    #[inline]
+    fn num_of_args_and_size(&self) -> (usize, usize) {
+        (self.num_of_args(), self.args_size())
     }
 
     /// This only exists internally as a workaround for the lack of
@@ -1152,7 +1229,28 @@ pub trait ToRedisArgs: Sized {
         }
     }
 
+    // this is used in absence of specialization to provide a default implementation for slices that can be overridden specifically for byte slices (&[u8])
     #[doc(hidden)]
+    #[inline]
+    fn num_of_args_and_size_for_slice(items: &[Self]) -> (usize, usize) {
+        items
+            .iter()
+            .map(|item| item.num_of_args_and_size())
+            .fold((0, 0), |(args, size), (item_args, item_size)| {
+                (args + item_args, size + item_size)
+            })
+    }
+
+    // this is used in absence of specialization to provide a default implementation for arrays that can be overridden specifically for byte arrays (&[u8; N])
+    #[doc(hidden)]
+    #[inline]
+    fn num_of_args_and_size_for_array<const N: usize>(items: &[Self; N]) -> (usize, usize) {
+        Self::num_of_args_and_size_for_slice(items.as_slice())
+    }
+
+    // this is used in absence of specialization to provide a default implementation for slices that can be overridden specifically for byte slices (&[u8])
+    #[doc(hidden)]
+    #[inline]
     fn is_single_vec_arg(items: &[Self]) -> bool {
         items.len() == 1 && items[0].num_of_args() <= 1
     }
@@ -1170,6 +1268,13 @@ macro_rules! itoa_based_to_redis_impl {
                 out.write_arg(s.as_bytes())
             }
 
+            #[inline]
+            fn args_size(&self) -> usize {
+                let mut buf = ::itoa::Buffer::new();
+                buf.format(*self).len()
+            }
+
+            #[inline]
             fn describe_numeric_behavior(&self) -> NumericBehavior {
                 $numeric
             }
@@ -1191,6 +1296,13 @@ macro_rules! non_zero_itoa_based_to_redis_impl {
                 out.write_arg(s.as_bytes())
             }
 
+            #[inline]
+            fn args_size(&self) -> usize {
+                let mut buf = ::itoa::Buffer::new();
+                buf.format(self.get()).len()
+            }
+
+            #[inline]
             fn describe_numeric_behavior(&self) -> NumericBehavior {
                 $numeric
             }
@@ -1212,6 +1324,13 @@ macro_rules! ryu_based_to_redis_impl {
                 out.write_arg(s.as_bytes())
             }
 
+            #[inline]
+            fn args_size(&self) -> usize {
+                let mut buf = ::ryu::Buffer::new();
+                buf.format(*self).len()
+            }
+
+            #[inline]
             fn describe_numeric_behavior(&self) -> NumericBehavior {
                 $numeric
             }
@@ -1231,6 +1350,12 @@ impl ToRedisArgs for u8 {
         out.write_arg(s.as_bytes());
     }
 
+    #[inline]
+    fn args_size(&self) -> usize {
+        let mut buf = ::itoa::Buffer::new();
+        buf.format(*self).len()
+    }
+
     fn write_args_from_slice<W>(items: &[Self], out: &mut W)
     where
         W: ?Sized + RedisWrite,
@@ -1238,6 +1363,17 @@ impl ToRedisArgs for u8 {
         out.write_arg(items);
     }
 
+    #[inline]
+    fn num_of_args_and_size_for_slice(items: &[Self]) -> (usize, usize) {
+        (1, items.len())
+    }
+
+    #[inline]
+    fn num_of_args_and_size_for_array<const N: usize>(_items: &[Self; N]) -> (usize, usize) {
+        (1, N)
+    }
+
+    #[inline]
     fn is_single_vec_arg(_items: &[Self]) -> bool {
         true
     }
@@ -1309,6 +1445,11 @@ impl ToRedisArgs for bool {
     {
         out.write_arg(if *self { b"1" } else { b"0" });
     }
+
+    #[inline]
+    fn args_size(&self) -> usize {
+        1
+    }
 }
 
 impl ToSingleRedisArg for bool {}
@@ -1320,6 +1461,11 @@ impl ToRedisArgs for String {
     {
         out.write_arg(self.as_bytes());
     }
+
+    #[inline]
+    fn args_size(&self) -> usize {
+        self.len()
+    }
 }
 impl ToSingleRedisArg for String {}
 
@@ -1329,6 +1475,11 @@ impl ToRedisArgs for &str {
         W: ?Sized + RedisWrite,
     {
         out.write_arg(self.as_bytes());
+    }
+
+    #[inline]
+    fn args_size(&self) -> usize {
+        self.len()
     }
 }
 
@@ -1347,6 +1498,14 @@ where
         match self {
             Cow::Borrowed(inner) => inner.write_redis_args(out),
             Cow::Owned(inner) => inner.write_redis_args(out),
+        }
+    }
+
+    #[inline]
+    fn args_size(&self) -> usize {
+        match self {
+            Cow::Borrowed(inner) => inner.args_size(),
+            Cow::Owned(inner) => inner.args_size(),
         }
     }
 }
@@ -1369,6 +1528,7 @@ impl<T: ToRedisArgs> ToRedisArgs for Option<T> {
         }
     }
 
+    #[inline]
     fn describe_numeric_behavior(&self) -> NumericBehavior {
         match *self {
             Some(ref x) => x.describe_numeric_behavior(),
@@ -1376,9 +1536,18 @@ impl<T: ToRedisArgs> ToRedisArgs for Option<T> {
         }
     }
 
+    #[inline]
     fn num_of_args(&self) -> usize {
         match *self {
             Some(ref x) => x.num_of_args(),
+            None => 0,
+        }
+    }
+
+    #[inline]
+    fn args_size(&self) -> usize {
+        match *self {
+            Some(ref x) => x.args_size(),
             None => 0,
         }
     }
@@ -1398,17 +1567,22 @@ macro_rules! impl_write_redis_args_for_collection {
                 ToRedisArgs::write_args_from_slice(self, out)
             }
 
+            #[inline]
             fn num_of_args(&self) -> usize {
-                if ToRedisArgs::is_single_vec_arg(&self[..]) {
-                    return 1;
-                }
-                if self.len() == 1 {
-                    self[0].num_of_args()
-                } else {
-                    self.len()
-                }
+                self.num_of_args_and_size().0
             }
 
+            #[inline]
+            fn args_size(&self) -> usize {
+                self.num_of_args_and_size().1
+            }
+
+            #[inline]
+            fn num_of_args_and_size(&self) -> (usize, usize) {
+                <T as ToRedisArgs>::num_of_args_and_size_for_slice(self)
+            }
+
+            #[inline]
             fn describe_numeric_behavior(&self) -> NumericBehavior {
                 NumericBehavior::NonNumeric
             }
@@ -1430,10 +1604,22 @@ macro_rules! deref_to_write_redis_args_impl {
                 (**self).write_redis_args(out)
             }
 
+            #[inline]
             fn num_of_args(&self) -> usize {
                 (**self).num_of_args()
             }
 
+            #[inline]
+            fn args_size(&self) -> usize {
+                (**self).args_size()
+            }
+
+            #[inline]
+            fn num_of_args_and_size(&self) -> (usize, usize) {
+                (**self).num_of_args_and_size()
+            }
+
+            #[inline]
             fn describe_numeric_behavior(&self) -> NumericBehavior {
                 (**self).describe_numeric_behavior()
             }
@@ -1477,8 +1663,23 @@ macro_rules! impl_to_redis_args_for_set {
                 ToRedisArgs::make_arg_iter_ref(self.iter(), out)
             }
 
+            #[inline]
             fn num_of_args(&self) -> usize {
-                self.len()
+                self.num_of_args_and_size().0
+            }
+
+            #[inline]
+            fn args_size(&self) -> usize {
+                self.num_of_args_and_size().1
+            }
+
+            #[inline]
+            fn num_of_args_and_size(&self) -> (usize, usize) {
+                self.iter()
+                    .map(|item| item.num_of_args_and_size())
+                    .fold((0, 0), |(args, size), (item_args, item_size)| {
+                        (args + item_args, size + item_size)
+                    })
             }
         }
     };
@@ -1532,8 +1733,27 @@ macro_rules! impl_to_redis_args_for_map {
                 }
             }
 
+            #[inline]
             fn num_of_args(&self) -> usize {
-                self.len()
+                self.num_of_args_and_size().0
+            }
+
+            #[inline]
+            fn args_size(&self) -> usize {
+                self.num_of_args_and_size().1
+            }
+
+            #[inline]
+            fn num_of_args_and_size(&self) -> (usize, usize) {
+                self.iter()
+                    .map(|(key, value)| {
+                        let (key_args, key_size) = key.num_of_args_and_size();
+                        let (value_args, value_size) = value.num_of_args_and_size();
+                        (key_args + value_args, key_size + value_size)
+                    })
+                    .fold((0, 0), |(args, size), (item_args, item_size)| {
+                        (args + item_args, size + item_size)
+                    })
             }
         }
     };
@@ -1576,10 +1796,24 @@ macro_rules! to_redis_args_for_tuple {
             }
 
             #[allow(non_snake_case, unused_variables)]
-            fn num_of_args(&self) -> usize {
+            #[inline] fn num_of_args(&self) -> usize {
                 let mut n: usize = 0;
                 $(let $name = (); n += 1;)*
                 n
+            }
+
+            #[allow(non_snake_case, unused_variables)]
+            #[inline] fn args_size(&self) -> usize {
+                let ($(ref $name,)*) = *self;
+                0 $( + $name.args_size())*
+            }
+
+            #[allow(non_snake_case, unused_variables)]
+            #[inline] fn num_of_args_and_size(&self) -> (usize, usize) {
+                let ($(ref $name,)*) = *self;
+                let args_count = 0usize $( + { let $name = (); 1usize })*;
+                let args_size = 0usize $( + $name.args_size())*;
+                (args_count, args_size)
             }
         }
     )
@@ -1606,15 +1840,19 @@ impl<T: ToRedisArgs, const N: usize> ToRedisArgs for &[T; N] {
         ToRedisArgs::write_args_from_slice(self.as_slice(), out);
     }
 
+    #[inline]
     fn num_of_args(&self) -> usize {
-        if ToRedisArgs::is_single_vec_arg(&self[..]) {
-            return 1;
-        }
-        if self.len() == 1 {
-            self[0].num_of_args()
-        } else {
-            self.len()
-        }
+        self.num_of_args_and_size().0
+    }
+
+    #[inline]
+    fn args_size(&self) -> usize {
+        self.num_of_args_and_size().1
+    }
+
+    #[inline]
+    fn num_of_args_and_size(&self) -> (usize, usize) {
+        <T as ToRedisArgs>::num_of_args_and_size_for_array(self)
     }
 }
 impl<const N: usize> ToSingleRedisArg for &[u8; N] {}
@@ -2545,6 +2783,11 @@ impl ToRedisArgs for uuid::Uuid {
     {
         out.write_arg(self.as_bytes());
     }
+
+    #[inline]
+    fn args_size(&self) -> usize {
+        self.as_bytes().len()
+    }
 }
 
 #[cfg(feature = "uuid")]
@@ -2648,6 +2891,19 @@ impl ToRedisArgs for ExpireOption {
             Self::GT => out.write_arg(b"GT"),
             Self::LT => out.write_arg(b"LT"),
             _ => {}
+        }
+    }
+
+    #[inline]
+    fn num_of_args(&self) -> usize {
+        1
+    }
+
+    #[inline]
+    fn args_size(&self) -> usize {
+        match self {
+            Self::NONE => b"NONE".len(),
+            Self::NX | Self::XX | Self::GT | Self::LT => 2,
         }
     }
 }
@@ -2817,6 +3073,17 @@ impl ToRedisArgs for ValueType {
     {
         let as_str = <&Self as Into<&str>>::into(self);
         out.write_arg(as_str.as_bytes());
+    }
+
+    #[inline]
+    fn num_of_args(&self) -> usize {
+        1
+    }
+
+    #[inline]
+    fn args_size(&self) -> usize {
+        let as_str = <&Self as Into<&str>>::into(self);
+        as_str.len()
     }
 }
 

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -83,6 +83,143 @@ mod types {
         assert_eq!(Rc::new(twobytesslice).num_of_args(), 2);
     }
 
+    #[test]
+    fn test_collection_args_size() {
+        let bytes: &[u8] = &[0, 42, 255];
+        assert_eq!(bytes.args_size(), bytes.len());
+
+        let byte_vec: Vec<u8> = vec![0, 42, 255];
+        assert_eq!(byte_vec.args_size(), byte_vec.len());
+        assert_eq!(vec![bytes, bytes].args_size(), byte_vec.len() * 2);
+
+        let numbers = [1_u16, 255_u16];
+        assert_eq!(numbers.as_slice().num_of_args(), numbers.len());
+        assert_eq!(numbers.as_slice().args_size(), 4);
+
+        let bytes_array_ref = &[0_u8, 42, 255];
+        assert_eq!(bytes_array_ref.num_of_args_and_size(), (1, 3));
+
+        let items: [(&str, &[u8]); 2] = [("foo1", bytes), ("foo2", bytes)];
+        let items_slice = items.as_slice();
+        assert_eq!(
+            <&[(&str, &[u8])] as ToRedisArgs>::num_of_args(&items_slice),
+            4
+        );
+        assert_eq!(
+            <&[(&str, &[u8])] as ToRedisArgs>::args_size(&items_slice),
+            8 + bytes.len() * 2
+        );
+    }
+
+    fn assert_arg_metadata<T: ToRedisArgs>(value: &T) {
+        assert_eq!(
+            value.num_of_args_and_size(),
+            (value.num_of_args(), value.args_size())
+        );
+    }
+
+    #[test]
+    fn test_collection_num_of_args_and_size_matches_separate_getters() {
+        let numbers = [1_u16, 255_u16];
+        let number_slice: &[u16] = &numbers;
+        assert_arg_metadata(&number_slice);
+
+        let mut mutable_numbers = [1_u16, 255_u16];
+        let mutable_number_slice: &mut [u16] = &mut mutable_numbers;
+        assert_arg_metadata(&mutable_number_slice);
+
+        let boxed_numbers: Box<[u16]> = vec![1_u16, 255_u16].into_boxed_slice();
+        assert_arg_metadata(&boxed_numbers);
+
+        let arc_numbers: Arc<[u16]> = Arc::from(vec![1_u16, 255_u16].into_boxed_slice());
+        assert_arg_metadata(&arc_numbers);
+
+        let rc_numbers: Rc<[u16]> = Rc::from(vec![1_u16, 255_u16].into_boxed_slice());
+        assert_arg_metadata(&rc_numbers);
+
+        let number_vec = vec![1_u16, 255_u16];
+        assert_arg_metadata(&number_vec);
+
+        let bytes = [0_u8, 42, 255];
+        let byte_slice: &[u8] = &bytes;
+        assert_arg_metadata(&byte_slice);
+
+        let mut mutable_bytes = [0_u8, 42, 255];
+        let mutable_byte_slice: &mut [u8] = &mut mutable_bytes;
+        assert_arg_metadata(&mutable_byte_slice);
+
+        let boxed_bytes: Box<[u8]> = vec![0_u8, 42, 255].into_boxed_slice();
+        assert_arg_metadata(&boxed_bytes);
+
+        let arc_bytes: Arc<[u8]> = Arc::from(vec![0_u8, 42, 255].into_boxed_slice());
+        assert_arg_metadata(&arc_bytes);
+
+        let rc_bytes: Rc<[u8]> = Rc::from(vec![0_u8, 42, 255].into_boxed_slice());
+        assert_arg_metadata(&rc_bytes);
+
+        let byte_vec = vec![0_u8, 42, 255];
+        assert_arg_metadata(&byte_vec);
+
+        let tuple_items: [(&str, &[u8]); 2] = [("foo1", byte_slice), ("foo2", byte_slice)];
+        let tuple_slice = tuple_items.as_slice();
+        assert_arg_metadata(&tuple_slice);
+
+        let number_array_ref = &numbers;
+        assert_arg_metadata(&number_array_ref);
+
+        let byte_array_ref = &bytes;
+        assert_arg_metadata(&byte_array_ref);
+
+        let tuple_array_ref = &tuple_items;
+        assert_arg_metadata(&tuple_array_ref);
+        assert_eq!(
+            tuple_array_ref.num_of_args_and_size(),
+            (4, 8 + byte_slice.len() * 2)
+        );
+
+        let number_hash_set = [1_u16, 255_u16].into_iter().collect::<HashSet<_>>();
+        assert_arg_metadata(&number_hash_set);
+
+        let number_btree_set = [1_u16, 255_u16]
+            .into_iter()
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_arg_metadata(&number_btree_set);
+
+        let number_hash_map = [("foo1", 1_u16), ("foo2", 255_u16)]
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+        assert_arg_metadata(&number_hash_map);
+
+        let number_btree_map = [("foo1", 1_u16), ("foo2", 255_u16)]
+            .into_iter()
+            .collect::<std::collections::BTreeMap<_, _>>();
+        assert_arg_metadata(&number_btree_map);
+    }
+
+    #[test]
+    fn test_deref_num_of_args_and_size_matches_separate_getters() {
+        let number = 255_u16;
+        let number_ref = &number;
+        assert_arg_metadata(&number_ref);
+
+        let mut mutable_number = 255_u16;
+        let number_mut_ref = &mut mutable_number;
+        assert_arg_metadata(&number_mut_ref);
+
+        let boxed_number = Box::new(255_u16);
+        assert_arg_metadata(&boxed_number);
+
+        let arc_number = Arc::new(255_u16);
+        assert_arg_metadata(&arc_number);
+
+        let rc_number = Rc::new(255_u16);
+        assert_arg_metadata(&rc_number);
+
+        let values = vec![1_u16, 255_u16];
+        let values_ref = &values;
+        assert_arg_metadata(&values_ref);
+    }
+
     /// The `FromRedisValue` trait provides two methods for parsing:
     /// - `fn from_redis_value_ref(&Value) -> Result<T, RedisError>`
     /// - `fn from_redis_value(Value) -> Result<T, RedisError>`


### PR DESCRIPTION
This change uses the number of args and their length in each of the known commands to preallocate the Cmd / Pipeline, in order to reduce the number of reallocations and copies when populating the arguments.