### PR TITLE
Drop unused Rust flags

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -310,6 +310,3 @@ required-features = ["cluster-async", "tokio-comp"]
 
 [lints]
 workspace = true
-
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-Clink-arg=-Wl,--no-rosegment"]


### PR DESCRIPTION
In 7060272 (pre-allocation of commands) unused Rust flags got added, which cargo complains about.

We drop them again.