### PR TITLE
Clean up idempotency for streams

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -2484,12 +2484,12 @@ implement_commands! {
 
 
     /// Returns info about high-level stream details
-    /// (first & last message `id`, length, number of groups, etc.)
-    /// Take note of the StreamInfoStreamReply return type.
     ///
-    /// *It's possible this return value might not contain new fields added by Redis in future versions,
-    /// such as the idempotency fields introduced in Redis 8.6. For IDMP tracking statistics, use
-    /// [`xinfo_stream_with_idempotency`](Self::xinfo_stream_with_idempotency).*
+    /// This includes first and last message `id`, length, number of groups, etc.
+    ///
+    /// Take note of the [`StreamInfoStreamReply`](streams::StreamInfoStreamReply)
+    /// return type.
+    /// It's IDMP fields, however, only get set, if [IDMP is configured for the stream](#xcfgset).
     ///
     /// ```text
     /// XINFO STREAM <key>
@@ -2498,23 +2498,6 @@ implement_commands! {
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xinfo_stream<K: ToRedisArgs>(key: K) -> (streams::StreamInfoStreamReply) {
-        ready_cmd!("XINFO", "STREAM", key).take()
-    }
-
-    // TODO: Remove this function when creating the next major release.
-    /// Returns stream info with idempotency tracking statistics (Redis 8.6+).
-    ///
-    /// This command returns [`StreamInfoStreamReplyWithIdempotency`](streams::StreamInfoStreamReplyWithIdempotency)
-    /// which composes [`StreamInfoStreamReply`](streams::StreamInfoStreamReply) (accessible via the `base` field)
-    /// and adds IDMP (Idempotent Message Processing) tracking fields.
-    ///
-    /// ```text
-    /// XINFO STREAM <key>
-    /// ```
-    /// [Redis Docs](https://redis.io/commands/XINFO-STREAM)
-    #[cfg(feature = "streams")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
-    fn xinfo_stream_with_idempotency<K: ToRedisArgs>(key: K) -> (streams::StreamInfoStreamReplyWithIdempotency) {
         ready_cmd!("XINFO", "STREAM", key).take()
     }
 

--- a/redis/src/commands/streams.rs
+++ b/redis/src/commands/streams.rs
@@ -831,20 +831,42 @@ pub struct StreamPendingCountReply {
     pub ids: Vec<StreamPendingId>,
 }
 
-/// Reply type used with [`xinfo_stream`] command, containing
-/// general information about the stream stored at the specified key.
+/// Reply type used with [`xinfo_stream`] command
+///
+/// It contains general information about the stream stored at the specified key.
 ///
 /// The very first and last IDs in the stream are shown,
 /// in order to give some sense about what is the stream content.
 ///
-/// **Note:** For Redis 8.6+ idempotency tracking fields, use [`StreamInfoStreamReplyWithIdempotency`]
-/// via the [`xinfo_stream_with_idempotency`] command instead.
+/// Note that [`xinfo_stream`] only sets IDMP fields, if IDMP is configured for the stream
+/// (See [`xcfgset`]).
 ///
-/// [`xinfo_stream`]: ../trait.Commands.html#method.xinfo_stream
-/// [`xinfo_stream_with_idempotency`]: ../trait.Commands.html#method.xinfo_stream_with_idempotency
+/// [`xinfo_stream`]: ../trait.Commands.html#method.xinfo_stream_with_idempotency
+/// [`xcfgset`]: ../trait.Commands.html#method.xcfgset
 ///
-#[non_exhaustive]
+/// # Example
+/// ```no_run
+/// use redis::{Commands, streams::StreamInfoStreamReply};
+/// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+/// # let mut con = client.get_connection().unwrap();
+///
+/// let info: StreamInfoStreamReply = con.xinfo_stream("stream").unwrap();
+///
+/// // Access base stream info
+/// println!("Stream length: {}", info.length);
+/// println!("Last ID: {}", info.last_generated_id);
+///
+/// // Access idempotency tracking (Only if IDMP was configured for the stream)
+/// println!("Producers tracked: {}", info.pids_tracked);
+/// println!("Idempotent IDs tracked: {}", info.iids_tracked);
+/// println!("Duplicates prevented: {}", info.iids_duplicates);
+/// ```
+// Idempotency fields are optional. Wrapping them by `Option` would mean lots of manual, unnecessary
+// unpacking for callers, as they typically know whether streams are configured to produce relevant
+// IDMP values or not. Also, the `Option` would be inconsistent with other fields. Hence, the IDMP
+// values are not wrapped by `Option`.
 #[derive(Default, Debug, Clone)]
+#[non_exhaustive]
 pub struct StreamInfoStreamReply {
     /// The last generated ID that may not be the same as the last
     /// entry ID in case some entry was deleted.
@@ -860,41 +882,6 @@ pub struct StreamInfoStreamReply {
     pub first_entry: StreamId,
     /// The very last entry in the stream.
     pub last_entry: StreamId,
-}
-
-// TODO: Remove this type and extend StreamInfoStreamReply when creating the next major release.
-/// Reply type used with [`xinfo_stream_with_idempotency`] command (Redis 8.6+).
-///
-/// This type composes [`StreamInfoStreamReply`] with additional idempotency tracking fields
-/// introduced in Redis 8.6.
-///
-/// The base stream information is accessible via the `base` field, while idempotency
-/// fields are directly available as top-level fields.
-///
-/// [`xinfo_stream_with_idempotency`]: ../trait.Commands.html#method.xinfo_stream_with_idempotency
-///
-/// # Example
-/// ```no_run
-/// use redis::{Commands, streams::StreamInfoStreamReplyWithIdempotency};
-/// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-/// # let mut con = client.get_connection().unwrap();
-///
-/// let info: StreamInfoStreamReplyWithIdempotency = con.xinfo_stream_with_idempotency("stream").unwrap();
-///
-/// // Access base stream info
-/// println!("Stream length: {}", info.base.length);
-/// println!("Last ID: {}", info.base.last_generated_id);
-///
-/// // Access idempotency tracking (Redis 8.6+)
-/// println!("Producers tracked: {}", info.pids_tracked);
-/// println!("Idempotent IDs tracked: {}", info.iids_tracked);
-/// println!("Duplicates prevented: {}", info.iids_duplicates);
-/// ```
-#[derive(Default, Debug, Clone)]
-#[non_exhaustive]
-pub struct StreamInfoStreamReplyWithIdempotency {
-    /// Base stream information
-    pub base: StreamInfoStreamReply,
     /// The duration in seconds that idempotent IDs are retained in the stream's IDMP map
     pub idmp_duration: u32,
     /// The maximum number of idempotent IDs kept for each producer in the stream's IDMP map
@@ -1359,41 +1346,6 @@ impl FromRedisValue for StreamInfoStreamReply {
         if let Some(v) = map.remove("last-entry") {
             reply.last_entry = StreamId::from_array_value(v)?;
         }
-        Ok(reply)
-    }
-}
-
-impl FromRedisValue for StreamInfoStreamReplyWithIdempotency {
-    fn from_redis_value(v: Value) -> Result<Self, ParsingError> {
-        let mut map: HashMap<String, Value> = from_redis_value(v)?;
-
-        // Parse base fields into the composed StreamInfoStreamReply
-        let mut base = StreamInfoStreamReply::default();
-        if let Some(v) = map.remove("last-generated-id") {
-            base.last_generated_id = from_redis_value(v)?;
-        }
-        if let Some(v) = map.remove("radix-tree-nodes") {
-            base.radix_tree_keys = from_redis_value(v)?;
-        }
-        if let Some(v) = map.remove("groups") {
-            base.groups = from_redis_value(v)?;
-        }
-        if let Some(v) = map.remove("length") {
-            base.length = from_redis_value(v)?;
-        }
-        if let Some(v) = map.remove("first-entry") {
-            base.first_entry = StreamId::from_array_value(v)?;
-        }
-        if let Some(v) = map.remove("last-entry") {
-            base.last_entry = StreamId::from_array_value(v)?;
-        }
-
-        // Parse idempotency fields
-        let mut reply = Self {
-            base,
-            ..Default::default()
-        };
-
         if let Some(v) = map.remove("idmp-duration") {
             reply.idmp_duration = from_redis_value(v)?;
         }

--- a/redis/tests/test_streams.rs
+++ b/redis/tests/test_streams.rs
@@ -2398,7 +2398,7 @@ mod idempotency_tests {
             .unwrap();
         assert!(id1.is_some());
         // Verify that the message was registered for tracking.
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.pids_tracked, 1);
         assert_eq!(info.iids_tracked, 1);
         assert_eq!(info.iids_duplicates, 0);
@@ -2414,7 +2414,7 @@ mod idempotency_tests {
         assert_eq!(id1, id2);
         assert_eq!(con.xlen(STREAM_NAME), Ok(1));
         // Verify that deduplication has taken place.
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.pids_tracked, 1);
         assert_eq!(info.iids_tracked, 1);
         assert_eq!(info.iids_duplicates, 1);
@@ -2429,7 +2429,7 @@ mod idempotency_tests {
         let reply = con.xrange_all(STREAM_NAME).unwrap();
         assert!(reply.ids[0].contains_key(FIELD_VALUES[0].0));
         // Verify that deduplication has taken place.
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.pids_tracked, 1);
         assert_eq!(info.iids_tracked, 1);
         assert_eq!(info.iids_duplicates, 2);
@@ -2443,7 +2443,7 @@ mod idempotency_tests {
         assert_ne!(id1, id4);
         assert_eq!(con.xlen(STREAM_NAME), Ok(2));
         // Verify that the message was registered for tracking.
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.pids_tracked, 1);
         assert_eq!(info.iids_tracked, 2);
         assert_eq!(info.iids_duplicates, 2);
@@ -2458,7 +2458,7 @@ mod idempotency_tests {
         assert_ne!(id4, id5);
         assert_eq!(con.xlen(STREAM_NAME), Ok(3));
         // Verify that the message was registered for tracking.
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.pids_tracked, 2);
         assert_eq!(info.iids_tracked, 3);
         assert_eq!(info.iids_duplicates, 2);
@@ -2480,7 +2480,7 @@ mod idempotency_tests {
             .unwrap();
         assert!(id1.is_some());
         // Verify that the message was registered for tracking.
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.pids_tracked, 1);
         assert_eq!(info.iids_tracked, 1);
         assert_eq!(info.iids_duplicates, 0);
@@ -2501,7 +2501,7 @@ mod idempotency_tests {
         assert_eq!(id1, id2);
         assert_eq!(con.xlen(STREAM_NAME), Ok(1));
         // Verify that deduplication has taken place.
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.pids_tracked, 1);
         assert_eq!(info.iids_tracked, 1);
         assert_eq!(info.iids_duplicates, 1);
@@ -2514,7 +2514,7 @@ mod idempotency_tests {
         assert_ne!(id1, id3);
         assert_eq!(con.xlen(STREAM_NAME), Ok(2));
         // Verify that the message was registered for tracking.
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.pids_tracked, 1);
         assert_eq!(info.iids_tracked, 2);
         assert_eq!(info.iids_duplicates, 1);
@@ -2528,7 +2528,7 @@ mod idempotency_tests {
         assert_ne!(id3, id4);
         assert_eq!(con.xlen(STREAM_NAME), Ok(3));
         // Verify that the message was registered for tracking.
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.pids_tracked, 2);
         assert_eq!(info.iids_tracked, 3);
         assert_eq!(info.iids_duplicates, 1);
@@ -2563,7 +2563,7 @@ mod idempotency_tests {
         assert_eq!(result, Ok(None));
 
         // Verify that the stream did not get created.
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME);
+        let info = con.xinfo_stream(STREAM_NAME);
         assert_matches!(&info, Err(e) if e.kind() == redis::ServerErrorKind::ResponseError.into()
             && e.code() == Some("ERR")
             && e.detail() == Some("no such key")
@@ -2574,7 +2574,7 @@ mod idempotency_tests {
             .map(|entry| con.xadd(STREAM_NAME, "*", &[entry]).unwrap().unwrap());
 
         // Verify that since idempotency was not used, no tracking of the messages has taken place.
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.pids_tracked, 0);
         assert_eq!(info.iids_tracked, 0);
         assert_eq!(info.iids_duplicates, 0);
@@ -2616,9 +2616,9 @@ mod idempotency_tests {
         // The stream should have been trimmed as its entries exceeded the maximum length.
         // As a result, the first entry should have been removed.
         assert_eq!(con.xlen(STREAM_NAME).unwrap(), INITIAL_STREAM_ENTRIES.len());
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
-        assert_eq!(info.base.first_entry.id, id2); // id1 should now be trimmed
-        assert_eq!(info.base.last_generated_id, id4);
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
+        assert_eq!(info.first_entry.id, id2); // id1 should now be trimmed
+        assert_eq!(info.last_generated_id, id4);
         // Additionally, verify that the message was registered for idempotency tracking.
         assert_eq!(info.pids_tracked, 1);
         assert_eq!(info.iids_tracked, 1);
@@ -2649,9 +2649,9 @@ mod idempotency_tests {
 
         // The stream should remain unchanged.
         assert_eq!(con.xlen(STREAM_NAME).unwrap(), INITIAL_STREAM_ENTRIES.len());
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
-        assert_eq!(info.base.first_entry.id, id2);
-        assert_eq!(info.base.last_generated_id, id4);
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
+        assert_eq!(info.first_entry.id, id2);
+        assert_eq!(info.last_generated_id, id4);
         // Additionally, verify that the message was deduplicated.
         assert_eq!(info.pids_tracked, 1);
         assert_eq!(info.iids_tracked, 1);
@@ -2678,9 +2678,9 @@ mod idempotency_tests {
         // The stream should have been trimmed again, as its entries once again exceeded the maximum length.
         // As a result, the first entry (second from the initial entries) should have been removed.
         assert_eq!(con.xlen(STREAM_NAME).unwrap(), INITIAL_STREAM_ENTRIES.len());
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
-        assert_eq!(info.base.first_entry.id, id3); // id2 should now be trimmed
-        assert_eq!(info.base.last_generated_id, id6);
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
+        assert_eq!(info.first_entry.id, id3); // id2 should now be trimmed
+        assert_eq!(info.last_generated_id, id6);
         // Additionally, verify that the message was registered for idempotency tracking.
         assert_eq!(info.pids_tracked, 1);
         assert_eq!(info.iids_tracked, 2);
@@ -2721,7 +2721,7 @@ mod idempotency_tests {
         let _: () = con
             .xgroup_create_mkstream(STREAM_NAME, "group", "$")
             .unwrap();
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         // Verify that initially the defaults are used.
         assert_eq!(info.idmp_duration, IDMP_DEFAULT_DURATION);
         assert_eq!(info.idmp_maxsize, IDMP_DEFAULT_MAXSIZE);
@@ -2735,7 +2735,7 @@ mod idempotency_tests {
             .unwrap(),
             "OK"
         );
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         // Verify that only the duration has changed.
         assert_eq!(info.idmp_duration, IDMP_CUSTOM_DURATION);
         assert_eq!(info.idmp_maxsize, IDMP_DEFAULT_MAXSIZE);
@@ -2749,7 +2749,7 @@ mod idempotency_tests {
             .unwrap(),
             "OK"
         );
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         // Verify that the new max size is applied and that the previously set duration is preserved.
         assert_eq!(info.idmp_duration, IDMP_CUSTOM_DURATION);
         assert_eq!(info.idmp_maxsize, IDMP_CUSTOM_MAXSIZE);
@@ -2760,7 +2760,7 @@ mod idempotency_tests {
             .idempotency_maxsize(IDMP_CUSTOM_MAXSIZE * 2)
             .unwrap();
         assert_eq!(con.xcfgset(STREAM_NAME, &opts).unwrap(), "OK");
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         // Verify that both parameters have changed and they are now doubled.
         assert_eq!(info.idmp_duration, IDMP_CUSTOM_DURATION * 2);
         assert_eq!(info.idmp_maxsize, IDMP_CUSTOM_MAXSIZE * 2);
@@ -2771,7 +2771,7 @@ mod idempotency_tests {
             .idempotency_seconds(IDMP_CUSTOM_DURATION)
             .unwrap();
         assert_eq!(con.xcfgset(STREAM_NAME, &opts).unwrap(), "OK");
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         // Verify that both parameters have changed and they are now set to the custom values.
         assert_eq!(info.idmp_duration, IDMP_CUSTOM_DURATION);
         assert_eq!(info.idmp_maxsize, IDMP_CUSTOM_MAXSIZE);
@@ -2800,7 +2800,7 @@ mod idempotency_tests {
         assert!(id2.is_some());
 
         // Verify that the IDMP map is populated.
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.pids_tracked, 1);
         assert_eq!(info.iids_tracked, 2);
         assert_eq!(info.iids_added, 2);
@@ -2813,7 +2813,7 @@ mod idempotency_tests {
         assert!(id3.is_some());
         assert_eq!(id1, id3);
 
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.iids_duplicates, 1);
 
         // Changing the configuration should clear the IDMP map.
@@ -2827,7 +2827,7 @@ mod idempotency_tests {
         );
 
         // Verify that the configuration was applied and the IDMP map was cleared.
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.idmp_duration, IDMP_CUSTOM_DURATION);
         assert_eq!(info.pids_tracked, 0);
         assert_eq!(info.iids_tracked, 0);
@@ -2846,7 +2846,7 @@ mod idempotency_tests {
         assert_ne!(id1, id4);
 
         // Verify the IDMP map is now tracking again.
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.pids_tracked, 1);
         assert_eq!(info.iids_tracked, 1);
         assert_eq!(info.iids_added, 3);
@@ -2859,7 +2859,7 @@ mod idempotency_tests {
         assert!(id5.is_some());
         assert_eq!(id4, id5);
 
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.iids_duplicates, 2);
 
         // Verify that changing maxsize also clears the IDMP map.
@@ -2872,7 +2872,7 @@ mod idempotency_tests {
             "OK"
         );
 
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.idmp_maxsize, IDMP_CUSTOM_MAXSIZE);
         assert_eq!(info.pids_tracked, 0);
         assert_eq!(info.iids_tracked, 0);
@@ -2908,7 +2908,7 @@ mod idempotency_tests {
             .unwrap(),
             "OK"
         );
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.idmp_maxsize, IDMP_MAXSIZE_LIMIT);
 
         // Add messages up to IDMP_MAXSIZE_LIMIT (2 IIDs).
@@ -2924,7 +2924,7 @@ mod idempotency_tests {
             .unwrap();
         assert!(id2.is_some());
 
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.pids_tracked, 1);
         assert_eq!(info.iids_tracked, 2);
         assert_eq!(info.iids_added, 2);
@@ -2938,7 +2938,7 @@ mod idempotency_tests {
         assert!(id3.is_some());
 
         // Verify that the IDMP map is still tracking exactly IDMP_MAXSIZE_LIMIT IIDs.
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.iids_tracked, IDMP_MAXSIZE_LIMIT as usize);
         assert_eq!(info.iids_added, 3);
 
@@ -2949,7 +2949,7 @@ mod idempotency_tests {
         assert!(id4.is_some());
         assert_ne!(id1, id4);
 
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.iids_added, 4);
         assert_eq!(info.iids_duplicates, 0);
 
@@ -2960,7 +2960,7 @@ mod idempotency_tests {
         assert!(id5.is_some());
         assert_eq!(id3, id5);
 
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.iids_duplicates, 1);
 
         // Test 2: Verify duration-based expiry
@@ -2977,7 +2977,7 @@ mod idempotency_tests {
             .unwrap(),
             "OK"
         );
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.idmp_duration, IDMP_SHORT_DURATION);
 
         // Add an idempotent message.
@@ -2994,7 +2994,7 @@ mod idempotency_tests {
         assert!(id2.is_some());
         assert_eq!(id1, id2);
 
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         assert_eq!(info.iids_tracked, 1);
         assert_eq!(info.iids_duplicates, 1);
 
@@ -3010,7 +3010,7 @@ mod idempotency_tests {
         assert!(id3.is_some());
         assert_ne!(id1, id3);
 
-        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        let info = con.xinfo_stream(STREAM_NAME).unwrap();
         // The IID should be tracked again (re-added after expiry).
         assert_eq!(info.iids_tracked, 1);
         assert_eq!(

--- a/version2.md
+++ b/version2.md
@@ -10,6 +10,17 @@ redis = "2"
 
 ## Breaking Changes
 
+### `StreamInfoStreamReplyWithIdempotency` got folded into `StreamInfoStreamReply`
+
+`StreamInfoStreamReply` had the idempotency fields added.
+
+This removed the need for `StreamInfoStreamReplyWithIdempotency` and the `xinfo_stream_with_idempotency` command, which therefore got dropped.
+
+**Migration:**
+
+* Switch from `StreamInfoStreamReplyWithIdempotency` to `StreamInfoStreamReply`, and
+* Switch from `xinfo_stream_with_idempotency` to `xinfo_stream`.
+
 ### Several `struct`s and `enum`s are now marked `#[non_exhaustive]` (Breaking Change)
 
 The `#[non_exhaustive]` will allow us to add fields without having to trigger version bumps, hence help with maintenance.


### PR DESCRIPTION
`StreamInfoStreamReplyWithIdempotency` got added in `4f11b5a` to allow accessing idempotency fields while staying backwards compatible on the v1 branch.

As v2 is now prepared, backwards-compatibility is no longer a concern, and we clean the idempotency structures up.