### PR TITLE
ci: Drop legacy logic to find the JSON module

### DIFF
--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -442,24 +442,9 @@ impl RedisServerCommand {
         for module in modules {
             match module {
                 Module::Json => {
-                    // Try to pick up json module path from REDISRS_REDIS_JSON_PATH environment variable
-                    let path = match env::var("REDISRS_REDIS_JSON_PATH") {
-                        Ok(path) => path,
-                        // Falling back to legacy REDIS_RS_REDIS_JSON_PATH environment variable
-                        Err(_) => match env::var("REDIS_RS_REDIS_JSON_PATH") {
-                            Ok(path) => {
-                                eprintln!(
-                                    "Warning: Use of REDIS_RS_REDIS_JSON_PATH is deprecated. Use REDISRS_REDIS_JSON_PATH (no '_' before 'RS') instead"
-                                );
-                                path
-                            }
-                            Err(_) => {
-                                panic!(
-                                    "Unable to find path to RedisJSON at REDISRS_REDIS_JSON_PATH, is it set?"
-                                );
-                            }
-                        },
-                    };
+                    let path = env::var("REDISRS_REDIS_JSON_PATH").expect(
+                        "Unable to find path to the JSON module at REDISRS_REDIS_JSON_PATH, is it set?",
+                    );
 
                     self.load_module(path);
                 }

--- a/version2.md
+++ b/version2.md
@@ -10,6 +10,14 @@ redis = "2"
 
 ## Breaking Changes
 
+### Tests: The path to the JSON module is no longer picked up from `REDIS_RS...`
+
+The path to the JSON module is now only picked up from the environment variable `REDISRS_REDIS_JSON_PATH` (no `_` before `RS`).
+
+The legacy logic to pick it up also from `REDIS_RS_REDIS_JSON_PATH` (`_` before `RS`) got removed. 
+
+**Migration:** Switch from `REDIS_RS_REDIS_JSON_PATH` to `REDISRS_REDIS_JSON_PATH`
+
 ### `StreamInfoStreamReplyWithIdempotency` got folded into `StreamInfoStreamReply`
 
 `StreamInfoStreamReply` had the idempotency fields added.


### PR DESCRIPTION
In addition to picking up the JSON module's path from `REDISRS_...`, we still had fallback logic to pick it up from the legacy `REDIS_RS_...` variable.

As we're preparing a new version, we drop that fallback logic to get a leaner code base.