### PR TITLE
spelling: Change `infos` to `info`

### DIFF
--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -337,7 +337,7 @@ mod cluster_async {
             .route_command(redis::cmd("INFO"), routing)
             .await
             .unwrap();
-        let (addresses, infos) = split_to_addresses_and_info(res);
+        let (addresses, info) = split_to_addresses_and_info(res);
 
         let mut cluster_addresses: Vec<_> = cluster_addresses
             .into_iter()
@@ -347,10 +347,10 @@ mod cluster_async {
 
         assert_eq!(addresses.len(), 6);
         assert_eq!(addresses, cluster_addresses);
-        assert_eq!(infos.len(), 6);
+        assert_eq!(info.len(), 6);
         for i in 0..6 {
             let split: Vec<_> = addresses[i].split(':').collect();
-            assert!(infos[i].contains(&format!("tcp_port:{}", split[1])));
+            assert!(info[i].contains(&format!("tcp_port:{}", split[1])));
         }
 
         let route_to_all_primaries = MultipleNodeRoutingInfo::AllMasters;
@@ -359,15 +359,15 @@ mod cluster_async {
             .route_command(redis::cmd("INFO"), routing)
             .await
             .unwrap();
-        let (addresses, infos) = split_to_addresses_and_info(res);
+        let (addresses, info) = split_to_addresses_and_info(res);
         assert_eq!(addresses.len(), 3);
-        assert_eq!(infos.len(), 3);
+        assert_eq!(info.len(), 3);
         // verify that all primaries have the correct port & host, and are marked as primaries.
         for i in 0..3 {
             assert!(cluster_addresses.contains(&addresses[i]));
             let split: Vec<_> = addresses[i].split(':').collect();
-            assert!(infos[i].contains(&format!("tcp_port:{}", split[1])));
-            assert!(infos[i].contains("role:primary") || infos[i].contains("role:master"));
+            assert!(info[i].contains(&format!("tcp_port:{}", split[1])));
+            assert!(info[i].contains("role:primary") || info[i].contains("role:master"));
         }
     }
 

--- a/redis/tests/test_module_bloom.rs
+++ b/redis/tests/test_module_bloom.rs
@@ -97,11 +97,11 @@ fn test_module_bloom_multiple_value_updates() {
 
 /// Tries to assure that information functions work
 #[test]
-fn test_module_bloom_infos() {
+fn test_module_bloom_info() {
     let ctx = TestContext::with_modules(&[Module::Bloom]);
     let mut con = ctx.connection();
 
-    // Check that getting infos on a not yet existing key does not panic
+    // Check that getting info on a not yet existing key does not panic
     assert_eq!(con.bf_card(KEY_1), Ok(0));
     assert_eq!(con.key_type(KEY_1), Ok(ValueType::None));
     assert_matches!(con.bf_info(KEY_1).unwrap_err().detail(), Some(d) if d.contains("not found"));
@@ -112,7 +112,7 @@ fn test_module_bloom_infos() {
         Ok(vec![false, false, false])
     );
 
-    // Add a single value and check its infos
+    // Add a single value and check its info
     assert_eq!(con.bf_add(KEY_1, "foo"), Ok(true));
     assert_eq!(con.bf_card(KEY_1), Ok(1));
     let bf_type = con.key_type(KEY_1).unwrap();
@@ -139,7 +139,7 @@ fn test_module_bloom_infos() {
         Ok(vec![true, false, false])
     );
 
-    // Add a second value and check its infos
+    // Add a second value and check its info
     assert_eq!(con.bf_add(KEY_1, "bar"), Ok(true));
     assert_eq!(con.bf_card(KEY_1), Ok(2));
     assert_eq!(con.key_type(KEY_1), Ok(bf_type.clone()));
@@ -162,7 +162,7 @@ fn test_module_bloom_infos() {
         Ok(vec![true, true, false])
     );
 
-    // Adding the first value again should not change infos, as that value was already added before.
+    // Adding the first value again should not change info, as that value was already added before.
     assert_eq!(con.bf_add(KEY_1, "foo"), Ok(false));
     assert_eq!(con.bf_card(KEY_1), Ok(2));
     assert_eq!(con.key_type(KEY_1), Ok(bf_type));
@@ -185,7 +185,7 @@ fn test_module_bloom_infos() {
         Ok(vec![true, true, false])
     );
 
-    // Check that getting infos on a not-Bloom-filter key does not panic or change its value
+    // Check that getting info on a not-Bloom-filter key does not panic or change its value
     assert_eq!(con.set(KEY_2, "quux"), Ok(()));
     assert_eq!(con.bf_card(KEY_2).unwrap_err().code(), Some("WRONGTYPE"));
     assert_eq!(con.bf_info(KEY_2).unwrap_err().code(), Some("WRONGTYPE"));

--- a/redis/tests/test_sentinel.rs
+++ b/redis/tests/test_sentinel.rs
@@ -81,7 +81,7 @@ fn connect_to_all_replicas(
     node_conn_info: &SentinelNodeConnectionInfo,
     number_of_replicas: u16,
 ) -> Vec<ConnectionAddr> {
-    let mut replica_conn_infos = vec![];
+    let mut replica_conn_info = vec![];
 
     for _ in 0..number_of_replicas {
         let replica_client = sentinel
@@ -89,18 +89,18 @@ fn connect_to_all_replicas(
             .unwrap();
         let mut replica_con = replica_client.get_connection().unwrap();
 
-        assert!(!replica_conn_infos.contains(replica_client.get_connection_info().addr()));
-        replica_conn_infos.push(replica_client.get_connection_info().addr().clone());
+        assert!(!replica_conn_info.contains(replica_client.get_connection_info().addr()));
+        replica_conn_info.push(replica_client.get_connection_info().addr().clone());
 
         assert_connection_is_replica_of_correct_master(&mut replica_con, master_client);
     }
 
-    replica_conn_infos
+    replica_conn_info
 }
 
 fn assert_connect_to_known_replicas(
     sentinel: &mut Sentinel,
-    replica_conn_infos: &[ConnectionAddr],
+    replica_conn_info: &[ConnectionAddr],
     master_name: &str,
     master_client: &Client,
     node_conn_info: &SentinelNodeConnectionInfo,
@@ -112,7 +112,7 @@ fn assert_connect_to_known_replicas(
             .unwrap();
         let mut replica_con = replica_client.get_connection().unwrap();
 
-        assert!(replica_conn_infos.contains(replica_client.get_connection_info().addr()));
+        assert!(replica_conn_info.contains(replica_client.get_connection_info().addr()));
 
         assert_connection_is_replica_of_correct_master(&mut replica_con, master_client);
     }
@@ -331,7 +331,7 @@ fn test_sentinel_connect_to_multiple_replicas() {
 
     assert_is_connection_to_master(&mut master_con);
 
-    let replica_conn_infos = connect_to_all_replicas(
+    let replica_conn_info = connect_to_all_replicas(
         sentinel,
         master_name,
         &master_client,
@@ -341,7 +341,7 @@ fn test_sentinel_connect_to_multiple_replicas() {
 
     assert_connect_to_known_replicas(
         sentinel,
-        &replica_conn_infos,
+        &replica_conn_info,
         master_name,
         &master_client,
         &node_conn_info,
@@ -369,7 +369,7 @@ fn test_sentinel_server_down() {
 
     let sentinel = context.sentinel_mut();
 
-    let replica_conn_infos = connect_to_all_replicas(
+    let replica_conn_info = connect_to_all_replicas(
         sentinel,
         master_name,
         &master_client,
@@ -379,7 +379,7 @@ fn test_sentinel_server_down() {
 
     assert_connect_to_known_replicas(
         sentinel,
-        &replica_conn_infos,
+        &replica_conn_info,
         master_name,
         &master_client,
         &node_conn_info,
@@ -652,7 +652,7 @@ pub mod async_tests {
         node_conn_info: &SentinelNodeConnectionInfo,
         number_of_replicas: u16,
     ) -> Vec<ConnectionAddr> {
-        let mut replica_conn_infos = vec![];
+        let mut replica_conn_info = vec![];
 
         for _ in 0..number_of_replicas {
             let replica_client = sentinel
@@ -665,23 +665,23 @@ pub mod async_tests {
                 .unwrap();
 
             assert!(
-                !replica_conn_infos.contains(replica_client.get_connection_info().addr()),
+                !replica_conn_info.contains(replica_client.get_connection_info().addr()),
                 "pushing {:?} into {:?}",
                 replica_client.get_connection_info().addr(),
-                replica_conn_infos
+                replica_conn_info
             );
-            replica_conn_infos.push(replica_client.get_connection_info().addr().clone());
+            replica_conn_info.push(replica_client.get_connection_info().addr().clone());
 
             async_assert_connection_is_replica_of_correct_master(&mut replica_con, master_client)
                 .await;
         }
 
-        replica_conn_infos
+        replica_conn_info
     }
 
     async fn async_assert_connect_to_known_replicas(
         sentinel: &mut Sentinel,
-        replica_conn_infos: &[ConnectionAddr],
+        replica_conn_info: &[ConnectionAddr],
         master_name: &str,
         master_client: &Client,
         node_conn_info: &SentinelNodeConnectionInfo,
@@ -697,7 +697,7 @@ pub mod async_tests {
                 .await
                 .unwrap();
 
-            assert!(replica_conn_infos.contains(replica_client.get_connection_info().addr()));
+            assert!(replica_conn_info.contains(replica_client.get_connection_info().addr()));
 
             async_assert_connection_is_replica_of_correct_master(&mut replica_con, master_client)
                 .await;
@@ -752,7 +752,7 @@ pub mod async_tests {
 
         async_assert_is_connection_to_master(&mut master_con).await;
 
-        let replica_conn_infos = async_connect_to_all_replicas(
+        let replica_conn_info = async_connect_to_all_replicas(
             sentinel,
             master_name,
             &master_client,
@@ -763,7 +763,7 @@ pub mod async_tests {
 
         async_assert_connect_to_known_replicas(
             sentinel,
-            &replica_conn_infos,
+            &replica_conn_info,
             master_name,
             &master_client,
             &node_conn_info,
@@ -797,7 +797,7 @@ pub mod async_tests {
 
         let sentinel = context.sentinel_mut();
 
-        let replica_conn_infos = async_connect_to_all_replicas(
+        let replica_conn_info = async_connect_to_all_replicas(
             sentinel,
             master_name,
             &master_client,
@@ -808,7 +808,7 @@ pub mod async_tests {
 
         async_assert_connect_to_known_replicas(
             sentinel,
-            &replica_conn_infos,
+            &replica_conn_info,
             master_name,
             &master_client,
             &node_conn_info,


### PR DESCRIPTION
Information does not have a plural in a strict grammatical sense.

cf. https://github.com/redis-rs/redis-rs/pull/2360#discussion_r3913961709