### PR TITLE
redis-test/RedisServer: Reduce server disk access

### DIFF
--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -275,6 +275,13 @@ impl RedisServer {
         // This stops littering `dump.rdb` files during testing/development.
         redis_cmd.arg2("--save", "");
 
+        // We'd like to prohibit loading dumps by setting `dbfilename` to the empty string. But that
+        // only works on Redis and is prohibited in Valkey.
+
+        // We'd prefer `flushdb` here to prohibit more disk actions, but this is only available on
+        // Redis 8.6+. So we fall back to `on-empty-db`, which also covers the typical setup.
+        redis_cmd.arg2("--repl-diskless-load", "on-empty-db");
+
         redis_cmd.load_modules(modules);
 
         let tempdir = tempfile::Builder::new()


### PR DESCRIPTION
Ideally, we'd like to prohibit all disk access to ease testing. But that's not portable, as for example Redis allows to disable loading dumps by setting `dbfilename` to ``, while Valkey prohibits this.

So we at least get rid of disk access during replication boot-up.