### PR TITLE
Mark `ReadCandidates` as `non_exhaustive` (12/15)

### DIFF
--- a/redis/src/cluster_handling/read_routing/interface.rs
+++ b/redis/src/cluster_handling/read_routing/interface.rs
@@ -177,6 +177,10 @@ impl<'a> ReplicasOnlyCandidates<'a> {
 /// The strategy is only called when there are replicas available for the
 /// target slot. If a slot has no replicas, the caller falls back to the
 /// primary without consulting the strategy.
+#[allow(
+    clippy::exhaustive_enums,
+    reason = "The effects of marking this 'non_exhaustive' are not ideal. See #2390."
+)]
 #[derive(Debug)]
 pub enum ReadCandidates<'a> {
     /// Any node (primary or replica) is acceptable for this read.


### PR DESCRIPTION
This is part of #2249