### PR TITLE
ci: Switch to `REDISRS_MODULE_<NAME>_PATH` for modules

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,8 +8,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  REDISRS_REDIS_JSON_PATH: "/tmp/librejson.so"
-  REDISRS_REDIS_BLOOM_PATH: "/tmp/redisbloom.so"
+  REDISRS_MODULE_JSON_PATH: "/tmp/librejson.so"
+  REDISRS_MODULE_BLOOM_PATH: "/tmp/redisbloom.so"
   REDISRS_TLS_KEY_CA: "/tmp/tls-ca.key"
   REDISRS_TLS_KEY_SERVER: "/tmp/tls-server.key"
   REDISRS_TLS_KEY_CLIENT: "/tmp/tls-client.key"
@@ -71,12 +71,12 @@ jobs:
       - name: Copy bundled RedisJSON into place
         if: matrix.config.json-module-version == 'bundled'
         run: |
-          cp "$HOME/db/rejson.so" "$REDISRS_REDIS_JSON_PATH"
+          cp "$HOME/db/rejson.so" "$REDISRS_MODULE_JSON_PATH"
 
       - name: Copy bundled RedisBloom into place
         if: matrix.config.bloom-module-version == 'bundled'
         run: |
-          cp "$HOME/db/redisbloom.so" "$REDISRS_REDIS_BLOOM_PATH"
+          cp "$HOME/db/redisbloom.so" "$REDISRS_MODULE_BLOOM_PATH"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
@@ -115,24 +115,24 @@ jobs:
           cp ./Cargo.toml ./Cargo.toml.actual
           echo $'\nexclude = [\"./__ci/redis-json\"]' >> Cargo.toml
           cargo +stable build --release --manifest-path ./__ci/redis-json/Cargo.toml
-          mv ./__ci/redis-json/target/release/librejson.so ${{ env.REDISRS_REDIS_JSON_PATH }}
+          mv ./__ci/redis-json/target/release/librejson.so ${{ env.REDISRS_MODULE_JSON_PATH }}
           rm ./Cargo.toml; mv ./Cargo.toml.actual ./Cargo.toml
           rm -rf ./__ci/redis-json
 
       - name: Verify RedisJSON module
         if: matrix.config.json-module-version != ''
         run: |
-          if [ ! -f "${{ env.REDISRS_REDIS_JSON_PATH }}" ]; then
-            echo "ERROR: RedisJSON module not found at ${{ env.REDISRS_REDIS_JSON_PATH }}"
+          if [ ! -f "${{ env.REDISRS_MODULE_JSON_PATH }}" ]; then
+            echo "ERROR: RedisJSON module not found at ${{ env.REDISRS_MODULE_JSON_PATH }}"
             exit 1
           fi
-          ls -lh "${{ env.REDISRS_REDIS_JSON_PATH }}"
+          ls -lh "${{ env.REDISRS_MODULE_JSON_PATH }}"
 
           # Test that Redis can load the module
           echo "Testing Redis server with module..."
           TEST_PORT=16379
           TEST_LOG="/tmp/redis-module-test.log"
-          redis-server --port $TEST_PORT --loadmodule "${{ env.REDISRS_REDIS_JSON_PATH }}" \
+          redis-server --port $TEST_PORT --loadmodule "${{ env.REDISRS_MODULE_JSON_PATH }}" \
             --logfile "$TEST_LOG" --daemonize yes || {
             echo "ERROR: Failed to start Redis with module"
             cat "$TEST_LOG"
@@ -192,7 +192,7 @@ jobs:
       - name: Copy Valkey Bloom into place
         if: startsWith(matrix.config.bloom-module-version, 'valkey-bloom:')
         run: |
-          cp /tmp/valkey-bloom/target/release/libvalkey_bloom.so "$REDISRS_REDIS_BLOOM_PATH"
+          cp /tmp/valkey-bloom/target/release/libvalkey_bloom.so "$REDISRS_MODULE_BLOOM_PATH"
 
       - name: Run RedisBloom tests
         if: matrix.config.bloom-module-version != ''
@@ -203,7 +203,7 @@ jobs:
         id: cache-redisjson-save
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ${{ env.REDISRS_REDIS_JSON_PATH }}
+          path: ${{ env.REDISRS_MODULE_JSON_PATH }}
           key: ${{ runner.os }}-redisjson-${{ matrix.config.json-module-version }}
 
   examples:
@@ -236,12 +236,12 @@ jobs:
       - name: Copy Valkey Bloom into place
         if: startsWith(matrix.config.bloom-module-version, 'valkey-bloom:')
         run: |
-          cp /tmp/valkey-bloom/target/release/libvalkey_bloom.so "$REDISRS_REDIS_BLOOM_PATH"
+          cp /tmp/valkey-bloom/target/release/libvalkey_bloom.so "$REDISRS_MODULE_BLOOM_PATH"
 
       - name: Copy bundled RedisBloom into place
         if: matrix.config.bloom-module-version == 'bundled'
         run: |
-          cp "$HOME/db/redisbloom.so" "$REDISRS_REDIS_BLOOM_PATH"
+          cp "$HOME/db/redisbloom.so" "$REDISRS_MODULE_BLOOM_PATH"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
@@ -253,10 +253,10 @@ jobs:
       - name: Start Redis
         run: |
           EXTRA_OPTS=()
-          if [ -e "$REDISRS_REDIS_BLOOM_PATH" ]
+          if [ -e "$REDISRS_MODULE_BLOOM_PATH" ]
           then
-            echo "Adding module '$REDISRS_REDIS_BLOOM_PATH'"
-            EXTRA_OPTS+=("--loadmodule" "$REDISRS_REDIS_BLOOM_PATH")
+            echo "Adding module '$REDISRS_MODULE_BLOOM_PATH'"
+            EXTRA_OPTS+=("--loadmodule" "$REDISRS_MODULE_BLOOM_PATH")
           fi
           redis-server "${EXTRA_OPTS[@]}" &
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -59,8 +59,8 @@ The tests need to be able to find Redis' tools and the modules. If automatic det
 | EnvVar Name | Description |
 | --- | --- |
 | `REDISRS_SERVER_BIN` | Binary to start Redis |
-| `REDISRS_REDIS_BLOOM_PATH` | Path to the `bloom` module |
-| `REDISRS_REDIS_JSON_PATH` | Path to the `json` module |
+| `REDISRS_MODULE_BLOOM_PATH` | Path to the `bloom` module |
+| `REDISRS_MODULE_JSON_PATH` | Path to the `json` module |
 
 ### Speeding up TLS tests
 

--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -458,10 +458,10 @@ impl RedisServerCommand {
         for module in modules {
             match module {
                 Module::Json => {
-                    self.load_module("REDISRS_REDIS_JSON_PATH", "JSON");
+                    self.load_module("REDISRS_MODULE_JSON_PATH", "JSON");
                 }
                 Module::Bloom => {
-                    self.load_module("REDISRS_REDIS_BLOOM_PATH", "Bloom");
+                    self.load_module("REDISRS_MODULE_BLOOM_PATH", "Bloom");
                 }
             }
         }

--- a/version2.md
+++ b/version2.md
@@ -10,13 +10,20 @@ redis = "2"
 
 ## Breaking Changes
 
-### Tests: The path to the JSON module is no longer picked up from `REDIS_RS...`
+### Tests: The path to Redis modules is only picked up from `REDISRS_MODULE_...` environment variables (Breaking Change)
 
-The path to the JSON module is now only picked up from the environment variable `REDISRS_REDIS_JSON_PATH` (no `_` before `RS`).
+The modules get picked only from the following environment variables:
 
-The legacy logic to pick it up also from `REDIS_RS_REDIS_JSON_PATH` (`_` before `RS`) got removed. 
+| EnvVar Name | Description |
+| --- | --- |
+| `REDISRS_MODULE_BLOOM_PATH` | Path to the `bloom` module |
+| `REDISRS_MODULE_JSON_PATH` | Path to the `json` module |
 
-**Migration:** Switch from `REDIS_RS_REDIS_JSON_PATH` to `REDISRS_REDIS_JSON_PATH`
+**Migration:**
+
+* Switch from `REDIS_RS_REDIS_JSON_PATH` to `REDISRS_MODULE_JSON_PATH`
+* Switch from `REDISRS_REDIS_JSON_PATH` to `REDISRS_MODULE_JSON_PATH`
+* Switch from `REDISRS_REDIS_BLOOM_PATH` to `REDISRS_MODULE_BLOOM_PATH`
 
 ### `StreamInfoStreamReplyWithIdempotency` got folded into `StreamInfoStreamReply`
 


### PR DESCRIPTION
The previous `REDISRS_REDIS_<NAME>_PATH` lacked that the environment variables were for _modules_ and by the duplicated `REDIS` suggested that only _Redis_ modules were supported. But Valkey modules are supported as well.

Fixes #2373