### PR TITLE
commands: Switch macros from `$body` to `Cmd` (typed-json 1/6)

### DIFF
--- a/redis/src/commands/macros.rs
+++ b/redis/src/commands/macros.rs
@@ -32,7 +32,7 @@ macro_rules! implement_command_async {
         ) -> crate::types::RedisFuture<$lifetime, $rettype>
 
         {
-            Box::pin(async move { $($body)*.query_async(self).await })
+            Box::pin(async move { Cmd::$name($($argname),*).query_async(self).await })
         }
     };
 }
@@ -261,6 +261,7 @@ macro_rules! implement_commands {
         impl Cmd {
             $(
                 $(#[$attr])*
+                #[inline]
                 #[allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
                 pub fn $name<$lifetime, $($tyargs: $ty),*>($($argname: $argty),*) -> Self {
                     $($body)*
@@ -310,7 +311,7 @@ macro_rules! implement_commands {
                 where
                     RV: FromRedisValue,
                 {
-                    Box::pin(async move { {$($body)*}.query_async(self).await })
+                    Box::pin(async move { Cmd::$name($($argname),*).query_async(self).await })
                 }
             )*
 


### PR DESCRIPTION
The macros to create commands used `$body` a lot. But, since the performance optimization in 706027, `$block` changed from `block` to multiple `tt`s, which made it tricky to implement the changes needed for typed JSON commands.

The issues of working with multiple `tt` `$body`s gave need for the `write_pipeline_command` macro which dupes the `ready_cmd` macro in one arm.

To simplify the macros, we switch from using `$body` in most places to using `Cmd`'s functions instead. That way `$body` is used only in a single place, and other code can call a single function.

This better organizes the code, gets rid of `write_pipeline_command` macro with its duplication, and prepares for a simpler addition typed JSON commands in follow-up commits.

This prepares for #2201